### PR TITLE
Don't use Gradle build and configuration cache for releases

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
     #  uses: github/codeql-action/autobuild@v2
 
     - name: Build
-      run: ./gradlew --build-cache --configuration-cache --no-daemon app:assembleOseDebug
+      run: ./gradlew --build-cache --configuration-cache --configuration-cache-problems=warn --no-daemon app:assembleOseDebug
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,6 +34,8 @@ jobs:
         distribution: 'temurin'
         java-version: 17
     - uses: gradle/actions/setup-gradle@v3
+      with:
+        cache-encryption-key: ${{ secrets.gradle_encryption_key }}
 
     - name: Use app/build and gradle configuration cache
       uses: actions/cache/restore@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,7 +55,7 @@ jobs:
     #  uses: github/codeql-action/autobuild@v2
 
     - name: Build
-      run: ./gradlew --no-daemon app:assembleOseDebug
+      run: ./gradlew --build-cache --configuration-cache --no-daemon app:assembleOseDebug
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,14 +29,9 @@ jobs:
       - name: Prepare keystore
         run: echo ${{ secrets.android_keystore_base64 }} | base64 -d >$GITHUB_WORKSPACE/keystore.jks
 
-      - name: Export library definitions
-        # --no-build-cache and --no-configuration-cache are required for AboutLibraries (bitfireAT/davx5#263, mikepenz/AboutLibraries#857).
-        # Safe to remove as soon as AboutLibraries is compatible with these caches.
-        run: ./gradlew --no-build-cache --no-configuration-cache -PaboutLibraries.exportPath=src/main/res/raw/ app:exportLibraryDefinitions
-
       - name: Build signed package
         # Make sure that caches are disabled to generate reproducible release builds
-        run: ./gradlew --no-build-cache --no-configuration-cache app:assembleRelease
+        run: ./gradlew --no-build-cache --no-configuration-cache --no-daemon app:assembleRelease
         env:
           ANDROID_KEYSTORE: ${{ github.workspace }}/keystore.jks
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.android_keystore_password }}

--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -39,15 +39,7 @@ jobs:
             app/build
 
       - name: Run lint and unit tests
-        run: ./gradlew app:check
-      - name: Archive results
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-results
-          path: |
-            app/build/outputs/lint*
-            app/build/reports
-          overwrite: true
+        run: ./gradlew --build-cache --configuration-cache app:check
 
   test_on_emulator:
     name: Tests with emulator
@@ -91,12 +83,5 @@ jobs:
           key: avd-${{ hashFiles('app/build.gradle.kts') }}   # gradle-managed devices are defined there
 
       - name: Run device tests
-        run: ./gradlew --no-daemon app:virtualCheck
+        run: ./gradlew --build-cache --configuration-cache app:virtualCheck
 
-      - name: Archive results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-results
-          path: app/build/reports
-          overwrite: true

--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -19,6 +19,8 @@ jobs:
           distribution: temurin
           java-version: 17
       - uses: gradle/actions/setup-gradle@v3
+        with:
+          cache-encryption-key: ${{ secrets.gradle_encryption_key }}
 
       - name: Create app/build and gradle configuration cache
         if: ${{ github.ref == 'refs/heads/dev-ose' }}
@@ -51,6 +53,8 @@ jobs:
           distribution: temurin
           java-version: 17
       - uses: gradle/actions/setup-gradle@v3
+        with:
+          cache-encryption-key: ${{ secrets.gradle_encryption_key }}
 
       - name: Create app/build and gradle configuration cache
         if: ${{ github.ref == 'refs/heads/dev-ose' }}

--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -41,7 +41,7 @@ jobs:
             app/build
 
       - name: Run lint and unit tests
-        run: ./gradlew --build-cache --configuration-cache app:check
+        run: ./gradlew --build-cache --configuration-cache --configuration-cache-problems=warn app:check
 
   test_on_emulator:
     name: Tests with emulator
@@ -87,5 +87,5 @@ jobs:
           key: avd-${{ hashFiles('app/build.gradle.kts') }}   # gradle-managed devices are defined there
 
       - name: Run device tests
-        run: ./gradlew --build-cache --configuration-cache app:virtualCheck
+        run: ./gradlew --build-cache --configuration-cache --configuration-cache-problems=warn app:virtualCheck
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,12 +11,6 @@ plugins {
     alias(libs.plugins.ksp)
 }
 
-aboutLibraries {
-    // This means that we have to generate the dependencies explicitly:
-    // ./gradlew --no-configuration-cache --no-build-cache -PaboutLibraries.exportPath=src/main/res/raw/ app:exportLibraryDefinitions
-    registerAndroidTasks = false
-}
-
 // Android configuration
 android {
     compileSdk = 34

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,12 +3,17 @@ org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=512m
 org.gradle.parallel=true
 
-org.gradle.configuration-cache=true
-org.gradle.configuration-cache.problems=warn
-
-# https://docs.gradle.org/current/userguide/build_cache.html
-org.gradle.caching=true
-
 # Android
 android.useAndroidX=true
 android.enableR8.fullMode=false
+
+
+# It's recommended to add these settings to your $GRADLE_USER_HOME/gradle.properties:
+
+# org.gradle.configuration-cache=true
+# org.gradle.configuration-cache.problems=warn
+
+# https://docs.gradle.org/current/userguide/build_cache.html
+# org.gradle.caching=true
+
+


### PR DESCRIPTION
- don't enable Gradle build and configuration cache for the project, but recommend it for the developer
- explicitly enable Gradle build and configuration cache for CI test jobs
- let AboutLibraries generate lib definitions itself again
- also don't archive test results (sometimes fails and we never use the results)