### PR TITLE
DavDocumentsProvider: Log a warning for responses of type OTHER.

### DIFF
--- a/app/src/main/java/at/bitfire/davdroid/webdav/DavDocumentsProvider.kt
+++ b/app/src/main/java/at/bitfire/davdroid/webdav/DavDocumentsProvider.kt
@@ -611,9 +611,11 @@ class DavDocumentsProvider: DocumentsProvider() {
                                     parent
                                 Response.HrefRelation.MEMBER ->     // it's about a member
                                     WebDavDocument(mountId = parent.mountId, parentId = parent.id, name = response.hrefName())
-                                else ->
-                                    // we didn't request this; ignore it
+                                else -> {
+                                    // we didn't request this; log a warning and ignore it
+                                    Logger.log.warning("Ignoring unexpected $response $relation in $parentUrl")
                                     return@propfind
+                                }
                             }
 
                         response[ResourceType::class.java]?.types?.let { types ->


### PR DESCRIPTION
If a WebDAV server is misconfigured (for example, behind an HTTP proxy that strips a URL prefix and doesn't correctly forward this to the WebDAV server) then PROPFIND can return resources whose URLs don't match the request URL. These are resolved by dav4jvm as HrefRelation.OTHER.

Currently this situation produces no output in DAVx5 (logs or app) and the WebDAV share appears accessible but empty. It is possible to create files in the share, but not to see them again afterwards!

Of course a misconfigured server isn't the WebDAV client's responsibility to resolve, but adding a warning in the log provides an extra clue for anyone trying to debug it.

Thanks for all your work on DAVx5, it's a great and extremely important app!