### PR TITLE
Rewrite ExceptionInfoFragment into Compose

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -161,6 +161,7 @@ dependencies {
     // Jetpack Compose
     implementation platform("androidx.compose:compose-bom:${versions.composeBom}")
     implementation 'androidx.compose.material:material'
+    implementation 'androidx.compose.material:material-icons-extended'
     implementation 'androidx.compose.runtime:runtime-livedata'
     debugImplementation 'androidx.compose.ui:ui-tooling'
     implementation 'androidx.compose.ui:ui-tooling-preview'


### PR DESCRIPTION
Temporally using a workaround to convert Compose into Dialog, but eventually, when `CreateCollectionFragment` and `DeleteCollectionFragment` (which use this dialog) are migrated to Compsoe, we will be able to simply use the `ExceptionInfoDialog` function and get rid of `ExceptionInfoFragment`.

New version:
![image](https://github.com/bitfireAT/davx5-ose/assets/12086466/4b229b21-5186-4aa3-bbad-ce4510a4331f)
