### PR TITLE
Remove unused string resources

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -29,8 +29,6 @@
   <string name="intro_slogan1">بياناتك. قرارك.</string>
   <string name="intro_slogan2">تحكَّم</string>
   <string name="intro_battery_title">الفواصل البينية للمزامنة</string>
-  <string name="intro_battery_not_whitelisted">عطِّل (غير منصوح به)</string>
-  <string name="intro_battery_whitelisted">مكِّن (منصوح به)</string>
   <string name="intro_battery_text">يجب السماح لـ %s بالعمل في الخلفية لتنجح المزامنة المجدولة. وإلا فإن آندرويد يمكنه إيقاف المزامنة في أية وقت.</string>
   <string name="intro_battery_dont_show">لا أحتاج إلى جدولة المزامنة.*</string>
   <string name="intro_autostart_title">توافق %s</string>
@@ -59,7 +57,6 @@
   <string name="about_libraries">المكتبات</string>
   <string name="about_version">النسخة %1$s (%2$d)</string>
   <string name="about_build_date">التجميع على %s</string>
-  <string name="about_flavor_info">هذا الإصدار صالح للتوزيع عبر Google Play فقط.</string>
   <string name="about_license_info_no_warranty">يقدَّم هذا البرنامج دون أدنى مسؤولية.  إنه برنامج حر، وندعوك لإعادة توزيعه حسب أحكام محددة.</string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">لا يمكن إنشاء ملف سجل</string>
@@ -74,8 +71,6 @@
   <string name="navigation_drawer_manual">دليل الاستخدام</string>
   <string name="navigation_drawer_faq">الأسئلة الشائعة</string>
   <string name="account_list_empty">مرحباً بك في DAVx⁵ !\n\n يمكنك إضافة حساب CalDAV أو CardDAV الآن.</string>
-  <string name="accounts_global_sync_disabled">تم تعطيل المزامنة التلقائية على مستوى النظام</string>
-  <string name="accounts_global_sync_enable">تفعيل</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">فشل اكتشاف الخدمة</string>
   <string name="refresh_collections_worker_refresh_couldnt_refresh">لم يتمكن التطبيق من تجديد قائمة المجموعة</string>
@@ -118,8 +113,6 @@
   <string name="account_read_only">للقراءة فقط</string>
   <string name="account_calendar">تقويم</string>
   <string name="account_task_list">قائمة مهام</string>
-  <string name="account_create_new_address_book">إنشاء دفتر عناوين جديد</string>
-  <string name="account_create_new_calendar">إنشاء تقويم جديد</string>
   <string name="account_no_webcal_handler_found">لم نجِد تطبيقاً قادراً على استخدام Webcal</string>
   <string name="account_install_icsx5">تثبيت ICSx⁵</string>
   <!--AddAccountActivity-->
@@ -148,7 +141,6 @@
   <string name="login_no_caldav_carddav">لم نجِد خدمة CalDAV أو CardDAV.</string>
   <string name="login_view_logs">عرض التفاصيل</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">%s الإعدادات:</string>
   <string name="settings_sync">المزامنة</string>
   <string name="settings_sync_interval_contacts">مدة مزامنة جهات الاتصال</string>
   <string name="settings_sync_summary_manually">يدوية فقط</string>
@@ -173,10 +165,8 @@
   <string name="settings_sync_wifi_only_ssids_message">أسماء (SSIDs) مفصولة بفواصل لشبكات WiFi المسموح الاتصال عبرها (اتركه فارغاً للسماح للكل)</string>
   <string name="settings_authentication">المصادقة</string>
   <string name="settings_username">اسم المستخدم</string>
-  <string name="settings_enter_username">أدخل اسم المستخدم:</string>
   <string name="settings_password">كلمة المرور</string>
   <string name="settings_password_summary">حدّث كلمة المرور المعمول بها في خادمك.</string>
-  <string name="settings_enter_password">أدخل كلمة المرور:</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">الحد الزمني للأحداث الماضية</string>
   <string name="settings_sync_time_range_past_none">ستتم مزامنة جميع الأحداث</string>
@@ -239,6 +229,4 @@
   <string name="sync_invalid_task">استلام مهمة غير صالحة من الخادم</string>
   <string name="sync_invalid_resources_ignoring">جرى تجاهل مورد غير صالح واحد أو أكثر</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵: أمن الاتصال</string>
-  <string name="trust_certificate_unknown_certificate_found">عثر DAVx⁵ على شهادة غير معروفة. هل تريد الوثوق بها؟</string>
 </resources>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -29,8 +29,6 @@
   <string name="intro_slogan1">Вашите данни. Вашият избор</string>
   <string name="intro_slogan2">Поемете контрол</string>
   <string name="intro_battery_title">Периодично синхронизиране</string>
-  <string name="intro_battery_not_whitelisted">Изключено (не се препоръчва)</string>
-  <string name="intro_battery_whitelisted">Включено (препоръчително)</string>
   <string name="intro_battery_text">За да синхронизира периодично, %s се нуждае от разрешение да работи на заден план. В противен случай Android може да спре синхронизацията по всяко време.</string>
   <string name="intro_battery_dont_show">Не желая периодично синхронизиране.*</string>
   <string name="intro_autostart_title">%s съвместимост</string>
@@ -68,8 +66,6 @@
   <string name="permissions_notification_status_off">Известията са изключени (непрепоръчително)</string>
   <string name="permissions_notification_status_on">Известията са еключени</string>
   <string name="permissions_jtx_title">Разрешения за jtx Board</string>
-  <string name="permissions_jtx_status_off">Без синхронизиране на задачи, дневници и бележки</string>
-  <string name="permissions_jtx_status_on">Възможно синхронизиране на задачи, дневници и бележки</string>
   <string name="permissions_opentasks_title">Разрешения за OpenTasks</string>
   <string name="permissions_tasksorg_title">Разрешения за Tasks</string>
   <string name="permissions_tasks_status_off">Няма синхронизация на задачи</string>
@@ -98,9 +94,7 @@
   <string name="about_version">Издание %1$s (%2$d)</string>
   <string name="about_build_date">Компилирано на %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) и сътрудници</string>
-  <string name="about_flavor_info">Тази версия може да се разпространява само чрез Google Play.</string>
   <string name="about_license_info_no_warranty">Тази програма се предлага с АБСОЛЮТНО НИКАКВА ГАРАНЦИЯ. Тя е свободен софтуер и можете да я разпространявате при определени условия.</string>
-  <string name="about_translations_thanks"><![CDATA[<i>Благодарение на: </i> %s]]></string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Не може да бъде създаден дневник</string>
   <string name="logging_notification_text">Действията на %s се записват в дневник</string>
@@ -110,7 +104,6 @@
   <string name="navigation_drawer_subtitle">Адаптор за синхронизиране на CalDAV/CardDAV</string>
   <string name="navigation_drawer_about">Относно / лиценз</string>
   <string name="navigation_drawer_beta_feedback">Обратна връзка към бета</string>
-  <string name="install_email_client">Инсталиране приложение за електронна поща</string>
   <string name="install_browser">Инсталиране на мрежов четец</string>
   <string name="navigation_drawer_settings">Настройки</string>
   <string name="navigation_drawer_news_updates">Новини и издания</string>
@@ -131,8 +124,6 @@
   <string name="account_list_low_storage">Пространството за съхранение е малко. Андроид няма да синхронизира местните промени веднага, а по време на следващата редовна синхронизация.</string>
   <string name="account_list_manage_storage">Управление на хранилището</string>
   <string name="account_list_empty">Добре дошли при DAVx⁵!\n\nМожете да добавите регистрация за CalDAV/CardDAV.</string>
-  <string name="accounts_global_sync_disabled">Автоматичното синхронизиране е изключено на ниво система</string>
-  <string name="accounts_global_sync_enable">Включване</string>
   <string name="accounts_sync_all">Синхронизиране на всички профили</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">Откриването на услугите се провали</string>
@@ -182,16 +173,11 @@
   <string name="app_settings_reset_hints_success">Всички подсказки ще бъдат показани отново</string>
   <string name="app_settings_integration">Интеграция</string>
   <string name="app_settings_tasks_provider">Приложението Tasks</string>
-  <string name="app_settings_tasks_provider_synchronizing_with">Синхронизиране чрез %s</string>
   <string name="app_settings_tasks_provider_none">Не е инсталирана съвместимо приложение за задачи.</string>
   <!--AccountActivity-->
   <string name="account_carddav">CardDAV</string>
   <string name="account_caldav">CalDAV</string>
   <string name="account_webcal">Webcal</string>
-  <string name="account_no_address_books">Няма адресници (все още)</string>
-  <string name="account_no_calendars">Няма календари (все още)</string>
-  <string name="account_no_webcals">Няма абонаменти за календари (все още)</string>
-  <string name="account_swipe_down">Дръпнете надолу за презареждане от сървъра.</string>
   <string name="account_synchronize_now">Синхронизация</string>
   <string name="account_settings">Настройки на регистрацията</string>
   <string name="account_rename">Преименуване на регистрация</string>
@@ -209,8 +195,6 @@
   <string name="account_task_list">списък със задачи</string>
   <string name="account_journal">дневник</string>
   <string name="account_only_personal">Само лични</string>
-  <string name="account_create_new_address_book">Създаване на адресник</string>
-  <string name="account_create_new_calendar">Създаване на календар</string>
   <string name="account_no_webcal_handler_found">Няма инсталирана програма за Webcal абонамент.</string>
   <string name="account_install_icsx5">Инсталиране на ICSx⁵</string>
   <!--AddAccountActivity-->
@@ -265,7 +249,6 @@
   <string name="login_username_password_wrong">Грешно потребителско име или парола?</string>
   <string name="login_view_logs">Подробности</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Настройки: %s</string>
   <string name="settings_sync">Синхронизация</string>
   <string name="settings_sync_interval_contacts">Интервал на синхронизиране на контактите</string>
   <string name="settings_sync_summary_manually">Само ръчно</string>
@@ -297,10 +280,8 @@
   <string name="settings_oauth">Повторно удостоверяване</string>
   <string name="settings_oauth_summary">Изпълнява повторно влизане чрез OAuth</string>
   <string name="settings_username">Потребителско име</string>
-  <string name="settings_enter_username">Въведете потребитеско име:</string>
   <string name="settings_password">Парола</string>
   <string name="settings_password_summary">Променете паролата съгласно сървъра.</string>
-  <string name="settings_enter_password">Въведете парола:</string>
   <string name="settings_certificate_install">Инсталиране на сертификат</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">Ограничения за събития от миналото</string>
@@ -424,6 +405,4 @@
   <string name="sync_invalid_task">Получен е недействителен файл от сървъра</string>
   <string name="sync_invalid_resources_ignoring">Пренебрегване на сбъркани данни</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵: Защита на връзката</string>
-  <string name="trust_certificate_unknown_certificate_found">DAVx⁵ се натъкна на непознат сертификат.  Ще му се довериш ли?</string>
 </resources>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -29,8 +29,6 @@
   <string name="intro_slogan1">Les teves dades. La teva elecció.</string>
   <string name="intro_slogan2">Pren el control.</string>
   <string name="intro_battery_title">Intervals de sincronització regulars</string>
-  <string name="intro_battery_not_whitelisted">Desactivat (no recomanat)</string>
-  <string name="intro_battery_whitelisted">Activat (recomanat)</string>
   <string name="intro_battery_text">Per la sincronització en intervals regulars, cal que %s tingui permís per executar-se en segon pla. En cas contrari, Android podria aturar la sincronització en qualsevol moment.</string>
   <string name="intro_battery_dont_show">No necessito intervals de sincronització regulars.*</string>
   <string name="intro_autostart_title">Compatibilitat amb %s</string>
@@ -68,8 +66,6 @@
   <string name="permissions_notification_status_off">Notificacions desactivades (no recomanat)</string>
   <string name="permissions_notification_status_on">Notificacions activades</string>
   <string name="permissions_jtx_title">Permisos de jtx Board</string>
-  <string name="permissions_jtx_status_off">Sense sincronització de tasques, diaris ni notes</string>
-  <string name="permissions_jtx_status_on">És possible la sincronització de tasques, diaris o notes</string>
   <string name="permissions_opentasks_title">Permisos d\'OpenTasks</string>
   <string name="permissions_tasksorg_title">Permisos de Tasks</string>
   <string name="permissions_tasks_status_off">Sense sincronització de les tasques</string>
@@ -98,9 +94,7 @@
   <string name="about_version">Versió %1$s (%2$d)</string>
   <string name="about_build_date">Compilat el %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) i col·laboradors</string>
-  <string name="about_flavor_info">Aquesta versió només és apta per la seva distribució a Google Play.</string>
   <string name="about_license_info_no_warranty">Aquest programa és distribuït sense CAP TIPUS DE GARANTIA. És programari lliure, i està permesa la seva re-distribució sota certes condicions.</string>
-  <string name="about_translations_thanks"><![CDATA[<i>Gràcies a: </i> %s]]></string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">No s\'ha pogut crear el fitxer de registre</string>
   <string name="logging_notification_text">Iniciant a totes les %s activitats</string>
@@ -110,7 +104,6 @@
   <string name="navigation_drawer_subtitle">Adaptador de sincronització CalDAV / CardDAV</string>
   <string name="navigation_drawer_about">Quant a/llicència</string>
   <string name="navigation_drawer_beta_feedback">Retroacció de la Beta</string>
-  <string name="install_email_client">Si us plau, instal·leu un client de correu</string>
   <string name="install_browser">Si us plau, instal·leu un navegador.</string>
   <string name="navigation_drawer_settings">Configuració</string>
   <string name="navigation_drawer_news_updates">Novetats i actualitzacions</string>
@@ -131,8 +124,6 @@
   <string name="account_list_low_storage">Espai d\'emmagatzematge baix. L\'Android no sincronitzarà els canvis locals immediatament, sinó durant la propera sincronització normal.</string>
   <string name="account_list_manage_storage">Gestiona l\'emmagatzematge</string>
   <string name="account_list_empty">Us donem la benvinguda a DAVx⁵! \n\nAra podeu afegir un compte CalDAV / CardDAV.</string>
-  <string name="accounts_global_sync_disabled">La sincronització automàtica de tot el sistema està inhabilitada</string>
-  <string name="accounts_global_sync_enable">Activa</string>
   <string name="accounts_sync_all">Sincronitza tots els comptes</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">Ha fallat la detecció del servei</string>
@@ -182,16 +173,11 @@
   <string name="app_settings_reset_hints_success">Es mostraran de nou tots els consells</string>
   <string name="app_settings_integration">Integració</string>
   <string name="app_settings_tasks_provider">Aplicació de tasques</string>
-  <string name="app_settings_tasks_provider_synchronizing_with">Sincronitzant amb %s</string>
   <string name="app_settings_tasks_provider_none">No s\'ha trobat cap aplicació de tasques compatible</string>
   <!--AccountActivity-->
   <string name="account_carddav">CardDAV</string>
   <string name="account_caldav">CalDAV</string>
   <string name="account_webcal">Webcal</string>
-  <string name="account_no_address_books">No existeixen llibretes d\'adreces (encara).</string>
-  <string name="account_no_calendars">No existeixen calendaris (encara).</string>
-  <string name="account_no_webcals">No hi ha subscripcions a calendaris (encara).</string>
-  <string name="account_swipe_down">Llisca avall per a refrescar la llista del servidor.</string>
   <string name="account_synchronize_now">Sincronitza ara</string>
   <string name="account_settings">Configuració del compte</string>
   <string name="account_rename">Canvia el nom del compte</string>
@@ -209,8 +195,6 @@
   <string name="account_task_list">Llista de tasques</string>
   <string name="account_journal">Diari</string>
   <string name="account_only_personal">Mostra només les personals</string>
-  <string name="account_create_new_address_book">Crea una llibreta d’adreces nova</string>
-  <string name="account_create_new_calendar">Crear nou calendari</string>
   <string name="account_no_webcal_handler_found">No s\'ha trobat cap aplicació compatible amb Webcal</string>
   <string name="account_install_icsx5">Instal·la ICSx⁵</string>
   <!--AddAccountActivity-->
@@ -265,7 +249,6 @@
   <string name="login_username_password_wrong">Nom d\'usuari (adreça de correu) / contrasenya incorrectes?</string>
   <string name="login_view_logs">Mostra els detalls</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Configuració: %s</string>
   <string name="settings_sync">Sincronització</string>
   <string name="settings_sync_interval_contacts">Interval de sincronització dels contactes</string>
   <string name="settings_sync_summary_manually">Només a mà</string>
@@ -297,10 +280,8 @@
   <string name="settings_oauth">Re-Autenticar</string>
   <string name="settings_oauth_summary">Tornar a realitzar l\'inici de sessió amb OAuth</string>
   <string name="settings_username">Nom d\'usuari/a</string>
-  <string name="settings_enter_username">Escriu el nom d\'usuari/a:</string>
   <string name="settings_password">Contrasenya</string>
   <string name="settings_password_summary">Actualitzeu la contrasenya segons el vostre servidor.</string>
-  <string name="settings_enter_password">Introduïu la contrasenya:</string>
   <string name="settings_certificate_install">Instal·la un certificat</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">Límit de temps dels esdeveniments passats</string>
@@ -424,6 +405,4 @@
   <string name="sync_invalid_task">S\'ha rebut una tasca no vàlida del servidor</string>
   <string name="sync_invalid_resources_ignoring">S\'ha ignorat un o més recursos no vàlids</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵: Seguretat de la connexió</string>
-  <string name="trust_certificate_unknown_certificate_found">El DAVx⁵ ha trobat un certificat desconegut. Voleu confiar-hi?</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -29,8 +29,6 @@
   <string name="intro_slogan1">Vaše data. Vaše volba.</string>
   <string name="intro_slogan2">Mějte pod svou kontrolou.</string>
   <string name="intro_battery_title">Synchronizace v pravidelných intervalech</string>
-  <string name="intro_battery_not_whitelisted">Vypnuto (nedoporučeno)</string>
-  <string name="intro_battery_whitelisted">Zapnuto (doporučeno)</string>
   <string name="intro_battery_text">Pokud chcete synchronizaci v pravidelných intervalech, je třeba %s povolit být spuštěné na pozadí. V opačném případě může systém Android synchronizaci kdykoli pozastavit.</string>
   <string name="intro_battery_dont_show">Nepotřebuji synchronizaci v pravidelných intervalech.*</string>
   <string name="intro_autostart_title">Kompatibilita %s</string>
@@ -68,8 +66,6 @@
   <string name="permissions_notification_status_off">Upozornění vypnuta (nedoporučeno)</string>
   <string name="permissions_notification_status_on">Upozornění zapnuta</string>
   <string name="permissions_jtx_title">Oprávnění pro jtx Board</string>
-  <string name="permissions_jtx_status_off">Bez synchronizace úkolů, žurnálů a poznámek</string>
-  <string name="permissions_jtx_status_on">Synchronizace úkolů, žurnálů a poznámek možná</string>
   <string name="permissions_opentasks_title">Oprávnění pro OpenTasks</string>
   <string name="permissions_tasksorg_title">Oprávnění pro úkoly</string>
   <string name="permissions_tasks_status_off">Žádné úlohy ohledně synchronizace</string>
@@ -98,9 +94,7 @@
   <string name="about_version">Verze %1$s (%2$d)</string>
   <string name="about_build_date">Sestaveno %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) a přispěvatelé</string>
-  <string name="about_flavor_info">Tuto verzi je možné šířit pouze přes Google Play.</string>
   <string name="about_license_info_no_warranty">Na tento program nejsou poskytovány ŽÁDNÉ ZÁRUKY. Jedná se o svobodný software a jeho šíření dál je vítáno, ovšem za podmínky, že stejné svobody zůstanou zachovány i všem dalším příjemcům.</string>
-  <string name="about_translations_thanks"><![CDATA[<i>Poděkování: </i> %s]]></string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Nedaří se vytvořit soubor pro záznam událostí</string>
   <string name="logging_notification_text">Nyní je zaznamenáváno všech %s aktivit</string>
@@ -110,7 +104,6 @@
   <string name="navigation_drawer_subtitle">Adaptér synchronizace CalDAV/CardDAV</string>
   <string name="navigation_drawer_about">O aplikaci / Licence</string>
   <string name="navigation_drawer_beta_feedback">Zpětná vazba k vývojové verzi</string>
-  <string name="install_email_client">Nainstalujte si e-mailového klienta</string>
   <string name="install_browser">Nainstalujte si webový prohlížeč</string>
   <string name="navigation_drawer_settings">Nastavení</string>
   <string name="navigation_drawer_news_updates">Novinky a aktualizace</string>
@@ -129,8 +122,6 @@
   <string name="account_list_low_storage">Málo volného místa v úložišti. Android nebude synchronizovat místní změny okamžitě, ale při další běžné synchronizaci.</string>
   <string name="account_list_manage_storage">Spravovat úložiště</string>
   <string name="account_list_empty">Vítejte v aplikaci DAVx⁵!\n\nNyní můžete přidat CalDAV/CardDAV účet.</string>
-  <string name="accounts_global_sync_disabled">Automatická synchronizace v rámci celého systému je vypnutá</string>
-  <string name="accounts_global_sync_enable">Zapnout</string>
   <string name="accounts_sync_all">Synchronizovat všechny účty</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">Vyhledání služby se nezdařilo</string>
@@ -180,16 +171,11 @@
   <string name="app_settings_reset_hints_success">Všechny rady budou znovu zobrazeny</string>
   <string name="app_settings_integration">Napojení</string>
   <string name="app_settings_tasks_provider">Aplikace pro úkoly</string>
-  <string name="app_settings_tasks_provider_synchronizing_with">Synchronizuje se s %s</string>
   <string name="app_settings_tasks_provider_none">Nenalezena žádná kompatibilní aplikace pro úkoly</string>
   <!--AccountActivity-->
   <string name="account_carddav">CardDAV</string>
   <string name="account_caldav">CalDAV</string>
   <string name="account_webcal">Webcal</string>
-  <string name="account_no_address_books">(Zatím) zde nejsou žádné adresáře kontaktů.</string>
-  <string name="account_no_calendars">(Zatím) zde nejsou žádné kalendáře.</string>
-  <string name="account_no_webcals">(Zatím) zde nejsou žádná přihlášení se k odebírání kalendáře.</string>
-  <string name="account_swipe_down">Seznam ze serveru znovu načtete přejetím prstem dolů.</string>
   <string name="account_synchronize_now">Synchronizovat nyní</string>
   <string name="account_settings">Nastavení účtu</string>
   <string name="account_rename">Přejmenovat účet</string>
@@ -205,8 +191,6 @@
   <string name="account_task_list">seznam úkolů</string>
   <string name="account_journal">žurnál</string>
   <string name="account_only_personal">Zobrazit pouze osobní</string>
-  <string name="account_create_new_address_book">Vytvořit nový adresář kontaktů</string>
-  <string name="account_create_new_calendar">Vytvořit nový kalendář</string>
   <string name="account_no_webcal_handler_found">Nenalezena žádná aplikace, která by umožňovala webcal</string>
   <string name="account_install_icsx5">Nainstalovat ICSx⁵</string>
   <!--AddAccountActivity-->
@@ -261,7 +245,6 @@
   <string name="login_username_password_wrong">Nesprávné uživatelské jméno (e-mailová adresa) nebo heslo?</string>
   <string name="login_view_logs">Zobrazit podrobnosti</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Nastavení: %s</string>
   <string name="settings_sync">Synchronizace</string>
   <string name="settings_sync_interval_contacts">Interval synchronizace kontaktů</string>
   <string name="settings_sync_summary_manually">Pouze ručně</string>
@@ -293,10 +276,8 @@
   <string name="settings_oauth">Znovu ověřit</string>
   <string name="settings_oauth_summary">Znovu provést přihlášení OAuth</string>
   <string name="settings_username">Uživatelské jméno</string>
-  <string name="settings_enter_username">Zadejte uživatelské jméno:</string>
   <string name="settings_password">Heslo</string>
   <string name="settings_password_summary">Aktualizovat heslo dle svého serveru.</string>
-  <string name="settings_enter_password">Zadejte své heslo:</string>
   <string name="settings_certificate_install">Instalovat certifikát</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">Časový limit pro staré události</string>
@@ -422,6 +403,4 @@
   <string name="sync_invalid_task">Ze serveru obdržen neplatný úkol</string>
   <string name="sync_invalid_resources_ignoring">Ignoruje se jeden či více neplatný prostředků</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵: Zabezpečení připojení</string>
-  <string name="trust_certificate_unknown_certificate_found">DAVx⁵ nalezlo neznámý certifikát. Chcete mu důvěřovat?</string>
 </resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -26,8 +26,6 @@
   <string name="intro_slogan1">Dine data. Dit valg.</string>
   <string name="intro_slogan2">Tag kontrol</string>
   <string name="intro_battery_title">Regelmæssigt synkroniseringsinterval</string>
-  <string name="intro_battery_not_whitelisted">Deaktiveret (ikke anbefalet)</string>
-  <string name="intro_battery_whitelisted">Aktiveret (anbefalet)</string>
   <string name="intro_battery_text">For regelmæssig synkroniseringsinterval, %s skal have tilladelse til at køre i baggrunden. Ellers kan Android til enhver tid pause synkronisering.</string>
   <string name="intro_battery_dont_show">Ingen regelmæssigt synkroniseringsinterval.*</string>
   <string name="intro_autostart_title">%s kompatibilitet</string>
@@ -65,8 +63,6 @@
   <string name="permissions_notification_status_off">Notifikationer slået fra (ej anbefalet)</string>
   <string name="permissions_notification_status_on">Notifikationer slået til</string>
   <string name="permissions_jtx_title">jtx Board rettigheder</string>
-  <string name="permissions_jtx_status_off">Ingen opgaver, journaler &amp; noter synkronisering</string>
-  <string name="permissions_jtx_status_on">Opgaver, journaler og noter synkronisering mulig</string>
   <string name="permissions_opentasks_title">OpenTasks rettigheder</string>
   <string name="permissions_tasksorg_title">Opgaver rettigheder</string>
   <string name="permissions_tasks_status_off">Ingen opgave synkronisering</string>
@@ -95,9 +91,7 @@
   <string name="about_version">Version %1$s (%2$d)</string>
   <string name="about_build_date">Oversat den %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) og bidragydere</string>
-  <string name="about_flavor_info">Denne version er kun berettiget til distribution via Google Play.</string>
   <string name="about_license_info_no_warranty">Dette program leveres ABSOLUT UDEN GARANTI. Det er fri software, og du er velkommen til at videredistribuere det under visse betingelse.</string>
-  <string name="about_translations_thanks"><![CDATA[<i>tak til: </i> %s]]></string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Kan ikke oprette log fil</string>
   <string name="logging_notification_text">Logger alle %s aktiviteter</string>
@@ -107,7 +101,6 @@
   <string name="navigation_drawer_subtitle">CalDAV/CardDAV synkroniseringsadapter</string>
   <string name="navigation_drawer_about">Om / licens</string>
   <string name="navigation_drawer_beta_feedback">Beta tilbagemelding</string>
-  <string name="install_email_client">Installér e-mail klient</string>
   <string name="install_browser">Installere netlæser</string>
   <string name="navigation_drawer_settings">Opsætning</string>
   <string name="navigation_drawer_news_updates">Nyheder &amp; opdateringer</string>
@@ -128,8 +121,6 @@ Synkronisering kører muligvis ikke.</string>
 Lav lagerplads. Android vil ikke synkronisere lokale ændringer med det samme, men under den næste almindelige synkronisering.</string>
   <string name="account_list_manage_storage">Administrer lagerplads</string>
   <string name="account_list_empty">Velkommen til DAVx⁵!\n\nDu kan nu tilføje en CalDAV/CardDAV konto.</string>
-  <string name="accounts_global_sync_disabled">Automatisk synkronisering på tværs af systemet er deaktiveret</string>
-  <string name="accounts_global_sync_enable">Aktivere</string>
   <string name="accounts_sync_all">Synkroniser alle konti</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">Registrering af tjeneste kunne ikke foretages</string>
@@ -179,16 +170,11 @@ Lav lagerplads. Android vil ikke synkronisere lokale ændringer med det samme, m
   <string name="app_settings_reset_hints_success">Al vejledning vil blive vist igen</string>
   <string name="app_settings_integration">Integration</string>
   <string name="app_settings_tasks_provider">Opgaver program</string>
