### PR TITLE
Update ical4android (contains a fix for double-encoded backslashes)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         // own libraries
         cert4android: '32104f5',
         dav4jvm: 'da94a8b',
-        ical4android: 'b682476',
+        ical4android: '916f222',
         vcard4android: 'b376d2e'
     ]
 


### PR DESCRIPTION
Updates ical4j to 3.2.13, which should fix the backslash issue