### PR TITLE
Shorten version hash of vcard4android library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
         commonsText: '1.3',
         // own libraries
         cert4android: 'c87a7e9',
-        vcard4android: 'c2f201ae62e01f59b8d7b08ffc8fc47ab83c041a',
+        vcard4android: 'c2f201a',
         dav4jvm: '47dd6a9'
     ]
 


### PR DESCRIPTION
Looks better in AboutLibraries and is more consistent with cert4android and dav4jvm.