-  <string name="app_settings_tasks_provider_synchronizing_with">Synkronisering med %s</string>
   <string name="app_settings_tasks_provider_none">Der er ikke fundet et program der kan håndtere opgaver</string>
   <!--AccountActivity-->
   <string name="account_carddav">CardDAV</string>
   <string name="account_caldav">CalDAV</string>
   <string name="account_webcal">Webcal</string>
-  <string name="account_no_address_books">Der er endnu ingen adressebog.</string>
-  <string name="account_no_calendars">Der er endnu ingen kalender.</string>
-  <string name="account_no_webcals">Der er endnu ingen kalender abonnementer.</string>
-  <string name="account_swipe_down">Træk ned for at genopfriske listen fra serveren.</string>
   <string name="account_synchronize_now">Synkronisere</string>
   <string name="account_settings">Opsætning af konti</string>
   <string name="account_rename">Omdøb konto</string>
@@ -204,8 +190,6 @@ Lav lagerplads. Android vil ikke synkronisere lokale ændringer med det samme, m
   <string name="account_task_list">opgave liste</string>
   <string name="account_journal">journal</string>
   <string name="account_only_personal">Vis kun personlig</string>
-  <string name="account_create_new_address_book">Oprett ny adressebog</string>
-  <string name="account_create_new_calendar">Oprette ny kalender</string>
   <string name="account_no_webcal_handler_found">Der er ikke fundet noget program der kan håndtere Webcal.</string>
   <string name="account_install_icsx5">Installere ICSx⁵</string>
   <!--AddAccountActivity-->
@@ -256,7 +240,6 @@ Lav lagerplads. Android vil ikke synkronisere lokale ændringer med det samme, m
   <string name="login_username_password_wrong">Brugernavn (e-mail adresse) / adgangskode forkert?</string>
   <string name="login_view_logs">Vis detaljer</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Indstillinger: %s</string>
   <string name="settings_sync">Synkronisering</string>
   <string name="settings_sync_interval_contacts">Synkroniseringsinterval for kontakter</string>
   <string name="settings_sync_summary_manually">Kun manuelt</string>
@@ -287,10 +270,8 @@ Lav lagerplads. Android vil ikke synkronisere lokale ændringer med det samme, m
   <string name="settings_authentication">Adgangsgodkendelse</string>
   <string name="settings_oauth_summary">Udfør OAuth-login igen</string>
   <string name="settings_username">Brugernavn</string>
-  <string name="settings_enter_username">Indtaste brugernavn:</string>
   <string name="settings_password">Adgangskode</string>
   <string name="settings_password_summary">Opdater adgangskoden, så den svarer til din server.</string>
-  <string name="settings_enter_password">Indtast adgangskode:</string>
   <string name="settings_certificate_install">Installere certifikat</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">Tidsafgrænsning for tidligere begivenheder</string>
@@ -412,6 +393,4 @@ Lav lagerplads. Android vil ikke synkronisere lokale ændringer med det samme, m
   <string name="sync_invalid_task">Modtaget ugyldig opgave fra server</string>
   <string name="sync_invalid_resources_ignoring">Ignorere en eller flere ugyldige kilder</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵: Forbindelsessikkerhed</string>
-  <string name="trust_certificate_unknown_certificate_found">DAVx⁵ er stødt på et ukendt certifikat. Vil du stole på det? </string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -29,8 +29,6 @@
   <string name="intro_slogan1">Dein Leben. Deine Daten.</string>
   <string name="intro_slogan2">Deine Entscheidung.</string>
   <string name="intro_battery_title">Regelmäßige Sync-Intervalle</string>
-  <string name="intro_battery_not_whitelisted">Deaktiviert (nicht empfohlen)</string>
-  <string name="intro_battery_whitelisted">Aktiviert (empfohlen)</string>
   <string name="intro_battery_text">Zur Synchronisierung in regelmäßigen Intervallen muss %s im Hintergrund laufen dürfen; ansonsten kann Android die Synchronisierung jederzeit aussetzen.</string>
   <string name="intro_battery_dont_show">Ich brauche keine regelmäßigen Sync-Intervalle.*</string>
   <string name="intro_autostart_title">%s-Kompatibilität</string>
@@ -68,8 +66,6 @@
   <string name="permissions_notification_status_off">Benachrichtigungen deaktiviert (nicht empfohlen)</string>
   <string name="permissions_notification_status_on">Benachrichtigungen aktiviert</string>
   <string name="permissions_jtx_title">jtx Board-Berechtigungen</string>
-  <string name="permissions_jtx_status_off">Keine Synchronisierung von Aufgaben, Journalen und Notizen</string>
-  <string name="permissions_jtx_status_on">Synchronisierung von Aufgaben, Journaleinträgen, Notizen möglich </string>
   <string name="permissions_opentasks_title">OpenTasks-Berechtigungen</string>
   <string name="permissions_tasksorg_title">Tasks-Berechtigungen</string>
   <string name="permissions_tasks_status_off">Keine Aufgabensynchronisierung</string>
@@ -98,9 +94,7 @@
   <string name="about_version">Version %1$s (%2$d)</string>
   <string name="about_build_date">Erstellt am %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) und Mitwirkende</string>
-  <string name="about_flavor_info">Diese Version ist nur zur Verteilung über Google Play bestimmt.</string>
   <string name="about_license_info_no_warranty">Dieses Programm wird OHNE JEDE GEWÄHRLEISTUNG bereitgestellt. Es ist freie Software – Sie können es also unter bestimmten Bedingungen weiterverbreiten.</string>
-  <string name="about_translations_thanks"><![CDATA[<i>Dank an: </i> %s]]></string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Protokolldatei konnte nicht angelegt werden</string>
   <string name="logging_notification_text">Alle %s-Aktivitäten werden protokolliert</string>
@@ -110,7 +104,6 @@
   <string name="navigation_drawer_subtitle">CalDAV/CardDAV-Sync-Adapter</string>
   <string name="navigation_drawer_about">Über / Lizenz</string>
   <string name="navigation_drawer_beta_feedback">Beta-Rückmeldung</string>
-  <string name="install_email_client">Bitte installieren Sie eine E-Mail-Anwendung</string>
   <string name="install_browser">Bitte installieren Sie einen Web-Browser</string>
   <string name="navigation_drawer_settings">Einstellungen</string>
   <string name="navigation_drawer_news_updates">Aktuelles</string>
@@ -132,8 +125,6 @@
   <string name="account_list_low_storage">Wenig Speicherplatz. Android wird lokale Änderungen nicht sofort synchronisieren, sondern bei der nächsten regulären Synchronisierung.</string>
   <string name="account_list_manage_storage">Speicherplatz verwalten</string>
   <string name="account_list_empty">Herzlich willkommen!\n\nSie können jetzt ein CalDAV/CardDAV-Konto hinzufügen.</string>
-  <string name="accounts_global_sync_disabled">Systemweite automatische Synchronisierung ist nicht aktiv</string>
-  <string name="accounts_global_sync_enable">Aktivieren</string>
   <string name="accounts_sync_all">Alle Konten synchronisieren</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">Diensterkennung fehlgeschlagen</string>
@@ -183,17 +174,12 @@
   <string name="app_settings_reset_hints_success">Alle Hinweise werden wieder angezeigt</string>
   <string name="app_settings_integration">Integration</string>
   <string name="app_settings_tasks_provider">Aufgaben-App</string>
-  <string name="app_settings_tasks_provider_synchronizing_with">Synchronisierung mit %s</string>
   <string name="app_settings_tasks_provider_none">Keine kompatible Aufgaben-App gefunden</string>
   <!--AccountActivity-->
   <string name="account_carddav">CardDAV</string>
   <string name="account_caldav">CalDAV</string>
   <string name="account_webcal">Webcal</string>
   <string name="account_manage_permissions">Berechtigungen verwalten</string>
-  <string name="account_no_address_books">(Noch) keine Adressbücher vorhanden</string>
-  <string name="account_no_calendars">(Noch) keine Kalender vorhanden</string>
-  <string name="account_no_webcals">(Noch) keine Kalender-Abos vorhanden</string>
-  <string name="account_swipe_down">Nach unten wischen, um neue Einträge am Server zu suchen.</string>
   <string name="account_synchronize_now">Jetzt synchronisieren</string>
   <string name="account_settings">Konto-Einstellungen</string>
   <string name="account_rename">Konto umbenennen</string>
@@ -213,8 +199,6 @@
   <string name="account_only_personal">Nur eigene anzeigen</string>
   <string name="account_refresh_collections">Ordner aktualisieren</string>
   <string name="account_refreshing_collections">Ordnerliste aktualisieren</string>
-  <string name="account_create_new_address_book">Neues Adressbuch erstellen</string>
-  <string name="account_create_new_calendar">Neuen Kalender erstellen</string>
   <string name="account_no_webcal_handler_found">Keine Webcal-App gefunden</string>
   <string name="account_install_icsx5">ICSx⁵ installieren</string>
   <!--AddAccountActivity-->
@@ -269,7 +253,6 @@
   <string name="login_username_password_wrong">Benutzername (Email-Adresse) / Passwort falsch?</string>
   <string name="login_view_logs">Details anzeigen</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Einstellungen: %s</string>
   <string name="settings_sync">Synchronisierung</string>
   <string name="settings_sync_interval_contacts">Häufigkeit der Kontakte-Synchronisierung</string>
   <string name="settings_sync_summary_manually">Nur manuell</string>
@@ -301,10 +284,8 @@
   <string name="settings_oauth">Erneut anmelden</string>
   <string name="settings_oauth_summary">Erneut mit OAuth anmelden</string>
   <string name="settings_username">Benutzername</string>
-  <string name="settings_enter_username">Benutzername eingeben:</string>
   <string name="settings_password">Passwort</string>
   <string name="settings_password_summary">Aktualisieren Sie Ihr Passwort gemäß den Server-Einstellungen.</string>
-  <string name="settings_enter_password">Passwort eingeben:</string>
   <string name="settings_certificate_alias">Client-Zertifikat</string>
   <string name="settings_certificate_alias_empty">Kein Zertifikat verfügbar oder ausgewählt</string>
   <string name="settings_certificate_install">Zertifikat installieren </string>
@@ -430,6 +411,4 @@
   <string name="sync_invalid_task">Ungültige Aufgabe vom Server erhalten</string>
   <string name="sync_invalid_resources_ignoring">Eine/mehrere ungültige Ressourcen ignoriert</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵: Verbindungssicherheit</string>
-  <string name="trust_certificate_unknown_certificate_found">DAVx⁵ ist auf ein unbekanntes Zertifikat gestoßen. Ist dieses vertrauenswürdig?</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -24,8 +24,6 @@
   <string name="intro_slogan1">Τα δεδομένα σου. Οι επιλογές σου.</string>
   <string name="intro_slogan2">Πάρε τον έλεγχο.</string>
   <string name="intro_battery_title">Τακτά διαστήματα συγχρονισμού</string>
-  <string name="intro_battery_not_whitelisted">Απενεργοποιημένο (δεν προτείνεται)</string>
-  <string name="intro_battery_whitelisted">Ενεργοποιημένο (προτείνεται)</string>
   <string name="intro_battery_text">Για συγχρονισμό σε τακτικά διαστήματα, πρέπει να επιτραπεί στο %s να λειτουργεί στο παρασκήνιο. Αλλιώς, το Android μπορεί να παύση τον συγχρονισμό ανά πάσα στιγμή.</string>
   <string name="intro_battery_dont_show">Δεν χρειάζομαι τακτικά διαστήματα συγχρονισμού.*</string>
   <string name="intro_autostart_title">%s Συμβατότητα</string>
@@ -77,7 +75,6 @@
   <string name="about_version">Έκδοση %1$s (%2$d)</string>
   <string name="about_build_date">Μεταγλωττισμένο σε %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) και συνεργάτες</string>
-  <string name="about_flavor_info">Αυτή η έκδοση είναι κατάλληλη μόνο για διανομή μέσω του Google Play.</string>
   <string name="about_license_info_no_warranty">Αυτό το πρόγραμμα συνοδεύεται χωρις ΚΑΜΙΑ ΕΓΓΥΗΣΗ. Είναι ελεύθερο λογισμικό και είστε ευπρόσδεκτοι να το αναδιανείμετε υπό ορισμένες προϋποθέσεις.</string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Αδυναμία δημιουργίας αρχείου ιστορικού</string>
@@ -88,7 +85,6 @@
   <string name="navigation_drawer_subtitle">Προσαρμογέας συγχρονισμού CalDAV/CardDAV</string>
   <string name="navigation_drawer_about">Περί / άδεια χρήσης</string>
   <string name="navigation_drawer_beta_feedback">Ανατροφοδότηση beta</string>
-  <string name="install_email_client">Παρακαλούμε εγκαταστήστε ένα πελάτη ηλεκτρονικού ταχυδρομείου</string>
   <string name="install_browser">Παρακαλούμε εγκαταστήστε έναν περιηγητή ιστού</string>
   <string name="navigation_drawer_settings">Ρυθμίσεις</string>
   <string name="navigation_drawer_news_updates">Νέα &amp; ενημερώσεις</string>
@@ -100,8 +96,6 @@
   <string name="navigation_drawer_community">Κοινότητα</string>
   <string name="navigation_drawer_privacy_policy">Πολιτική απορρήτου</string>
   <string name="account_list_empty">Καλώς ήρθατε στο DAVx⁵!\n\nΜπορείτε να προσθέσετε τώρα έναν λογαριασμό CalDAV/CardDAV.</string>
-  <string name="accounts_global_sync_disabled">Ο αυτόματος συγχρονισμός σε όλο το σύστημα είναι απενεργοποιημένος</string>
-  <string name="accounts_global_sync_enable">Ενεργοποίηση</string>
   <string name="accounts_sync_all">Συγχρονισμός όλων των λογαριασμών</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">Αποτυχία ανίχνευσης υπηρεσίας</string>
@@ -144,16 +138,11 @@
   <string name="app_settings_reset_hints_success">Όλες οι συμβουλές θα εμφανιστούν ξανά</string>
   <string name="app_settings_integration">Ενσωμάτωση</string>
   <string name="app_settings_tasks_provider">Εφαρμογή εργασιών</string>
-  <string name="app_settings_tasks_provider_synchronizing_with">Γίνεται συγχρονισμός με %s</string>
   <string name="app_settings_tasks_provider_none">Δεν βρέθηκε συμβατή εφαρμογή εργασιών</string>
   <!--AccountActivity-->
   <string name="account_carddav">CardDAV</string>
   <string name="account_caldav">CalDAV</string>
   <string name="account_webcal">Webcal</string>
-  <string name="account_no_address_books">Δεν υπάρχουν βιβλία διευθύνσεων (ακόμα).</string>
-  <string name="account_no_calendars">Δεν υπάρχουν ημερολόγια (ακόμα).</string>
-  <string name="account_no_webcals">Δεν υπάρχουν συνδρομές ημερολογίου (ακόμα).</string>
-  <string name="account_swipe_down">Σύρετε προς τα κάτω για να ανανεώσετε τη λίστα από το διακομιστή.</string>
   <string name="account_synchronize_now">Συγχρονισμός τώρα</string>
   <string name="account_settings">Ρυθμίσεις λογαριασμού</string>
   <string name="account_rename">Μετονομασία λογαριασμού</string>
@@ -168,8 +157,6 @@
   <string name="account_calendar">ημερολόγιο</string>
   <string name="account_task_list">λίστα εργασιών</string>
   <string name="account_only_personal">Εμφάνιση μόνο προσωπικών</string>
-  <string name="account_create_new_address_book">Δημιουργία νέου βιβλίου διευθύνσεων</string>
-  <string name="account_create_new_calendar">Δημιουργία νέου ημερολογίου</string>
   <string name="account_no_webcal_handler_found">Δεν βρέθηκε εφαρμογή με δυνατότητα Webcal</string>
   <string name="account_install_icsx5">Εγκατάσταση ICSx⁵</string>
   <!--AddAccountActivity-->
@@ -204,7 +191,6 @@
   <string name="login_username_password_wrong">Λάθος ονομασία χρήστη (διεύθυνση ηλ. ταχυδρομείου) / συνθηματικού</string>
   <string name="login_view_logs">Εμφάνιση λεπτομερειών</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Ρυθμίσεις: %s</string>
   <string name="settings_sync">Συγχρονισμός</string>
   <string name="settings_sync_interval_contacts">Μεσοδιάστημα συγχρονισμού επαφών</string>
   <string name="settings_sync_summary_manually">Μόνο χειροκίνητα</string>
@@ -231,10 +217,8 @@
   <string name="settings_sync_wifi_only_ssids_permissions_action">Διαχείριση</string>
   <string name="settings_authentication">Πιστοποίηση</string>
   <string name="settings_username">Όνομα χρήστη</string>
-  <string name="settings_enter_username">Εισάγετε όνομα χρήστη:</string>
   <string name="settings_password">Συνθηματικό</string>
   <string name="settings_password_summary">Ενημερώστε το συνθηματικό σύμφωνα με τον διακομιστή σας.</string>
-  <string name="settings_enter_password">Εισάγετε το συνθηματικό σας:</string>
   <string name="settings_certificate_install">Εγκατάσταση πιστοποιητικού</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">Προθεσμία παρελθόντος συμβάντος</string>
@@ -339,6 +323,4 @@
   <string name="sync_invalid_task">Έλαβε μη έγκυρη εργασία από το διακομιστή</string>
   <string name="sync_invalid_resources_ignoring">Αγνόηση ενός ή περισσοτέρων μη έγκυρων πόρων</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵: Ασφάλεια σύνδεσης</string>
-  <string name="trust_certificate_unknown_certificate_found">Το DAVx⁵ εντόπισε ένα άγνωστο πιστοποιητικό. Θέλετε να το εμπιστεύεστε;</string>
 </resources>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -26,8 +26,6 @@
   <string name="intro_slogan1">Your data. Your choice.</string>
   <string name="intro_slogan2">Take control.</string>
   <string name="intro_battery_title">Regular sync intervals</string>
-  <string name="intro_battery_not_whitelisted">Disabled (not recommended)</string>
-  <string name="intro_battery_whitelisted">Enabled (recommended)</string>
   <string name="intro_battery_text">For synchronisation at regular intervals, %s must be allowed to run in the background. Otherwise, Android may pause synchronisation at any time.</string>
   <string name="intro_battery_dont_show">I don\'t need regular sync intervals.*</string>
   <string name="intro_autostart_title">%s compatibility</string>
@@ -65,8 +63,6 @@
   <string name="permissions_notification_status_off">Notifications disabled (not recommended)</string>
   <string name="permissions_notification_status_on">Notifications enabled</string>
   <string name="permissions_jtx_title">jtx Board permissions</string>
-  <string name="permissions_jtx_status_off">No tasks, journals, notes sync</string>
-  <string name="permissions_jtx_status_on">Tasks, journals, notes sync possible</string>
   <string name="permissions_opentasks_title">OpenTasks permissions</string>
   <string name="permissions_tasksorg_title">Tasks permissions</string>
   <string name="permissions_tasks_status_off">No task sync</string>
@@ -95,9 +91,7 @@
   <string name="about_version">Version %1$s (%2$d)</string>
   <string name="about_build_date">Compiled on %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) and contributors</string>
-  <string name="about_flavor_info">This version is only eligible for distribution over Google Play.</string>
   <string name="about_license_info_no_warranty">This program comes with ABSOLUTELY NO WARRANTY. It is free software, and you are welcome to redistribute it under certain conditions.</string>
-  <string name="about_translations_thanks"><![CDATA[<i>Thanks to: </i> %s]]></string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Couldn\'t create log file</string>
   <string name="logging_notification_text">Now logging all %s activities</string>
@@ -107,7 +101,6 @@
   <string name="navigation_drawer_subtitle">CalDAV/CardDAV Sync Adapter</string>
   <string name="navigation_drawer_about">About / License</string>
   <string name="navigation_drawer_beta_feedback">Beta feedback</string>
-  <string name="install_email_client">Please install an email client</string>
   <string name="install_browser">Please install a Web browser</string>
   <string name="navigation_drawer_settings">Settings</string>
   <string name="navigation_drawer_news_updates">News &amp; updates</string>
@@ -126,8 +119,6 @@
   <string name="account_list_low_storage">Storage space low. Android will not sync local changes immediately, but during the next regular sync.</string>
   <string name="account_list_manage_storage">Manage storage</string>
   <string name="account_list_empty">Welcome to DAVx⁵!\n\nYou can add a CalDAV/CardDAV account now.</string>
-  <string name="accounts_global_sync_disabled">System-wide automatic synchronisation is disabled</string>
-  <string name="accounts_global_sync_enable">Enable</string>
   <string name="accounts_sync_all">Sync all accounts</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">Service detection failed</string>
@@ -177,16 +168,11 @@
   <string name="app_settings_reset_hints_success">All hints will be shown again</string>
   <string name="app_settings_integration">Integration</string>
   <string name="app_settings_tasks_provider">Tasks app</string>
-  <string name="app_settings_tasks_provider_synchronizing_with">Synchronising with %s</string>
   <string name="app_settings_tasks_provider_none">No compatible tasks app found</string>
   <!--AccountActivity-->
   <string name="account_carddav">CardDAV</string>
   <string name="account_caldav">CalDAV</string>
   <string name="account_webcal">Webcal</string>
-  <string name="account_no_address_books">There are no address books (yet).</string>
-  <string name="account_no_calendars">There are no calendars (yet).</string>
-  <string name="account_no_webcals">There are no calendar subscriptions (yet).</string>
-  <string name="account_swipe_down">Swipe down to refresh the list from the server.</string>
   <string name="account_synchronize_now">Synchronise now</string>
   <string name="account_settings">Account settings</string>
   <string name="account_rename">Rename account</string>
@@ -202,8 +188,6 @@
   <string name="account_task_list">task list</string>
   <string name="account_journal">journal</string>
   <string name="account_only_personal">Show only personal</string>
-  <string name="account_create_new_address_book">Create new address book</string>
-  <string name="account_create_new_calendar">Create new calendar</string>
   <string name="account_no_webcal_handler_found">No Webcal-capable app found</string>
   <string name="account_install_icsx5">Install ICSx⁵</string>
   <!--AddAccountActivity-->
@@ -256,7 +240,6 @@
   <string name="login_username_password_wrong">Username (email address) / password wrong?</string>
   <string name="login_view_logs">Show details</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Settings: %s</string>
   <string name="settings_sync">Synchronisation</string>
   <string name="settings_sync_interval_contacts">Contacts sync. interval</string>
   <string name="settings_sync_summary_manually">Only manually</string>
@@ -288,10 +271,8 @@
   <string name="settings_oauth">Re-authenticate</string>
   <string name="settings_oauth_summary">Perform OAuth login again</string>
   <string name="settings_username">User name</string>
-  <string name="settings_enter_username">Enter user name:</string>
   <string name="settings_password">Password</string>
   <string name="settings_password_summary">Update the password according to your server.</string>
-  <string name="settings_enter_password">Enter your password:</string>
   <string name="settings_certificate_install">Install certificate</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">Past event time limit</string>
@@ -413,6 +394,4 @@
   <string name="sync_invalid_task">Received invalid task from server</string>
   <string name="sync_invalid_resources_ignoring">Ignoring one or more invalid resources</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵: Connection security</string>
-  <string name="trust_certificate_unknown_certificate_found">DAVx⁵ has encountered an unknown certificate. Do you want to trust it?</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -26,8 +26,6 @@
   <string name="intro_slogan1">Sus datos. Su elección.</string>
   <string name="intro_slogan2">Tome el control.</string>
   <string name="intro_battery_title">Sincronización a intervalos regulares</string>
-  <string name="intro_battery_not_whitelisted">Deshabilitado (no se recomienda)</string>
-  <string name="intro_battery_whitelisted">Habilitado (se recomienda)</string>
   <string name="intro_battery_text">Para sincronizar a intervalos regulares, se tiene que permitir a %sejecutarse como tarea de fondo. En caso contrario, Android podría pausar la sincronización en cualquier instante. </string>
   <string name="intro_battery_dont_show">No necesito la sincronización a intervalos regulares.*</string>
   <string name="intro_autostart_title">Compatibilidad %s</string>
@@ -60,8 +58,6 @@
   <string name="permissions_calendar_status_off">Sin sincronización de calendario (no recomendado)</string>
   <string name="permissions_calendar_status_on">Sincronización de calendario permitida</string>
   <string name="permissions_jtx_title">Permisos de tablero jtx</string>
-  <string name="permissions_jtx_status_off">Tareas, diarios, notas sin sincronizar</string>
-  <string name="permissions_jtx_status_on">Sincronización posible de tareas, diarios y notas</string>
   <string name="permissions_opentasks_title">Permisos de OpenTasks</string>
   <string name="permissions_tasksorg_title">Permisos de las tareas</string>
   <string name="permissions_tasks_status_off">Sin sincronización de tareas</string>
@@ -90,9 +86,7 @@
   <string name="about_version">Versión %1$s (%2$d)</string>
   <string name="about_build_date">Compilada en %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) y colaboradores </string>
-  <string name="about_flavor_info">Esta versión sólo está disponible para distribución en Google Play. </string>
   <string name="about_license_info_no_warranty">Este programa viene sin NINGÚN TIPO DE GARANTÍA. Es software libre, y cualquier contribución es bienvenida y redistribuida bajo ciertas condiciones.</string>
-  <string name="about_translations_thanks"><![CDATA[<i>Agradecimientos para: </i> %s]]></string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">No se puede crear el fichero del registro.</string>
   <string name="logging_notification_text">Ahora se registran todas las activdades %s </string>
@@ -102,7 +96,6 @@
   <string name="navigation_drawer_subtitle">Adaptador de sincronización CalDAV/CardDAV</string>
   <string name="navigation_drawer_about">Acerca de / Licencia</string>
   <string name="navigation_drawer_beta_feedback">Retroalimentación Beta</string>
-  <string name="install_email_client">Por favor, instale un cliente de email</string>
   <string name="install_browser">Por favor, instale un navegador web</string>
   <string name="navigation_drawer_settings">Ajustes</string>
   <string name="navigation_drawer_news_updates">Noticias y actualizaciones</string>
@@ -114,8 +107,6 @@
   <string name="navigation_drawer_community">Comunidad</string>
   <string name="navigation_drawer_privacy_policy">Reglamento de privacidad</string>
   <string name="account_list_empty">Bienvenido a DAVx⁵!\n\nAhora puedes añadir una cuenta CalDAV/CardDAV.</string>
-  <string name="accounts_global_sync_disabled">Sincronización automática del sistema completo está deshabilitada</string>
-  <string name="accounts_global_sync_enable">Activar</string>
   <string name="accounts_sync_all">Sincronizar todas las cuentas</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">Falló la detección del servicio</string>
@@ -165,16 +156,11 @@
   <string name="app_settings_reset_hints_success">Todas las advertencias se mostrarán nuevamente</string>
   <string name="app_settings_integration">Integración</string>
   <string name="app_settings_tasks_provider">Aplicación de tareas</string>
-  <string name="app_settings_tasks_provider_synchronizing_with">Sincronizando con %s</string>
   <string name="app_settings_tasks_provider_none">No se han encontrado aplicaciones de tareas compatibles</string>
   <!--AccountActivity-->
   <string name="account_carddav">CardDAV</string>
   <string name="account_caldav">CalDAV</string>
   <string name="account_webcal">Webcal</string>
-  <string name="account_no_address_books">No hay libretas de direciones (todavía).</string>
-  <string name="account_no_calendars">No hay calendarios (todavía). </string>
-  <string name="account_no_webcals">No hay suscripciones a calendarios (todavía).</string>
-  <string name="account_swipe_down">Desliza hacia abajo para actualizar la lista desde el servidor. </string>
   <string name="account_synchronize_now">Sincronizar ahora</string>
   <string name="account_settings">Ajustes de cuenta</string>
   <string name="account_rename">Renombrar cuenta</string>
@@ -190,8 +176,6 @@
   <string name="account_task_list">lista de tareas</string>
   <string name="account_journal">diario</string>
   <string name="account_only_personal">Mostrar solo personal</string>
-  <string name="account_create_new_address_book">Crear nueva agenda</string>
-  <string name="account_create_new_calendar">Crear nuevo calendario</string>
   <string name="account_no_webcal_handler_found">No se encontró aplicación para administrar Webcal</string>
   <string name="account_install_icsx5">Instalar ICSx⁵</string>
   <!--AddAccountActivity-->
