### PR TITLE
Disable configuration cache again as it breaks AboutLibraries

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,10 +3,6 @@ org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=512m
 org.gradle.parallel=true
 
-# configuration cache [https://developer.android.com/build/optimize-your-build#use-the-configuration-cache-experimental]
-org.gradle.unsafe.configuration-cache=true
-org.gradle.unsafe.configuration-cache-problems=warn
-
 # Android
 android.databinding.incremental=true
 android.useAndroidX=true


### PR DESCRIPTION
With the configuration cache enabled:
```
./gradlew findLibraries
Configuration cache is an incubating feature.
Reusing configuration cache.

> Task :app:findLibraries
variant: oseDebug
variant: oseDebugAndroidTest
variant: oseDebugUnitTest
variant: oseRelease
variant: oseReleaseUnitTest

--> Retrieved no components for: androidx.activity:activity:1.7.2
--> Retrieved no components for: androidx.activity:activity-compose:1.7.2
--> Retrieved no components for: androidx.activity:activity-ktx:1.7.2
--> Retrieved no components for: androidx.annotation:annotation-experimental:1.3.0
--> Retrieved no components for: androidx.annotation:annotation-jvm:1.6.0
--> Retrieved no components for: androidx.appcompat:appcompat:1.6.1
--> Retrieved no components for: androidx.appcompat:appcompat-resources:1.6.1
--> Retrieved no components for: androidx.arch.core:core-common:2.2.0
--> Retrieved no components for: androidx.arch.core:core-runtime:2.2.0
--> Retrieved no components for: androidx.autofill:autofill:1.0.0
--> Retrieved no components for: androidx.browser:browser:1.5.0
--> Retrieved no components for: androidx.cardview:cardview:1.0.0
--> Retrieved no components for: androidx.collection:collection:1.1.0
--> Retrieved no components for: androidx.collection:collection-ktx:1.1.0
--> Retrieved no components for: androidx.compose.animation:animation:1.4.3
--> Retrieved no components for: androidx.compose.animation:animation-core:1.4.3
--> Retrieved no components for: androidx.compose.foundation:foundation:1.4.3
--> Retrieved no components for: androidx.compose.foundation:foundation-layout:1.4.3
--> Retrieved no components for: androidx.compose.material:material:1.4.3
--> Retrieved no components for: androidx.compose.material:material-icons-core:1.4.3
--> Retrieved no components for: androidx.compose.material:material-ripple:1.4.3
--> Retrieved no components for: androidx.compose.runtime:runtime:1.4.3
--> Retrieved no components for: androidx.compose.runtime:runtime-livedata:1.4.3
--> Retrieved no components for: androidx.compose.runtime:runtime-saveable:1.4.3
--> Retrieved no components for: androidx.compose.ui:ui:1.4.3
--> Retrieved no components for: androidx.compose.ui:ui-geometry:1.4.3
--> Retrieved no components for: androidx.compose.ui:ui-graphics:1.4.3
--> Retrieved no components for: androidx.compose.ui:ui-text:1.4.3
--> Retrieved no components for: androidx.compose.ui:ui-tooling-preview:1.4.3
--> Retrieved no components for: androidx.compose.ui:ui-unit:1.4.3
--> Retrieved no components for: androidx.compose.ui:ui-util:1.4.3
--> Retrieved no components for: androidx.compose:compose-bom:2023.05.01
--> Retrieved no components for: androidx.concurrent:concurrent-futures:1.1.0
--> Retrieved no components for: androidx.concurrent:concurrent-futures-ktx:1.1.0
--> Retrieved no components for: androidx.constraintlayout:constraintlayout:2.1.4
--> Retrieved no components for: androidx.constraintlayout:constraintlayout-core:1.0.4
--> Retrieved no components for: androidx.coordinatorlayout:coordinatorlayout:1.1.0
--> Retrieved no components for: androidx.core:core:1.10.1
--> Retrieved no components for: androidx.core:core-ktx:1.10.1
--> Retrieved no components for: androidx.cursoradapter:cursoradapter:1.0.0
--> Retrieved no components for: androidx.customview:customview:1.1.0
--> Retrieved no components for: androidx.customview:customview-poolingcontainer:1.0.0
--> Retrieved no components for: androidx.databinding:databinding-adapters:8.0.2
--> Retrieved no components for: androidx.databinding:databinding-common:8.0.2
--> Retrieved no components for: androidx.databinding:databinding-ktx:8.0.2
--> Retrieved no components for: androidx.databinding:databinding-runtime:8.0.2
--> Retrieved no components for: androidx.databinding:viewbinding:8.0.2
--> Retrieved no components for: androidx.documentfile:documentfile:1.0.0
--> Retrieved no components for: androidx.drawerlayout:drawerlayout:1.1.1
--> Retrieved no components for: androidx.dynamicanimation:dynamicanimation:1.0.0
--> Retrieved no components for: androidx.emoji2:emoji2:1.3.0
--> Retrieved no components for: androidx.emoji2:emoji2-views-helper:1.3.0
--> Retrieved no components for: androidx.fragment:fragment:1.5.7
--> Retrieved no components for: androidx.fragment:fragment-ktx:1.5.7
--> Retrieved no components for: androidx.hilt:hilt-common:1.0.0
--> Retrieved no components for: androidx.hilt:hilt-work:1.0.0
--> Retrieved no components for: androidx.interpolator:interpolator:1.0.0
--> Retrieved no components for: androidx.legacy:legacy-support-core-utils:1.0.0
--> Retrieved no components for: androidx.lifecycle:lifecycle-common:2.6.1
--> Retrieved no components for: androidx.lifecycle:lifecycle-extensions:2.2.0
--> Retrieved no components for: androidx.lifecycle:lifecycle-livedata:2.6.1
--> Retrieved no components for: androidx.lifecycle:lifecycle-livedata-core:2.6.1
--> Retrieved no components for: androidx.lifecycle:lifecycle-livedata-core-ktx:2.6.1
--> Retrieved no components for: androidx.lifecycle:lifecycle-livedata-ktx:2.6.1
--> Retrieved no components for: androidx.lifecycle:lifecycle-process:2.6.1
--> Retrieved no components for: androidx.lifecycle:lifecycle-runtime:2.6.1
--> Retrieved no components for: androidx.lifecycle:lifecycle-runtime-ktx:2.6.1
--> Retrieved no components for: androidx.lifecycle:lifecycle-service:2.6.1
--> Retrieved no components for: androidx.lifecycle:lifecycle-viewmodel:2.6.1
--> Retrieved no components for: androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1
--> Retrieved no components for: androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1
--> Retrieved no components for: androidx.loader:loader:1.0.0
--> Retrieved no components for: androidx.localbroadcastmanager:localbroadcastmanager:1.0.0
--> Retrieved no components for: androidx.paging:paging-common:3.1.1
--> Retrieved no components for: androidx.paging:paging-common-ktx:3.1.1
--> Retrieved no components for: androidx.paging:paging-runtime:3.1.1
--> Retrieved no components for: androidx.paging:paging-runtime-ktx:3.1.1
--> Retrieved no components for: androidx.preference:preference:1.2.0
--> Retrieved no components for: androidx.preference:preference-ktx:1.2.0
--> Retrieved no components for: androidx.print:print:1.0.0
--> Retrieved no components for: androidx.profileinstaller:profileinstaller:1.3.0
--> Retrieved no components for: androidx.recyclerview:recyclerview:1.2.0
--> Retrieved no components for: androidx.resourceinspection:resourceinspection-annotation:1.0.1
--> Retrieved no components for: androidx.room:room-common:2.5.1
--> Retrieved no components for: androidx.room:room-ktx:2.5.1
--> Retrieved no components for: androidx.room:room-paging:2.5.1
--> Retrieved no components for: androidx.room:room-runtime:2.5.1
--> Retrieved no components for: androidx.savedstate:savedstate:1.2.1
--> Retrieved no components for: androidx.savedstate:savedstate-ktx:1.2.1
--> Retrieved no components for: androidx.security:security-crypto:1.1.0-alpha06
--> Retrieved no components for: androidx.slidingpanelayout:slidingpanelayout:1.2.0
--> Retrieved no components for: androidx.sqlite:sqlite:2.3.1
--> Retrieved no components for: androidx.sqlite:sqlite-framework:2.3.1
--> Retrieved no components for: androidx.startup:startup-runtime:1.1.1
--> Retrieved no components for: androidx.swiperefreshlayout:swiperefreshlayout:1.1.0
--> Retrieved no components for: androidx.tracing:tracing:1.0.0
--> Retrieved no components for: androidx.transition:transition:1.4.1
--> Retrieved no components for: androidx.vectordrawable:vectordrawable:1.1.0
--> Retrieved no components for: androidx.vectordrawable:vectordrawable-animated:1.1.0
--> Retrieved no components for: androidx.versionedparcelable:versionedparcelable:1.1.1
--> Retrieved no components for: androidx.viewpager2:viewpager2:1.0.0
--> Retrieved no components for: androidx.viewpager:viewpager:1.0.0
--> Retrieved no components for: androidx.window:window:1.0.0
--> Retrieved no components for: androidx.work:work-runtime:2.8.1
--> Retrieved no components for: androidx.work:work-runtime-ktx:2.8.1
--> Retrieved no components for: com.damnhandy:handy-uri-templates:2.1.8
--> Retrieved no components for: com.fasterxml.jackson.core:jackson-core:2.14.2
--> Retrieved no components for: com.fasterxml.jackson:jackson-bom:2.14.2
--> Retrieved no components for: com.github.AppIntro:AppIntro:6.2.0
--> Retrieved no components for: com.github.bitfireAT:cert4android:c87a7e9
--> Retrieved no components for: com.github.bitfireAT:dav4jvm:47dd6a9
--> Retrieved no components for: com.github.erosb:everit-json-schema:1.14.1
--> Retrieved no components for: com.github.mangstadt:vinnie:2.0.2
--> Retrieved no components for: com.google.accompanist:accompanist-themeadapter-core:0.30.1
--> Retrieved no components for: com.google.accompanist:accompanist-themeadapter-material:0.30.1
--> Retrieved no components for: com.google.android.flexbox:flexbox:3.0.0
--> Retrieved no components for: com.google.android.material:material:1.9.0
--> Retrieved no components for: com.google.code.findbugs:jsr305:3.0.2
--> Retrieved no components for: com.google.code.gson:gson:2.8.9
--> Retrieved no components for: com.google.crypto.tink:tink-android:1.8.0
--> Retrieved no components for: com.google.dagger:dagger:2.46.1
--> Retrieved no components for: com.google.dagger:dagger-lint-aar:2.46.1
--> Retrieved no components for: com.google.dagger:hilt-android:2.46.1
--> Retrieved no components for: com.google.dagger:hilt-core:2.46.1
--> Retrieved no components for: com.google.errorprone:error_prone_annotations:2.15.0
--> Retrieved no components for: com.google.guava:listenablefuture:1.0
--> Retrieved no components for: com.google.re2j:re2j:1.6
--> Retrieved no components for: com.googlecode.ez-vcard:ez-vcard:0.12.0
--> Retrieved no components for: com.jaredrummler:colorpicker:1.1.0
--> Retrieved no components for: com.mikepenz:aboutlibraries-compose-android:10.6.2
--> Retrieved no components for: com.mikepenz:aboutlibraries-core-android-debug:10.6.2
--> Retrieved no components for: com.squareup.okhttp3:logging-interceptor:4.10.0
--> Retrieved no components for: com.squareup.okhttp3:okhttp:4.11.0
--> Retrieved no components for: com.squareup.okhttp3:okhttp-brotli:4.10.0
--> Retrieved no components for: com.squareup.okio:okio-jvm:3.2.0
--> Retrieved no components for: commons-beanutils:commons-beanutils:1.9.4
--> Retrieved no components for: commons-codec:commons-codec:1.15
--> Retrieved no components for: commons-collections:commons-collections:3.2.2
--> Retrieved no components for: commons-digester:commons-digester:2.1
--> Retrieved no components for: commons-io:commons-io:2.8.0
--> Retrieved no components for: commons-validator:commons-validator:1.7
--> Retrieved no components for: dnsjava:dnsjava:2.1.9
--> Retrieved no components for: jakarta-regexp:jakarta-regexp:1.4
--> Retrieved no components for: javax.cache:cache-api:1.1.1
--> Retrieved no components for: javax.inject:javax.inject:1
--> Retrieved no components for: joda-time:joda-time:2.10.2
--> Retrieved no components for: org.apache.commons:commons-collections4:4.2
--> Retrieved no components for: org.apache.commons:commons-lang3:3.8.1
--> Retrieved no components for: org.apache.commons:commons-text:1.3
--> Retrieved no components for: org.brotli:dec:0.1.2
--> Retrieved no components for: org.conscrypt:conscrypt-android:2.5.2
--> Retrieved no components for: org.jetbrains.kotlin:kotlin-stdlib:1.8.21
--> Retrieved no components for: org.jetbrains.kotlin:kotlin-stdlib-common:1.8.21
--> Retrieved no components for: org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.21
--> Retrieved no components for: org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.21
--> Retrieved no components for: org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.1
--> Retrieved no components for: org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.1
--> Retrieved no components for: org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.1
--> Retrieved no components for: org.jetbrains:annotations:23.0.0
--> Retrieved no components for: org.jparsec:jparsec:3.1
--> Retrieved no components for: org.mnode.ical4j:ical4j:3.2.11
--> Retrieved no components for: org.ogce:xpp3:1.1.6
--> Retrieved no components for: org.slf4j:slf4j-api:2.0.3
--> Retrieved no components for: org.slf4j:slf4j-jdk14:2.0.3
--> Retrieved no components for: org.threeten:threeten-extra:1.7.0
--> Retrieved no components for: androidx.arch.core:core-testing:2.2.0
--> Retrieved no components for: androidx.multidex:multidex:2.0.1
--> Retrieved no components for: androidx.room:room-migration:2.5.1
--> Retrieved no components for: androidx.room:room-testing:2.5.1
--> Retrieved no components for: androidx.test.ext:junit:1.1.5
--> Retrieved no components for: androidx.test.ext:junit-ktx:1.1.5
--> Retrieved no components for: androidx.test.services:storage:1.4.2
--> Retrieved no components for: androidx.test:annotation:1.0.1
--> Retrieved no components for: androidx.test:core:1.5.0
--> Retrieved no components for: androidx.test:core-ktx:1.5.0
--> Retrieved no components for: androidx.test:monitor:1.6.1
--> Retrieved no components for: androidx.test:rules:1.5.0
--> Retrieved no components for: androidx.test:runner:1.5.2
--> Retrieved no components for: androidx.work:work-testing:2.8.1
--> Retrieved no components for: com.google.dagger:hilt-android-testing:2.46.1
--> Retrieved no components for: com.jakewharton.android.repackaged:dalvik-dx:9.0.0_r3
--> Retrieved no components for: com.linkedin.dexmaker:dexmaker:2.28.1
--> Retrieved no components for: com.squareup.okhttp3:mockwebserver:4.10.0
--> Retrieved no components for: io.mockk:mockk-agent-android:1.13.4
--> Retrieved no components for: io.mockk:mockk-agent-api-jvm:1.13.4
--> Retrieved no components for: io.mockk:mockk-agent-jvm:1.13.4
--> Retrieved no components for: io.mockk:mockk-android:1.13.4
--> Retrieved no components for: io.mockk:mockk-core-jvm:1.13.4
--> Retrieved no components for: io.mockk:mockk-dsl-jvm:1.13.4
--> Retrieved no components for: io.mockk:mockk-jvm:1.13.4
--> Retrieved no components for: junit:junit:4.13.2
--> Retrieved no components for: net.bytebuddy:byte-buddy:1.12.20
--> Retrieved no components for: net.bytebuddy:byte-buddy-agent:1.12.20
--> Retrieved no components for: org.hamcrest:hamcrest-core:1.3
--> Retrieved no components for: org.jetbrains.kotlin:kotlin-reflect:1.8.0
--> Retrieved no components for: org.junit.jupiter:junit-jupiter:5.8.2
--> Retrieved no components for: org.junit.jupiter:junit-jupiter-api:5.8.2
--> Retrieved no components for: org.junit.jupiter:junit-jupiter-engine:5.8.2
--> Retrieved no components for: org.junit.jupiter:junit-jupiter-params:5.8.2
--> Retrieved no components for: org.junit.platform:junit-platform-commons:1.8.2
--> Retrieved no components for: org.junit.platform:junit-platform-engine:1.8.2
--> Retrieved no components for: org.mockito:mockito-core:2.25.0
--> Retrieved no components for: org.objenesis:objenesis:3.3
--> Retrieved no components for: org.opentest4j:opentest4j:1.2.0
--> Retrieved no components for: com.mikepenz:aboutlibraries-core-android:10.6.2

BUILD SUCCESSFUL in 1s
2 actionable tasks: 1 executed, 1 up-to-date
Configuration cache entry reused.
```