### PR TITLE
Add battery saver warning

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsActivity.kt
@@ -14,6 +14,7 @@ import android.content.pm.ShortcutManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.provider.Settings
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
@@ -49,7 +50,12 @@ import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.BatterySaver
+import androidx.compose.material.icons.filled.DataSaverOn
 import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.NotificationsOff
+import androidx.compose.material.icons.filled.SignalCellularOff
+import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
@@ -183,19 +189,25 @@ class AccountsActivity: AppCompatActivity() {
                                 },
                                 internetWarning = warnings.networkAvailable.observeAsState().value == false,
                                 onManageConnections = {
-                                    val intent = Intent(android.provider.Settings.ACTION_WIRELESS_SETTINGS)
-                                    if (intent.resolveActivity(packageManager) != null)
-                                        startActivity(intent)
-                                },
-                                lowStorageWarning = warnings.storageLow.observeAsState().value == true,
-                                onManageStorage = {
-                                    val intent = Intent(android.provider.Settings.ACTION_INTERNAL_STORAGE_SETTINGS)
+                                    val intent = Intent(Settings.ACTION_WIRELESS_SETTINGS)
                                     if (intent.resolveActivity(packageManager) != null)
                                         startActivity(intent)
                                 },
                                 dataSaverActive = warnings.dataSaverEnabled.observeAsState().value == true,
                                 onManageDataSaver = {
                                     val intent = Intent(android.provider.Settings.ACTION_IGNORE_BACKGROUND_DATA_RESTRICTIONS_SETTINGS, Uri.parse("package:" + packageName))
+                                    if (intent.resolveActivity(packageManager) != null)
+                                        startActivity(intent)
+                                },
+                                batterySaverActive = warnings.batterySaverActive.observeAsState().value == true,
+                                onManageBatterySaver = {
+                                    val intent = Intent(Settings.ACTION_BATTERY_SAVER_SETTINGS)
+                                    if (intent.resolveActivity(packageManager) != null)
+                                        startActivity(intent)
+                                },
+                                lowStorageWarning = warnings.storageLow.observeAsState().value == true,
+                                onManageStorage = {
+                                    val intent = Intent(android.provider.Settings.ACTION_INTERNAL_STORAGE_SETTINGS)
                                     if (intent.resolveActivity(packageManager) != null)
                                         startActivity(intent)
                                 }