@@ -227,7 +211,6 @@
   <string name="login_username_password_wrong">¿Nombre de usuario (dirección de correo electrónico) / contraseña incorrecta?</string>
   <string name="login_view_logs">Mostrar detalles</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Ajustes: %s</string>
   <string name="settings_sync">Sincronización</string>
   <string name="settings_sync_interval_contacts">Intervalo de sincronización de contactos</string>
   <string name="settings_sync_summary_manually">Solo manualmente</string>
@@ -254,10 +237,8 @@
   <string name="settings_sync_wifi_only_ssids_permissions_action">Administrar</string>
   <string name="settings_authentication">Autenticación</string>
   <string name="settings_username">Nombre de usuario</string>
-  <string name="settings_enter_username">Introduce tu nombre de usuario:</string>
   <string name="settings_password">Contraseña</string>
   <string name="settings_password_summary">Actualiza la contraseña de acuerdo a tu servidor.</string>
-  <string name="settings_enter_password">Introduce tu contraseña:</string>
   <string name="settings_certificate_install">Instalar certificado</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">Límite de tiempo de eventos pasados</string>
@@ -378,6 +359,4 @@
   <string name="sync_invalid_task">Tarea inválida recibidas del servidor</string>
   <string name="sync_invalid_resources_ignoring">Ignorando uno o más recursos inválidos</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵: Seguridad de conexión</string>
-  <string name="trust_certificate_unknown_certificate_found">DAVx⁵ ha encontrado un certificado desconocido. ¿Quieres que sea válido?</string>
 </resources>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -29,8 +29,6 @@
   <string name="intro_slogan1">Zure datuak. Zure aukera.</string>
   <string name="intro_slogan2">Har ezazu kontrola.</string>
   <string name="intro_battery_title">Sinkronizazio tarte erregularrak</string>
-  <string name="intro_battery_not_whitelisted">Desgaituta (ez gomendatuta)</string>
-  <string name="intro_battery_whitelisted">Gaituta (gomendatuta)</string>
   <string name="intro_battery_text">Sinkronizazioa tarte erregularretan ahalbidetzeko, %s atzeko planoan exekutatzen utzi behar da. Bestela, Androidek sinkronizazioa gelditu dezake edozein unean.</string>
   <string name="intro_battery_dont_show">Ez ditut sinkronizazio tarte erregularrak behar.*</string>
   <string name="intro_autostart_title">%s bateragarritasuna</string>
@@ -68,8 +66,6 @@
   <string name="permissions_notification_status_off">Jakinarazpenak desgaituta (ez gomendatuta)</string>
   <string name="permissions_notification_status_on">Jakinarazpenak gaituta</string>
   <string name="permissions_jtx_title">jtx taularen baimenak</string>
-  <string name="permissions_jtx_status_off">Zeregin, egunkari, noten sinkronizaziorik ez</string>
-  <string name="permissions_jtx_status_on">Zeregin, egunkari, noten sinkronizazioa posible</string>
   <string name="permissions_opentasks_title">OpenTasks baimenak</string>
   <string name="permissions_tasksorg_title">Tasks baimenak</string>
   <string name="permissions_tasks_status_off">Zeregin sink. ez</string>
@@ -98,9 +94,7 @@
   <string name="about_version">%1$s (%2$d) bertsioa</string>
   <string name="about_build_date">%s(e)an konpilatuta</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) eta kolaboratzaileak</string>
-  <string name="about_flavor_info">Bertsio hau Google Play bidez soilik banatu daiteke.</string>
   <string name="about_license_info_no_warranty">Programa hau INOLAKO BERMERIK GABE dator. Software librea da, eta birbanatzeko baimena duzu baldintza batzuk kontuan hartuz.</string>
-  <string name="about_translations_thanks"><![CDATA[<i>Eskerrik asko: </i> %s]]></string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Ezin izan da egunkari fitxategia sortu</string>
   <string name="logging_notification_text">%s jarduera guztiak erregistratzen</string>
@@ -110,7 +104,6 @@
   <string name="navigation_drawer_subtitle">CalDAV/CardDAV sinkronizazio moldagailua</string>
   <string name="navigation_drawer_about">Honi buruz / Lizentzia</string>
   <string name="navigation_drawer_beta_feedback">Beta iritzia</string>
-  <string name="install_email_client">Instalatu e-mail bezero bat</string>
   <string name="install_browser">Instalatu web nabigatzaile bat</string>
   <string name="navigation_drawer_settings">Ezarpenak</string>
   <string name="navigation_drawer_news_updates">Berriak eta eguneraketak</string>
@@ -131,8 +124,6 @@
   <string name="account_list_low_storage">Biltegiratze lekua baxua. Android-ek ez ditu tokiko aldaketak berehala sinkronizatuko, hurrengo sinkronizazio arruntean baizik.</string>
   <string name="account_list_manage_storage">Kudeatu biltegia</string>
   <string name="account_list_empty">Ongi etorri DAVx⁵ aplikaziora!\n\nCalDAV/CardDAV kontu bat gehitu dezakezu orain.</string>
-  <string name="accounts_global_sync_disabled">Sistema osoko sinkronizazio automatikoa desgaituta dago</string>
-  <string name="accounts_global_sync_enable">Gaitu</string>
   <string name="accounts_sync_all">Sinkronizatu kontu guztiak</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">Zerbitzuaren detekzioak huts egin du</string>
@@ -182,16 +173,11 @@
   <string name="app_settings_reset_hints_success">Aholku guztiak erakutsiko dira berriro</string>
   <string name="app_settings_integration">Integrazioa</string>
   <string name="app_settings_tasks_provider">Tasks aplikazioa</string>
-  <string name="app_settings_tasks_provider_synchronizing_with">%s(r)ekin sinkronizatzen</string>
   <string name="app_settings_tasks_provider_none">Ez da zeregin aplikazio bategarririk aurkitu</string>
   <!--AccountActivity-->
   <string name="account_carddav">CardDAV</string>
   <string name="account_caldav">CalDAV</string>
   <string name="account_webcal">Webcal</string>
-  <string name="account_no_address_books">Ez dago helbide libururik (oraindik).</string>
-  <string name="account_no_calendars">Ez dago egutegirik (oraindik).</string>
-  <string name="account_no_webcals">Ez dago egutegi harpidetzarik (oraindik).</string>
-  <string name="account_swipe_down">Lerratu beherantz zerbitzariaren zerrenda freskatzeko.</string>
   <string name="account_synchronize_now">Sinkronizatu orain</string>
   <string name="account_settings">Kontuaren ezarpenak</string>
   <string name="account_rename">Berrizendatu kontua</string>
@@ -209,8 +195,6 @@
   <string name="account_task_list">zeregin zerrenda</string>
   <string name="account_journal">egunkaria</string>
   <string name="account_only_personal">Erakutsi pertsonala soilik</string>
-  <string name="account_create_new_address_book">Sortu helbide liburu berria</string>
-  <string name="account_create_new_calendar">Sortu egutegi berria</string>
   <string name="account_no_webcal_handler_found">Ez da Webcal-ekin bateragarria den aplikaziorik aurkitu</string>
   <string name="account_install_icsx5">Instalatu ICSx⁵</string>
   <!--AddAccountActivity-->
@@ -265,7 +249,6 @@
   <string name="login_username_password_wrong">Erabiltzaile-izena (eposta) / pasahitza txarto dago?</string>
   <string name="login_view_logs">Erakutsi xehetasunak</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Ezarpenak: %s</string>
   <string name="settings_sync">Sinkronizazioa</string>
   <string name="settings_sync_interval_contacts">Kontaktuen sink. tartea</string>
   <string name="settings_sync_summary_manually">Eskuz soilik</string>
@@ -297,10 +280,8 @@
   <string name="settings_oauth">Berriro autentifikatu</string>
   <string name="settings_oauth_summary">Egin OAuth saioa berriro</string>
   <string name="settings_username">Erabiltzaile izena</string>
-  <string name="settings_enter_username">Sartu erabiltzaile izena:</string>
   <string name="settings_password">Pasahitza</string>
   <string name="settings_password_summary">Eguneratu pasahitza zure zerbitzariaren arabera</string>
-  <string name="settings_enter_password">Sartu zure pasahitza:</string>
   <string name="settings_certificate_install">Instalatu ziurtagiria</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">Aurreko gertaeren denbora muga</string>
@@ -424,6 +405,4 @@
   <string name="sync_invalid_task">Zeregin baliogabea jaso da zerbitzaritik</string>
   <string name="sync_invalid_resources_ignoring">Baliabide baliogabe bat edo gehiago ezikusten</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵: Konexio segurtasuna</string>
-  <string name="trust_certificate_unknown_certificate_found">DAVx⁵ aplikazioak ziurtagiri ezezagun bat aurkitu du. Fidagarritzat jo nahi duzu?</string>
 </resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -26,8 +26,6 @@
   <string name="intro_slogan1">داده های شما، انتخاب شما</string>
   <string name="intro_slogan2">کنترل را بدست بگیرید</string>
   <string name="intro_battery_title">فواصل همگام سازی منظم</string>
-  <string name="intro_battery_not_whitelisted">غیر فعال (توصیه نمی‌شود)</string>
-  <string name="intro_battery_whitelisted">فعال (توصیه می‌شود)</string>
   <string name="intro_battery_text">برای همگام سازی در فواصل منظم ، باید %s در پس زمینه اجرا شود. در غیر این صورت ، اندروید ممکن است هماهنگ سازی را متوقف کند.</string>
   <string name="intro_battery_dont_show">من به فواصل همگام سازی منظم نیاز ندارم. *</string>
   <string name="intro_autostart_title">سازگاری %s</string>
@@ -65,8 +63,6 @@
   <string name="permissions_notification_status_off">اعلان ها غیرفعال اند (توصیه نمی شود).</string>
   <string name="permissions_notification_status_on">اعلان ها فعال اند.</string>
   <string name="permissions_jtx_title">مجوز برنامه jtx Board</string>
-  <string name="permissions_jtx_status_off">تسک، ثبت وقایع و یادداشت ها همگام سازی نمی شوند.</string>
-  <string name="permissions_jtx_status_on">تسک، ثبت وقایع و یادداشت ها همگام سازی می شوند.</string>
   <string name="permissions_opentasks_title">مجوزهای OpenTasks</string>
   <string name="permissions_tasksorg_title">مجوز فعالیت ها</string>
   <string name="permissions_tasks_status_off">عدم همگام سازی وظایف</string>
@@ -94,9 +90,7 @@
   <string name="about_libraries">کتابخانه ها</string>
   <string name="about_version">ورژن %1$s (%2$d)</string>
   <string name="about_build_date">در %s وارد شده است</string>
-  <string name="about_flavor_info">این نسخه تنها برای پخش در Google Play واجد شرایط است.</string>
   <string name="about_license_info_no_warranty">این برنامه کاملاً بدون ضمانت است. این یک نرم افزار رایگان است ، و شما می توانید تحت شرایط خاص توزیع مجدد آن را انجام دهید.</string>
-  <string name="about_translations_thanks"><![CDATA[<i>با تشکر از: </i> %s]]></string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">پرونده ثبت ایجاد نشد</string>
   <string name="logging_notification_text">اکنون همه %s فعالیت ها را ثبت می کنید</string>
@@ -106,7 +100,6 @@
   <string name="navigation_drawer_subtitle"> همگام سازی CalDAV / CardDAV</string>
   <string name="navigation_drawer_about">درباره / مجوز</string>
   <string name="navigation_drawer_beta_feedback">بازخورد بتا</string>
-  <string name="install_email_client">لطفاً یک سرویس گیرنده ایمیل نصب کنید</string>
   <string name="install_browser">لطفاً یک مرورگر وب نصب کنید</string>
   <string name="navigation_drawer_settings">تنظیمات</string>
   <string name="navigation_drawer_news_updates">اخبار و amp؛ به روز رسانی</string>
@@ -123,8 +116,6 @@
   <string name="account_list_manage_datasaver">مدیریت محافظ داده</string>
   <string name="account_list_manage_storage">مدیریت حافظه</string>
   <string name="account_list_empty">به همگام‌ساز DAVx⁵ خوش آمدید</string>
-  <string name="accounts_global_sync_disabled">همگام سازی خودکار در کل سیستم غیرفعال است</string>
-  <string name="accounts_global_sync_enable">فعال</string>
   <string name="accounts_sync_all">همگام سازی همه حساب‌ها</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">تشخیص سرویس ناموفق بود</string>
@@ -174,16 +165,11 @@
   <string name="app_settings_reset_hints_success">همه نکات دوباره نشان داده خواهد شد</string>
   <string name="app_settings_integration">ادغام</string>
   <string name="app_settings_tasks_provider">برنامه مدیریت فعالیت ها</string>
-  <string name="app_settings_tasks_provider_synchronizing_with">همگام سازی با %s</string>
   <string name="app_settings_tasks_provider_none">برنامه سازگار یافت نشد</string>
   <!--AccountActivity-->
   <string name="account_carddav">CardDAV</string>
   <string name="account_caldav">CalDAV</string>
   <string name="account_webcal">Webcal</string>
-  <string name="account_no_address_books">هیچ کتاب آدرسی وجود ندارد (هنوز).</string>
-  <string name="account_no_calendars">هیچ تقویمی وجود ندارد (هنوز).</string>
-  <string name="account_no_webcals">هیچ اشتراک تقویمی وجود ندارد (هنوز).</string>
-  <string name="account_swipe_down">برای تازه کردن لیست از سرور ، صفحه را به پایین بکشید.</string>
   <string name="account_synchronize_now">اکنون همگام سازی کنید</string>
   <string name="account_settings">تنظیمات حساب</string>
   <string name="account_rename">تغییر نام حساب</string>
@@ -199,8 +185,6 @@
   <string name="account_task_list">لیست کار</string>
   <string name="account_journal">وقایع</string>
   <string name="account_only_personal">فقط شخصی ها را نمایش بده</string>
-  <string name="account_create_new_address_book">کتاب آدرس جدید ایجاد کنید</string>
-  <string name="account_create_new_calendar">تقویم جدید ایجاد کنید</string>
   <string name="account_no_webcal_handler_found">هیچ برنامه ای با قابلیت Webcal پیدا نشد</string>
   <string name="account_install_icsx5">ICSx⁵ را نصب کنید</string>
   <!--AddAccountActivity-->
@@ -236,7 +220,6 @@
   <string name="login_username_password_wrong">نام کاربری (آدرس ایمیل) / رمز عبور اشتباه است؟</string>
   <string name="login_view_logs">نمایش جزئیات</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">تنظیمات %s</string>
   <string name="settings_sync">همگام سازی</string>
   <string name="settings_sync_interval_contacts">همگام سازی مخاطبین </string>
   <string name="settings_sync_summary_manually">فقط دستی</string>
@@ -263,10 +246,8 @@
   <string name="settings_sync_wifi_only_ssids_permissions_action">مدیریت</string>
   <string name="settings_authentication">احراز هویت</string>
   <string name="settings_username">نام کاربری</string>
-  <string name="settings_enter_username">نام کاربری را وارد کنید</string>
   <string name="settings_password">گذرواژه</string>
   <string name="settings_password_summary">رمز عبور را با توجه به سرور خود به روز کنید.</string>
-  <string name="settings_enter_password">گذرواژه را وارد کنید:</string>
   <string name="settings_certificate_install">نصب گواهی</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">محدودیت زمانی رویداد گذشته</string>
@@ -374,6 +355,4 @@
   <string name="sync_invalid_task">کار نامعتبر از سرور دریافت شد</string>
   <string name="sync_invalid_resources_ignoring">نادیده گرفتن یک یا چند منبع نامعتبر</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">همگام ساز DAVx⁵: امنیت اتصال</string>
-  <string name="trust_certificate_unknown_certificate_found">همگام ساز DAVx⁵ با یک گواهی ناشناخته روبرو شده است. آیا می خواهید به آن اعتماد کنید؟</string>
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -32,7 +32,6 @@
   <string name="login_type_url">Kirjaudu verkko-osoitteella ja käyttäjänimellä</string>
   <string name="login_user_name">Käyttäjänimi</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Asetukset: %s</string>
   <string name="settings_username">Käyttäjänimi</string>
   <string name="settings_password">Salasana</string>
   <!--collection management-->

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -29,8 +29,6 @@
   <string name="intro_slogan1">Vos données. Votre choix.</string>
   <string name="intro_slogan2">Prenez le contrôle.</string>
   <string name="intro_battery_title">Intervalles de synchronisation réguliers</string>
-  <string name="intro_battery_not_whitelisted">Désactivé (non recommandé)</string>
-  <string name="intro_battery_whitelisted">Activé (recommandé)</string>
   <string name="intro_battery_text">Pour la synchronisation à intervalles réguliers, %s doit être autorisé à fonctionner en arrière-plan. Sinon, Android peut interrompre la synchronisation à tout moment.</string>
   <string name="intro_battery_dont_show">Je n\'ai pas besoin d\'intervalles de synchronisation réguliers.*</string>
   <string name="intro_autostart_title">%s compatibilité</string>
@@ -68,8 +66,6 @@
   <string name="permissions_notification_status_off">Les notifications sont désactivées (non recommandé)</string>
   <string name="permissions_notification_status_on">Notifications activées </string>
   <string name="permissions_jtx_title">Autorisations jtx Board</string>
-  <string name="permissions_jtx_status_off">Pas de synchronisation des tâches, journaux et notes</string>
-  <string name="permissions_jtx_status_on">Synchronisation possible des tâches, des journaux et des notes</string>
   <string name="permissions_opentasks_title">Autorisations d\'OpenTasks</string>
   <string name="permissions_tasksorg_title">Autorisations de Tasks</string>
   <string name="permissions_tasks_status_off">Aucune tâche synchronisée</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -27,8 +27,6 @@
   <string name="intro_slogan1">Vos données, votre choix.</string>
   <string name="intro_slogan2">Prenez le contrôle.</string>
   <string name="intro_battery_title">Intervalles de synchronisation régulières</string>
-  <string name="intro_battery_not_whitelisted">Désactiver (non recommandé)</string>
-  <string name="intro_battery_whitelisted">Activé (recommandé)</string>
   <string name="intro_battery_text">Pour une synchronisation à intervalles régulières, %s doit être autorisé à fonctionner en arrière-plan. Sinon, Android peut interrompre la synchronisation à tout moment.</string>
   <string name="intro_battery_dont_show">Je n\'ai pas besoin d\'intervalles de synchronisation régulières.*</string>
   <string name="intro_autostart_title">%s compatibilité</string>
@@ -66,8 +64,6 @@
   <string name="permissions_notification_status_off">Notifications désactivées (non recommandé)</string>
   <string name="permissions_notification_status_on">Notifications activées</string>
   <string name="permissions_jtx_title">Autorisations jtx Board</string>
-  <string name="permissions_jtx_status_off">Pas de synchronisation des tâches, journaux et notes</string>
-  <string name="permissions_jtx_status_on">Synchronisation possible des tâches, des journaux et des notes</string>
   <string name="permissions_opentasks_title">Autorisations d\'OpenTasks</string>
   <string name="permissions_tasksorg_title">Autorisations de Tasks</string>
   <string name="permissions_tasks_status_off">Aucune tâche de synchro</string>
@@ -96,9 +92,7 @@
   <string name="about_version">Version %1$s (%2$d)</string>
   <string name="about_build_date">Générée le %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) et les contributeurs</string>
-  <string name="about_flavor_info">Cette version ne peut être distribuée que sur Google Play.</string>
   <string name="about_license_info_no_warranty">Ce programme est fourni sans AUCUNE GARANTIE. C\'est un logiciel libre, et vous êtes en droit de le redistribuer sous certaines conditions.</string>
-  <string name="about_translations_thanks"><![CDATA[<i>Merci à : </i> %s]]></string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Impossible de créer le fichier journal</string>
   <string name="logging_notification_text">Maintenant toutes les activités de %s seront enregistrées</string>
@@ -108,7 +102,6 @@
   <string name="navigation_drawer_subtitle">Adaptateur de synchronisation CalDAV/CardDAV</string>
   <string name="navigation_drawer_about">À propos / Licence</string>
   <string name="navigation_drawer_beta_feedback">Commentaire pour la version Beta</string>
-  <string name="install_email_client">Veuillez installer un client mail</string>
   <string name="install_browser">Veuillez installer un navigateur</string>
   <string name="navigation_drawer_settings">Paramètres</string>
   <string name="navigation_drawer_news_updates">Actualités &amp; mises à jour</string>
@@ -129,8 +122,6 @@
   <string name="account_list_low_storage">Espace de stockage faible. Android ne synchronisera pas les changements locaux immédiatement mais pendant la prochaine synchronisation.</string>
   <string name="account_list_manage_storage">Gérer le stockage</string>
   <string name="account_list_empty">Bienvenue sur DAVx⁵!\n\nVous pouvez maintenant ajouter un compte CalDAV ou CardDAV.</string>
-  <string name="accounts_global_sync_disabled">La synchronisation automatique globale est désactivée</string>
-  <string name="accounts_global_sync_enable">Activer</string>
   <string name="accounts_sync_all">Synchroniser tous les comptes</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">La détection du service a échoué</string>
@@ -180,16 +171,11 @@
   <string name="app_settings_reset_hints_success">Toutes les astuces seront affichés à nouveau</string>
   <string name="app_settings_integration">Intégration</string>
   <string name="app_settings_tasks_provider">Applications de gestion de taches</string>
-  <string name="app_settings_tasks_provider_synchronizing_with">Synchronisation avec %s</string>
   <string name="app_settings_tasks_provider_none">Aucune application de tâches compatibles trouvée</string>
   <!--AccountActivity-->
   <string name="account_carddav">Carnets d\'adresses</string>
   <string name="account_caldav">Agendas</string>
   <string name="account_webcal">WebCal</string>
-  <string name="account_no_address_books">Il n\'y a pas (encore) de carnet d\'adresses.</string>
-  <string name="account_no_calendars">Il n\'y a pas (encore) de calendriers.</string>
-  <string name="account_no_webcals">Il n\'y a pas (encore) d\'abonnement à des calendriers.</string>
-  <string name="account_swipe_down">Glisser vers le bas pour rafraîchir la liste à partir du serveur.</string>
   <string name="account_synchronize_now">Synchroniser maintenant</string>
   <string name="account_settings">Paramètres du compte</string>
   <string name="account_rename">Renommer le compte</string>
@@ -206,8 +192,6 @@
   <string name="account_task_list">liste de tâche</string>
   <string name="account_journal">journal</string>
   <string name="account_only_personal">N\'afficher que les comptes perso.</string>
-  <string name="account_create_new_address_book">Créer un nouveau carnet d\'adresses</string>
-  <string name="account_create_new_calendar">Créer un nouveau calendrier</string>
   <string name="account_no_webcal_handler_found">Aucune application compatible WebCal</string>
   <string name="account_install_icsx5">Installer ICSx⁵</string>
   <!--AddAccountActivity-->
@@ -259,7 +243,6 @@
   <string name="login_username_password_wrong">Nom d\'utilisateur (courriel) / mot de passe incorrect ?</string>
   <string name="login_view_logs">Afficher les détails</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Paramètres: %s</string>
   <string name="settings_sync">Synchronisation</string>
   <string name="settings_sync_interval_contacts">Intervalle de synchronisation des carnets d\'adresses</string>
   <string name="settings_sync_summary_manually">Manuellement</string>
@@ -286,10 +269,8 @@
   <string name="settings_sync_wifi_only_ssids_permissions_action">Gérer</string>
   <string name="settings_authentication">Authentification</string>
   <string name="settings_username">Nom d\'utilisateur</string>
-  <string name="settings_enter_username">Saisissez votre nom d\'utilisateur :</string>
   <string name="settings_password">Mot de passe</string>
   <string name="settings_password_summary">Mettre à jour le mot de passe </string>
-  <string name="settings_enter_password">Saisissez votre mot de passe :</string>
   <string name="settings_certificate_install">Installer un certificat</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">Limite des événements passés</string>
@@ -412,6 +393,4 @@
   <string name="sync_invalid_task">Reçu une tâche invalide du serveur</string>
   <string name="sync_invalid_resources_ignoring">Ignorer une ou plusieurs ressources non valides</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵ : Sécurité de la connexion</string>
-  <string name="trust_certificate_unknown_certificate_found">DAVx⁵ a rencontré un certificat inconnu. Voulez-vous lui faire confiance?</string>
 </resources>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -30,8 +30,6 @@
   <string name="intro_slogan1">Os teus datos. Ti elixes.</string>
   <string name="intro_slogan2">Toma o control.</string>
   <string name="intro_battery_title">Intervalos regulares de sincronización</string>
-  <string name="intro_battery_not_whitelisted">Desactivado (non recomendado)</string>
-  <string name="intro_battery_whitelisted">Activado (recomendado)</string>
   <string name="intro_battery_text">Para sincronizar a intervalos regulares, %s debe ter permiso para executarse en segundo plano. Se non, Android podería deter a sincronización.</string>
   <string name="intro_battery_dont_show">Non preciso sincr. con regularidade.*</string>
   <string name="intro_autostart_title">Compatibilidade de %s</string>
@@ -69,8 +67,6 @@
   <string name="permissions_notification_status_off">Notificacións desactivadas (non recomendado)</string>
   <string name="permissions_notification_status_on">Notificacións activadas</string>
   <string name="permissions_jtx_title">permisos para jtx Board</string>
-  <string name="permissions_jtx_status_off">Sen sincr. de tarefas, diarios, notas</string>
-  <string name="permissions_jtx_status_on">Dispoñible sincr. de tarefas, diarios e notas</string>
   <string name="permissions_opentasks_title">Permisos para OpenTasks</string>
   <string name="permissions_tasksorg_title">Permisos para Tasks</string>
   <string name="permissions_tasks_status_off">Tarefas non sincr.</string>
@@ -100,9 +96,7 @@
   <string name="about_version">Versión  %1$s (%2$d)</string>
   <string name="about_build_date">Compilada en %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) e colaboradoras</string>
-  <string name="about_flavor_info">Esta versión só está dispoñible para distribución en Google Play.</string>
   <string name="about_license_info_no_warranty">Este programa non proporciona NINGUNHA GARANTÍA. É software libre, e convidámoste a redistribuílo baixo certas condicións.</string>
-  <string name="about_translations_thanks"><![CDATA[<i>Grazas a: </i> %s]]></string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Non se creou ficheiro de rexistro</string>
   <string name="logging_notification_text">Rexistrando todas as %s actividades</string>
@@ -112,7 +106,6 @@
   <string name="navigation_drawer_subtitle">Adaptador de sincr. CalDAV/CardDAV</string>
   <string name="navigation_drawer_about">Acerca de / Licenza</string>
   <string name="navigation_drawer_beta_feedback">Comenta sobre a Beta</string>
-  <string name="install_email_client">Instala un cliente de email</string>
   <string name="install_browser">Instala un navegador web</string>
   <string name="navigation_drawer_settings">Axustes</string>
   <string name="navigation_drawer_news_updates">Novas &amp; actualizacións</string>
@@ -135,8 +128,6 @@
   <string name="account_list_low_storage">Queda pouco espazo de almacenaxe. Android non vai sincronizar os cambios locais inmediatamente, farao na próxima sincronización regular.</string>
   <string name="account_list_manage_storage">Xestionar almacenaxe</string>
   <string name="account_list_empty">Benvida a DAVx⁵!\n\nXa podes engadir unha conta CalDAV/CardDAV</string>
-  <string name="accounts_global_sync_disabled">A sincronización global automática do sistema está desactivada</string>
-  <string name="accounts_global_sync_enable">Activar</string>
   <string name="accounts_sync_all">Sincroniza todas as contas</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">Fallou a detección do servizo</string>
@@ -188,7 +179,6 @@
   <string name="app_settings_reset_hints_success">Mostraranse todos os consellos de novo</string>
   <string name="app_settings_integration">Integración</string>
   <string name="app_settings_tasks_provider">App Tarefas</string>
-  <string name="app_settings_tasks_provider_synchronizing_with">Sincronizando con %s</string>
   <string name="app_settings_tasks_provider_none">Non se atopan app de tarefas compatible</string>
   <!--AccountActivity-->
   <string name="account_carddav">CardDAV</string>
