### PR TITLE
prepareForUpload: use UID from data class

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalContact.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalContact.kt
@@ -70,21 +70,20 @@ class LocalContact: AndroidContact, LocalAddress {
 
 
     override fun prepareForUpload(): String {
-        var uid: String? = null
-        addressBook.provider!!.query(rawContactSyncURI(), arrayOf(COLUMN_UID), null, null, null)?.use { cursor ->
-            if (cursor.moveToNext())
-                uid = StringUtils.trimToNull(cursor.getString(0))
-        }
-
-        if (uid == null) {
+        val contact = getContact()
+        val uid: String = contact.uid ?: run {
             // generate new UID
-            uid = UUID.randomUUID().toString()
+            val newUid = UUID.randomUUID().toString()
 
+            // update in contacts provider
             val values = ContentValues(1)
-            values.put(COLUMN_UID, uid)
+            values.put(COLUMN_UID, newUid)
             addressBook.provider!!.update(rawContactSyncURI(), values, null, null)
 
-            getContact().uid = uid
+            // update this event
+            contact.uid = newUid
+
+            newUid
         }
 
         return "$uid.vcf"

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalEvent.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalEvent.kt
@@ -20,7 +20,6 @@ import at.bitfire.ical4android.ICalendar
 import at.bitfire.ical4android.Ical4Android
 import at.bitfire.ical4android.util.MiscUtils.asSyncAdapter
 import net.fortuna.ical4j.model.property.ProdId
-import org.apache.commons.lang3.StringUtils
 import java.util.UUID
 
 class LocalEvent: AndroidEvent, LocalResource<Event> {
@@ -203,15 +202,8 @@ class LocalEvent: AndroidEvent, LocalResource<Event> {
      * @return file name to use at upload
      */
     override fun prepareForUpload(): String {
-        // fetch UID_2445 from calendar provider
-        var dbUid: String? = null
-        calendar.provider.query(eventSyncURI(), arrayOf(Events.UID_2445), null, null, null)?.use { cursor ->
-            if (cursor.moveToNext())
-                dbUid = StringUtils.trimToNull(cursor.getString(0))
-        }
-
         // make sure that UID is set
-        val uid: String = dbUid ?: run {
+        val uid: String = event!!.uid ?: run {
             // generate new UID
             val newUid = UUID.randomUUID().toString()
 
@@ -220,7 +212,7 @@ class LocalEvent: AndroidEvent, LocalResource<Event> {
             values.put(Events.UID_2445, newUid)
             calendar.provider.update(eventSyncURI(), values, null, null)
 
-            // Update this event
+            // update this event
             event?.uid = newUid
 
             newUid

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalTask.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalTask.kt
@@ -59,21 +59,19 @@ class LocalTask: AndroidTask, LocalResource<Task> {
     /* custom queries */
 
     override fun prepareForUpload(): String {
-        var uid: String? = null
-        taskList.provider.client.query(taskSyncURI(), arrayOf(Tasks._UID), null, null, null)?.use { cursor ->
-            if (cursor.moveToNext())
-                uid = cursor.getString(0)
-        }
-
-        if (uid == null) {
+        val uid: String = task!!.uid ?: run {
             // generate new UID
-            uid = UUID.randomUUID().toString()
+            val newUid = UUID.randomUUID().toString()
 
+            // update in tasks provider
             val values = ContentValues(1)
-            values.put(Tasks._UID, uid)
+            values.put(Tasks._UID, newUid)
             taskList.provider.client.update(taskSyncURI(), values, null, null)
 
-            task!!.uid = uid
+            // update this task
+            task!!.uid = newUid
+
+            newUid
         }
 
         return "$uid.ics"


### PR DESCRIPTION
… instead of querying it explicitly from content provider.

Reason: the `uid` of the data class is not always filled by exactly one field like the `UID_2445` in case of events. Instead, the `uid` could have been taken for instance from a proprietary field (like bitfireAT/ical4android#125).

I wonder why the query is even explicit. I guess there was a reason, but as it's undocumented and doesn't seem to be necessary, we should get rid of this anyway.

This is a big change that can break a lot of important things and we should test it well (generate/update events, contacts etc).

@ArnyminerZ @sunkup Please both have a look at it (including testing use cases that require `prepareUpload`) and check if you see any problems.