### PR TITLE
Add framagenda to pre-set URLs

### DIFF
--- a/app/src/main/assets/known-base-urls.txt
+++ b/app/src/main/assets/known-base-urls.txt
@@ -6,6 +6,7 @@ dav.edis.at
 dav.fruux.com
 caldav.gmx.net
 carddav.gmx.net
+framagenda.org/remote.php/dav/
 icloud.com
 cloud.liberta.vip
 office.luckycloud.de


### PR DESCRIPTION
Adds framagenda (french non-profit calendar service) to pre-set URLs list.

https://docs.framasoft.org/fr/agenda/Synchronisation/Android.html