@@ -196,10 +186,6 @@
   <string name="account_webcal">Webcal</string>
   <string name="account_missing_permissions">Requírense permisos adicionais para poder sincronizar estas coleccións.</string>
   <string name="account_manage_permissions">Xestionar permisos</string>
-  <string name="account_no_address_books">No existen libretas de enderezos (aínda).</string>
-  <string name="account_no_calendars">Non existen calendarios (aínda).</string>
-  <string name="account_no_webcals">Non tes subscricións a calendario (aínda).</string>
-  <string name="account_swipe_down">Arrastra hacia abaixo para actualizar a lista desde o servidor.</string>
   <string name="account_synchronize_now">Sincronizar agora</string>
   <string name="account_settings">Axustes da conta</string>
   <string name="account_rename">Renomear conta</string>
@@ -219,8 +205,6 @@
   <string name="account_only_personal">Mostrar só personal</string>
   <string name="account_refresh_collections">Actualizar coleccións</string>
   <string name="account_refreshing_collections">A actualizar a lista de coleccións</string>
-  <string name="account_create_new_address_book">Crear nova libreta de enderezos</string>
-  <string name="account_create_new_calendar">Crear novo calendario</string>
   <string name="account_webcal_external_app">As subscricións Webcal poden sincronizarse con apps externas.</string>
   <string name="account_no_webcal_handler_found">Non se atopou app para Webcal</string>
   <string name="account_install_icsx5">Instalar ICSx⁵</string>
@@ -276,7 +260,6 @@
   <string name="login_username_password_wrong">¿Usuaria (enderezo email) / contrasinal incorrectos?</string>
   <string name="login_view_logs">Mostrar detalles</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Axustes: %s</string>
   <string name="settings_sync">Sincronización</string>
   <string name="settings_sync_interval_contacts">Intervalo de sincr. contactos</string>
   <string name="settings_sync_summary_manually">Só manual</string>
@@ -308,10 +291,8 @@
   <string name="settings_oauth">Volver a autenticar</string>
   <string name="settings_oauth_summary">Intentar acceder con OAuth outra vez</string>
   <string name="settings_username">Nome de usuaria</string>
-  <string name="settings_enter_username">Escribe o nome de usuaria:</string>
   <string name="settings_password">Contrasinal</string>
   <string name="settings_password_summary">Actualizar o contrasinal de acordo ao teu servidor.</string>
-  <string name="settings_enter_password">Escribir contrasinal:</string>
   <string name="settings_certificate_alias">Certificado do cliente</string>
   <string name="settings_certificate_alias_empty">Sen certificado dispoñible ou seleccionado</string>
   <string name="settings_certificate_install">Instalar certificado</string>
@@ -437,6 +418,4 @@
   <string name="sync_invalid_task">Recibida tarefa non válida desde o servidor</string>
   <string name="sync_invalid_resources_ignoring">Ignorando un ou varios recursos non válidos</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵: seguridade da conexión</string>
-  <string name="trust_certificate_unknown_certificate_found">DAVx⁵ atopou un certificado descoñecido. Queres confiar nel?</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -21,8 +21,6 @@
   <string name="intro_slogan1">Vaši podaci. Vaš izbor.</string>
   <string name="intro_slogan2">Preuzmite kontrolu.</string>
   <string name="intro_battery_title">Redoviti intervali sinkronizacije</string>
-  <string name="intro_battery_not_whitelisted">Onemogućeno (nije preporučeno)</string>
-  <string name="intro_battery_whitelisted">Omogućeno (preporučeno)</string>
   <string name="intro_battery_text">Za sinkronizaciju u redovitim intervalima, %s mora imati omogućen rad u pozadini. Inače, Android može zaustaviti sinkronizaciju u bilo kojem trenutku.</string>
   <string name="intro_battery_dont_show">Ne trebam redovita sinkroniziranja.</string>
   <string name="intro_autostart_title">%s kompatibilnost</string>
@@ -77,9 +75,7 @@
   <string name="about_libraries">Bibiloteke</string>
   <string name="about_version">Verzija %1$s(%2$d)</string>
   <string name="about_build_date">Kompilirano na %s</string>
-  <string name="about_flavor_info">Ova verzija ispunjava uvjete za distribuciju samo na Google Play trgovini. </string>
   <string name="about_license_info_no_warranty">Ovaj program dolazi BEZ APSOLUTNO BILO KAKVOG JAMSTVA. To je besplatni softver i možete ga distribuirati pod određenim uvjetima. </string>
-  <string name="about_translations_thanks"><![CDATA[<i>Thanks to: </i> %s]]></string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Couldn\'t create log file</string>
   <string name="logging_notification_text">Now logging all %s activities </string>
@@ -89,7 +85,6 @@
   <string name="navigation_drawer_subtitle">CalDAV/CardDAV Sync Adapter</string>
   <string name="navigation_drawer_about">About / License</string>
   <string name="navigation_drawer_beta_feedback">Beta feedback</string>
-  <string name="install_email_client">Molimo instalirajte aplikaciju za e-poštu</string>
   <string name="install_browser">Molimo instalirajte web preglednik</string>
   <string name="navigation_drawer_settings">Postavke</string>
   <string name="navigation_drawer_news_updates">Novosti &amp; aktualnosti</string>
@@ -99,8 +94,6 @@
   <string name="navigation_drawer_faq">FAQ</string>
   <string name="navigation_drawer_privacy_policy">Pravila o zaštiti privatnosti</string>
   <string name="account_list_empty">Dobrodošli u DAVx⁵!\n\nSada možete dodati CalDAV/CardDAV račun.</string>
-  <string name="accounts_global_sync_disabled">Automatska sinkronizacija je onemogućena na razini sustava</string>
-  <string name="accounts_global_sync_enable">Omogući</string>
   <string name="accounts_sync_all">Sinkroniziraj sve račune</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">Detekcija servisa nije uspjela</string>
@@ -134,16 +127,11 @@
   <string name="app_settings_reset_hints_success">Sve naznake će ponovno biti prikazane</string>
   <string name="app_settings_integration">Integracija</string>
   <string name="app_settings_tasks_provider">Tasks aplikacija</string>
-  <string name="app_settings_tasks_provider_synchronizing_with">Sinkronizira sa %s</string>
   <string name="app_settings_tasks_provider_none">Kompatibilna aplikacija za zadatke nije pronađena</string>
   <!--AccountActivity-->
   <string name="account_carddav">CardDAV</string>
   <string name="account_caldav">CalDAV</string>
   <string name="account_webcal">Webcal</string>
-  <string name="account_no_address_books">Ne postoji adresar (još).</string>
-  <string name="account_no_calendars">Ne postoji kalendar (još).</string>
-  <string name="account_no_webcals">Ne postoje pretplate na kalendar (još).</string>
-  <string name="account_swipe_down">Povucite prstom prema dolje za osvježavanje popisa sa poslužitelja.</string>
   <string name="account_synchronize_now">Sinkroniziraj sada</string>
   <string name="account_settings">Postavke računa</string>
   <string name="account_rename">Preimenuj račun</string>
@@ -158,8 +146,6 @@
   <string name="account_calendar">kalendar</string>
   <string name="account_task_list">popis zadataka</string>
   <string name="account_only_personal">Prikaži samo osobno</string>
-  <string name="account_create_new_address_book">Kreiraj novi adresar</string>
-  <string name="account_create_new_calendar">Kreiraj novi kalendar</string>
   <string name="account_no_webcal_handler_found">Aplikacija sa Webcal mogućnostima nije pronađena</string>
   <string name="account_install_icsx5">Instaliraj ICSx⁵</string>
   <!--AddAccountActivity-->
@@ -194,7 +180,6 @@
   <string name="login_username_password_wrong">Korisničko ime (adresa e-pošte) / lozinka pogrešni?</string>
   <string name="login_view_logs">Prikaži detalje</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Postavke %s</string>
   <string name="settings_sync">Sinkronizacija</string>
   <string name="settings_sync_interval_contacts">Interval sinkr. kontakata</string>
   <string name="settings_sync_summary_manually">Samo ručno</string>
@@ -221,10 +206,8 @@
   <string name="settings_sync_wifi_only_ssids_permissions_action">Upravljaj</string>
   <string name="settings_authentication">Autentifkacija</string>
   <string name="settings_username">Korisničko ime</string>
-  <string name="settings_enter_username">Unesite korisničko ime:</string>
   <string name="settings_password">Lozinka</string>
   <string name="settings_password_summary">Ažurirajte lozinku vezanu uz vaš poslužitelj.</string>
-  <string name="settings_enter_password">Unesite svoju lozinku:</string>
   <string name="settings_certificate_install">Instaliraj certifikat</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">Vremensko ograničenje za prošli događaj</string>
@@ -322,6 +305,4 @@
   <string name="sync_invalid_task">Primljen je nevažeći zadatak sa poslužitelja</string>
   <string name="sync_invalid_resources_ignoring">Zanemarivanje jednog ili više nevaljanih resursa</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵: Sigurnost veze</string>
-  <string name="trust_certificate_unknown_certificate_found">DAVx⁵ je naišao na nepoznati certifikat. Želite li mu vjerovati?</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -29,8 +29,6 @@
   <string name="intro_slogan1">Az Ön adatai.  Az Ön döntése.</string>
   <string name="intro_slogan2">Vegye kézbe az irányítást.</string>
   <string name="intro_battery_title">Rendszeres ütemezett szinkronizálás</string>
-  <string name="intro_battery_not_whitelisted">Kikapcsolva (nem javasolt)</string>
-  <string name="intro_battery_whitelisted">Bekapcsolva (javasolt)</string>
   <string name="intro_battery_text">A rendszeres ütemezett szinkronizáláshoz a %s számára engedélyezni kell a háttérben futást, különben az Android rendszer a szinkronizálást bármikor leállíthatja.</string>
   <string name="intro_battery_dont_show">Nincs szükségem rendszeres ütemezett szinkronizálásra.*</string>
   <string name="intro_autostart_title">%s kompatibilitás</string>
@@ -68,8 +66,6 @@
   <string name="permissions_notification_status_off">Az értesítések tiltása (nem ajánlott)</string>
   <string name="permissions_notification_status_on">Értesítések engedélyezése</string>
   <string name="permissions_jtx_title">jtx Board engedélyek</string>
-  <string name="permissions_jtx_status_off">Nincsenek szinkronizálandó feladatok, naplóbejegyzések és jegyzetek</string>
-  <string name="permissions_jtx_status_on">Van lehetőség a feladatok, naplóbejegyzések és jegyzetek szinkronizálására</string>
   <string name="permissions_opentasks_title">OpenTasks engedélyek</string>
   <string name="permissions_tasksorg_title">Feladat engedélyek</string>
   <string name="permissions_tasks_status_off">Nincs feladatszinkronizálás</string>
@@ -98,9 +94,7 @@
   <string name="about_version">Verziószám:%1$s (%2$d)</string>
   <string name="about_build_date">Fordítás ideje: %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) és a közreműködők</string>
-  <string name="about_flavor_info">Ez a verzió csak a Google Play Áruházon keresztül terjeszthető</string>
   <string name="about_license_info_no_warranty">Ehhez a program SEMMIFÉLE GARANCIA NEM JÁR.   Ez a program szabad szoftver, ami a bizonyos feltételek mellett szabadon terjeszthető.</string>
-  <string name="about_translations_thanks"><![CDATA[<i>Köszönet a következőknek: </i> %s]]></string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">A naplófájl létrehozása nem sikerült</string>
   <string name="logging_notification_text">Mostantól %s minden művelete naplózásra kerül</string>
@@ -110,7 +104,6 @@
   <string name="navigation_drawer_subtitle">CalDAV/CardDAV szinkronizációs adapter</string>
   <string name="navigation_drawer_about">Névjegy / Licenc</string>
   <string name="navigation_drawer_beta_feedback">Tesztelői visszajelzés</string>
-  <string name="install_email_client">Kérjük, telepítsen egy levelező-klienst</string>
   <string name="install_browser">Kérjük, telepítsen egy böngészőt</string>
   <string name="navigation_drawer_settings">Beállítások</string>
   <string name="navigation_drawer_news_updates">Hírek és frissítések</string>
@@ -129,8 +122,6 @@
   <string name="account_list_low_storage">A rendelkezésre álló tárhely kevés.  Az Android nem fogja a helyi erőforrásokat azonnal szinkronizálni, csak a következő rendes alkalommal.</string>
   <string name="account_list_manage_storage">Tárhely kezelése</string>
   <string name="account_list_empty">Üdvözöljük a DAVx⁵ felhasználók között!\n\nMost már felvehet CalDAV/CardDav fiókokat.</string>
-  <string name="accounts_global_sync_disabled">A rendszerszintű automatikus szinkronizálás ki van kapcsolva</string>
-  <string name="accounts_global_sync_enable">Bekapcsolás</string>
   <string name="accounts_sync_all">Az összes fiók szinkronizálása</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">Szolgáltatások felderítése nem sikerült</string>
@@ -180,16 +171,11 @@
   <string name="app_settings_reset_hints_success">Az összes tipp újra meg fog jelenni</string>
   <string name="app_settings_integration">Integráció</string>
   <string name="app_settings_tasks_provider">Feladatok alkalmazás</string>
-  <string name="app_settings_tasks_provider_synchronizing_with">Szinkronizálás ezzel: %s </string>
   <string name="app_settings_tasks_provider_none">Nem található kompatibilis feladat alkalmazás</string>
   <!--AccountActivity-->
   <string name="account_carddav">CardDAV</string>
   <string name="account_caldav">CalDAV</string>
   <string name="account_webcal">Webcal</string>
-  <string name="account_no_address_books">Nincsenek címjegyzékek (még).</string>
-  <string name="account_no_calendars">Nincsenek naptárak (még).</string>
-  <string name="account_no_webcals">Nem iratkozott fel egyetlen naptárra sem (még).</string>
-  <string name="account_swipe_down">Lefelé húzással frissítse a listát a szerverről.</string>
   <string name="account_synchronize_now">Szinkronizálás most</string>
   <string name="account_settings">Fiókbeállítások</string>
   <string name="account_rename">Fiók átnevezése</string>
@@ -205,8 +191,6 @@
   <string name="account_task_list">feladatlista</string>
   <string name="account_journal">napló</string>
   <string name="account_only_personal">Csak a személyesek megjelenítése</string>
-  <string name="account_create_new_address_book">Új címjegyzék létrehozása</string>
-  <string name="account_create_new_calendar">Új naptár létrehozása</string>
   <string name="account_no_webcal_handler_found">Nem található Webcal-képes alkalmazás</string>
   <string name="account_install_icsx5">ICSx⁵ telepítése</string>
   <!--AddAccountActivity-->
@@ -261,7 +245,6 @@
   <string name="login_username_password_wrong">Felhasználónév (e-mail cím) vagy jelszó hibás?</string>
   <string name="login_view_logs">Részletek mutatása</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Beállítások: %s</string>
   <string name="settings_sync">Szinkronizálás</string>
   <string name="settings_sync_interval_contacts">Névjegyszinkronizálás sűrűsége</string>
   <string name="settings_sync_summary_manually">Manuális</string>
@@ -293,10 +276,8 @@
   <string name="settings_oauth">Autentikáció megismétlése</string>
   <string name="settings_oauth_summary">Az OAuth bejelentkezés megismétlése</string>
   <string name="settings_username">Felhasználónév</string>
-  <string name="settings_enter_username">Adja meg a felhasználónevet:</string>
   <string name="settings_password">Jelszó</string>
   <string name="settings_password_summary">Adja meg a szerveren érvényes új jelszót.</string>
-  <string name="settings_enter_password">Adja meg a jelszót:</string>
   <string name="settings_certificate_install">Tanúsítvány telepítése</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">Múltbéli események időkorlátja</string>
@@ -418,6 +399,4 @@
   <string name="sync_invalid_task">A szerver érvénytelen feladatot küldött</string>
   <string name="sync_invalid_resources_ignoring">Egy vagy több érvénytelen erőforrás kihagyva</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵: kapcsolatbiztonság</string>
-  <string name="trust_certificate_unknown_certificate_found">Egy eddig ismeretlen tanúsítvány érkezett.  Megbízhatónak kívánja elfogadni?</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -27,8 +27,6 @@
   <string name="intro_slogan1">Tuoi i dati. Tua la scelta.</string>
   <string name="intro_slogan2">Riprendi il controllo.</string>
   <string name="intro_battery_title">Intervalli di sincronizzazione regolari.</string>
-  <string name="intro_battery_not_whitelisted">Disabilitato (sconsigliato)</string>
-  <string name="intro_battery_whitelisted">Abilitato (scelta consigliata)</string>
   <string name="intro_battery_text">Per sincronizzare i dati a intervalli regolari, %s deve essere autorizzato a girare in background. Altrimenti Android può mettere in pausa gli aggiornamenti in qualunque momento.</string>
   <string name="intro_battery_dont_show">Non ho bisogno di sincronizzare a intervalli di tempo regolari.*</string>
   <string name="intro_autostart_title">%s compatibilità</string>
@@ -90,9 +88,7 @@
   <string name="about_version">Versione %1$s (%2$d)</string>
   <string name="about_build_date">Compilato su %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) e contibutori</string>
-  <string name="about_flavor_info">Questa versione è idonea solo per la distribuzione tramite Google Play</string>
   <string name="about_license_info_no_warranty">Il programma è distribuito SENZA ALCUNA GARANZIA. È software libero e può essere redistribuito sotto alcune condizioni.</string>
-  <string name="about_translations_thanks"><![CDATA[<i>Grazie a: </i>%s]]></string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Impossibile creare il file di log</string>
   <string name="logging_notification_text">Adesso l\'accesso all\' %s delle attività </string>
@@ -102,7 +98,6 @@
   <string name="navigation_drawer_subtitle">CalDAV/CardDAV adattatore di sincronizzazione</string>
   <string name="navigation_drawer_about">Informazioni / Licenza</string>
   <string name="navigation_drawer_beta_feedback">Feedback sulla beta</string>
-  <string name="install_email_client">Installare un client email</string>
   <string name="install_browser">Installare un browser Web</string>
   <string name="navigation_drawer_settings">Impostazioni</string>
   <string name="navigation_drawer_news_updates">Notizie &amp; aggiornamenti</string>
@@ -114,8 +109,6 @@
   <string name="navigation_drawer_community">Comunità</string>
   <string name="navigation_drawer_privacy_policy">Politica sulla riservatezza</string>
   <string name="account_list_empty">Benvenuto a DAVx⁵!\n\nÈ ora possibile aggiungere account CalDAV/CardDAV.</string>
-  <string name="accounts_global_sync_disabled">La sincronizzazione automatica dell\'intero sistema è disabilitata</string>
-  <string name="accounts_global_sync_enable">Attiva</string>
   <string name="accounts_sync_all">Sincronizzazione di tutti gli account</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">Impossibile trovare il servizio</string>
@@ -165,16 +158,11 @@
   <string name="app_settings_reset_hints_success">I suggerimenti verranno mostrati</string>
   <string name="app_settings_integration">Integrazione</string>
   <string name="app_settings_tasks_provider">Funzioni dell\'applicazione</string>
-  <string name="app_settings_tasks_provider_synchronizing_with">Sincronizzazione con %s</string>
   <string name="app_settings_tasks_provider_none">Nessuna applicazione compatibile con e funzionalità trovata</string>
   <!--AccountActivity-->
   <string name="account_carddav">CardDAV</string>
   <string name="account_caldav">CalDAV</string>
   <string name="account_webcal">Webcal</string>
-  <string name="account_no_address_books">Non ci sono rubriche indirizzi (ancora)</string>
-  <string name="account_no_calendars">Non ci sono calendari (ancora)</string>
-  <string name="account_no_webcals">Non ci sono sottoscrizioni a calendari (ancora)</string>
-  <string name="account_swipe_down">Scorri in basso per aggiornare la lista dal server</string>
   <string name="account_synchronize_now">Sincronizza adesso</string>
   <string name="account_settings">Impostazioni account</string>
   <string name="account_rename">Rinomina account</string>
@@ -189,8 +177,6 @@
   <string name="account_calendar">calendario</string>
   <string name="account_task_list">elenco attività</string>
   <string name="account_only_personal">Mostra solo personale</string>
-  <string name="account_create_new_address_book">Crea un nuovo indirizzario</string>
-  <string name="account_create_new_calendar">Crea nuovo calendario</string>
   <string name="account_no_webcal_handler_found">Non ho trovato nessuna applicazione abilitata per Webcal</string>
   <string name="account_install_icsx5">Installa ICSx⁵</string>
   <!--AddAccountActivity-->
@@ -231,7 +217,6 @@
   <string name="login_username_password_wrong">Nome utente (indirizzo email) / password sbagliata?</string>
   <string name="login_view_logs">Visualizza dettagli</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Impostazioni: %s</string>
   <string name="settings_sync">Sincronizzazione</string>
   <string name="settings_sync_interval_contacts">Intervallo sincr. Contatti</string>
   <string name="settings_sync_summary_manually">Solo manualmente</string>
@@ -261,10 +246,8 @@
   <string name="settings_ignore_vpns_off">La VPN senza una connessione internet validata è sufficiente per lanciare la sincronizzazione</string>
   <string name="settings_authentication">Autenticazione</string>
   <string name="settings_username">Nome utente</string>
-  <string name="settings_enter_username">Inserisci nome utente:</string>
   <string name="settings_password">Password</string>
   <string name="settings_password_summary">Aggiorna la password come sul tuo server.</string>
-  <string name="settings_enter_password">Inserisci la tua password:</string>
   <string name="settings_certificate_install">Installa il certificato</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">Limite di tempo per gli eventi trascorsi</string>
@@ -384,6 +367,4 @@ Lasciare vuoto per non creare un promemoria predefinito.</string>
   <string name="sync_invalid_task">Attività non valida ricevuta dal server</string>
   <string name="sync_invalid_resources_ignoring">Una o più risorse non valide ignorate</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵: sicurezza della connessione</string>
-  <string name="trust_certificate_unknown_certificate_found">DAVx⁵ ha trovato un certificato sconosciuto. Ritenerlo affidabile?</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -30,8 +30,6 @@
   <string name="intro_slogan1">あなたのデータはあなたの手に</string>
   <string name="intro_slogan2">コントロールを始める</string>
   <string name="intro_battery_title">一定の間隔で同期</string>
-  <string name="intro_battery_not_whitelisted">無効 (非推奨)</string>
-  <string name="intro_battery_whitelisted">有効 (推奨)</string>
   <string name="intro_battery_text">一定の間隔で同期するには、%s のバックグラウンドでの動作を許可する必要があります。許可しない場合、Android によって同期が停止されることがあります。</string>
   <string name="intro_battery_dont_show">一定間隔での同期は不要です*</string>
   <string name="intro_autostart_title">%s 適合性</string>
@@ -69,8 +67,6 @@
   <string name="permissions_notification_status_off">通知が無効です (非推奨)</string>
   <string name="permissions_notification_status_on">通知が有効です</string>
   <string name="permissions_jtx_title">jtx Board へのアクセス</string>
-  <string name="permissions_jtx_status_off">ジャーナル、メモ、タスクを同期しない</string>
-  <string name="permissions_jtx_status_on">ジャーナル、メモ、タスクを同期できます</string>
   <string name="permissions_opentasks_title">OpenTasks へのアクセス</string>
   <string name="permissions_tasksorg_title">Tasks へのアクセス</string>
   <string name="permissions_tasks_status_off">タスクを同期しない</string>
@@ -101,9 +97,7 @@
   <string name="about_version">バージョン %1$s (%2$d)</string>
   <string name="about_build_date">コンパイル日時 %s</string>
   <string name="about_copyright">© Ricki Hirner、Bernhard Stockmann (bitfire web engineering GmbH) と貢献者</string>
-  <string name="about_flavor_info">このバージョンは Google Play での配信にのみ対応しています。</string>
   <string name="about_license_info_no_warranty">このプログラムは完全に無保証で提供されます。これはフリーソフトウェアで、特定の条件下での再頒布を歓迎します。</string>
-  <string name="about_translations_thanks"><![CDATA[<i>Thanks to: </i> %s]]></string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">ログファイルを作成できませんでした</string>
   <string name="logging_notification_text">%s のすべてのアクティビティのログを記録しています</string>
@@ -113,7 +107,6 @@
   <string name="navigation_drawer_subtitle">CalDAV/CardDAV 同期アダプター</string>
   <string name="navigation_drawer_about">アプリについて / ライセンス</string>
   <string name="navigation_drawer_beta_feedback">ベータフィードバック</string>
-  <string name="install_email_client">メールクライアントをインストールしてください</string>
   <string name="install_browser">ウェブブラウザをインストールしてください</string>
   <string name="navigation_drawer_settings">設定</string>
   <string name="navigation_drawer_news_updates">ニュース &amp; アップデート</string>
@@ -136,8 +129,6 @@
   <string name="account_list_low_storage">ストレージの容量が残りわずかです。Android はローカルの変更を即座に同期しませんが、次の通常サイクルで同期します。</string>
   <string name="account_list_manage_storage">ストレージを管理</string>
   <string name="account_list_empty">DAVx⁵ にようこそ！\n\nCalDAV/CardDAV アカウントを追加できるようになりました。</string>
-  <string name="accounts_global_sync_disabled">システム全体の自動同期が無効です</string>
-  <string name="accounts_global_sync_enable">有効</string>
   <string name="accounts_sync_all">すべてのアカウントを同期</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">サービスの検出に失敗しました</string>
@@ -189,7 +180,6 @@
   <string name="app_settings_reset_hints_success">すべてのヒントを再表示します</string>
   <string name="app_settings_integration">統合</string>
   <string name="app_settings_tasks_provider">タスク管理アプリ</string>
-  <string name="app_settings_tasks_provider_synchronizing_with">%s と同期しています</string>
   <string name="app_settings_tasks_provider_none">連携できるアプリがありません</string>
   <!--AccountActivity-->
   <string name="account_carddav">CardDAV</string>
@@ -197,10 +187,6 @@
   <string name="account_webcal">Webcal</string>
   <string name="account_missing_permissions">これらのコレクションを同期するには、追加の権限が必要です。</string>
   <string name="account_manage_permissions">権限を管理</string>
-  <string name="account_no_address_books">アドレス帳は (まだ) ありません。</string>
-  <string name="account_no_calendars">カレンダーは (まだ) ありません。</string>
-  <string name="account_no_webcals">カレンダーのサブスクリプションは (まだ) ありません。</string>
-  <string name="account_swipe_down">下にスワイプすると、サーバーからリストを再読み込みします。</string>
   <string name="account_synchronize_now">今すぐ同期</string>
   <string name="account_settings">アカウント設定</string>
   <string name="account_rename">アカウントの名前を変更</string>
@@ -220,8 +206,6 @@
   <string name="account_only_personal">プライベートのみ表示</string>
   <string name="account_refresh_collections">コレクションを再読み込み</string>
   <string name="account_refreshing_collections">コレクションリストを再読み込みしています</string>
-  <string name="account_create_new_address_book">新しいアドレス帳を作成</string>
-  <string name="account_create_new_calendar">新しいカレンダーを作成</string>
   <string name="account_webcal_external_app">Webcal の購読は外部アプリで同期できます。</string>
   <string name="account_no_webcal_handler_found">Webcal に対応するアプリが見つかりませんでした</string>
   <string name="account_install_icsx5">ICSx⁵ をインストール</string>
@@ -277,7 +261,6 @@
   <string name="login_username_password_wrong">ユーザー名 (メールアドレス) / パスワード が間違っていませんか？</string>
   <string name="login_view_logs">詳細を表示</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">設定: %s</string>
   <string name="settings_sync">同期</string>
   <string name="settings_sync_interval_contacts">連絡先の同期間隔</string>
   <string name="settings_sync_summary_manually">手動のみ</string>
@@ -309,10 +292,8 @@
   <string name="settings_oauth">再認証</string>
   <string name="settings_oauth_summary">もう一度 OAuth ログインを実行</string>
   <string name="settings_username">ユーザー名</string>
-  <string name="settings_enter_username">ユーザー名を入力:</string>
   <string name="settings_password">パスワード</string>
   <string name="settings_password_summary">ご利用のサーバーに従ってパスワードを更新します。</string>
-  <string name="settings_enter_password">パスワードを入力:</string>
   <string name="settings_certificate_alias">クライアント証明書</string>
   <string name="settings_certificate_alias_empty">クライアント証明書が使用できないか、選択されていません</string>
   <string name="settings_certificate_install">証明書をインストール</string>
