### PR TITLE
LoginSetupActivity: allow http/https in intent filter

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -118,13 +118,17 @@
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <category android:name="android.intent.category.DEFAULT"/>
-                <data android:scheme="http"/>
-                <data android:scheme="https"/>
                 <data android:scheme="caldav"/>
                 <data android:scheme="caldavs"/>
                 <data android:scheme="carddav"/>
                 <data android:scheme="carddavs"/>
                 <data android:scheme="davx5"/>
+            </intent-filter>
+            <intent-filter>
+                <action android:name="loginFlow" /> <!-- Ensures this filter matches, even if the sending app is not defining an action -->
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="http" />
+                <data android:scheme="https" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -118,6 +118,8 @@
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <category android:name="android.intent.category.DEFAULT"/>
+                <data android:scheme="http"/>
+                <data android:scheme="https"/>
                 <data android:scheme="caldav"/>
                 <data android:scheme="caldavs"/>
                 <data android:scheme="carddav"/>


### PR DESCRIPTION
Initially introduced in https://github.com/bitfireAT/davx5-ose/commit/054f1ece612eceef962b356b7ad8b2b7125a6393, this `intent-filter` breaks login from the Nextcloud app, as we send the server URI as `http`/`https`, and the intent resolution fails.

Closes https://github.com/nextcloud/android/issues/11126

Signed-off-by: Álvaro Brey <alvaro.brey@nextcloud.com>
