### PR TITLE
SettingsLiveData: post initial value even when it's null

### DIFF
--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/settings/SettingsManagerTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/settings/SettingsManagerTest.kt
@@ -5,6 +5,7 @@
 package at.bitfire.davdroid.settings
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.map
 import at.bitfire.davdroid.TestUtils.getOrAwaitValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -59,6 +60,20 @@ class SettingsManagerTest {
         assertEquals(Settings.PROXY_TYPE_SYSTEM, settingsManager.getInt(Settings.PROXY_TYPE))
     }
 
+
+    @Test
+    fun test_getBooleanLive_initialValuePostedEvenWhenNull() {
+        val live = settingsManager.getBooleanLive(SETTING_TEST).map { value ->
+            value
+        }
+        assertNull(live.getOrAwaitValue())
+
+        // posts value to main thread, InstantTaskExecutorRule is required to execute it instantly
+        settingsManager.putBoolean(SETTING_TEST, true)
+        runBlocking(Dispatchers.Main) {     // observeForever can't be run in background thread
+            assertTrue(live.getOrAwaitValue()!!)
+        }
+    }
 
     @Test
     fun test_getBooleanLive_getValue() {

--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/SettingsManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/SettingsManager.kt
@@ -178,6 +178,8 @@ class SettingsManager internal constructor(
     inner class SettingLiveData<T>(
         val getValueOrNull: () -> T?
     ): LiveData<T>(), OnChangeListener {
+        private var hasValue = false
+
         override fun onActive() {
             addOnChangeListener(this)
             update()
@@ -194,7 +196,7 @@ class SettingsManager internal constructor(
         @Synchronized
         private fun update() {
             val newValue = getValueOrNull()
-            if (value != newValue)
+            if (!hasValue || value != newValue)
                 postValue(newValue)
         }
     }


### PR DESCRIPTION
This is a quick fix.

I think on the long-term we should switch to Kotlin Flows instead if LiveData, then these things are more explicit.