@@ -436,6 +417,4 @@
   <string name="sync_invalid_task">サーバーから無効なタスクを受信しました</string>
   <string name="sync_invalid_resources_ignoring">1 件または複数の無効なリソースを無視します</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵: 接続セキュリティ</string>
-  <string name="trust_certificate_unknown_certificate_found">DAVx⁵ が未知の証明書を検出しました。信頼しますか？</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -24,8 +24,6 @@
   <string name="intro_slogan1">당신의 데이터. 당신의 선택.</string>
   <string name="intro_slogan2">관리.</string>
   <string name="intro_battery_title">정기적 동기화 주기</string>
-  <string name="intro_battery_not_whitelisted">사용 안 함(권장하지 않음)</string>
-  <string name="intro_battery_whitelisted">사용(권장)</string>
   <string name="intro_battery_text">정기적으로 동기화하려면 백그라운드에서 %s이 실행되도록 허용해야 합니다. 그렇지 않으면 Android는 언제든지 동기화를 일시 중지할 수 있습니다.</string>
   <string name="intro_battery_dont_show">나는 정기적인 동기화 주기가 필요하지 않다.*</string>
   <string name="intro_autostart_title">%s 호환성</string>
@@ -58,8 +56,6 @@
   <string name="permissions_calendar_status_off">캘린더 동기화 없음(권장하지 않음)</string>
   <string name="permissions_calendar_status_on">캘린더를 동기화 할 수 있음</string>
   <string name="permissions_jtx_title">jtx Board 권한</string>
-  <string name="permissions_jtx_status_off">동기화할 작업, 일지, 노트가 없음</string>
-  <string name="permissions_jtx_status_on">동기회 가능한 작업, 일지, 노트</string>
   <string name="permissions_opentasks_title">OpenTasks 권한</string>
   <string name="permissions_tasksorg_title">작업 권한</string>
   <string name="permissions_tasks_status_off">할일 목록 동기화 하지않음</string>
@@ -88,9 +84,7 @@
   <string name="about_version">버전 %1$s (%2$d)</string>
   <string name="about_build_date">%s에서 컴파일</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) and contributors</string>
-  <string name="about_flavor_info">이 버전은 Google Play를 통해서만 배포될 수 있습니다.</string>
   <string name="about_license_info_no_warranty">이 프로그램은 보증 없이 제공됩니다. 그것은 무료 소프트웨어이며, 특정한 조건 하에서 재배포하는 것을 환영합니다.</string>
-  <string name="about_translations_thanks"><![CDATA[<i>Thanks to:</i> %s]]></string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">log file을 만들 수 없습니다.</string>
   <string name="logging_notification_text">이제 모든 %s 활동을 logging합니다.</string>
@@ -100,7 +94,6 @@
   <string name="navigation_drawer_subtitle">CalDAV/CardDAV 동기화 어댑터</string>
   <string name="navigation_drawer_about">관련 / 라이센스</string>
   <string name="navigation_drawer_beta_feedback">베타 피드백</string>
-  <string name="install_email_client">이메일 클라이언트를 설치하십시오.</string>
   <string name="install_browser">웹 브라우저를 설치해 주십시오.</string>
   <string name="navigation_drawer_settings">설정</string>
   <string name="navigation_drawer_news_updates">뉴스 &amp; 업데이트</string>
@@ -113,8 +106,6 @@
   <string name="navigation_drawer_privacy_policy">개인 정보 보호 정책</string>
   <string name="account_list_empty">DAVx⁵에 오신 것을 환영 합니다!/n/n
 당신은  CalDAV/CardDAV 계정을 지금 추가 할 수 있습니다.</string>
-  <string name="accounts_global_sync_disabled">시스템 전체 자동 동기화가 비활성화됩니다.</string>
-  <string name="accounts_global_sync_enable">활성</string>
   <string name="accounts_sync_all">모든 계정 동기화</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">서비스 검색 실패</string>
@@ -164,16 +155,11 @@
   <string name="app_settings_reset_hints_success">모든 힌트가 다시 표기</string>
   <string name="app_settings_integration">통합</string>
   <string name="app_settings_tasks_provider">테스크 앱</string>
-  <string name="app_settings_tasks_provider_synchronizing_with">%s과 동기화</string>
   <string name="app_settings_tasks_provider_none">호환되는 작업 앱을 찾을 수 없습니다.</string>
   <!--AccountActivity-->
   <string name="account_carddav">CardDAV</string>
   <string name="account_caldav">CalDAV</string>
   <string name="account_webcal">Webcal</string>
-  <string name="account_no_address_books">주소록이 없다. (yet)</string>
-  <string name="account_no_calendars">캘린더가 없다.(yet)</string>
-  <string name="account_no_webcals">구독하는 캘린더가 없습니다. (yet)</string>
-  <string name="account_swipe_down">서버에서 목록을 새로 고치려면 아래로 스와이프하세요.</string>
   <string name="account_synchronize_now">동기화</string>
   <string name="account_settings">계정 설정</string>
   <string name="account_rename">계정 이름 바꾸기</string>
@@ -189,8 +175,6 @@
   <string name="account_task_list">할일 목록</string>
   <string name="account_journal">일지</string>
   <string name="account_only_personal">개인만 표시</string>
-  <string name="account_create_new_address_book">새 주소록 만들기</string>
-  <string name="account_create_new_calendar">새 캘린더 작성</string>
   <string name="account_no_webcal_handler_found">Webcal 지원 앱을 찾을 수 없습니다.</string>
   <string name="account_install_icsx5">ICSx⁵를 설치합니다.</string>
   <!--AddAccountActivity-->
@@ -226,7 +210,6 @@
   <string name="login_username_password_wrong">사용자 이름 (email address) / 비밀번호 가 잘못되었습니까?</string>
   <string name="login_view_logs">자세히</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">설정: %s</string>
   <string name="settings_sync">동기화</string>
   <string name="settings_sync_interval_contacts">주기적 연락처 동기화 </string>
   <string name="settings_sync_summary_manually">직접 선택</string>
@@ -253,10 +236,8 @@
   <string name="settings_sync_wifi_only_ssids_permissions_action">관리</string>
   <string name="settings_authentication">인증</string>
   <string name="settings_username">사용자 이름</string>
-  <string name="settings_enter_username">사용자 이름 입력:</string>
   <string name="settings_password">비밀번호</string>
   <string name="settings_password_summary">귀하의 서버에  비밀번호 업데이트.</string>
-  <string name="settings_enter_password">비밀번호를 입력:</string>
   <string name="settings_certificate_install">인증서 설치</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">지난 이벤트 시간 제한</string>
@@ -371,6 +352,4 @@
   <string name="sync_invalid_task">서버에서 잘못된 작업을 수신했습니다.</string>
   <string name="sync_invalid_resources_ignoring">하나 이상의 잘못된 리소스 무시</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx²: 연결 보안</string>
-  <string name="trust_certificate_unknown_certificate_found">DAVx®에서 알 수 없는 인증서를 발견했습니다. 신뢰할 수 있습니까?</string>
 </resources>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -20,7 +20,6 @@
   <string name="about_libraries">Bibliotek</string>
   <string name="about_version">Versjon %1$s(%2$d)</string>
   <string name="about_build_date">Kompilert på %s</string>
-  <string name="about_flavor_info">Denne versjonen kan bare distribueres over Google Play.</string>
   <string name="about_license_info_no_warranty">Dette programmet kommer uten NOEN FORM FOR GARANTI. Det er fri programvare, og du er velkommen til å redistribuere det under gitte forhold.</string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Kan ikke opprette loggfil</string>
@@ -39,8 +38,6 @@
   <string name="navigation_drawer_forums">Hjelp / Forum</string>
   <string name="navigation_drawer_donate">Doner</string>
   <string name="account_list_empty">Velkommen til DAVx⁵.\n\nDu kan legge til en CalDAV/CardDAV-konto nå.</string>
-  <string name="accounts_global_sync_disabled">Systemomspennende automatisk synkronisering avskrudd</string>
-  <string name="accounts_global_sync_enable">Skru på</string>
   <!--DavService-->
   <string name="dav_service_refresh_failed">Tjenesteoppdagelse mislyktes</string>
   <string name="dav_service_refresh_couldnt_refresh">Kunne ikke gjenoppfriske innsamlingsliste</string>
@@ -75,10 +72,6 @@
   <string name="account_carddav">CardDAV</string>
   <string name="account_caldav">CalDAV</string>
   <string name="account_webcal">Webcal</string>
-  <string name="account_no_address_books">Det eksisterer ingen adressebøker (enda).</string>
-  <string name="account_no_calendars">Det eksisterer ingen kalendere (enda).</string>
-  <string name="account_no_webcals">Du abonnerer ikke på noen kalendere (enda).</string>
-  <string name="account_swipe_down">Dra ned for å oppdatere listen fra serveren.</string>
   <string name="account_synchronize_now">Synkroniser nå</string>
   <string name="account_synchronizing_now">Synkroniserer nå</string>
   <string name="account_settings">Kontoinnstillinger</string>
@@ -93,9 +86,7 @@
   <string name="account_calendar">kalender</string>
   <string name="account_task_list">oppgaveliste</string>
   <string name="account_refresh_address_book_list">Gjenoppfrisk adressebokliste</string>
-  <string name="account_create_new_address_book">Opprett ny adressebok</string>
   <string name="account_refresh_calendar_list">Gjenoppfrisk kalenderliste</string>
-  <string name="account_create_new_calendar">Opprett ny kalender</string>
   <string name="account_no_webcal_handler_found">Fant ingen programmer med støtte for Webcal</string>
   <string name="account_install_icsx5">Installer ICSx⁵</string>
   <!--AddAccountActivity-->
@@ -123,7 +114,6 @@
   <string name="login_no_caldav_carddav">Fant ikke CalDAV eller CardDAV-tjeneste.</string>
   <string name="login_view_logs">Vis fler detaljer</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Innstillinger: %s</string>
   <string name="settings_sync">Synkronisering</string>
   <string name="settings_sync_interval_contacts">Intervall for kontaktsynkronisering</string>
   <string name="settings_sync_summary_manually">Åpne manuelt</string>
@@ -150,10 +140,8 @@
   <string name="settings_more_info_faq">Mer informasjon (FAQ)</string>
   <string name="settings_authentication">Identitetsbekreftelse</string>
   <string name="settings_username">Brukernavn</string>
-  <string name="settings_enter_username">Skriv inn brukernavn:</string>
   <string name="settings_password">Passord</string>
   <string name="settings_password_summary">Oppdater passordet i henhold til din tjener.</string>
-  <string name="settings_enter_password">Skriv inn passordet ditt:</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">Tidsgrense for tidligere hendelser</string>
   <string name="settings_sync_time_range_past_none">Alle gjøremål vil bli synkronisert</string>
@@ -209,6 +197,4 @@
   <string name="sync_error_retry">Forsøk igjen</string>
   <string name="sync_invalid_contact">Fikk ugyldig kontakt fra server</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵: Tilkoblingssikkerhet</string>
-  <string name="trust_certificate_unknown_certificate_found">DAVx⁵ har støtt på et ukjent sertifikat. Har du tiltro til det?</string>
 </resources>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -23,7 +23,6 @@
   <string name="about_libraries">Bibliotek</string>
   <string name="about_version">Versjon %1$s(%2$d)</string>
   <string name="about_build_date">Kompilert på %s</string>
-  <string name="about_flavor_info">Denne versjonen kan bare distribueres over Google Play.</string>
   <string name="about_license_info_no_warranty">Dette programmet kommer uten NOEN FORM FOR GARANTI. Det er fri programvare, og du er velkommen til å redistribuere det under gitte forhold.</string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Kan ikke opprette loggfil</string>
@@ -38,8 +37,6 @@
   <string name="navigation_drawer_manual">Manuell</string>
   <string name="navigation_drawer_faq">O-S-S</string>
   <string name="account_list_empty">Velkommen til DAVx⁵.\n\nDu kan legge til en CalDAV/CardDAV-konto nå.</string>
-  <string name="accounts_global_sync_disabled">Systemomspennende automatisk synkronisering avskrudd</string>
-  <string name="accounts_global_sync_enable">Skru på</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">Tjenesteoppdagelse mislyktes</string>
   <string name="refresh_collections_worker_refresh_couldnt_refresh">Kunne ikke gjenoppfriske innsamlingsliste</string>
@@ -69,10 +66,6 @@
   <string name="account_carddav">CardDAV</string>
   <string name="account_caldav">CalDAV</string>
   <string name="account_webcal">Webcal</string>
-  <string name="account_no_address_books">Det eksisterer ingen adressebøker (enda).</string>
-  <string name="account_no_calendars">Det eksisterer ingen kalendere (enda).</string>
-  <string name="account_no_webcals">Du abonnerer ikke på noen kalendere (enda).</string>
-  <string name="account_swipe_down">Dra ned for å oppdatere listen fra serveren.</string>
   <string name="account_synchronize_now">Synkroniser nå</string>
   <string name="account_settings">Kontoinnstillinger</string>
   <string name="account_rename">Gi konto nytt navn</string>
@@ -85,8 +78,6 @@
   <string name="account_read_only">kun lesbar</string>
   <string name="account_calendar">kalender</string>
   <string name="account_task_list">oppgaveliste</string>
-  <string name="account_create_new_address_book">Opprett ny adressebok</string>
-  <string name="account_create_new_calendar">Opprett ny kalender</string>
   <string name="account_no_webcal_handler_found">Fant ingen programmer med støtte for Webcal</string>
   <string name="account_install_icsx5">Installer ICSx⁵</string>
   <!--AddAccountActivity-->
@@ -114,7 +105,6 @@
   <string name="login_no_caldav_carddav">Fant ikke CalDAV eller CardDAV-tjeneste.</string>
   <string name="login_view_logs">Vis fler detaljer</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Innstillinger: %s</string>
   <string name="settings_sync">Synkronisering</string>
   <string name="settings_sync_interval_contacts">Intervall for kontaktsynkronisering</string>
   <string name="settings_sync_summary_manually">Åpne manuelt</string>
@@ -139,10 +129,8 @@
   <string name="settings_sync_wifi_only_ssids_message">Kommainndelte navn (SSID-er) på tillatte Wi-Fi -nettverk (la stå tomt for alle)</string>
   <string name="settings_authentication">Identitetsbekreftelse</string>
   <string name="settings_username">Brukernavn</string>
-  <string name="settings_enter_username">Skriv inn brukernavn:</string>
   <string name="settings_password">Passord</string>
   <string name="settings_password_summary">Oppdater passordet i henhold til din tjener.</string>
-  <string name="settings_enter_password">Skriv inn passordet ditt:</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">Tidsgrense for tidligere hendelser</string>
   <string name="settings_sync_time_range_past_none">Alle gjøremål vil bli synkronisert</string>
@@ -195,6 +183,4 @@
   <string name="sync_error_local_storage">Feil med lokallagring - %s</string>
   <string name="sync_invalid_contact">Fikk ugyldig kontakt fra server</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵: Tilkoblingssikkerhet</string>
-  <string name="trust_certificate_unknown_certificate_found">DAVx⁵ har støtt på et ukjent sertifikat. Har du tiltro til det?</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -29,8 +29,6 @@
   <string name="intro_slogan1">Jouw gegevens. Jouw keuze.</string>
   <string name="intro_slogan2">Houd zelf de controle</string>
   <string name="intro_battery_title">regelmatige sync-intervallen</string>
-  <string name="intro_battery_not_whitelisted">Uitgeschakeld (niet aanbevolen)</string>
-  <string name="intro_battery_whitelisted">Ingeschakeld (aanbevolen)</string>
   <string name="intro_battery_text">Om op gezette tijden te synchroniseren moet %s zonder beperking op de achtergrond kunnen draaien. Anders kan Android het synchroniseren op elk moment onderbreken.</string>
   <string name="intro_battery_dont_show">Synchroniseren op gezette tijden is niet nodig.*</string>
   <string name="intro_autostart_title">%s compatibiliteit</string>
@@ -68,8 +66,6 @@
   <string name="permissions_notification_status_off">Meldingen uitgeschakeld (niet aanbevolen)</string>
   <string name="permissions_notification_status_on">Meldingen ingeschakeld</string>
   <string name="permissions_jtx_title">jtx Board-rechten</string>
-  <string name="permissions_jtx_status_off">Geen taak-, kalender- en notitiesync</string>
-  <string name="permissions_jtx_status_on">Taak-, kalender- en notitie-sync mogelijk</string>
   <string name="permissions_opentasks_title">OpenTasks rechten</string>
   <string name="permissions_tasksorg_title">Rechten voor taken</string>
   <string name="permissions_tasks_status_off">Geen taak-sync</string>
@@ -98,9 +94,7 @@
   <string name="about_version">Versie%1$s (%2$d)</string>
   <string name="about_build_date">Gecompileerd op %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) en bijdragers</string>
-  <string name="about_flavor_info">Deze versie is enkel beschikbaar in Google Play</string>
   <string name="about_license_info_no_warranty">Dit programma wordt geleverd met ABSOLUUT GEEN GARANTIE. Het is gratis software, en mag opnieuw worden verspreid onder bepaalde voorwaarden.</string>
-  <string name="about_translations_thanks"><![CDATA[<i>Dank aan: </i> %s]]></string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Kon geen logbestand aanmaken</string>
   <string name="logging_notification_text">Logt nu alle %s activiteiten</string>
@@ -110,7 +104,6 @@
   <string name="navigation_drawer_subtitle">CalDAV/CardDAV Sync adapter</string>
   <string name="navigation_drawer_about">Over / Licentie</string>
   <string name="navigation_drawer_beta_feedback">Beta terugkoppeling</string>
-  <string name="install_email_client">E-mailprogramma is vereist</string>
   <string name="install_browser">Webbrowser is vereist</string>
   <string name="navigation_drawer_settings">Instellingen</string>
   <string name="navigation_drawer_news_updates">Nieuws &amp; updates</string>
@@ -131,8 +124,6 @@
   <string name="account_list_low_storage">Weinig opslagruimte. Android zal lokale wijzigingen niet onmiddellijk synchroniseren, maar tijdens de volgende reguliere synchronisatie.</string>
   <string name="account_list_manage_storage">Opslag beheren</string>
   <string name="account_list_empty">Welkom bij DAVx⁵!\n\nJe kunt nu een CalDAV/CardDAV account toevoegen.</string>
-  <string name="accounts_global_sync_disabled">Automatisch synchroniseren is voor alle accounts uitgeschakeld</string>
-  <string name="accounts_global_sync_enable">Inschakelen</string>
   <string name="accounts_sync_all">Alle accounts synchroniseren</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">Service herkenning is mislukt</string>
@@ -182,16 +173,11 @@
   <string name="app_settings_reset_hints_success">Alle hints opnieuw weergeven</string>
   <string name="app_settings_integration">Integratie</string>
   <string name="app_settings_tasks_provider">Taken app</string>
-  <string name="app_settings_tasks_provider_synchronizing_with">Synchroniseren met %s</string>
   <string name="app_settings_tasks_provider_none">Geen compatibele taken app gevonden</string>
   <!--AccountActivity-->
   <string name="account_carddav">CardDAV</string>
   <string name="account_caldav">CalDAV</string>
   <string name="account_webcal">Webcal</string>
-  <string name="account_no_address_books">Er zijn (nog) geen adresboeken.</string>
-  <string name="account_no_calendars">Er zijn (nog) geen kalenders.</string>
-  <string name="account_no_webcals">Er zijn (nog) geen kalender abonnementen.</string>
-  <string name="account_swipe_down">Omlaag vegen om de lijst van de server te actualiseren.</string>
   <string name="account_synchronize_now">Nu synchroniseren</string>
   <string name="account_settings">Account instellingen</string>
   <string name="account_rename">Naam account wijzigen</string>
@@ -209,8 +195,6 @@
   <string name="account_task_list">takenlijst</string>
   <string name="account_journal">logboek</string>
   <string name="account_only_personal">Alleen persoonlijk tonen</string>
-  <string name="account_create_new_address_book">Nieuw adresboek maken</string>
-  <string name="account_create_new_calendar">Nieuwe kalender maken</string>
   <string name="account_no_webcal_handler_found">Geen Webcal-app gevonden</string>
   <string name="account_install_icsx5">ICSx⁵ installeren</string>
   <!--AddAccountActivity-->
@@ -265,7 +249,6 @@
   <string name="login_username_password_wrong">Is gebruikersnaam (e-mailadres) / wachtwoord verkeerd?</string>
   <string name="login_view_logs">Details weergeven</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Instellingen: %s</string>
   <string name="settings_sync">Synchronisatie</string>
   <string name="settings_sync_interval_contacts">Contacten synchronisatie interval</string>
   <string name="settings_sync_summary_manually">Alleen handmatig</string>
@@ -297,10 +280,8 @@
   <string name="settings_oauth">Opnieuw authenticeren</string>
   <string name="settings_oauth_summary">Voer OAuth-aanmelding opnieuw uit</string>
   <string name="settings_username">Gebruikersnaam</string>
-  <string name="settings_enter_username">Gebruikersnaam invoeren:</string>
   <string name="settings_password">Wachtwoord</string>
   <string name="settings_password_summary">Gebruik het zelfde wachtwoord als op de server.</string>
-  <string name="settings_enter_password">Wachtwoord invoeren:</string>
   <string name="settings_certificate_install">Certificaat installeren</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">Gebeurtenissen in verleden tijd</string>
@@ -424,6 +405,4 @@
   <string name="sync_invalid_task">Ongeldige taak ontvangen van server</string>
   <string name="sync_invalid_resources_ignoring">Een of meer ongeldige bronnen negeren</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵: Beveiliging van de verbinding</string>
-  <string name="trust_certificate_unknown_certificate_found">DAVx⁵ is een onbekend certificaat tegengekomen. Moet het vertrouwd worden?</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -29,8 +29,6 @@
   <string name="intro_slogan1">Twoje dane. Twój wybór.</string>
   <string name="intro_slogan2">Przejmij kontrolę.</string>
   <string name="intro_battery_title">Regularne przedziały synchronizacji</string>
-  <string name="intro_battery_not_whitelisted">Wyłączone (nie rekomendowane)</string>
-  <string name="intro_battery_whitelisted">Włączone (rekomendowane)</string>
   <string name="intro_battery_text">Dla synchronizacji w regularnych przedziałach, %s musi mieć pozwolenie na pracę w tle. W przeciwnym razie, Android może wstrzymać synchronizację w dowolnym momencie.</string>
   <string name="intro_battery_dont_show">Nie potrzebuję regularnych przedziałów synchronizacji.*</string>
   <string name="intro_autostart_title">%s kompatybilność</string>
@@ -68,8 +66,6 @@
   <string name="permissions_notification_status_off">Powiadomienia wyłączone (niezalecane)</string>
   <string name="permissions_notification_status_on">Powiadomienia włączone</string>
   <string name="permissions_jtx_title">Uprawnienia jtx Board</string>
-  <string name="permissions_jtx_status_off">Brak synchronizacji zadań, dzienników, notatek</string>
-  <string name="permissions_jtx_status_on">Możliwa synchronizacja zadań, dzienników, notatek</string>
   <string name="permissions_opentasks_title">Uprawnienia OpenTasks</string>
   <string name="permissions_tasksorg_title">Uprawnienia zadań</string>
   <string name="permissions_tasks_status_off">Brak synchronizacji zadań</string>
@@ -98,9 +94,7 @@
   <string name="about_version">Wersja %1$s (%2$d)</string>
   <string name="about_build_date">Skompilowano %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) i współpracownicy</string>
-  <string name="about_flavor_info">Ta wersja jest przeznaczona do dystrybucji wyłączenie poprzez Google Play.</string>
   <string name="about_license_info_no_warranty">Ten program jest ABSOLUTNIE BEZ GWARANCJI. To jest wolne oprogramowanie i mile widziane jest dalsze rozpowszechnianie go zgodnie z warunkami licencji.</string>
-  <string name="about_translations_thanks"><![CDATA[<i>Dzięki życzliwości: </i> %s]]></string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Nie udało się utworzyć pliku logu</string>
   <string name="logging_notification_text">Obecnie zapisywane są wszystkie %s aktywności</string>
@@ -110,7 +104,6 @@
   <string name="navigation_drawer_subtitle">Adapter synchronizacji CalDAV/CardDAV</string>
   <string name="navigation_drawer_about">Informacje/Licencja</string>
   <string name="navigation_drawer_beta_feedback">Przekaż opinię</string>
-  <string name="install_email_client">Proszę zainstalować klienta poczty elektronicznej</string>
   <string name="install_browser">Proszę zainstalować przeglądarkę internetową</string>
   <string name="navigation_drawer_settings">Ustawienia</string>
   <string name="navigation_drawer_news_updates">Nowości i aktualizacje</string>
@@ -129,8 +122,6 @@
   <string name="account_list_low_storage">Mało miejsca do przechowywania. Android nie zsynchronizuje lokalnych zmian od razu, ale podczas następnej regularnej synchronizacji.</string>
   <string name="account_list_manage_storage">Zarządzaj pamięcią</string>
   <string name="account_list_empty">Witamy w DAVx⁵!\n\nMożesz teraz dodać konto CalDAV/CardDAV.</string>
-  <string name="accounts_global_sync_disabled">Automatyczna synchronizacja dla całego systemu jest wyłączona</string>
-  <string name="accounts_global_sync_enable">Włącz</string>
   <string name="accounts_sync_all">Synchronizuj wszystkie konta</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">Wykrycie serwisu nie powiodło się</string>
@@ -180,16 +171,11 @@
   <string name="app_settings_reset_hints_success">Wszystkie wskazówki pojawią się ponownie</string>
   <string name="app_settings_integration">Integracja</string>
   <string name="app_settings_tasks_provider">Aplikacja zadań</string>
-  <string name="app_settings_tasks_provider_synchronizing_with">Synchronizacja z %s</string>
   <string name="app_settings_tasks_provider_none">Nie znaleziono kompatybilnej aplikacji zadań</string>
   <!--AccountActivity-->
   <string name="account_carddav">CardDAV</string>
   <string name="account_caldav">CalDAV</string>
   <string name="account_webcal">Webcal</string>
-  <string name="account_no_address_books">Nie ma (jeszcze) książek adresowych.</string>
-  <string name="account_no_calendars">Nie ma (jeszcze) kalendarzy.</string>
-  <string name="account_no_webcals">Nie ma (jeszcze) subskrypcji kalendarzy.</string>
-  <string name="account_swipe_down">Przesuń palcem w dół, aby odświeżyć listę z serwera.</string>
   <string name="account_synchronize_now">Synchronizuj teraz</string>
   <string name="account_settings">Ustawienia konta</string>
   <string name="account_rename">Zmień nazwę konta</string>
@@ -205,8 +191,6 @@
   <string name="account_task_list">lista zadań</string>
   <string name="account_journal">dziennik</string>
   <string name="account_only_personal">Pokaż tylko osobiste</string>
-  <string name="account_create_new_address_book">Stwórz nową książkę adresową</string>
-  <string name="account_create_new_calendar">Stwórz nowy kalendarz</string>
   <string name="account_no_webcal_handler_found">Nie znaleziono aplikacji obsługującej Webcal</string>
   <string name="account_install_icsx5">Zainstaluj ICSx⁵</string>
   <!--AddAccountActivity-->
@@ -259,7 +243,6 @@
   <string name="login_username_password_wrong">Błędna nazwa użytkownika (adres e-mail)/hasło?</string>
   <string name="login_view_logs">Pokaż szczegóły</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Ustawienia: %s</string>
   <string name="settings_sync">Synchronizacja</string>
   <string name="settings_sync_interval_contacts">Częstotliwość synchronizacji kontaktów</string>
   <string name="settings_sync_summary_manually">Tylko ręcznie</string>
@@ -291,10 +274,8 @@
   <string name="settings_oauth">Uwierzytelnij ponownie</string>
   <string name="settings_oauth_summary">Wykonaj ponownie logowanie OAuth</string>
   <string name="settings_username">Nazwa użytkownika</string>
-  <string name="settings_enter_username">Wpisz nazwę użytkownika:</string>
   <string name="settings_password">Hasło</string>
   <string name="settings_password_summary">Zaktualizuj hasło zgodnie z serwerem</string>
