### PR TITLE
Switch to Switch

### DIFF
--- a/app/src/main/res/layout/activity_permissions.xml
+++ b/app/src/main/res/layout/activity_permissions.xml
@@ -104,7 +104,7 @@
                         app:layout_constraintEnd_toStartOf="@id/autoResetSwitch"
                         app:layout_constraintStart_toEndOf="@id/start"
                         app:layout_constraintTop_toBottomOf="@id/autoResetHeading" />
-                    <com.google.android.material.switchmaterial.SwitchMaterial
+                    <Switch
                         android:id="@+id/autoResetSwitch"
                         android:layout_width="wrap_content"
                         android:layout_height="match_parent"
@@ -139,7 +139,7 @@
                         app:layout_constraintEnd_toStartOf="@id/allSwitch"
                         app:layout_constraintStart_toEndOf="@id/start"
                         app:layout_constraintTop_toBottomOf="@id/allHeading" />
-                    <com.google.android.material.switchmaterial.SwitchMaterial
+                    <Switch
                         android:id="@+id/allSwitch"
                         android:layout_width="wrap_content"
                         android:layout_height="match_parent"
@@ -172,7 +172,7 @@
                         app:layout_constraintEnd_toStartOf="@id/contactsSwitch"
                         app:layout_constraintStart_toEndOf="@id/start"
                         app:layout_constraintTop_toBottomOf="@id/contactsHeading" />
-                    <com.google.android.material.switchmaterial.SwitchMaterial
+                    <Switch
                         android:id="@+id/contactsSwitch"
                         android:layout_width="wrap_content"
                         android:layout_height="match_parent"
@@ -205,7 +205,7 @@
                         app:layout_constraintEnd_toStartOf="@id/calendarSwitch"
                         app:layout_constraintStart_toEndOf="@id/start"
                         app:layout_constraintTop_toBottomOf="@id/calendarHeading" />
-                    <com.google.android.material.switchmaterial.SwitchMaterial
+                    <Switch
                         android:id="@+id/calendarSwitch"
                         android:layout_width="wrap_content"
                         android:layout_height="match_parent"
@@ -240,7 +240,7 @@
                         app:layout_constraintEnd_toStartOf="@id/openTasksSwitch"
                         app:layout_constraintStart_toEndOf="@id/start"
                         app:layout_constraintTop_toBottomOf="@id/openTasksHeading" />
-                    <com.google.android.material.switchmaterial.SwitchMaterial
+                    <Switch
                         android:id="@+id/openTasksSwitch"
                         android:layout_width="wrap_content"
                         android:layout_height="match_parent"
@@ -276,7 +276,7 @@
                         app:layout_constraintEnd_toStartOf="@id/tasksOrgSwitch"
                         app:layout_constraintStart_toEndOf="@id/start"
                         app:layout_constraintTop_toBottomOf="@id/tasksOrgHeading" />
-                    <com.google.android.material.switchmaterial.SwitchMaterial
+                    <Switch
                         android:id="@+id/tasksOrgSwitch"
                         android:layout_width="wrap_content"
                         android:layout_height="match_parent"
@@ -312,7 +312,7 @@
                         app:layout_constraintEnd_toStartOf="@id/jtxSwitch"
                         app:layout_constraintStart_toEndOf="@id/start"
                         app:layout_constraintTop_toBottomOf="@id/jtxHeading" />
-                    <com.google.android.material.switchmaterial.SwitchMaterial
+                    <Switch
                         android:id="@+id/jtxSwitch"
                         android:layout_width="wrap_content"
                         android:layout_height="match_parent"

--- a/app/src/main/res/layout/activity_tasks.xml
+++ b/app/src/main/res/layout/activity_tasks.xml
@@ -104,7 +104,7 @@
                         app:layout_constraintEnd_toStartOf="@id/end"
                         style="@style/TextAppearance.MaterialComponents.Body2"
                         app:html="@{@string/intro_tasks_jtx_info}" />
-                    <com.google.android.material.switchmaterial.SwitchMaterial
+                    <Switch
                         android:id="@+id/jtxSwitch"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
@@ -137,7 +137,7 @@
                         app:layout_constraintEnd_toStartOf="@id/end"
                         style="@style/TextAppearance.MaterialComponents.Body2"
                         app:html="@{@string/intro_tasks_opentasks_info}"/>
-                    <com.google.android.material.switchmaterial.SwitchMaterial
+                    <Switch
                         android:id="@+id/openTasksSwitch"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
@@ -170,7 +170,7 @@
                         app:layout_constraintEnd_toStartOf="@id/end"
                         style="@style/TextAppearance.MaterialComponents.Body2"
                         app:html="@{@string/intro_tasks_tasks_org_info}" />
-                    <com.google.android.material.switchmaterial.SwitchMaterial
+                    <Switch
                         android:id="@+id/tasksOrgSwitch"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_wifi_permissions.xml
+++ b/app/src/main/res/layout/activity_wifi_permissions.xml
@@ -53,7 +53,7 @@
                 app:layout_constraintEnd_toStartOf="@id/locationSwitch"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/locationTitle" />
-            <com.google.android.material.switchmaterial.SwitchMaterial
+            <Switch
                 android:id="@+id/locationSwitch"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -88,7 +88,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/backgroundLocationTitle"
                 tools:text="@string/wifi_permissions_background_location_permission_off" />
-            <com.google.android.material.switchmaterial.SwitchMaterial
+            <Switch
                 android:id="@+id/backgroundLocationSwitch"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -138,7 +138,7 @@
                 app:layout_constraintEnd_toStartOf="@id/locationEnabledSwitch"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/locationEnabledTitle" />
-            <com.google.android.material.switchmaterial.SwitchMaterial
+            <Switch
                 android:id="@+id/locationEnabledSwitch"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout/intro_battery_optimizations.xml
+++ b/app/src/main/res/layout/intro_battery_optimizations.xml
@@ -53,7 +53,7 @@
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/batteryHeading" />
 
-                    <com.google.android.material.switchmaterial.SwitchMaterial
+                    <Switch
                         android:id="@+id/batterySwitch"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"


### PR DESCRIPTION
The intro screens use
com.google.android.material.switchmaterial.SwitchMaterial
which look out of place in dark mode as they have very low contrast. It
also looks inconsistent with the switches used in the (account) settings
screen.
Use Switch which enables a more consistent look.