### PR TITLE
Auto generated changelog on release

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,16 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - someuser
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: Exciting New Features 🎉
+      labels:
+        - enhancement
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,4 +36,5 @@ jobs:
         with:
           prerelease: ${{ contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc') }}
           files: app/build/outputs/apk/ose/release/*.apk
+          generate_release_notes: true
           fail_on_unmatched_files: true


### PR DESCRIPTION
At least you can use it as a blueprint.
Here you can see an example https://github.com/gitx/gitx/releases/tag/0.21