-  <string name="settings_enter_password">Wpisz hasło:</string>
   <string name="settings_certificate_install">Zainstaluj certyfikat</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">Limit czasowy przeszłych wydarzeń</string>
@@ -420,6 +401,4 @@
   <string name="sync_invalid_task">Otrzymano błędne zadanie z serwera</string>
   <string name="sync_invalid_resources_ignoring">Zignorowano jeden lub więcej nieważnych zasobów</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵: Bezpieczeństwo połączenia</string>
-  <string name="trust_certificate_unknown_certificate_found">DAVx⁵ napotkał nieznany certyfikat. Czy chcesz go dodać?</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -26,8 +26,6 @@
   <string name="intro_slogan1">Seus dados. Sua escolha.</string>
   <string name="intro_slogan2">Assuma o controle.</string>
   <string name="intro_battery_title">Intervalos de sincronização regulares</string>
-  <string name="intro_battery_not_whitelisted">Desativado (não recomendado)</string>
-  <string name="intro_battery_whitelisted">Ativado (recomendado)</string>
   <string name="intro_battery_text">Para sincronização em intervalos regulares, o %s deve ter permissão para executar em segundo plano. Caso contrário, o Android poderá pausar a sincronização a qualquer momento.</string>
   <string name="intro_battery_dont_show">Eu não preciso de intervalos de sincronização regulares.*</string>
   <string name="intro_autostart_title">Compatibilidade %s</string>
@@ -77,9 +75,7 @@
   <string name="about_libraries">Bibliotecas</string>
   <string name="about_version">Versão %1$s (%2$d)</string>
   <string name="about_build_date">Compilado em %s</string>
-  <string name="about_flavor_info">Esta versão só é elegível para distribuição na Google Play.</string>
   <string name="about_license_info_no_warranty">Este programa é distribuído SEM NENHUMA GARANTIA. Ele é software livre e pode ser redistribuído sob algumas condições.</string>
-  <string name="about_translations_thanks"><![CDATA[<i>Agradecemos a: </i> %s]]></string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Não foi possível criar o arquivo de log</string>
   <string name="logging_notification_view_share">Ver/partilhar</string>
@@ -88,7 +84,6 @@
   <string name="navigation_drawer_subtitle">Sincronização de CalDAV/CardDAV</string>
   <string name="navigation_drawer_about">Sobre / Licença</string>
   <string name="navigation_drawer_beta_feedback">Comentários sobre a versão beta</string>
-  <string name="install_email_client">Instale um cliente de e-mail</string>
   <string name="install_browser">Instale um navegador Web</string>
   <string name="navigation_drawer_settings">Configurações</string>
   <string name="navigation_drawer_news_updates">Novidades e atualizações</string>
@@ -102,8 +97,6 @@
   <string name="account_list_manage_connections">Gerenciar conexões</string>
   <string name="account_list_manage_storage">Gerenciar armazenamento</string>
   <string name="account_list_empty">Bem-vindo(a) ao DAVx⁵!\n\nVocê pode adicionar uma conta CalDAV/CardDAV agora.</string>
-  <string name="accounts_global_sync_disabled">A sincronização automática pelo sistema está desativada</string>
-  <string name="accounts_global_sync_enable">Ativar</string>
   <string name="accounts_sync_all">Sincronizar todas as contas</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">Falha na detecção do serviço</string>
@@ -149,15 +142,10 @@
   <string name="app_settings_reset_hints_summary">Restaura as sugestões que foram descartadas anteriormente</string>
   <string name="app_settings_reset_hints_success">Todas as sugestões serão exibidas novamente</string>
   <string name="app_settings_integration">Integração</string>
-  <string name="app_settings_tasks_provider_synchronizing_with">Sincronizando com %s</string>
   <!--AccountActivity-->
   <string name="account_carddav">CardDAV</string>
   <string name="account_caldav">CalDAV</string>
   <string name="account_webcal">Webcal</string>
-  <string name="account_no_address_books">Não há livros de endereços (ainda).</string>
-  <string name="account_no_calendars">Não há calendários (ainda).</string>
-  <string name="account_no_webcals">Não há assinaturas de calendário (ainda).</string>
-  <string name="account_swipe_down">Deslize para baixo para atualizar a lista do servidor.</string>
   <string name="account_synchronize_now">Sincronizar agora</string>
   <string name="account_settings">Configurações da conta</string>
   <string name="account_rename">Renomear conta</string>
@@ -171,8 +159,6 @@
   <string name="account_read_only">Somente leitura</string>
   <string name="account_calendar">calendário</string>
   <string name="account_task_list">lista de tarefas</string>
-  <string name="account_create_new_address_book">Criar novo livro de endereços</string>
-  <string name="account_create_new_calendar">Criar novo calendário</string>
   <string name="account_no_webcal_handler_found">Não foi encontrado um aplicativo capaz de lidar com Webcal</string>
   <string name="account_install_icsx5">Instalar ICSx⁵</string>
   <!--AddAccountActivity-->
@@ -208,7 +194,6 @@
   <string name="login_username_password_wrong">Nome de usuário (endereço de e-mail) / senha incorreto?</string>
   <string name="login_view_logs">Mostrar detalhes</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Configurações: %s</string>
   <string name="settings_sync">Sincronização</string>
   <string name="settings_sync_interval_contacts">Intervalo sinc. de contatos</string>
   <string name="settings_sync_summary_manually">Apenas manualmente</string>
@@ -234,10 +219,8 @@
   <string name="settings_sync_wifi_only_ssids_permissions_action">Gerenciar</string>
   <string name="settings_authentication">Autenticação</string>
   <string name="settings_username">Nome do usuário</string>
-  <string name="settings_enter_username">Digite o nome do usuário:</string>
   <string name="settings_password">Senha</string>
   <string name="settings_password_summary">Atualize a senha de acordo com seu servidor</string>
-  <string name="settings_enter_password">Digite sua senha:</string>
   <string name="settings_certificate_install">Instalar certificado</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">Limite de tempo para eventos passados</string>
@@ -333,6 +316,4 @@
   <string name="sync_invalid_task">Tarefa inválida recebida do servidor</string>
   <string name="sync_invalid_resources_ignoring">Ignorando um ou mais recursos inválidos</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵: Segurança da conexão</string>
-  <string name="trust_certificate_unknown_certificate_found">O DAVx⁵ encontrou um certificado desconhecido. Deseja torná-lo confiável?</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -29,8 +29,6 @@
   <string name="intro_slogan1">Datele tale. Alegerea ta.</string>
   <string name="intro_slogan2">Preia controlul.</string>
   <string name="intro_battery_title">Intervale regulate de sincronizare</string>
-  <string name="intro_battery_not_whitelisted">Dezactivat (nu este recomandat)</string>
-  <string name="intro_battery_whitelisted">Activat (recomandat)</string>
   <string name="intro_battery_text">Pentru sincronizare la intervale regulate, %s trebuie să aibă voie să ruleze în fundal. În caz contrar, Android poate întrerupe sincronizarea în orice moment.</string>
   <string name="intro_battery_dont_show">Nu am nevoie de intervale regulate de sincronizare.*</string>
   <string name="intro_autostart_title">Compatibilitate %s </string>
@@ -68,8 +66,6 @@
   <string name="permissions_notification_status_off">Notificări dezactivate (nu este recomandat)</string>
   <string name="permissions_notification_status_on">Notificări activate</string>
   <string name="permissions_jtx_title">Permisiuni pentru jtx Board</string>
-  <string name="permissions_jtx_status_off">Nicio sarcină, jurnale și note sincronizate</string>
-  <string name="permissions_jtx_status_on">Este posibilă sincronizarea sarcinilor, jurnalelor, notelor</string>
   <string name="permissions_opentasks_title">Permisiuni OpenTasks</string>
   <string name="permissions_tasksorg_title">Permisiuni pentru sarcini</string>
   <string name="permissions_tasks_status_off">Nicio sincronizare a sarcinilor</string>
@@ -98,9 +94,7 @@
   <string name="about_version">Versiune %1$s (%2$d)</string>
   <string name="about_build_date">Compilată la %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (inginerie web bitfire GmbH) și contribuitori</string>
-  <string name="about_flavor_info">Această versiune este eligibilă pentru distribuție numai prin Google Play.</string>
   <string name="about_license_info_no_warranty">Acest program vine cu ABSOLUT NICIO GARANȚIE. Este software gratuit și ești binevenit să îl redistribui în anumite condiții.</string>
-  <string name="about_translations_thanks"><![CDATA[<i>Mulțumiri: </i> %s]]></string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Nu s-a putut crea fișierul jurnal</string>
   <string name="logging_notification_text">Acum se înregistrează toate activitățile %s</string>
@@ -110,7 +104,6 @@
   <string name="navigation_drawer_subtitle">Adaptor de sincronizare CalDAV/CardDAV</string>
   <string name="navigation_drawer_about">Despre / Licență</string>
   <string name="navigation_drawer_beta_feedback">Feedback beta</string>
-  <string name="install_email_client">Instalează un client de e-mail</string>
   <string name="install_browser">Instalează un browser web</string>
   <string name="navigation_drawer_settings">Setări</string>
   <string name="navigation_drawer_news_updates">Știri și actualizări</string>
@@ -131,8 +124,6 @@
   <string name="account_list_low_storage">Spațiu de depozitare redus. Android nu va sincroniza modificările locale imediat, ci în timpul următoarei sincronizări obișnuite.</string>
   <string name="account_list_manage_storage">Gestionează stocarea</string>
   <string name="account_list_empty">Bun venit la DAVx⁵!\n\nPoți adăuga acum un cont CalDAV/CardDAV.</string>
-  <string name="accounts_global_sync_disabled">Sincronizarea automată la nivel de sistem este dezactivată</string>
-  <string name="accounts_global_sync_enable">Activează</string>
   <string name="accounts_sync_all">Sincronizează toate conturile</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">Detectarea serviciului a eșuat</string>
@@ -182,16 +173,11 @@
   <string name="app_settings_reset_hints_success">Toate sugestiile vor fi afișate din nou</string>
   <string name="app_settings_integration">Integrare</string>
   <string name="app_settings_tasks_provider">Aplicația de sarcini</string>
-  <string name="app_settings_tasks_provider_synchronizing_with">Sincronizare cu %s</string>
   <string name="app_settings_tasks_provider_none">Nu a fost găsită nicio aplicație de sarcini compatibilă</string>
   <!--AccountActivity-->
   <string name="account_carddav">CardDAV</string>
   <string name="account_caldav">CalDAV</string>
   <string name="account_webcal">Webcal</string>
-  <string name="account_no_address_books">Nu există  (încă) agende de adrese.</string>
-  <string name="account_no_calendars">Nu există calendare (încă).</string>
-  <string name="account_no_webcals">Nu există abonamente la calendar (încă).</string>
-  <string name="account_swipe_down">Glisează în jos pentru a reîmprospăta lista de pe server.</string>
   <string name="account_synchronize_now">Sincronizează acum</string>
   <string name="account_settings">Setările contului</string>
   <string name="account_rename">Redenumește contul</string>
@@ -209,8 +195,6 @@
   <string name="account_task_list">lista de sarcini</string>
   <string name="account_journal">jurnal</string>
   <string name="account_only_personal">Afișează numai personal</string>
-  <string name="account_create_new_address_book">Creează o nouă agendă de adrese</string>
-  <string name="account_create_new_calendar">Creează un calendar nou</string>
   <string name="account_no_webcal_handler_found">Nu a fost găsită nicio aplicație compatibilă cu Webcal</string>
   <string name="account_install_icsx5">Instalează ICSx⁵</string>
   <!--AddAccountActivity-->
@@ -265,7 +249,6 @@
   <string name="login_username_password_wrong">Nume de utilizator (adresă de e-mail)/parolă greșită?</string>
   <string name="login_view_logs">Afișează detaliile</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Setări: %s</string>
   <string name="settings_sync">Sincronizare</string>
   <string name="settings_sync_interval_contacts">Interval de sincronizare a contactelor</string>
   <string name="settings_sync_summary_manually">Doar manual</string>
@@ -297,10 +280,8 @@
   <string name="settings_oauth">Reautentificare</string>
   <string name="settings_oauth_summary">Efectuează din nou autentificarea OAuth</string>
   <string name="settings_username">Nume de utilizator</string>
-  <string name="settings_enter_username">Introdu numele de utilizator:</string>
   <string name="settings_password">Parolă</string>
   <string name="settings_password_summary">Actualizează parola în funcție de server.</string>
-  <string name="settings_enter_password">Introdu parola:</string>
   <string name="settings_certificate_install">Instalare certificat</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">Limită de timp pentru evenimentele din trecut</string>
@@ -426,6 +407,4 @@
   <string name="sync_invalid_task">S-a primit sarcină nevalidă de la server</string>
   <string name="sync_invalid_resources_ignoring">Ignorarea uneia sau mai multor resurse nevalide</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵: Securitatea conexiunii</string>
-  <string name="trust_certificate_unknown_certificate_found">DAVx⁵ a întâlnit un certificat necunoscut. Vrei să ai încredere?</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -29,8 +29,6 @@
   <string name="intro_slogan1">Ваши данные. Ваш выбор.</string>
   <string name="intro_slogan2">Возьмите под контроль.</string>
   <string name="intro_battery_title">Регулярные интервалы синхронизации</string>
-  <string name="intro_battery_not_whitelisted">Отключено (не рекомендуется)</string>
-  <string name="intro_battery_whitelisted">Включено (рекомендуется)</string>
   <string name="intro_battery_text">Для обеспечения синхронизации с регулярными интервалами необходимо разрешить работу %s в фоновом режиме. В противном случае, Android может приостановить синхронизацию в любое время.</string>
   <string name="intro_battery_dont_show">Мне не нужна синхронизация с регулярными интервалами.*</string>
   <string name="intro_autostart_title">Совместимость %s</string>
@@ -68,8 +66,6 @@
   <string name="permissions_notification_status_off">Уведомления отключены (не рекомендуется)</string>
   <string name="permissions_notification_status_on">Уведомления включены</string>
   <string name="permissions_jtx_title">Разрешения jtx Board</string>
-  <string name="permissions_jtx_status_off">Не синхронизируются задачи, журналы, заметки</string>
-  <string name="permissions_jtx_status_on">Возможна синхронизация задач, журналов и заметок</string>
   <string name="permissions_opentasks_title">Разрешения OpenTasks</string>
   <string name="permissions_tasksorg_title">Разрешения Tasks</string>
   <string name="permissions_tasks_status_off">Не синхронизируются задачи</string>
@@ -98,9 +94,7 @@
   <string name="about_version">Версия %1$s (%2$d)</string>
   <string name="about_build_date">Скомпилировано %s</string>
   <string name="about_copyright">© Рикки Хирнер (Ricki Hirner), Бернхард Штокманн (Bernhard Stockmann) (bitfire web engineering GmbH) и контрибьюторы</string>
-  <string name="about_flavor_info">Эта версия может распространяться только через Google Play.</string>
   <string name="about_license_info_no_warranty">Эта программа поставляется БЕЗ КАКИХ-ЛИБО ГАРАНТИЙ. Это свободное программное обеспечение и вы можете распространять его при соблюдении определенных условий.</string>
-  <string name="about_translations_thanks"><![CDATA[<i>Благодарность: </i> %s]]></string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Не удалось создать файл лога</string>
   <string name="logging_notification_text">Сейчас логируется вся активность %s </string>
@@ -110,7 +104,6 @@
   <string name="navigation_drawer_subtitle">Адаптер синхронизации CalDAV/CardDAV</string>
   <string name="navigation_drawer_about">О программе / Лицензия</string>
   <string name="navigation_drawer_beta_feedback">Отзыв о бета-тестировании</string>
-  <string name="install_email_client">Пожалуйста, установите почтовый клиент</string>
   <string name="install_browser">Пожалуйста, установите браузер</string>
   <string name="navigation_drawer_settings">Настройки</string>
   <string name="navigation_drawer_news_updates">Новости и обновления</string>
@@ -131,8 +124,6 @@
   <string name="account_list_low_storage">Недостаточно памяти для хранения данных. Android будет синхронизировать локальные изменения не сразу, а во время следующей регулярной синхронизации.</string>
   <string name="account_list_manage_storage">Управление хранилищем</string>
   <string name="account_list_empty">Добро пожаловать в DAVx⁵!\n\nТеперь вы можете добавить аккаунт CalDAV/CardDAV.</string>
-  <string name="accounts_global_sync_disabled">Синхронизация отключена на уровне устройства</string>
-  <string name="accounts_global_sync_enable">Включить</string>
   <string name="accounts_sync_all">Синхронизировать все аккаунты</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">Не удалось обнаружить службу</string>
@@ -182,16 +173,11 @@
   <string name="app_settings_reset_hints_success">Все подсказки будут показаны снова</string>
   <string name="app_settings_integration">Интеграция</string>
   <string name="app_settings_tasks_provider">Приложение Tasks</string>
-  <string name="app_settings_tasks_provider_synchronizing_with">Синхронизация с %s</string>
   <string name="app_settings_tasks_provider_none">Не найдено совместимое приложение для задач</string>
   <!--AccountActivity-->
   <string name="account_carddav">CardDAV</string>
   <string name="account_caldav">CalDAV</string>
   <string name="account_webcal">WebСal</string>
-  <string name="account_no_address_books">Нет адресных книг (пока).</string>
-  <string name="account_no_calendars">Нет календарей (пока).</string>
-  <string name="account_no_webcals">Нет подписок на календарь (пока).</string>
-  <string name="account_swipe_down">Потяните вниз, чтобы обновить список с сервера.</string>
   <string name="account_synchronize_now">Синхронизировать</string>
   <string name="account_settings">Настройки аккаунта</string>
   <string name="account_rename">Переименовать аккаунт</string>
@@ -209,8 +195,6 @@
   <string name="account_task_list">список задач</string>
   <string name="account_journal">журнал</string>
   <string name="account_only_personal">Показать только личные</string>
-  <string name="account_create_new_address_book">Создать новую адресную книгу</string>
-  <string name="account_create_new_calendar">Создать новый календарь</string>
   <string name="account_no_webcal_handler_found">Не найдено приложение, поддерживающее WebCal</string>
   <string name="account_install_icsx5">Установить ICSx⁵</string>
   <!--AddAccountActivity-->
@@ -265,7 +249,6 @@
   <string name="login_username_password_wrong">Имя пользователя (адрес email) / пароль неверны?</string>
   <string name="login_view_logs">Показать детали</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Настройки: %s</string>
   <string name="settings_sync">Синхронизация</string>
   <string name="settings_sync_interval_contacts">Интервал синхронизации контактов</string>
   <string name="settings_sync_summary_manually">Вручную</string>
@@ -297,10 +280,8 @@
   <string name="settings_oauth">Повторная аутентификация</string>
   <string name="settings_oauth_summary">Выполните вход через OAuth повторно</string>
   <string name="settings_username">Имя пользователя</string>
-  <string name="settings_enter_username">Введите имя пользователя:</string>
   <string name="settings_password">Пароль</string>
   <string name="settings_password_summary">Обновить пароль</string>
-  <string name="settings_enter_password">Введите свой пароль:</string>
   <string name="settings_certificate_install">Установить сертификат</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">Ограничение по времени для прошедших событий</string>
@@ -428,6 +409,4 @@
   <string name="sync_invalid_task">Получена недействительная задача от сервера</string>
   <string name="sync_invalid_resources_ignoring">Игнорирование одного или нескольких недействительных ресурсов</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵: безопасность подключения</string>
-  <string name="trust_certificate_unknown_certificate_found">DAVx⁵ обнаружил неизвестный сертификат. Вы согласны ему доверять?</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -22,7 +22,6 @@
   <string name="about_libraries">Knižnice</string>
   <string name="about_version">Verzia %1$s (%2$d)</string>
   <string name="about_build_date">Preložené na %s</string>
-  <string name="about_flavor_info">Túto verziu je možné šíriť iba prostredníctvom Google Play.</string>
   <string name="about_license_info_no_warranty">Tento program sa poskytuje BEZ AKEJKOĽVEK ZÁRUKY. Je to slobodný softvér a môžete ho ďalej šíriť pri splnení určitých podmienok.</string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Nie je možné vytvoriť súbor protokolu</string>
@@ -30,7 +29,6 @@
   <string name="navigation_drawer_subtitle">CalDAV/CardDAV Sync Adaptér</string>
   <string name="navigation_drawer_about">O programe / Licencia</string>
   <string name="navigation_drawer_beta_feedback">Odozva na beta-verziu</string>
-  <string name="install_email_client">Prosím, nainštalujte e-mailového klienta</string>
   <string name="install_browser">Prosím, nainštalujte webový prehliadač</string>
   <string name="navigation_drawer_settings">Nastavenia</string>
   <string name="navigation_drawer_news_updates">Novinky &amp; aktualizácie</string>
@@ -40,8 +38,6 @@
   <string name="navigation_drawer_faq">FAQ</string>
   <string name="navigation_drawer_privacy_policy">Zásady bezpečnosti</string>
   <string name="account_list_empty">Vitajte v programe DAVx⁵!\n\nTeraz môžete pridať používateľský účet pre CalDAV/CardDAV .</string>
-  <string name="accounts_global_sync_disabled">Automatická synchronizácia platná pre celý systém je zakázaná</string>
-  <string name="accounts_global_sync_enable">Povoliť</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">Zisťovanie služby zlyhalo</string>
   <string name="refresh_collections_worker_refresh_couldnt_refresh">Nie je možné obnoviť zoznam kolekcií</string>
@@ -72,10 +68,6 @@
   <string name="account_carddav">CardDAV</string>
   <string name="account_caldav">CalDAV</string>
   <string name="account_webcal">Webcal</string>
-  <string name="account_no_address_books">Neexistujú žiadne adresáre (zatiaľ)</string>
-  <string name="account_no_calendars">Neexistujú žiadne kalendáre (zatiaľ)</string>
-  <string name="account_no_webcals">Neexistujú žiadne odbery pre kalendár (zatiaľ)</string>
-  <string name="account_swipe_down">Potiahnite nadol aby ste znovu načítali zoznam zo serveru</string>
   <string name="account_synchronize_now">Teraz synchronizovať</string>
   <string name="account_settings">Nastavenia používateľského účtu</string>
   <string name="account_rename">Premenovať používateľský účet</string>
@@ -88,8 +80,6 @@
   <string name="account_read_only">len na čítanie</string>
   <string name="account_calendar">kalendár</string>
   <string name="account_task_list">zoznam úloh</string>
-  <string name="account_create_new_address_book">Vytvoriť nový adresár</string>
-  <string name="account_create_new_calendar">Vytvoriť nový kalendár</string>
   <string name="account_no_webcal_handler_found">Nenašla sa žiadna aplikácia schopná používať Webcal</string>
   <string name="account_install_icsx5">Nainštalovať ICSx⁵</string>
   <!--AddAccountActivity-->
@@ -118,7 +108,6 @@
   <string name="login_no_caldav_carddav">Nie je možné nájsť služby CalDAV ani CardDAV.</string>
   <string name="login_view_logs">Zobraziť podrobnosti</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Nastavenia: %s</string>
   <string name="settings_sync">Synchronizácia</string>
   <string name="settings_sync_interval_contacts">Synchr. interval pre kontakty</string>
   <string name="settings_sync_summary_manually">Iba manuálne</string>
@@ -143,10 +132,8 @@
   <string name="settings_sync_wifi_only_ssids_message">Čiarkou oddelený zoznam mien (SSID) povolených WiFi sietí (ponechať prázdne pre všetky)</string>
   <string name="settings_authentication">Overenie</string>
   <string name="settings_username">Meno používateľa</string>
-  <string name="settings_enter_username">Zadajte meno používateľa:</string>
   <string name="settings_password">Heslo</string>
   <string name="settings_password_summary">Aktualizujte heslo podľa vášho servera.</string>
-  <string name="settings_enter_password">Zadajte vaše heslo:</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">Uplynul časový limit pre udalosť</string>
   <string name="settings_sync_time_range_past_none">Budú sa synchronizovať všetky udalosti</string>
@@ -220,6 +207,4 @@
   <string name="sync_invalid_task">Úloha prijatá zo servera nie je platná</string>
   <string name="sync_invalid_resources_ignoring">Ignoruje sa jeden alebo viac neplatných zdrojov</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵: Zabezpečenie spojenia</string>
-  <string name="trust_certificate_unknown_certificate_found">DAVx⁵ zistil neznámy certifikát. Prajete si dôverovať mu?</string>
 </resources>

--- a/app/src/main/res/values-sl-rSI/strings.xml
+++ b/app/src/main/res/values-sl-rSI/strings.xml
@@ -22,7 +22,6 @@
   <string name="about_libraries">Knjižnice </string>
   <string name="about_version">Verzija %1$s (%2$d)</string>
   <string name="about_build_date">Združeno na %s</string>
-  <string name="about_flavor_info">Ta verzija je na voljo samo za distribucijo preko Google Play.</string>
   <string name="about_license_info_no_warranty">Ta program ne vsebuje NIČ garancije. To je brezplačna programska oprema in jo lahko pod določenimi pogoji delite naprej.</string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Ni bilo mogoče ustvariti zapisnika</string>
@@ -41,8 +40,6 @@
   <string name="navigation_drawer_forums">Pomoč / forumi</string>
   <string name="navigation_drawer_donate">Prispevaj</string>
   <string name="account_list_empty">Dobrodošli v DAVx⁵!\n\nZdaj lahko dodate CalDAV/CardDAV račun.</string>
-  <string name="accounts_global_sync_disabled">Sistemska avtomatska sinhronizacija je izklopljena</string>
-  <string name="accounts_global_sync_enable">Omogoči</string>
   <!--DavService-->
   <string name="dav_service_refresh_failed">Zaznava storitve ni uspela</string>
   <string name="dav_service_refresh_couldnt_refresh">Zbirke ni bilo mogoče osvežiti</string>
@@ -78,10 +75,6 @@
   <string name="account_carddav">CardDAV</string>
   <string name="account_caldav">CalDAV</string>
   <string name="account_webcal">Webcal</string>
-  <string name="account_no_address_books">Trenutno ni nobenega imenika (še).</string>
-  <string name="account_no_calendars">Trenutno ni nobenega koledarja (še).</string>
-  <string name="account_no_webcals">Trenutno ni nobene koledar naročnine (še).</string>
-  <string name="account_swipe_down">Potegni navzdol za osvežitev strežniškega seznama.</string>
   <string name="account_synchronize_now">Sinhroniziraj zdaj</string>
   <string name="account_synchronizing_now">Sinhronizacija v teku</string>
   <string name="account_settings">Nastavitve računa</string>
@@ -96,9 +89,7 @@
   <string name="account_calendar">koledar</string>
   <string name="account_task_list">seznam opravil</string>
   <string name="account_refresh_address_book_list">Osveži seznam imenikov</string>
-  <string name="account_create_new_address_book">Ustvari nov imenik</string>
   <string name="account_refresh_calendar_list">Osveži seznam koledarjev</string>
-  <string name="account_create_new_calendar">Ustvari nov koledar</string>
   <string name="account_no_webcal_handler_found">Nobena Webcal sposobna aplikacija ni bila najdena</string>
   <string name="account_install_icsx5">Namesti ICSx⁵</string>
   <!--AddAccountActivity-->
@@ -128,7 +119,6 @@
   <string name="login_no_caldav_carddav">CalDAV ali CardDAV storitve ni bilo mogoče najti.</string>
   <string name="login_view_logs">Pokaži podrobnosti</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Nastavitve: %s</string>
   <string name="settings_sync">Sinhronizacija</string>
   <string name="settings_sync_interval_contacts">Kontakti interval sinhronizacije</string>
   <string name="settings_sync_summary_manually">Samo ročno</string>
@@ -155,10 +145,8 @@
   <string name="settings_more_info_faq">Več informacij (pogosta vprašanja)</string>
   <string name="settings_authentication">Avtentikacija</string>
   <string name="settings_username">Uporabniško ime</string>
-  <string name="settings_enter_username">Vnesi uporabniško ime:</string>
   <string name="settings_password">Geslo</string>
   <string name="settings_password_summary">Posodobi geslo ustrezajoč strežniku.</string>
-  <string name="settings_enter_password">Vnesi vaše geslo:</string>
   <string name="settings_certificate_alias">Alias certifikata klienta</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">Pretekli dogodek časovna omejitev</string>
