### PR TITLE
Rewrite RenameAccountFragment to compose (closes #478)

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/RenameAccountFragment.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/RenameAccountFragment.kt
@@ -21,6 +21,7 @@ import android.widget.Toast
 import androidx.annotation.MainThread
 import androidx.annotation.WorkerThread
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.AlertDialog
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
@@ -29,9 +30,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
@@ -99,7 +102,10 @@ class RenameAccountFragment: DialogFragment() {
                         onDismissRequest = { dismiss() },
                         title = { Text(stringResource(R.string.account_rename)) },
                         text = { Column {
-                            Text(stringResource(R.string.account_rename_new_name_description))
+                            Text(
+                                stringResource(R.string.account_rename_new_name_description),
+                                modifier = Modifier.padding(bottom = 8.dp)
+                            )
                             TextField(
                                 value = accountName,
                                 onValueChange = { accountName = it },
@@ -107,9 +113,10 @@ class RenameAccountFragment: DialogFragment() {
                             )
                         }},
                         confirmButton = {
-                            TextButton(onClick = {
-                                model.renameAccount(oldAccount, accountName)
-                            }) {
+                            TextButton(
+                                onClick = { model.renameAccount(oldAccount, accountName) },
+                                enabled = oldAccount.name != accountName
+                            ) {
                                 Text(stringResource(R.string.account_rename_rename).uppercase())
                             }
                         },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -243,7 +243,8 @@
     <string name="account_synchronize_now">Synchronize now</string>
     <string name="account_settings">Account settings</string>
     <string name="account_rename">Rename account</string>
-    <string name="account_rename_new_name">Unsaved local data may be dismissed. Re-synchronization is required after renaming. New account name:</string>
+    <string name="account_rename_new_name_description">Unsaved local data may be dismissed. Re-synchronization is required after renaming.</string>
+    <string name="account_rename_new_name">New account name</string>
     <string name="account_rename_rename">Rename</string>
     <string name="account_rename_exists_already">Account name already taken</string>
     <string name="account_rename_couldnt_rename">Couldn\'t rename account</string>


### PR DESCRIPTION
@rfc2822 

The new `TextField` does not look like the old one did. Should we change that in the composable and make it resusable for all our future textfields or is there a way to do it with the theming engine? Especially changing the padding would require a custom crafted text field by using `BasicTextField` as template. But then again, in regards to the padding, maybe it's good to stick with the defaults, for better UX. 

Setting the focus at the end of the textfield value is still quite cumbersome in compose. I skipped that for now, but can add it if desired?  