### PR TITLE
WebDAV password change support

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/webdav/ChangeWebdavMountPasswordDialog.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/webdav/ChangeWebdavMountPasswordDialog.kt
@@ -1,0 +1,266 @@
+package at.bitfire.davdroid.ui.webdav
+
+import android.app.Application
+import android.content.DialogInterface
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.material.TextField
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.core.os.bundleOf
+import androidx.fragment.app.DialogFragment
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.CreationExtras
+import androidx.lifecycle.viewmodel.compose.viewModel
+import at.bitfire.davdroid.R
+import at.bitfire.davdroid.webdav.CredentialsStore
+import com.google.accompanist.themeadapter.material.MdcTheme
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import okhttp3.HttpUrl
+
+class ChangeWebdavMountPasswordDialog : DialogFragment() {
+    companion object {
+        const val ARG_MOUNT_ID = "mount_id"
+
+        fun build(mountId: Long) =
+            ChangeWebdavMountPasswordDialog().apply {
+                arguments = bundleOf(
+                    ARG_MOUNT_ID to mountId
+                )
+            }
+    }
+
+    private var mountId: Long? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        mountId = arguments?.getLong(ARG_MOUNT_ID)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        if (mountId == null) {
+            dismiss()
+            return View(requireContext())
+        }
+        return ComposeView(requireContext()).apply {
+            setContent {
+                MdcTheme {
+                    DialogView()
+                }
+            }
+        }
+    }
+
+    @Composable
+    fun DialogView(
+        model: Model = viewModel(factory = Model.Factory(mountId!!))
+    ) {
+        val isLoading by model.isLoading.observeAsState(false)
+        val error by model.error.observeAsState(null)
+        val password by model.password.observeAsState()
+
+        LaunchedEffect(isLoading) {
+            dialog?.setCanceledOnTouchOutside(!isLoading)
+        }
+
+        DialogView(
+            password = password,
+            onPasswordChanged = model.password::postValue,
+            isLoading = isLoading,
+            onSave = {
+                model.save().invokeOnCompletion {
+                    if (error == null) dismiss()
+                }
+            },
+            onDismiss = ::dismiss
+        )
+    }
+
+    @Composable
+    fun DialogView(
+        password: String?,
+        onPasswordChanged: (String) -> Unit,
+        isLoading: Boolean,
+        onSave: () -> Unit,
+        onDismiss: () -> Unit
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.webdav_change_password_title),
+                style = MaterialTheme.typography.h5
+            )
+            Text(
+                text = stringResource(R.string.webdav_change_password_message),
+                style = MaterialTheme.typography.body1,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp)
+            )
+
+            var hidePassword by remember { mutableStateOf(true) }
+
+            TextField(
+                value = password ?: "",
+                onValueChange = onPasswordChanged,
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                maxLines = 1,
+                keyboardActions = KeyboardActions { onSave() },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Password,
+                    imeAction = ImeAction.Go
+                ),
+                visualTransformation = if (hidePassword)
+                    PasswordVisualTransformation()
+                else
+                    VisualTransformation.None,
+                trailingIcon = {
+                    IconButton(
+                        onClick = { hidePassword = !hidePassword }
+                    ) {
+                        Icon(
+                            imageVector = if (hidePassword)
+                                Icons.Filled.Visibility
+                            else
+                                Icons.Filled.VisibilityOff,
+                            contentDescription = null
+                        )
+                    }
+                },
+                enabled = !isLoading
+            )
+            Text(
+                text = stringResource(R.string.webdav_change_password_supporting),
+                style = MaterialTheme.typography.caption
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End
+            ) {
+                TextButton(
+                    onClick = onDismiss,
+                    enabled = !isLoading
+                ) {
+                    Text(text = stringResource(R.string.webdav_change_password_dismiss).uppercase())
+                }
+                TextButton(
+                    onClick = onSave,
+                    enabled = !isLoading
+                ) {
+                    Text(text = stringResource(R.string.webdav_change_password_save).uppercase())
+                }
+            }
+        }
+    }
+
+    @Preview(showBackground = true)
+    @Composable
+    fun DialogView_Preview() {
+        DialogView(
+            password = "sample-password",
+            onPasswordChanged = {},
+            isLoading = false,
+            onSave = {},
+            onDismiss = {}
+        )
+    }
+
+    class Model(
+        application: Application,
+        private val mountId: Long
+    ) : AndroidViewModel(application) {
+        private val credentialsStore = CredentialsStore(application)
+        val credentials = credentialsStore.getCredentials(mountId)
+
+        val password = MutableLiveData<String?>(null)
+
+        val isLoading = MutableLiveData(false)
+
+        val error = MutableLiveData<Throwable?>(null)
+
+        init {
+            password.postValue(credentials?.password)
+
+            // TODO: If no credentials are available, dismiss dialog, we are missing data
+        }
+
+        fun save() = viewModelScope.launch(Dispatchers.IO) {
+            try {
+                isLoading.postValue(true)
+                error.postValue(null)
+
+                val newCredentials = credentials?.copy(
+                    password = password.value
+                )
+                credentialsStore.setCredentials(mountId, newCredentials)
+            } catch (e: Throwable) {
+                Log.e("CWMPDVM", "Could not store new credentials.", e)
+                error.postValue(e)
+            } finally {
+                isLoading.postValue(false)
+            }
+        }
+
+
+        class Factory(
+            private val mountId: Long
+        ) : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(
+                modelClass: Class<T>,
+                extras: CreationExtras
+            ): T {
+                // Get the Application object from extras
+                val application = checkNotNull(extras[APPLICATION_KEY])
+                return Model(application, mountId) as T
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/webdav/ChangeWebdavMountPasswordDialog.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/webdav/ChangeWebdavMountPasswordDialog.kt
@@ -1,3 +1,7 @@
+/***************************************************************************************************
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ **************************************************************************************************/
+
 package at.bitfire.davdroid.ui.webdav
 
 import android.app.Application

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/webdav/ChangeWebdavMountPasswordDialog.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/webdav/ChangeWebdavMountPasswordDialog.kt
@@ -7,6 +7,9 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -31,7 +34,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -97,6 +102,8 @@ class ChangeWebdavMountPasswordDialog : DialogFragment() {
     fun DialogView(
         model: Model = viewModel(factory = Model.Factory(mountId!!))
     ) {
+        val context = LocalContext.current
+
         val isLoading by model.isLoading.observeAsState(false)
         val error by model.error.observeAsState(null)
         val password by model.password.observeAsState()
@@ -111,9 +118,14 @@ class ChangeWebdavMountPasswordDialog : DialogFragment() {
             isLoading = isLoading,
             onSave = {
                 model.save().invokeOnCompletion {
-                    if (error == null) dismiss()
+                    if (error == null) {
+                        Toast.makeText(context, R.string.webdav_change_password_toast, Toast.LENGTH_SHORT)
+                            .show()
+                        dismiss()
+                    }
                 }
             },
+            error = error,
             onDismiss = ::dismiss
         )
     }
@@ -123,6 +135,7 @@ class ChangeWebdavMountPasswordDialog : DialogFragment() {
         password: String?,
         onPasswordChanged: (String) -> Unit,
         isLoading: Boolean,
+        error: Throwable?,
         onSave: () -> Unit,
         onDismiss: () -> Unit
     ) {
@@ -179,6 +192,19 @@ class ChangeWebdavMountPasswordDialog : DialogFragment() {
                 text = stringResource(R.string.webdav_change_password_supporting),
                 style = MaterialTheme.typography.caption
             )
+            AnimatedContent(
+                targetState = error,
+                label = "error animation"
+            ) { throwable ->
+                throwable?.message?.let { message ->
+                    Text(
+                        text = message,
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+                        color = Color.Red,
+                        style = MaterialTheme.typography.body2
+                    )
+                }
+            }
 
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -207,6 +233,7 @@ class ChangeWebdavMountPasswordDialog : DialogFragment() {
             password = "sample-password",
             onPasswordChanged = {},
             isLoading = false,
+            error = Exception("If any error occurs, it will show here"),
             onSave = {},
             onDismiss = {}
         )

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/webdav/WebdavMountsActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/webdav/WebdavMountsActivity.kt
@@ -4,11 +4,14 @@
 
 package at.bitfire.davdroid.ui.webdav
 
+import android.app.Activity
 import android.app.AlertDialog
 import android.app.Application
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.os.Parcel
+import android.os.Parcelable
 import android.provider.DocumentsContract
 import android.text.method.LinkMovementMethod
 import android.view.LayoutInflater
@@ -23,6 +26,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ShareCompat
 import androidx.core.text.HtmlCompat
 import androidx.core.view.MenuProvider
+import androidx.core.view.isVisible
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
@@ -48,6 +52,8 @@ import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.apache.commons.io.FileUtils
 import java.util.logging.Level
 import javax.inject.Inject
@@ -143,6 +149,8 @@ class WebdavMountsActivity: AppCompatActivity() {
 
         val authority = context.getString(R.string.webdav_authority)
 
+        private val credentialsStore = CredentialsStore(context)
+
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
             val inflater = LayoutInflater.from(parent.context)
             val binding = WebdavMountsItemBinding.inflate(inflater, parent, false)
@@ -194,6 +202,15 @@ class WebdavMountsActivity: AppCompatActivity() {
                     }
                     .setNegativeButton(R.string.dialog_deny, null)
                     .show()
+            }
+
+            binding.changePassword.isVisible = credentialsStore.getCredentials(info.mount.id) != null
+            binding.changePassword.setOnClickListener {
+                ChangeWebdavMountPasswordDialog.build(info.mount.id)
+                    .show(
+                        (context as AppCompatActivity).supportFragmentManager,
+                        "change-webdav-password"
+                    )
             }
         }
     }

--- a/app/src/main/res/drawable/ic_password.xml
+++ b/app/src/main/res/drawable/ic_password.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M2,17h20v2H2V17zM3.15,12.95L4,11.47l0.85,1.48l1.3,-0.75L5.3,10.72H7v-1.5H5.3l0.85,-1.47L4.85,7L4,8.47L3.15,7l-1.3,0.75L2.7,9.22H1v1.5h1.7L1.85,12.2L3.15,12.95zM9.85,12.2l1.3,0.75L12,11.47l0.85,1.48l1.3,-0.75l-0.85,-1.48H15v-1.5h-1.7l0.85,-1.47L12.85,7L12,8.47L11.15,7l-1.3,0.75l0.85,1.47H9v1.5h1.7L9.85,12.2zM23,9.22h-1.7l0.85,-1.47L20.85,7L20,8.47L19.15,7l-1.3,0.75l0.85,1.47H17v1.5h1.7l-0.85,1.48l1.3,0.75L20,11.47l0.85,1.48l1.3,-0.75l-0.85,-1.48H23V9.22z"/>
+</vector>

--- a/app/src/main/res/layout/webdav_mounts_item.xml
+++ b/app/src/main/res/layout/webdav_mounts_item.xml
@@ -69,6 +69,20 @@
                 android:text="@string/webdav_mounts_share_content" />
 
             <ImageButton
+                android:id="@+id/change_password"
+                app:layout_constraintTop_toTopOf="@id/browse"
+                app:layout_constraintBottom_toBottomOf="@id/browse"
+                app:layout_constraintEnd_toStartOf="@id/remove_mountpoint"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:srcCompat="@drawable/ic_password"
+                app:tint="?android:attr/colorControlNormal"
+                android:backgroundTint="@color/colorOnSecondary"
+                android:tooltipText="@string/webdav_mounts_change_password"
+                android:contentDescription="@string/webdav_mounts_change_password"
+                tools:ignore="UnusedAttribute" />
+
+            <ImageButton
                 android:id="@+id/remove_mountpoint"
                 app:layout_constraintTop_toTopOf="@id/browse"
                 app:layout_constraintBottom_toBottomOf="@id/browse"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -480,6 +480,7 @@
     <string name="webdav_mounts_quota_used_available">Quota used: %1$s / available: %2$s</string>
     <string name="webdav_mounts_share_content">Share content</string>
     <string name="webdav_mounts_unmount">Unmount</string>
+    <string name="webdav_mounts_change_password">Change Password</string>
     <string name="webdav_add_mount_title">Add WebDAV mount</string>
     <string name="webdav_mounts_empty">Directly access your cloud files by adding a WebDAV mount!</string>
     <string name="webdav_add_mount_empty_more_info"><![CDATA[See the manual for <a href="%1$s">how WebDAV mounts work</a>.</string>]]></string>
@@ -496,6 +497,12 @@
     <string name="webdav_notification_download">Downloading WebDAV file</string>
     <string name="webdav_notification_upload">Uploading WebDAV file</string>
     <string name="webdav_provider_root_title">WebDAV mount</string>
+    <string name="webdav_change_password_title">Change Mount Password</string>
+    <string name="webdav_change_password_message">If you have changed the password used to access the mount, introduce a new one here, and we will store it for you.</string>
+    <string name="webdav_change_password_hint">New Password</string>
+    <string name="webdav_change_password_supporting">Please, make sure to introduce the password correctly, no validation will be performed now.</string>
+    <string name="webdav_change_password_dismiss">Cancel</string>
+    <string name="webdav_change_password_save">Save</string>
 
     <!-- sync -->
     <string name="sync_error_permissions">DAVx⁵ permissions</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -503,6 +503,7 @@
     <string name="webdav_change_password_supporting">Please, make sure to introduce the password correctly, no validation will be performed now.</string>
     <string name="webdav_change_password_dismiss">Cancel</string>
     <string name="webdav_change_password_save">Save</string>
+    <string name="webdav_change_password_toast">Password updated!</string>
 
     <!-- sync -->
     <string name="sync_error_permissions">DAVx⁵ permissions</string>


### PR DESCRIPTION
I guess we don't want to add new features as of right now. But it would be a quick feature, which shouldn't break anything.

So if you want to give it a try @rfc2822 

It adds a new dialog to the mounts that have a password:

![webdav_list](https://github.com/bitfireAT/davx5-ose/assets/12086466/389898a2-4779-4476-bc60-8c0e9287f9f4)

And when you tap it, a dialog shows up allowing to change the stored password:

![webdav_change](https://github.com/bitfireAT/davx5-ose/assets/12086466/bcaf0fda-5582-49d8-83b7-f495b398fd0c)