@@ -223,6 +211,4 @@
   <string name="sync_invalid_task">S strežnika so bili prejeti neveljavni dogodki</string>
   <string name="sync_invalid_resources_ignoring">Eden ali več neveljavnih virov bo ignoriranih</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵:  Varnost povezave</string>
-  <string name="trust_certificate_unknown_certificate_found">DAVx⁵ je naletel na neznan certifikat. Ali mu zaupate?</string>
 </resources>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -25,8 +25,6 @@
   <!--IntroActivity-->
   <string name="intro_slogan1">Tvoji podatki. Tvoja izbira.</string>
   <string name="intro_slogan2">Prevzemi nadzor</string>
-  <string name="intro_battery_not_whitelisted">Onemogočeno (nepriporočljivo)</string>
-  <string name="intro_battery_whitelisted">Omogočeno (priporočljivo)</string>
   <string name="intro_battery_dont_show">Ne potrebujem enakomernih intervalov sinhroniziranja</string>
   <string name="intro_autostart_title">%szdružljivost</string>
   <string name="intro_more_info">Več informacij</string>
@@ -55,7 +53,6 @@
   <string name="about_libraries">Knjižnice </string>
   <string name="about_version">Verzija %1$s (%2$d)</string>
   <string name="about_build_date">Združeno na %s</string>
-  <string name="about_flavor_info">Ta verzija je na voljo samo za distribucijo preko Google Play.</string>
   <string name="about_license_info_no_warranty">Ta program ne vsebuje NIČ garancije. To je brezplačna programska oprema in jo lahko pod določenimi pogoji delite naprej.</string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Ni bilo mogoče ustvariti zapisnika</string>
@@ -70,8 +67,6 @@
   <string name="navigation_drawer_manual">Priročnik</string>
   <string name="navigation_drawer_faq">Pogosta vprašanja</string>
   <string name="account_list_empty">Dobrodošli v DAVx⁵!\n\nZdaj lahko dodate CalDAV/CardDAV račun.</string>
-  <string name="accounts_global_sync_disabled">Sistemska avtomatska sinhronizacija je izklopljena</string>
-  <string name="accounts_global_sync_enable">Omogoči</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">Zaznava storitve ni uspela</string>
   <string name="refresh_collections_worker_refresh_couldnt_refresh">Zbirke ni bilo mogoče osvežiti</string>
@@ -102,10 +97,6 @@
   <string name="account_carddav">CardDAV</string>
   <string name="account_caldav">CalDAV</string>
   <string name="account_webcal">Webcal</string>
-  <string name="account_no_address_books">Trenutno ni nobenega imenika (še).</string>
-  <string name="account_no_calendars">Trenutno ni nobenega koledarja (še).</string>
-  <string name="account_no_webcals">Trenutno ni nobene koledar naročnine (še).</string>
-  <string name="account_swipe_down">Potegni navzdol za osvežitev strežniškega seznama.</string>
   <string name="account_synchronize_now">Sinhroniziraj zdaj</string>
   <string name="account_settings">Nastavitve računa</string>
   <string name="account_rename">Preimenuj račun</string>
@@ -120,8 +111,6 @@
   <string name="account_task_list">seznam opravil</string>
   <string name="account_journal">dnevnik</string>
   <string name="account_only_personal">Pokaži samo osebno</string>
-  <string name="account_create_new_address_book">Ustvari nov imenik</string>
-  <string name="account_create_new_calendar">Ustvari nov koledar</string>
   <string name="account_no_webcal_handler_found">Nobena Webcal sposobna aplikacija ni bila najdena</string>
   <string name="account_install_icsx5">Namesti ICSx⁵</string>
   <!--AddAccountActivity-->
@@ -150,7 +139,6 @@
   <string name="login_no_caldav_carddav">CalDAV ali CardDAV storitve ni bilo mogoče najti.</string>
   <string name="login_view_logs">Pokaži podrobnosti</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Nastavitve: %s</string>
   <string name="settings_sync">Sinhronizacija</string>
   <string name="settings_sync_interval_contacts">Kontakti interval sinhronizacije</string>
   <string name="settings_sync_summary_manually">Samo ročno</string>
@@ -175,10 +163,8 @@
   <string name="settings_sync_wifi_only_ssids_message">Z vejico ločena imena (SSID) dovoljenih WiFi omrežij (pusti prazno za vse)</string>
   <string name="settings_authentication">Avtentikacija</string>
   <string name="settings_username">Uporabniško ime</string>
-  <string name="settings_enter_username">Vnesi uporabniško ime:</string>
   <string name="settings_password">Geslo</string>
   <string name="settings_password_summary">Posodobi geslo ustrezajoč strežniku.</string>
-  <string name="settings_enter_password">Vnesi vaše geslo:</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">Pretekli dogodek časovna omejitev</string>
   <string name="settings_sync_time_range_past_none">Vsi dogodki bodo sinhronizirani</string>
@@ -239,6 +225,4 @@
   <string name="sync_invalid_task">S strežnika so bili prejeti neveljavni dogodki</string>
   <string name="sync_invalid_resources_ignoring">Eden ali več neveljavnih virov bo ignoriranih</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵:  Varnost povezave</string>
-  <string name="trust_certificate_unknown_certificate_found">DAVx⁵ je naletel na neznan certifikat. Ali mu zaupate?</string>
 </resources>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -26,8 +26,6 @@
   <string name="intro_slogan1">Ваши подаци. Ваш избор.</string>
   <string name="intro_slogan2">Преузмите контролу.</string>
   <string name="intro_battery_title">Регуларни интервали синхронизације</string>
-  <string name="intro_battery_not_whitelisted">Онемогућено (није препоручено)</string>
-  <string name="intro_battery_whitelisted">Омогућено (препоручено)</string>
   <string name="intro_battery_text">За синхронизацију у регуларним интервалима, %s мора бити дозвољено да се извршава у позадини. У супротном, Андроид може зауставити синхронизацију у било ком тренутку.</string>
   <string name="intro_battery_dont_show">Не требају ми регуларни интервали синхронизације.*</string>
   <string name="intro_autostart_title">%s компатибилност</string>
@@ -62,8 +60,6 @@
   <string name="permissions_notification_title">Дозволе за обавештења</string>
   <string name="permissions_notification_status_off">Обавештења су онемогућена (није препоручено)</string>
   <string name="permissions_notification_status_on">Обавештења су омогућена</string>
-  <string name="permissions_jtx_status_off">Без синхронизације задатака, вести, белешки</string>
-  <string name="permissions_jtx_status_on">Могућа је синхронизација задатака, вести, белешки</string>
   <string name="permissions_opentasks_title">Дозволе за OpenTasks</string>
   <string name="permissions_tasksorg_title">Дозволе за задатке</string>
   <string name="permissions_tasks_status_off">Без синхронизације задатака</string>
@@ -90,7 +86,6 @@
   <string name="about_version">Издање %1$s (%2$d)</string>
   <string name="about_build_date">Компилован %s</string>
   <string name="about_license_info_no_warranty">Овај програм НЕМА НИКАКВЕ ГАРАНЦИЈЕ. Бесплатан је софтвер којег можете слободно да делите под одређеним условима.</string>
-  <string name="about_translations_thanks"><![CDATA[<i>Захвалница: </i> %s]]></string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Није се могла направити датотека записа</string>
   <string name="logging_notification_text">Сада се записују све %s активности</string>
@@ -100,7 +95,6 @@
   <string name="navigation_drawer_subtitle">КалДАВ/КардДАВ адаптер синхронизације</string>
   <string name="navigation_drawer_about">О програму/лиценца</string>
   <string name="navigation_drawer_beta_feedback">Повратне информације бета издања</string>
-  <string name="install_email_client">Молим вас инсталирајте клијент е-поште</string>
   <string name="install_browser">Молим вас инсталирајте прегледач интернета</string>
   <string name="navigation_drawer_settings">Поставке</string>
   <string name="navigation_drawer_news_updates">Новости и ажурирања</string>
@@ -114,8 +108,6 @@
   <string name="account_list_no_notification_permission">Обавештења су онемогућена. Нећете бити обавештени о проблемима са синхронизацијом.</string>
   <string name="account_list_manage_storage">Управљајте складиштем</string>
   <string name="account_list_empty">Добро дошли у ДАВдроид!\n\nМожете сада да додате КалДАВ/КардДАВ налог.</string>
-  <string name="accounts_global_sync_disabled">Синхронизација је системски искључена</string>
-  <string name="accounts_global_sync_enable">Укључи</string>
   <string name="accounts_sync_all">Синхронизуј све налоге</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">Откривање услуге није успело</string>
@@ -162,15 +154,10 @@
   <string name="app_settings_reset_hints_success">Сви савети ће поново бити приказани</string>
   <string name="app_settings_integration">Интеграција</string>
   <string name="app_settings_tasks_provider">Апликација за задатке</string>
-  <string name="app_settings_tasks_provider_synchronizing_with">Синхронизовање са %s</string>
   <!--AccountActivity-->
   <string name="account_carddav">КардДАВ</string>
   <string name="account_caldav">КалДАВ</string>
   <string name="account_webcal">Вебкал</string>
-  <string name="account_no_address_books">Нема именика (још увек).</string>
-  <string name="account_no_calendars">Нема календара (још увек).</string>
-  <string name="account_no_webcals">Нема претплата на календаре (још увек).</string>
-  <string name="account_swipe_down">Повуците на доле да би сте освежили списак са сервера.</string>
   <string name="account_synchronize_now">Синхронизуј одмах</string>
   <string name="account_settings">Поставке налога</string>
   <string name="account_rename">Преименуј налог</string>
@@ -186,8 +173,6 @@
   <string name="account_task_list">листа задатака</string>
   <string name="account_journal">журнал</string>
   <string name="account_only_personal">Прикажи само личне</string>
-  <string name="account_create_new_address_book">Направи нови адресар</string>
-  <string name="account_create_new_calendar">Направи нови календар</string>
   <string name="account_no_webcal_handler_found">Нема апликације за Вебкал</string>
   <string name="account_install_icsx5">Инсталирај ICSx⁵</string>
   <!--AddAccountActivity-->
@@ -226,7 +211,6 @@
   <string name="login_username_password_wrong">Корисничко име (адреса е-поште) / лозинка је погрешна?</string>
   <string name="login_view_logs">Прикажи детаље</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Поставке: %s</string>
   <string name="settings_sync">Синхронизација</string>
   <string name="settings_sync_interval_contacts">Интервал синх. контаката</string>
   <string name="settings_sync_summary_manually">Само ручно</string>
@@ -253,10 +237,8 @@
   <string name="settings_authentication">Аутентификација</string>
   <string name="settings_oauth">Поновна аутентификација</string>
   <string name="settings_username">Корисничко име</string>
-  <string name="settings_enter_username">Унесите корисничко име:</string>
   <string name="settings_password">Лозинка</string>
   <string name="settings_password_summary">Ажурирајте лозинку за ваш сервер.</string>
-  <string name="settings_enter_password">Унесите лозинку:</string>
   <string name="settings_certificate_install">Инсталирај сертификат</string>
   <string name="settings_caldav">КалДАВ</string>
   <string name="settings_sync_time_range_past">Ограничење догађаја у прошлости</string>
@@ -318,6 +300,4 @@
   <string name="sync_error_local_storage">Грешка локалног складишта – %s</string>
   <string name="sync_error_view_item">Прикажи ставку</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">ДАВдроид: Безбедност везе</string>
-  <string name="trust_certificate_unknown_certificate_found">ДАВдроид је наишао на непознат сертификат. Желите ли да се поуздате у њега?</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -29,8 +29,6 @@
   <string name="intro_slogan1">Din data. Ditt val.</string>
   <string name="intro_slogan2">Ta kontroll</string>
   <string name="intro_battery_title">Regelbundna synkroniseringsintervall</string>
-  <string name="intro_battery_not_whitelisted">Inaktiverat (ej rekommenderat)</string>
-  <string name="intro_battery_whitelisted">Aktiverat (rekommenderat)</string>
   <string name="intro_battery_text">För att programmet skall kunna köra regelbunden synkronisering %s måste det tillåtas att köra i bakgrunden. Annars kan Android pausa synkroniseringen när som helst.</string>
   <string name="intro_battery_dont_show">Jag behöver inte regelbunden synkronisering.*</string>
   <string name="intro_autostart_title">%s kompatibilitet</string>
@@ -68,8 +66,6 @@
   <string name="permissions_notification_status_off">Notifieringar avaktiverade (ej rekommenderat)</string>
   <string name="permissions_notification_status_on">Notifieringar aktiva</string>
   <string name="permissions_jtx_title">jtx Bordsbehörigheter</string>
-  <string name="permissions_jtx_status_off">Ingen synkronisering av uppgifter, journaler, anteckningar</string>
-  <string name="permissions_jtx_status_on">Synkronisering av uppgifter, journaler, anteckningar är möjlig</string>
   <string name="permissions_opentasks_title">OpenTasks-behörigheter</string>
   <string name="permissions_tasksorg_title">Tasks behörighet</string>
   <string name="permissions_tasks_status_off">Ingen synkronisering av uppgifter</string>
@@ -98,9 +94,7 @@
   <string name="about_version">Version %1$s (%2$d)</string>
   <string name="about_build_date">Kompilerad på %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) och bidragsgivare</string>
-  <string name="about_flavor_info">Den här versionen är endast berättigad för distribution genom Google Play</string>
   <string name="about_license_info_no_warranty">Detta program levereras med ABSOLUT INGEN GARANTI. Det är fri programvara, och du kan vidaredistribuera den under vissa förutsättningar.</string>
-  <string name="about_translations_thanks"><![CDATA[<i>Tack till: </i> %s ]]></string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Kunde inte skapa loggfil</string>
   <string name="logging_notification_text">Loggar nu alla %s aktiviteter</string>
@@ -110,7 +104,6 @@
   <string name="navigation_drawer_subtitle">CalDAV/CardDAV Synk Adapter</string>
   <string name="navigation_drawer_about">Om / Licens</string>
   <string name="navigation_drawer_beta_feedback">Betafeedback</string>
-  <string name="install_email_client">Installera en e-postklient</string>
   <string name="install_browser">Installera en webbläsare</string>
   <string name="navigation_drawer_settings">Inställningar</string>
   <string name="navigation_drawer_news_updates">Nyheter &amp; uppdateringar</string>
@@ -129,8 +122,6 @@
   <string name="account_list_low_storage">Lagringsutrymmet är lågt. Android kommer inte synka lokala ändringar direkt, utan vänta till nästa regelbundna synkronisering.</string>
   <string name="account_list_manage_storage">Hantera lagring</string>
   <string name="account_list_empty">Välkommen till DAVx⁵!\n\nDu kan lägga till ett CalDAV/CardDAV-konto nu.</string>
-  <string name="accounts_global_sync_disabled">Systemomfattande automatisk synkronisering är inaktiverad</string>
-  <string name="accounts_global_sync_enable">Aktivera</string>
   <string name="accounts_sync_all">Synkronisera alla konton</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">Servicedetektering misslyckades</string>
@@ -180,16 +171,11 @@
   <string name="app_settings_reset_hints_success">Alla tips kommer visas igen</string>
   <string name="app_settings_integration">Integrering</string>
   <string name="app_settings_tasks_provider">Tasks appen</string>
-  <string name="app_settings_tasks_provider_synchronizing_with">Synkroniserar med %s</string>
   <string name="app_settings_tasks_provider_none">Ingen kompatibel task-app hittades</string>
   <!--AccountActivity-->
   <string name="account_carddav">CardDAV</string>
   <string name="account_caldav">CalDAV</string>
   <string name="account_webcal">Webcal</string>
-  <string name="account_no_address_books">Det finns inga adressböcker (ännu).</string>
-  <string name="account_no_calendars">Det finns inga kalendrar (ännu).</string>
-  <string name="account_no_webcals">Det finns inga kalenderprenumerationer (ännu).</string>
-  <string name="account_swipe_down">Svep nedåt för att uppdatera listan från servern.</string>
   <string name="account_synchronize_now">Synkronisera nu</string>
   <string name="account_settings">Kontoinställningar</string>
   <string name="account_rename">Byt namn på kontot</string>
@@ -205,8 +191,6 @@
   <string name="account_task_list">uppgiftslista</string>
   <string name="account_journal">Journal</string>
   <string name="account_only_personal">Visa endast personligt</string>
-  <string name="account_create_new_address_book">Skapa ny adressbok</string>
-  <string name="account_create_new_calendar">Skapa ny kalender</string>
   <string name="account_no_webcal_handler_found">Ingen Webcal-kompatibel app hittades</string>
   <string name="account_install_icsx5">Installera ICSx⁵</string>
   <!--AddAccountActivity-->
@@ -261,7 +245,6 @@
   <string name="login_username_password_wrong">Användarnamn (e-postadress) / lösenord är fel?</string>
   <string name="login_view_logs">Visa detaljer</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Inställningar: %s</string>
   <string name="settings_sync">Synkronisering</string>
   <string name="settings_sync_interval_contacts">Intervall för kontaktsynkronisering</string>
   <string name="settings_sync_summary_manually">Bara manuellt</string>
@@ -293,10 +276,8 @@
   <string name="settings_oauth">Autentisera på nytt</string>
   <string name="settings_oauth_summary">Genomför OAuth-inloggning igen</string>
   <string name="settings_username">Användarnamn</string>
-  <string name="settings_enter_username">Skriv in användarnamn</string>
   <string name="settings_password">Lösenord</string>
   <string name="settings_password_summary">Uppdatera lösenordet enligt din server.</string>
-  <string name="settings_enter_password">Ange ditt lösenord:</string>
   <string name="settings_certificate_install">Installera certifikat</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">Tidsgräns för tidigare händelser</string>
@@ -418,6 +399,4 @@
   <string name="sync_invalid_task">Fick ogiltigt ärende från servern</string>
   <string name="sync_invalid_resources_ignoring">Ignorerar en eller flera ogiltiga resurser</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵: Anslutningssäkerhet</string>
-  <string name="trust_certificate_unknown_certificate_found">DAVx⁵ har stött på ett okänt certifikat. Vill du lita på det?</string>
 </resources>

--- a/app/src/main/res/values-szl/strings.xml
+++ b/app/src/main/res/values-szl/strings.xml
@@ -18,8 +18,6 @@
   <string name="intro_slogan1">Twoje dane. Twōj wybōr.</string>
   <string name="intro_slogan2">Przejmij kōntrola.</string>
   <string name="intro_battery_title">Regularne interwały synchrōnizacyje</string>
-  <string name="intro_battery_not_whitelisted">Zastawiōne (niyrekōmyndowane)</string>
-  <string name="intro_battery_whitelisted">Włōnczōne (rekōmyndowane)</string>
   <string name="intro_battery_text">Żeby regularnie synchrōnizować, %s musi mieć zwolo na fungowanie na zadku. W inkszym przipadku Android może w kożdyj chwili zastawić synchrōnizacyjo.</string>
   <string name="intro_battery_dont_show">Niy potrzebuja regularnyj synchrōnizacyje.*</string>
   <string name="intro_autostart_title">Zgodność %s</string>
@@ -40,16 +38,13 @@
   <string name="about_libraries">Bibliotyki</string>
   <string name="about_version">Wersyjo %1$s (%2$d)</string>
   <string name="about_build_date">Skōmpilowano %s</string>
-  <string name="about_flavor_info">Ta wersyjo je do dystrybucyje ino na Google Play.</string>
   <string name="about_license_info_no_warranty">Tyn program przichodzi BEZ ŻODNYJ GWARANCYJE. To je wolne ôprogramowanie i możesz je rozkludzać pod ôkryślōnymi warōnkami.</string>
-  <string name="about_translations_thanks"><![CDATA[<i>Dziynki: </i> %s]]></string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Niy szło stworzić zbioru dziynnika</string>
   <!--AccountsActivity-->
   <string name="navigation_drawer_subtitle">Adapter synchrōnizacyje CalDAV/CardDAV</string>
   <string name="navigation_drawer_about">Ô DAVx⁵ / Licyncyjo</string>
   <string name="navigation_drawer_beta_feedback">Przekoż ôpinijo</string>
-  <string name="install_email_client">Zainstaluj klijynt emaila</string>
   <string name="install_browser">Zainstaluj przeglōndarka internetowo</string>
   <string name="navigation_drawer_settings">Sztelōnki</string>
   <string name="navigation_drawer_news_updates">Nowości i aktualizacyje</string>
@@ -59,8 +54,6 @@
   <string name="navigation_drawer_faq">Pytania i ôdpowiedzi</string>
   <string name="navigation_drawer_privacy_policy">Polityka prywatności</string>
   <string name="account_list_empty">Witōmy w DAVx⁵!\n\nMożesz teroz przidać kōnto CalDAV/CardDAV.</string>
-  <string name="accounts_global_sync_disabled">Autōmatyczno synchrōnizacyjo dlo cołkigo systymu je zastawiōno</string>
-  <string name="accounts_global_sync_enable">Włōncz</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">Niy szło ôdświyżyć serwisu</string>
   <string name="refresh_collections_worker_refresh_couldnt_refresh">Niy szło ôdświyżyć listy kolekcyje</string>
@@ -91,10 +84,6 @@
   <string name="account_carddav">CardDAV</string>
   <string name="account_caldav">CalDAV</string>
   <string name="account_webcal">Webcal</string>
-  <string name="account_no_address_books">Niy ma (jeszcze) żodnych ksiōnżek adresowych.</string>
-  <string name="account_no_calendars">Niy ma (jeszcze) żodnych kalyndorzōw.</string>
-  <string name="account_no_webcals">Niy ma (jeszcze) żodnych subskrypcyji kalyndorzōw.</string>
-  <string name="account_swipe_down">Przeciōng w dōł, żeby ôdświyżyć lista ze serwera.</string>
   <string name="account_synchronize_now">Synchrōnizuj teroz</string>
   <string name="account_settings">Sztelōnki kōnta</string>
   <string name="account_rename">Przemianuj kōnto</string>
@@ -107,8 +96,6 @@
   <string name="account_read_only">ino do ôdczytu</string>
   <string name="account_calendar">kalyndorz</string>
   <string name="account_task_list">lista zadań</string>
-  <string name="account_create_new_address_book">Stwōrz nowo ksiōnżka adresowo</string>
-  <string name="account_create_new_calendar">Stwōrz nowy kalyndorz</string>
   <string name="account_no_webcal_handler_found">Niy szło znojś aplikacyje, co ôbsuguje Webcal</string>
   <string name="account_install_icsx5">Zainstaluj ICSx⁵</string>
   <!--AddAccountActivity-->
@@ -137,7 +124,6 @@
   <string name="login_no_caldav_carddav">Niy idzie znojść usugi CalDAV abo CardDAV.</string>
   <string name="login_view_logs">Pokoż informacyje</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Sztelōnki: %s</string>
   <string name="settings_sync">Synchrōnizacyjo</string>
   <string name="settings_sync_interval_contacts">Frekwyncyjo synchrōnizacyje kōntaktōw</string>
   <string name="settings_sync_summary_manually">Ino ryncznie</string>
@@ -162,10 +148,8 @@
   <string name="settings_sync_wifi_only_ssids_message">Ôddzielōne kōmami miana (SSID) przizwolōnych necōw WiFi (ôstow prōzne dlo wszyjskich)</string>
   <string name="settings_authentication">Autoryzowanie</string>
   <string name="settings_username">Miano używocza</string>
-  <string name="settings_enter_username">Wpisz miano używocza:</string>
   <string name="settings_password">Hasło</string>
   <string name="settings_password_summary">Zaktualizuj hasło zgodnie ze serwerym.</string>
-  <string name="settings_enter_password">Wpisz hasło:</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">Limit czasowy przeszłych zdarzyń</string>
   <string name="settings_sync_time_range_past_none">Wszyjske zdarzynia bydōm zsynchrōnizowane</string>
@@ -237,6 +221,4 @@
   <string name="sync_invalid_task">Dostane zadanie ze serwera je niynoleżne</string>
   <string name="sync_invalid_resources_ignoring">Ignorowanie jednego abo wiyncyj niynoleżnych zasobōw</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵: Bezpieczyństwo połōnczynio</string>
-  <string name="trust_certificate_unknown_certificate_found">DAVx⁵ trefiōł niyznōmy certyfikat. Chcesz go przidać?</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -48,8 +48,6 @@
   <string name="account_delete_confirmation_title">Hesap gerçekten silinsin mi?</string>
   <string name="account_delete_confirmation_text">Rehber, takvim ve iş listelerinin tüm yerel kopyaları silinecektir.</string>
   <string name="account_read_only">salt-okunur</string>
-  <string name="account_create_new_address_book">Yeni rehber oluştur</string>
-  <string name="account_create_new_calendar">Yeni takvim oluştur</string>
   <!--AddAccountActivity-->
   <string name="login_title">Hesap ekle</string>
   <string name="login_type_email">Eposta adresi ile giriş yap</string>
@@ -73,7 +71,6 @@
   <string name="login_no_caldav_carddav">CalDAV veya CardDAV servisi bulunamadı.</string>
   <string name="login_view_logs">Detayları göster</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Ayarlar: %s</string>
   <string name="settings_sync">Senkronizasyon</string>
   <string name="settings_sync_interval_contacts">Kişiler senk. aralığı</string>
   <string name="settings_sync_summary_manually">Sadece elle</string>
@@ -86,10 +83,8 @@
   <string name="settings_sync_wifi_only_ssids">WiFi SSID kısıtlaması</string>
   <string name="settings_authentication">Doğrulama</string>
   <string name="settings_username">Kullanıcı adı</string>
-  <string name="settings_enter_username">Kullanıcı adı girin:</string>
   <string name="settings_password">Parola</string>
   <string name="settings_password_summary">Parolayı sunucunuza göre güncelleyin.</string>
-  <string name="settings_enter_password">Parola girin:</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">Geçmiş olay zaman sınırı</string>
   <string name="settings_sync_time_range_past_none">Tüm olaylar senkronize edilecek</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -24,8 +24,6 @@
   <string name="intro_slogan1">Ваша дата. Ваш вибір.</string>
   <string name="intro_slogan2">Візьміть під свій контроль.</string>
   <string name="intro_battery_title">Інтервали регулярної синхронізації</string>
-  <string name="intro_battery_not_whitelisted">Вимкнено (не рекомендуєтсья)</string>
-  <string name="intro_battery_whitelisted">Дозволено (рекомендується)</string>
   <string name="intro_battery_dont_show">Мені не потрібні інтервали регулярної синхронізації.*</string>
   <string name="intro_more_info">Детальніше</string>
   <string name="intro_tasks_title">Підтримка завдань</string>
@@ -52,7 +50,6 @@
   <string name="about_libraries">Бібліотеки</string>
   <string name="about_version">Версія %1$s (%2$d)</string>
   <string name="about_build_date">Складено на %s</string>
-  <string name="about_flavor_info">Цю версію прийнятно розповсюджувати тільки через Google Play.</string>
   <string name="about_license_info_no_warranty">Цей програмний засіб постачається АБСОЛЮТНО БЕЗ БУДЬ-ЯКИХ ГАРАНТІЙ. Це вільне програмне забезпечення, і ви можете поширювати її, за деякими умовами.</string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Не вдалося створити файл звіту</string>
@@ -61,7 +58,6 @@
   <string name="navigation_drawer_subtitle">Адаптер синхронізації CalDAV/CardDAV</string>
   <string name="navigation_drawer_about">Про / Ліцензія</string>
   <string name="navigation_drawer_beta_feedback">Beta відгук</string>
-  <string name="install_email_client">Будь ласка, встановіть клієнт електронної пошти</string>
   <string name="install_browser">Будь ласка, встановіть веб-браузер</string>
   <string name="navigation_drawer_settings">Налаштування</string>
   <string name="navigation_drawer_news_updates">Новини та оновлення</string>
@@ -71,8 +67,6 @@
   <string name="navigation_drawer_faq">Питання/Відповіді</string>
   <string name="navigation_drawer_privacy_policy">Політика конфіденційності</string>
   <string name="account_list_empty">Вітаємо у DAVx⁵!\n\nТепер можете додавати облікові записи CalDAV/CardDAV.</string>
-  <string name="accounts_global_sync_disabled">Автоматичну синхронізацію вимкнено зі сторони системи</string>
-  <string name="accounts_global_sync_enable">Увімкнути</string>
   <string name="accounts_sync_all">Синхронізувати всі обліківки</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">Не вдалося виявити сервіси</string>
