### PR TITLE
Do not show existing password on password change

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsActivity.kt
@@ -435,8 +435,8 @@ class AccountSettingsActivity: AppCompatActivity() {
                     )
                     if (showPasswordDialog)
                         EditTextInputDialog(
-                            title = stringResource(R.string.settings_password),
-                            initialValue = credentials.password,
+                            title = stringResource(R.string.settings_new_password),
+                            initialValue = null, // Do not show the existing password
                             onValueEntered = { newValue ->
                                 onUpdateCredentials(credentials.copy(password = newValue))
                             },

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsActivity.kt
@@ -415,7 +415,7 @@ class AccountSettingsActivity: AppCompatActivity() {
                     if (showUsernameDialog)
                         EditTextInputDialog(
                             title = stringResource(R.string.settings_username),
-                            initialValue = credentials.username ?: "",
+                            initialValue = credentials.username,
                             onValueEntered = { newValue ->
                                 onUpdateCredentials(credentials.copy(username = newValue))
                             },
@@ -435,8 +435,10 @@ class AccountSettingsActivity: AppCompatActivity() {
                     )
                     if (showPasswordDialog)
                         EditTextInputDialog(
-                            title = stringResource(R.string.settings_new_password),
+                            title = stringResource(R.string.settings_password),
+                            inputLabel = stringResource(R.string.settings_new_password),
                             initialValue = null, // Do not show the existing password
+                            passwordField = true,
                             onValueEntered = { newValue ->
                                 onUpdateCredentials(credentials.copy(password = newValue))
                             },

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/composable/InputDialogs.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/composable/InputDialogs.kt
@@ -42,7 +42,9 @@ import androidx.compose.ui.window.Dialog
 fun EditTextInputDialog(
     title: String,
     initialValue: String? = null,
-    keyboardType: KeyboardType = KeyboardType.Text,
+    inputLabel: String? = null,
+    passwordField: Boolean = false,
+    keyboardType: KeyboardType = if (passwordField) KeyboardType.Password else KeyboardType.Text,
     onValueEntered: (String) -> Unit = {},
     onDismiss: () -> Unit = {},
 ) {
@@ -62,22 +64,31 @@ fun EditTextInputDialog(
         },
         text = {
             val focusRequester = remember { FocusRequester() }
-            TextField(
-                value = textValue,
-                onValueChange = { textValue = it },
-                singleLine = true,
-                keyboardOptions = KeyboardOptions(
-                    keyboardType = keyboardType,
-                    imeAction = ImeAction.Done
-                ),
-                keyboardActions = KeyboardActions(
-                    onDone = {
-                        onValueEntered(textValue.text)
-                        onDismiss()
-                    }
-                ),
-                modifier = Modifier.focusRequester(focusRequester)
-            )
+            if (passwordField)
+                PasswordTextField(
+                    password = textValue.text,
+                    labelText = inputLabel,
+                    onPasswordChange = { textValue = TextFieldValue(it) },
+                    modifier = Modifier.focusRequester(focusRequester)
+                )
+            else
+                TextField(
+                    label = { inputLabel?.let { Text(it) } },
+                    value = textValue,
+                    onValueChange = { textValue = it },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = keyboardType,
+                        imeAction = ImeAction.Done
+                    ),
+                    keyboardActions = KeyboardActions(
+                        onDone = {
+                            onValueEntered(textValue.text)
+                            onDismiss()
+                        }
+                    ),
+                    modifier = Modifier.focusRequester(focusRequester)
+                )
             LaunchedEffect(Unit) {
                 focusRequester.requestFocus()
             }
@@ -108,7 +119,18 @@ fun EditTextInputDialog(
 fun EditTextInputDialog_Preview() {
     EditTextInputDialog(
         title = "Enter Some Text",
+        inputLabel = "Some Label",
         initialValue = "initial value"
+    )
+}
+
+@Composable
+@Preview
+fun EditTextInputDialog_Preview_Password() {
+    EditTextInputDialog(
+        title = "New Password",
+        passwordField = true,
+        initialValue = "some password"
     )
 }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/composable/PasswordTextField.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/composable/PasswordTextField.kt
@@ -30,7 +30,7 @@ import at.bitfire.davdroid.R
 @Composable
 fun PasswordTextField(
     password: String,
-    labelText: String,
+    labelText: String?,
     onPasswordChange: (String) -> Unit,
     modifier: Modifier = Modifier,
     leadingIcon: @Composable (() -> Unit)? = null,
@@ -44,7 +44,7 @@ fun PasswordTextField(
     OutlinedTextField(
         value = password,
         onValueChange = onPasswordChange,
-        label = { Text(labelText) },
+        label = { if (labelText != null) Text(labelText) },
         leadingIcon = leadingIcon,
         isError = isError,
         singleLine = true,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -339,6 +339,7 @@
     <string name="settings_oauth_summary">Perform OAuth login again</string>
     <string name="settings_username">User name</string>
     <string name="settings_password">Password</string>
+    <string name="settings_new_password">New Password</string>
     <string name="settings_password_summary">Update the password according to your server.</string>
     <string name="settings_certificate_alias">Client certificate</string>
     <string name="settings_certificate_alias_empty">No certificate available or selected</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -339,7 +339,7 @@
     <string name="settings_oauth_summary">Perform OAuth login again</string>
     <string name="settings_username">User name</string>
     <string name="settings_password">Password</string>
-    <string name="settings_new_password">New Password</string>
+    <string name="settings_new_password">New password</string>
     <string name="settings_password_summary">Update the password according to your server.</string>
     <string name="settings_certificate_alias">Client certificate</string>
     <string name="settings_certificate_alias_empty">No certificate available or selected</string>


### PR DESCRIPTION
Not showing the password and then showing the new password in plain text provides better UX and less trouble than masking and unmasking the password. Note that I left the `initialValue=null` intentionally to show this. 