@@ -539,15 +551,17 @@ fun SyncWarnings(
     onClickPermissions: () -> Unit = {},
     internetWarning: Boolean,
     onManageConnections: () -> Unit = {},
-    lowStorageWarning: Boolean,
-    onManageStorage: () -> Unit = {},
+    batterySaverActive: Boolean,
+    onManageBatterySaver: () -> Unit = {},
     dataSaverActive: Boolean,
-    onManageDataSaver: () -> Unit = {}
+    onManageDataSaver: () -> Unit = {},
+    lowStorageWarning: Boolean,
+    onManageStorage: () -> Unit = {}
 ) {
     Column(Modifier.padding(horizontal = 8.dp, vertical = 4.dp)) {
         if (notificationsWarning)
             ActionCard(
-                icon = painterResource(R.drawable.ic_notifications_off),
+                icon = Icons.Default.NotificationsOff,
                 actionText = stringResource(R.string.account_permissions_action),
                 onAction = onClickPermissions
             ) {
@@ -556,29 +570,38 @@ fun SyncWarnings(
 
         if (internetWarning)
             ActionCard(
-                icon = painterResource(R.drawable.ic_signal_cellular_off),
+                icon = Icons.Default.SignalCellularOff,
                 actionText = stringResource(R.string.account_list_manage_connections),
                 onAction = onManageConnections
             ) {
                 Text(stringResource(R.string.account_list_no_internet))
             }
 
-        if (lowStorageWarning)
+        if (batterySaverActive)
             ActionCard(
-                icon = painterResource(R.drawable.ic_storage),
-                actionText = stringResource(R.string.account_list_manage_storage),
-                onAction = onManageStorage
+                icon = Icons.Default.BatterySaver,
+                actionText = stringResource(R.string.account_list_manage_battery_saver),
+                onAction = onManageBatterySaver
             ) {
-                Text(stringResource(R.string.account_list_low_storage))
+                Text(stringResource(R.string.account_list_battery_saver_enabled))
             }
 
         if (dataSaverActive)
             ActionCard(
-                icon = painterResource(R.drawable.ic_datasaver_on),
+                icon = Icons.Default.DataSaverOn,
                 actionText = stringResource(R.string.account_list_manage_datasaver),
                 onAction = onManageDataSaver
             ) {
                 Text(stringResource(R.string.account_list_datasaver_enabled))
+            }
+
+        if (lowStorageWarning)
+            ActionCard(
+                icon = Icons.Default.Storage,
+                actionText = stringResource(R.string.account_list_manage_storage),
+                onAction = onManageStorage
+            ) {
+                Text(stringResource(R.string.account_list_low_storage))
             }
     }
 }
@@ -589,7 +612,8 @@ fun SyncWarnings_Preview() {
     SyncWarnings(
         notificationsWarning = true,
         internetWarning = true,
-        lowStorageWarning = true,
-        dataSaverActive = true
+        batterySaverActive = true,
+        dataSaverActive = true,
+        lowStorageWarning = true
     )
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoActivity.kt
@@ -600,7 +600,7 @@ class DebugInfoActivity : AppCompatActivity() {
                 // system-wide sync
                 writer.append("System-wide synchronization: ")
                     .append(if (ContentResolver.getMasterSyncAutomatically()) "automatically" else "manually")
-                    .append('\n')
+                    .append("\n\n")
 
                 // connectivity
                 context.getSystemService<ConnectivityManager>()?.let { connectivityManager ->

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoActivity.kt
@@ -557,10 +557,10 @@ class DebugInfoActivity : AppCompatActivity() {
                 val locales: Any = LocaleList.getAdjustedDefault()
                 writer.append(
                     "\nSYSTEM INFORMATION\n\n" +
-                            "Android version: ${Build.VERSION.RELEASE} (${Build.DISPLAY})\n" +
-                            "Device: ${Build.MANUFACTURER} ${Build.MODEL} (${Build.DEVICE})\n\n" +
-                            "Locale(s): $locales\n" +
-                            "Time zone: ${TimeZone.getDefault().id}\n"
+                    "Android version: ${Build.VERSION.RELEASE} (${Build.DISPLAY})\n" +
+                    "Device: ${Build.MANUFACTURER} ${Build.MODEL} (${Build.DEVICE})\n\n" +
+                    "Locale(s): $locales\n" +
+                    "Time zone: ${TimeZone.getDefault().id}\n"
                 )
                 val filesPath = Environment.getDataDirectory()
                 val statFs = StatFs(filesPath.path)
@@ -578,12 +578,12 @@ class DebugInfoActivity : AppCompatActivity() {
                             .append("App standby bucket: ")
                             .append(
                                 when {
-                                    bucket <= 5 -> "exempted"
-                                    bucket <= UsageStatsManager.STANDBY_BUCKET_ACTIVE -> "active"
-                                    bucket <= UsageStatsManager.STANDBY_BUCKET_WORKING_SET -> "frequent (job restrictions apply!)"
-                                    bucket <= UsageStatsManager.STANDBY_BUCKET_FREQUENT -> "frequent (job restrictions apply!)"
-                                    bucket <= UsageStatsManager.STANDBY_BUCKET_RARE -> "rare  (job and network restrictions apply!)"
-                                    bucket <= UsageStatsManager.STANDBY_BUCKET_RESTRICTED -> "restricted (job and network restrictions apply!)"
+                                    bucket <= 5 -> "exempted (very good)"
+                                    bucket <= UsageStatsManager.STANDBY_BUCKET_ACTIVE -> "active (good)"
+                                    bucket <= UsageStatsManager.STANDBY_BUCKET_WORKING_SET -> "working set (bad: job restrictions apply)"
+                                    bucket <= UsageStatsManager.STANDBY_BUCKET_FREQUENT -> "frequent (bad: job restrictions apply)"
+                                    bucket <= UsageStatsManager.STANDBY_BUCKET_RARE -> "rare (very bad: job and network restrictions apply)"
+                                    bucket <= UsageStatsManager.STANDBY_BUCKET_RESTRICTED -> "restricted (very bad: job and network restrictions apply)"
                                     else -> "$bucket"
                                 }
                             )
@@ -591,10 +591,10 @@ class DebugInfoActivity : AppCompatActivity() {
                     }
                 context.getSystemService<PowerManager>()?.let { powerManager ->
                     writer.append("App exempted from power saving: ")
-                        .append(if (powerManager.isIgnoringBatteryOptimizations(BuildConfig.APPLICATION_ID)) "yes" else "NO")
+                        .append(if (powerManager.isIgnoringBatteryOptimizations(BuildConfig.APPLICATION_ID)) "yes (good)" else "no (bad)")
                         .append('\n')
                         .append("System in power-save mode: ")
-                        .append(if (powerManager.isPowerSaveMode) "YES (restrictions apply!)" else "no")
+                        .append(if (powerManager.isPowerSaveMode) "yes (restrictions apply!)" else "no")
                         .append('\n')
                 }
                 // system-wide sync

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountActivity.kt
@@ -103,11 +103,16 @@ class AccountActivity: AppCompatActivity() {
         TooltipCompat.setTooltipText(binding.sync, binding.sync.contentDescription)
         warningsModel.networkAvailable.observe(this) { networkAvailable ->
             binding.sync.setOnClickListener {
-                    Snackbar.make(
-                        binding.sync,
-                        R.string.sync_enqueued,
-                        Snackbar.LENGTH_SHORT
-                    ).show()
+                val msgId =
+                    if (warningsModel.networkAvailable.value == true)
+                        R.string.sync_started
+                    else
+                        R.string.no_internet_sync_scheduled
+                Snackbar.make(
+                    binding.sync,
+                    msgId,
+                    Snackbar.LENGTH_SHORT
+                ).show()
                 SyncWorker.enqueueAllAuthorities(this, model.account)
             }
         }

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/widget/ActionCard.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/widget/ActionCard.kt
@@ -13,10 +13,12 @@ import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.NotificationAdd
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -24,7 +26,7 @@ import at.bitfire.davdroid.R
 
 @Composable
 fun ActionCard(
-    icon: Painter? = null,
+    icon: ImageVector? = null,
     actionText: String? = null,
     onAction: () -> Unit = {},
     content: @Composable () -> Unit
@@ -59,7 +61,7 @@ fun ActionCard(
 @Preview
 fun ActionCard_Sample() {
     ActionCard(
-        icon = painterResource(R.drawable.ic_notifications_off),
+        icon = Icons.Default.NotificationAdd,
         actionText = "Some Action"
     ) {
         Text("Some Content")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,8 +16,9 @@
     <string name="help">Help</string>
     <string name="manage_accounts">Manage accounts</string>
     <string name="navigate_up">Navigate up</string>
+    <string name="no_internet_sync_scheduled">No Internet, scheduling sync</string>
     <string name="share">Share</string>
-    <string name="sync_enqueued">Synchronization enqueued</string>
+    <string name="sync_started">Synchronization started</string>
 
     <string name="database_destructive_migration_title">Database corrupted</string>
     <string name="database_destructive_migration_text">All accounts have been removed locally.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,9 +16,8 @@
     <string name="help">Help</string>
     <string name="manage_accounts">Manage accounts</string>
     <string name="navigate_up">Navigate up</string>
-    <string name="no_internet_sync_scheduled">No Internet, scheduling sync</string>
     <string name="share">Share</string>
-    <string name="sync_started">Synchronization started</string>
+    <string name="sync_enqueued">Synchronization enqueued</string>
 
     <string name="database_destructive_migration_title">Database corrupted</string>
     <string name="database_destructive_migration_text">All accounts have been removed locally.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -145,10 +145,12 @@
     <string name="account_list_no_notification_permission">Notifications disabled. You won\'t be notified about sync errors.</string>
     <string name="account_list_no_internet">No validated Internet connectivity. Synchronization may not run.</string>
     <string name="account_list_manage_connections">Manage connections</string>
-    <string name="account_list_low_storage">Storage space low. Android will not sync local changes immediately, but during the next regular sync.</string>
-    <string name="account_list_manage_storage">Manage storage</string>
     <string name="account_list_datasaver_enabled">Data saver enabled. Background synchronization is restricted.</string>
     <string name="account_list_manage_datasaver">Manage data saver</string>
+    <string name="account_list_battery_saver_enabled">Battery saver enabled. Synchronization may be restricted.</string>
+    <string name="account_list_manage_battery_saver">Manage battery saver</string>
+    <string name="account_list_low_storage">Storage space low. Android will not sync local changes immediately, but during the next regular sync.</string>
+    <string name="account_list_manage_storage">Manage storage</string>
     <string name="account_list_empty">Welcome to DAVx⁵!\n\nYou can add a CalDAV/CardDAV account now.</string>
     <string name="accounts_global_sync_disabled">System-wide automatic synchronization is disabled</string>
     <string name="accounts_global_sync_enable">Enable</string>


### PR DESCRIPTION
An active _battery saver_ can also be the cause of _sync is not running_. This is the main motivation for this PR.

- add battery saver warning to Accounts activity
- debug info:
  - add info about battery saver
  - more verbose standby bucket info
- refactoring: convert `AppWarningsManager` into a model class (it's only used as data source for the UI)

@sunkup Can you please test / have a look?