### PR TITLE
Add dav.mailbox.org to known base URLs

### DIFF
--- a/app/src/main/assets/known-base-urls.txt
+++ b/app/src/main/assets/known-base-urls.txt
@@ -4,6 +4,7 @@ calendar.dingtalk.com/dav/
 cloud.disroot.org
 dav.edis.at
 dav.fruux.com
+dav.mailbox.org
 caldav.gmx.net
 carddav.gmx.net
 framagenda.org/remote.php/dav/

--- a/app/src/main/assets/known-base-urls.txt
+++ b/app/src/main/assets/known-base-urls.txt
@@ -4,7 +4,6 @@ calendar.dingtalk.com/dav/
 cloud.disroot.org
 dav.edis.at
 dav.fruux.com
-dav.mailbox.org
 caldav.gmx.net
 carddav.gmx.net
 framagenda.org/remote.php/dav/
@@ -12,7 +11,7 @@ icloud.com
 cloud.liberta.vip
 office.luckycloud.de
 calendar.mail.ru
-mailbox.org
+dav.mailbox.org
 mailfence.com
 posteo.de:8443
 dav.runbox.com


### PR DESCRIPTION
See e.g. this help center article: https://kb.mailbox.org/en/private/calendar-article/caldav-and-carddav-for-other-devices