@@ -113,10 +107,6 @@
   <string name="account_carddav">CardDAV</string>
   <string name="account_caldav">CalDAV</string>
   <string name="account_webcal">Webcal</string>
-  <string name="account_no_address_books">Немає адресних книг (поки що).</string>
-  <string name="account_no_calendars">Немає жодного календаря. (поки що)</string>
-  <string name="account_no_webcals">Немає підписок на календар (поки що).</string>
-  <string name="account_swipe_down">Потягніть донизу, аби оновити список з серверу.</string>
   <string name="account_synchronize_now">Синхронізувати зараз</string>
   <string name="account_settings">Налаштування облікового запису</string>
   <string name="account_rename">Перейменувати обліковий запис</string>
@@ -130,8 +120,6 @@
   <string name="account_read_only">лише читання</string>
   <string name="account_calendar">календар</string>
   <string name="account_task_list">перелік завдань</string>
-  <string name="account_create_new_address_book">Створити нову адресну книгу</string>
-  <string name="account_create_new_calendar">Створити новий календар</string>
   <string name="account_no_webcal_handler_found">Не знайдено додатку з підтримкою Webcal</string>
   <string name="account_install_icsx5">Встановити ICSx⁵</string>
   <!--AddAccountActivity-->
@@ -165,7 +153,6 @@
   <string name="login_username_password_wrong">Невірне імʼя користувача (електронна адреса)/пароль?</string>
   <string name="login_view_logs">Показати деталі</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Налаштування: %s</string>
   <string name="settings_sync">Синхронізація</string>
   <string name="settings_sync_interval_contacts">Інтервал синхронізації контактів</string>
   <string name="settings_sync_summary_manually">Лише вручну</string>
@@ -191,10 +178,8 @@
   <string name="settings_sync_wifi_only_ssids_permissions_action">Керувати</string>
   <string name="settings_authentication">Автентифікація</string>
   <string name="settings_username">Ім\'я користувача</string>
-  <string name="settings_enter_username">Введіть ім\'я користувача:</string>
   <string name="settings_password">Пароль</string>
   <string name="settings_password_summary">Оновити пароль, згідно налаштувань Вашого сервера.</string>
-  <string name="settings_enter_password">Введіть Ваш пароль:</string>
   <string name="settings_certificate_install">Встановити сертифікат</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">Інтервал синхронізації</string>
@@ -276,6 +261,4 @@
   <string name="sync_invalid_task">Отримано помилкове завдання від сервера</string>
   <string name="sync_invalid_resources_ignoring">Ігнорування одного або більше хибних джерел</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵: Безпека з\'єднання</string>
-  <string name="trust_certificate_unknown_certificate_found">DAVx⁵ зіткнувся з невідомим сертифікатом. Чи довіряти йому?</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -26,8 +26,6 @@
   <string name="intro_slogan1">Dữ liệu của bạn. Lựa chọn của bạn.</string>
   <string name="intro_slogan2">Giành quyền kiểm soát.</string>
   <string name="intro_battery_title">Khoảng thời gian thông thường giữa mỗi lần đồng bộ</string>
-  <string name="intro_battery_not_whitelisted">Tắt (không được khuyến nghị)</string>
-  <string name="intro_battery_whitelisted">Bật (được khuyến nghị)</string>
   <string name="intro_battery_text">Để đồng bộ hoá tại những khoảng thời gian thông thường, %s phải được cho phép chạy trong nền. Nếu không, Android có thể sẽ tạm dừng đồng bộ hoá bất cứ lúc nào.</string>
   <string name="intro_battery_dont_show">Tôi không cần khoảng thời gian đồng bộ thông thường.*</string>
   <string name="intro_autostart_title">Sự tương thích với %s</string>
@@ -60,8 +58,6 @@
   <string name="permissions_calendar_status_off">Không đồng bộ lịch (không được khuyến nghị)</string>
   <string name="permissions_calendar_status_on">Có thể đồng bộ lịch</string>
   <string name="permissions_jtx_title">Quyền của jtx Board</string>
-  <string name="permissions_jtx_status_off">Không đồng bộ công việc, nhật ký, ghi chú</string>
-  <string name="permissions_jtx_status_on">Có thể đồng bộ công việc, nhật ký, ghi chú</string>
   <string name="permissions_opentasks_title">Quyền OpenTasks</string>
   <string name="permissions_tasksorg_title">Quyền Tasks</string>
   <string name="permissions_tasks_status_off">Không đồng bộ công việc</string>
@@ -90,9 +86,7 @@
   <string name="about_version">Phiên bản %1$s (%2$d)</string>
   <string name="about_build_date">Biên dịch vào %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) và những người đóng góp</string>
-  <string name="about_flavor_info">Phiên bản này chỉ đủ điều kiện để phân phối qua Google Play.</string>
   <string name="about_license_info_no_warranty">Chương trình này KHÔNG CÓ SỰ ĐẢM BẢO NÀO. Nó là phần mềm tự do, và bạn có thể tuỳ ý phân phối lại nó dưới các điều kiện cụ thể. </string>
-  <string name="about_translations_thanks"><![CDATA[<i>Nhờ có: </i> %s]]></string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Không thể tạo tệp nhật ký</string>
   <string name="logging_notification_text">Bây giờ đang ghi lại tất cả %s hoạt động</string>
@@ -102,7 +96,6 @@
   <string name="navigation_drawer_subtitle">Đồng bộ CalDAV/CardDAV</string>
   <string name="navigation_drawer_about">Giới thiệu / Giấy phép</string>
   <string name="navigation_drawer_beta_feedback">Phản hồi về bản beta</string>
-  <string name="install_email_client">Vui lòng cài đặt một ứng dụng email khách</string>
   <string name="install_browser">Vui lòng cài đặt một trình duyệt web</string>
   <string name="navigation_drawer_settings">Cài đặt</string>
   <string name="navigation_drawer_news_updates">Tin tức &amp; cập nhật</string>
@@ -114,8 +107,6 @@
   <string name="navigation_drawer_community">Cộng đồng</string>
   <string name="navigation_drawer_privacy_policy">Chính sách riêng tư</string>
   <string name="account_list_empty">Chào mừng đến DAVx⁵!\n\nBạn có thể thêm một tài khoản CalDAV/CardDAV ngay.</string>
-  <string name="accounts_global_sync_disabled">Đồng bộ hoá tự động trên toàn hệ thống bị tắt</string>
-  <string name="accounts_global_sync_enable">Bật</string>
   <string name="accounts_sync_all">Đồng bộ tất cả tài khoản</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">Dò tìm dịch vụ thất bại</string>
@@ -165,16 +156,11 @@
   <string name="app_settings_reset_hints_success">Tất cả gợi ý sẽ được hiện lại</string>
   <string name="app_settings_integration">Tích hợp</string>
   <string name="app_settings_tasks_provider">Ứng dụng công việc</string>
-  <string name="app_settings_tasks_provider_synchronizing_with">Đang đồng bộ hoá bằng %s</string>
   <string name="app_settings_tasks_provider_none">Không tìm thấy ứng dụng công việc tương thích</string>
   <!--AccountActivity-->
   <string name="account_carddav">CardDAV</string>
   <string name="account_caldav">CalDAV</string>
   <string name="account_webcal">Webcal</string>
-  <string name="account_no_address_books">Chưa có sổ địa chỉ nào.</string>
-  <string name="account_no_calendars">Chưa có lịch nào.</string>
-  <string name="account_no_webcals">Chưa có lượt đăng ký lịch nào.</string>
-  <string name="account_swipe_down">Vuốt xuống để làm mới danh sách từ máy chủ.</string>
   <string name="account_synchronize_now">Đồng bộ hoá ngay</string>
   <string name="account_settings">Cài đặt tài khoản</string>
   <string name="account_rename">Đổi tên tài khoản</string>
@@ -190,8 +176,6 @@
   <string name="account_task_list">danh sách công việc</string>
   <string name="account_journal">nhật ký</string>
   <string name="account_only_personal">Chỉ hiện cá nhân</string>
-  <string name="account_create_new_address_book">Tạo sổ địa chỉ mới</string>
-  <string name="account_create_new_calendar">Tạo lịch mới</string>
   <string name="account_no_webcal_handler_found">Không tìm thấy ứng dụng nào có khả năng xử lý Webcal</string>
   <string name="account_install_icsx5">Cài đặt ICSx⁵</string>
   <!--AddAccountActivity-->
@@ -227,7 +211,6 @@
   <string name="login_username_password_wrong">Tên người dùng (địa chỉ email) / mật khẩu bị sai?</string>
   <string name="login_view_logs">Hiện chi tiết</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">Cài đặt: %s</string>
   <string name="settings_sync">Đồng bộ hoá</string>
   <string name="settings_sync_interval_contacts">Khoảng thời gian giữa mỗi lần đồng bộ danh bạ</string>
   <string name="settings_sync_summary_manually">Chỉ thủ công</string>
@@ -254,10 +237,8 @@
   <string name="settings_sync_wifi_only_ssids_permissions_action">Quản lý</string>
   <string name="settings_authentication">Xác thực</string>
   <string name="settings_username">Tên người dùng</string>
-  <string name="settings_enter_username">Nhập tên người dùng:</string>
   <string name="settings_password">Mật khẩu</string>
   <string name="settings_password_summary">Cập nhật mật khẩu theo như máy chủ của bạn.</string>
-  <string name="settings_enter_password">Nhập mật khẩu:</string>
   <string name="settings_certificate_install">Cài đặt chứng chỉ</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">Giới hạn thời gian cho sự kiện trong quá khứ</string>
@@ -374,6 +355,4 @@
   <string name="sync_invalid_task">Đã nhận công việc không hợp lệ từ máy chủ</string>
   <string name="sync_invalid_resources_ignoring">Đang bỏ qua một hoặc nhiều tài nguyên không hợp lệ</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵: Sự bảo mật của kết nối</string>
-  <string name="trust_certificate_unknown_certificate_found">DAVx⁵ đã gặp một chứng chỉ không xác định. Bạn có muốn tin tưởng nó không?</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -24,8 +24,6 @@
   <string name="intro_slogan1">您的資料，您的選擇</string>
   <string name="intro_slogan2">權力在握</string>
   <string name="intro_battery_title">定期同步間隔</string>
-  <string name="intro_battery_not_whitelisted">停用（不建議）</string>
-  <string name="intro_battery_whitelisted">啟用（建議）</string>
   <string name="intro_battery_text">為了定期進行同步，必須允許 %s 在背景運行，否則 Android 可能會隨時暫停同步。</string>
   <string name="intro_battery_dont_show">我不需要定期同步間隔*</string>
   <string name="intro_autostart_title">%s 相容性</string>
@@ -47,7 +45,6 @@
   <string name="about_libraries">函式庫</string>
   <string name="about_version">版本號 %1$s（%2$d）</string>
   <string name="about_build_date">編譯於 %s</string>
-  <string name="about_flavor_info">本功能僅在Google Play上面發行的程式上可用。</string>
   <string name="about_license_info_no_warranty">我們｢完全不保證｣本程式無瑕疵。這是個自由軟體，歡迎您在符合公用授權條款的情況下任意散布它。</string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">無法創建事項記錄文檔</string>
@@ -55,7 +52,6 @@
   <string name="navigation_drawer_subtitle">CalDAV/CardDAV 同步器</string>
   <string name="navigation_drawer_about">關於我們 / 授權條款</string>
   <string name="navigation_drawer_beta_feedback">為測試版本給回饋意見</string>
-  <string name="install_email_client">請安裝一個email程式</string>
   <string name="install_browser">請安裝一個瀏覽器程式</string>
   <string name="navigation_drawer_settings">設定</string>
   <string name="navigation_drawer_news_updates">新聞 &amp; 更新</string>
@@ -65,8 +61,6 @@
   <string name="navigation_drawer_faq">常見問答</string>
   <string name="navigation_drawer_privacy_policy">隱私權政策</string>
   <string name="account_list_empty">歡迎使用 DAVx⁵!\n\n您現在可以新增 CalDAV/CardDAV 帳號</string>
-  <string name="accounts_global_sync_disabled">操作系統的自動同步被關閉了</string>
-  <string name="accounts_global_sync_enable">啟用</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">未發現遠端服務</string>
   <string name="refresh_collections_worker_refresh_couldnt_refresh">無法更新清單</string>
@@ -98,10 +92,6 @@
   <string name="account_carddav">CardDAV聯絡人檔案</string>
   <string name="account_caldav">CalDav行事曆檔案</string>
   <string name="account_webcal">Webcal網際網絡行事曆</string>
-  <string name="account_no_address_books">（目前）沒有通訊錄</string>
-  <string name="account_no_calendars">（目前）沒有行事曆</string>
-  <string name="account_no_webcals">（目前）沒有行事曆訂閲</string>
-  <string name="account_swipe_down">下拉可從伺服器獲取最新清單</string>
   <string name="account_synchronize_now">立即同步</string>
   <string name="account_settings">帳號設定</string>
   <string name="account_rename">重新命名帳號</string>
@@ -116,8 +106,6 @@
   <string name="account_calendar">行事曆</string>
   <string name="account_task_list">待辦事項</string>
   <string name="account_only_personal">只顯示個人</string>
-  <string name="account_create_new_address_book">建立新的通訊錄</string>
-  <string name="account_create_new_calendar">建立新行事曆</string>
   <string name="account_no_webcal_handler_found">未找到支援Webcal的APP</string>
   <string name="account_install_icsx5">安裝ICSx⁵</string>
   <!--AddAccountActivity-->
@@ -146,7 +134,6 @@
   <string name="login_no_caldav_carddav">找不到 CalDAV 或 CardDAV 服務。</string>
   <string name="login_view_logs">顯示詳細訊息</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">設定: %s</string>
   <string name="settings_sync">同步設定</string>
   <string name="settings_sync_interval_contacts">聯絡人同步間隔</string>
   <string name="settings_sync_summary_manually">只手動同步</string>
@@ -172,10 +159,8 @@
   <string name="settings_sync_wifi_only_ssids_permissions_action">管理</string>
   <string name="settings_authentication">認證</string>
   <string name="settings_username">使用者帳號</string>
-  <string name="settings_enter_username">輸入帳號名稱:</string>
   <string name="settings_password">密碼</string>
   <string name="settings_password_summary">您在伺服器上使用中的密碼</string>
-  <string name="settings_enter_password">輸入密碼：</string>
   <string name="settings_caldav">CalDAV</string>
   <string name="settings_sync_time_range_past">過去活動的時間限制</string>
   <string name="settings_sync_time_range_past_none">將會同步所有活動</string>
@@ -243,6 +228,4 @@
   <string name="sync_invalid_task">收到了無效的任務</string>
   <string name="sync_invalid_resources_ignoring">略過了一個或多個無效的資料</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵: 連線安全性</string>
-  <string name="trust_certificate_unknown_certificate_found">DAVx⁵ 發現未知的憑證，您要信任它嗎?</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -30,8 +30,6 @@
   <string name="intro_slogan1">您的数据。您的选择。</string>
   <string name="intro_slogan2">获得控制。</string>
   <string name="intro_battery_title">定期同步间隔</string>
-  <string name="intro_battery_not_whitelisted">禁用（不推荐）</string>
-  <string name="intro_battery_whitelisted">启用（推荐）</string>
   <string name="intro_battery_text">为了定期进行同步，必须允许%s在后台运行。否则，Android可能会随时暂停同步。</string>
   <string name="intro_battery_dont_show">我不需要定期的同步。*</string>
   <string name="intro_autostart_title">%s兼容性</string>
@@ -69,8 +67,6 @@
   <string name="permissions_notification_status_off">已禁用通知（不推荐）</string>
   <string name="permissions_notification_status_on">已启用通知</string>
   <string name="permissions_jtx_title">jtx Board 权限</string>
-  <string name="permissions_jtx_status_off">无任务、日记、笔记同步</string>
-  <string name="permissions_jtx_status_on">可同步任务、日记和笔记</string>
   <string name="permissions_opentasks_title">OpenTasks权限</string>
   <string name="permissions_tasksorg_title">Tasks权限</string>
   <string name="permissions_tasks_status_off">无任务同步</string>
@@ -101,9 +97,7 @@
   <string name="about_version">版本 %1$s (%2$d)</string>
   <string name="about_build_date">编译于 %s</string>
   <string name="about_copyright">©Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) 及贡献者</string>
-  <string name="about_flavor_info">此版本只允许在 Google Play 上发行。</string>
   <string name="about_license_info_no_warranty">本程序不附带任何担保。这是一款自由软件，你可以有条件地传播它。</string>
-  <string name="about_translations_thanks"><![CDATA[<i>谢谢：</i>%s]]></string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">无法创建日志文件</string>
   <string name="logging_notification_text">正记录%s的所有活动</string>
@@ -113,7 +107,6 @@
   <string name="navigation_drawer_subtitle">CalDAV/CardDAV 同步器</string>
   <string name="navigation_drawer_about">关于 / 许可</string>
   <string name="navigation_drawer_beta_feedback">测试版反馈</string>
-  <string name="install_email_client">请安装邮件客户端</string>
   <string name="install_browser">请安装网页浏览器</string>
   <string name="navigation_drawer_settings">设置</string>
   <string name="navigation_drawer_news_updates">最新消息</string>
@@ -136,8 +129,6 @@
   <string name="account_list_low_storage">低存储空间。Android 不会立即同步本地更改，但会在下次定期同步时进行</string>
   <string name="account_list_manage_storage">管理存储</string>
   <string name="account_list_empty">欢迎使用 DAVx⁵！\n\n请开始增加 CalDAV/CardDAV 账户。</string>
-  <string name="accounts_global_sync_disabled">系统全局自动同步已禁用</string>
-  <string name="accounts_global_sync_enable">启用</string>
   <string name="accounts_sync_all">同步所有账户</string>
   <!--RefreshCollectionsWorker-->
   <string name="refresh_collections_worker_refresh_failed">服务配置检测失败</string>
@@ -189,7 +180,6 @@
   <string name="app_settings_reset_hints_success">所有提示将会再次显示</string>
   <string name="app_settings_integration">集成</string>
   <string name="app_settings_tasks_provider">Tasks 应用</string>
-  <string name="app_settings_tasks_provider_synchronizing_with">正与%s同步</string>
   <string name="app_settings_tasks_provider_none">未找到兼容的任务应用</string>
   <!--AccountActivity-->
   <string name="account_carddav">CardDAV</string>
@@ -197,10 +187,6 @@
   <string name="account_webcal">Webcal</string>
   <string name="account_missing_permissions">需要额外权限来同步这些集合</string>
   <string name="account_manage_permissions">管理权限</string>
-  <string name="account_no_address_books">暂无通讯录。</string>
-  <string name="account_no_calendars">暂无日历。</string>
-  <string name="account_no_webcals">暂无日历订阅。</string>
-  <string name="account_swipe_down">下拉可从服务器获取最新列表。</string>
   <string name="account_synchronize_now"> 立即同步</string>
   <string name="account_settings">账户设置</string>
   <string name="account_rename">重命名账户</string>
@@ -220,8 +206,6 @@
   <string name="account_only_personal">只显示个人</string>
   <string name="account_refresh_collections">刷新集合</string>
   <string name="account_refreshing_collections">正在刷新集合列表</string>
-  <string name="account_create_new_address_book">创建通讯录</string>
-  <string name="account_create_new_calendar">创建日历</string>
   <string name="account_webcal_external_app">可以用外部应用来同步 Webcal 订阅</string>
   <string name="account_no_webcal_handler_found">找不到支持 Webcal 的应用</string>
   <string name="account_install_icsx5">安装 ICSx⁵</string>
@@ -277,7 +261,6 @@
   <string name="login_username_password_wrong">用户名（邮箱地址）或密码错误？</string>
   <string name="login_view_logs">显示详情</string>
   <!--AccountSettingsActivity-->
-  <string name="settings_title">设置：%s</string>
   <string name="settings_sync">同步</string>
   <string name="settings_sync_interval_contacts">通讯录自动同步间隔</string>
   <string name="settings_sync_summary_manually">手动同步</string>
@@ -309,10 +292,8 @@
   <string name="settings_oauth">重新验证身份</string>
   <string name="settings_oauth_summary">再次进行 OAuth 登录</string>
   <string name="settings_username">用户名</string>
-  <string name="settings_enter_username">输入用户名</string>
   <string name="settings_password">密码</string>
   <string name="settings_password_summary">修改服务器密码</string>
-  <string name="settings_enter_password">输入密码</string>
   <string name="settings_certificate_alias">客户端证书</string>
   <string name="settings_certificate_alias_empty">无证书可用或未选择证书</string>
   <string name="settings_certificate_install">安装证书</string>
@@ -436,6 +417,4 @@
   <string name="sync_invalid_task">从服务器收到无效的任务项</string>
   <string name="sync_invalid_resources_ignoring">正在忽略若干无效资源</string>
   <!--cert4android-->
-  <string name="certificate_notification_connection_security">DAVx⁵: 连接安全性</string>
-  <string name="trust_certificate_unknown_certificate_found">DAVx⁵ 遇到了未知证书。你是否要信任该证书？</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,8 +38,6 @@
     <string name="intro_slogan1">Your data. Your choice.</string>
     <string name="intro_slogan2">Take control.</string>
     <string name="intro_battery_title">Regular sync intervals</string>
-    <string name="intro_battery_not_whitelisted">Disabled (not recommended)</string>
-    <string name="intro_battery_whitelisted">Enabled (recommended)</string>
     <string name="intro_battery_text">For synchronization at regular intervals, %s must be allowed to run in the background. Otherwise, Android may pause synchronization at any time.</string>
     <string name="intro_battery_dont_show">I don\'t need regular sync intervals.*</string>
     <string name="intro_autostart_title">%s compatibility</string>
@@ -78,8 +76,6 @@
     <string name="permissions_notification_status_off">Notifications disabled (not recommended)</string>
     <string name="permissions_notification_status_on">Notifications enabled</string>
     <string name="permissions_jtx_title">jtx Board permissions</string>
-    <string name="permissions_jtx_status_off">No tasks, journals, notes sync</string>
-    <string name="permissions_jtx_status_on">Tasks, journals, notes sync possible</string>
     <string name="permissions_opentasks_title">OpenTasks permissions</string>
     <string name="permissions_tasksorg_title">Tasks permissions</string>
     <string name="permissions_tasks_status_off">No task sync</string>
@@ -112,9 +108,7 @@
     <string name="about_version">Version %1$s (%2$d)</string>
     <string name="about_build_date">Compiled on %s</string>
     <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) and contributors</string>
-    <string name="about_flavor_info">This version is only eligible for distribution over Google Play.</string>
     <string name="about_license_info_no_warranty">This program comes with ABSOLUTELY NO WARRANTY. It is free software, and you are welcome to redistribute it under certain conditions.</string>
-    <string name="about_translations_thanks"><![CDATA[<i>Thanks to: </i> %s]]></string>
 
     <!-- global settings -->
     <string name="logging_couldnt_create_file">Couldn\'t create log file</string>
@@ -126,7 +120,6 @@
     <string name="navigation_drawer_subtitle">CalDAV/CardDAV Sync Adapter</string>
     <string name="navigation_drawer_about">About / License</string>
     <string name="navigation_drawer_beta_feedback">Beta feedback</string>
-    <string name="install_email_client">Please install an email client</string>
     <string name="install_browser">Please install a Web browser</string>
     <string name="navigation_drawer_settings">Settings</string>
     <string name="navigation_drawer_news_updates">News &amp; updates</string>
@@ -149,8 +142,6 @@
     <string name="account_list_low_storage">Storage space low. Android will not sync local changes immediately, but during the next regular sync.</string>
     <string name="account_list_manage_storage">Manage storage</string>
     <string name="account_list_empty">Welcome to DAVx⁵!\n\nYou can add a CalDAV/CardDAV account now.</string>
-    <string name="accounts_global_sync_disabled">System-wide automatic synchronization is disabled</string>
-    <string name="accounts_global_sync_enable">Enable</string>
     <string name="accounts_sync_all">Sync all accounts</string>
 
     <!-- RefreshCollectionsWorker -->
@@ -216,7 +207,6 @@
     <string name="app_settings_reset_hints_success">All hints will be shown again</string>
     <string name="app_settings_integration">Integration</string>
     <string name="app_settings_tasks_provider">Tasks app</string>
-    <string name="app_settings_tasks_provider_synchronizing_with">Synchronizing with %s</string>
     <string name="app_settings_tasks_provider_none">No compatible tasks app found</string>
 
     <!-- AccountActivity -->
@@ -225,10 +215,6 @@
     <string name="account_webcal">Webcal</string>
     <string name="account_missing_permissions">Additional permissions are required to synchronize these collections.</string>
     <string name="account_manage_permissions">Manage permissions</string>
-    <string name="account_no_address_books">There are no address books (yet).</string>
-    <string name="account_no_calendars">There are no calendars (yet).</string>
-    <string name="account_no_webcals">There are no calendar subscriptions (yet).</string>
-    <string name="account_swipe_down">Swipe down to refresh the list from the server.</string>
     <string name="account_synchronize_now">Synchronize now</string>
     <string name="account_settings">Account settings</string>
     <string name="account_rename">Rename account</string>
@@ -248,8 +234,6 @@
     <string name="account_only_personal">Show only personal</string>
     <string name="account_refresh_collections">Refresh collections</string>
     <string name="account_refreshing_collections">Refreshing collection list</string>
-    <string name="account_create_new_address_book">Create new address book</string>
-    <string name="account_create_new_calendar">Create new calendar</string>
     <string name="account_webcal_external_app">"Webcal subscriptions can be synchronized with external apps."</string>
     <string name="account_no_webcal_handler_found">No Webcal-capable app found</string>
     <string name="account_install_icsx5">Install ICSx⁵</string>
@@ -308,7 +292,6 @@
     <string name="login_view_logs">Show details</string>
 
     <!-- AccountSettingsActivity -->
-    <string name="settings_title">Settings: %s</string>
     <string name="settings_sync">Synchronization</string>
     <string name="settings_sync_interval_contacts">Contacts sync. interval</string>
     <string name="settings_sync_summary_manually">Only manually</string>
@@ -349,10 +332,8 @@
     <string name="settings_oauth">Re-authenticate</string>
     <string name="settings_oauth_summary">Perform OAuth login again</string>
     <string name="settings_username">User name</string>
-    <string name="settings_enter_username">Enter user name:</string>
     <string name="settings_password">Password</string>
     <string name="settings_password_summary">Update the password according to your server.</string>
-    <string name="settings_enter_password">Enter your password:</string>
     <string name="settings_certificate_alias">Client certificate</string>
     <string name="settings_certificate_alias_empty">No certificate available or selected</string>
     <string name="settings_certificate_install">Install certificate</string>
@@ -364,7 +345,6 @@
         <item quantity="other">Events more than %d days in the past will be ignored</item>
     </plurals>
     <string name="settings_sync_time_range_past_message">Events which are more than this number of days in the past will be ignored (may be 0). Leave blank to synchronize all events.</string>
-    <string name="settings_key_default_alarm" translatable="false">default_alarm</string>
     <string name="settings_default_alarm">Default reminder</string>
     <plurals name="settings_default_alarm_on">
         <item quantity="one">Default reminder one minute before event</item>
@@ -491,7 +471,5 @@
     <string name="sync_invalid_resources_ignoring">Ignoring one or more invalid resources</string>
 
     <!-- cert4android -->
-    <string name="certificate_notification_connection_security">DAVx⁵: Connection security</string>
-    <string name="trust_certificate_unknown_certificate_found">DAVx⁵ has encountered an unknown certificate. Do you want to trust it?</string>
 
 </resources>


### PR DESCRIPTION
The list was computed in an automated way and includes:
```
intro_battery_not_whitelisted
intro_battery_whitelisted
permissions_jtx_status_off
permissions_jtx_status_on
about_flavor_info
about_translations_thanks
install_email_client
accounts_global_sync_disabled
accounts_global_sync_enable
app_settings_tasks_provider_synchronizing_with
account_no_address_books
account_no_calendars
account_no_webcals
account_swipe_down
account_create_new_address_book
account_create_new_calendar
settings_title
settings_enter_username
settings_enter_password
settings_key_default_alarm
certificate_notification_connection_security
trust_certificate_unknown_certificate_found
```