### PR TITLE
SettingsManager: use Flows instead of LiveData

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -149,6 +149,7 @@ dependencies {
     implementation(libs.androidx.core)
     implementation(libs.androidx.fragment)
     implementation(libs.androidx.hilt.work)
+    implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.viewmodel.base)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.paging)

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/settings/SettingsManagerTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/settings/SettingsManagerTest.kt
@@ -7,6 +7,10 @@ package at.bitfire.davdroid.settings
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -54,7 +58,7 @@ class SettingsManagerTest {
     }
 
 
-    /*@Test
+    @Test
     fun test_observerFlow_initialValue() = runBlocking {
         var counter = 0
         val live = settingsManager.observerFlow {
@@ -63,7 +67,7 @@ class SettingsManagerTest {
             else
                 throw AssertionError("A second value was requested")
         }
-        assertEquals(23, live.singleOrNull())
+        assertEquals(23, live.first())
     }
 
     @Test
@@ -71,30 +75,19 @@ class SettingsManagerTest {
         var counter = 0
         val live = settingsManager.observerFlow {
             when (counter++) {
-                0 -> 23     // initial value
+                0 -> {
+                    // update some setting so that we will be called a second time
+                    settingsManager.putBoolean(SETTING_TEST, true)
+                    // and emit initial value
+                    23
+                }
                 1 -> 42     // updated value
                 else -> throw AssertionError()
             }
         }
 
-        var collectCounter = 0
-        live.collect {
-            when (collectCounter++) {
-                0 -> {
-                    assertEquals(23, it)
-                    // first value collected, send some update so that onChange listener is triggered
-                    settingsManager.putBoolean(SETTING_TEST, true)
-                }
-                1 -> {
-                    assertEquals(42, it)
-                    // second value collected, success, stop here
-                    cancel()
-                }
-                else -> throw AssertionError()
-            }
-        }
-        // two values should have been collected
-        assertEquals(2, collectCounter)
-    }*/
+        val result = live.take(2).toList()
+        assertEquals(listOf(23, 42), result)
+    }
 
 }

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/settings/SettingsManagerTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/settings/SettingsManagerTest.kt
@@ -5,18 +5,11 @@
 package at.bitfire.davdroid.settings
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import androidx.lifecycle.map
-import at.bitfire.davdroid.TestUtils.getOrAwaitValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -61,52 +54,47 @@ class SettingsManagerTest {
     }
 
 
-    @Test
-    fun test_getBooleanLive_initialValuePostedEvenWhenNull() {
-        val live = settingsManager.getBooleanLive(SETTING_TEST).map { value ->
-            value
+    /*@Test
+    fun test_observerFlow_initialValue() = runBlocking {
+        var counter = 0
+        val live = settingsManager.observerFlow {
+            if (counter++ == 0)
+                23
+            else
+                throw AssertionError("A second value was requested")
         }
-        assertNull(live.getOrAwaitValue())
-
-        // posts value to main thread, InstantTaskExecutorRule is required to execute it instantly
-        settingsManager.putBoolean(SETTING_TEST, true)
-        runBlocking(Dispatchers.Main) {     // observeForever can't be run in background thread
-            assertTrue(live.getOrAwaitValue()!!)
-        }
+        assertEquals(23, live.singleOrNull())
     }
 
     @Test
-    fun test_getBooleanLive_getValue() {
-        val live = settingsManager.getBooleanLive(SETTING_TEST)
-        assertNull(live.value)
-
-        // posts value to main thread, InstantTaskExecutorRule is required to execute it instantly
-        settingsManager.putBoolean(SETTING_TEST, true)
-        runBlocking(Dispatchers.Main) {     // observeForever can't be run in background thread
-            assertTrue(live.getOrAwaitValue()!!)
-        }
-    }
-
-
-    @Test
-    fun test_ObserverCalledWhenValueChanges() {
-        val value = CompletableDeferred<Int>()
-        val observer = SettingsManager.OnChangeListener {
-            value.complete(settingsManager.getInt(SETTING_TEST))
-        }
-
-        try {
-            settingsManager.addOnChangeListener(observer)
-            settingsManager.putInt(SETTING_TEST, 123)
-
-            runBlocking {
-                // wait until observer is called
-                assertEquals(123, value.await())
+    fun test_observerFlow_updatedValue() = runBlocking {
+        var counter = 0
+        val live = settingsManager.observerFlow {
+            when (counter++) {
+                0 -> 23     // initial value
+                1 -> 42     // updated value
+                else -> throw AssertionError()
             }
-
-        } finally {
-            settingsManager.removeOnChangeListener(observer)
         }
-    }
+
+        var collectCounter = 0
+        live.collect {
+            when (collectCounter++) {
+                0 -> {
+                    assertEquals(23, it)
+                    // first value collected, send some update so that onChange listener is triggered
+                    settingsManager.putBoolean(SETTING_TEST, true)
+                }
+                1 -> {
+                    assertEquals(42, it)
+                    // second value collected, success, stop here
+                    cancel()
+                }
+                else -> throw AssertionError()
+            }
+        }
+        // two values should have been collected
+        assertEquals(2, collectCounter)
+    }*/
 
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/SettingsManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/SettingsManager.kt
@@ -109,6 +109,8 @@ class SettingsManager internal constructor(
      *
      * - always emits the initial value of the setting, and then
      * - emits the new value whenever the setting changes.
+     *
+     * @param getValue   used to determine the current value of the setting
      */
     @VisibleForTesting
     internal fun<T> observerFlow(getValue: () -> T): Flow<T> = callbackFlow {

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsActivity.kt
@@ -57,6 +57,8 @@ import androidx.core.content.getSystemService
 import androidx.core.graphics.drawable.toBitmap
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.preference.PreferenceManager
 import at.bitfire.cert4android.CustomCertStore
@@ -149,16 +151,16 @@ class AppSettingsActivity: AppCompatActivity() {
                     )
 
                     AppSettings_Connection(
-                        proxyType = model.settings.getIntLive(Settings.PROXY_TYPE).observeAsState().value ?: Settings.PROXY_TYPE_NONE,
+                        proxyType = model.settings.getIntFlow(Settings.PROXY_TYPE).collectAsStateWithLifecycle(null).value ?: Settings.PROXY_TYPE_NONE,
                         onProxyTypeUpdated = { model.settings.putInt(Settings.PROXY_TYPE, it) },
-                        proxyHostName = model.settings.getStringLive(Settings.PROXY_HOST).observeAsState(null).value,
+                        proxyHostName = model.settings.getStringFlow(Settings.PROXY_HOST).collectAsStateWithLifecycle(null).value,
                         onProxyHostNameUpdated = { model.settings.putString(Settings.PROXY_HOST, it) },
-                        proxyPort = model.settings.getIntLive(Settings.PROXY_PORT).observeAsState(null).value,
+                        proxyPort = model.settings.getIntFlow(Settings.PROXY_PORT).collectAsStateWithLifecycle(null).value,
                         onProxyPortUpdated = { model.settings.putInt(Settings.PROXY_PORT, it) }
                     )
 
                     AppSettings_Security(
-                        distrustSystemCerts = model.settings.getBooleanLive(Settings.DISTRUST_SYSTEM_CERTIFICATES).observeAsState().value ?: false,
+                        distrustSystemCerts = model.settings.getBooleanFlow(Settings.DISTRUST_SYSTEM_CERTIFICATES).collectAsStateWithLifecycle(null).value ?: false,
                         onDistrustSystemCertsUpdated = { model.settings.putBoolean(Settings.DISTRUST_SYSTEM_CERTIFICATES, it) },
                         onResetCertificates = {
                             model.resetCertificates()
@@ -170,7 +172,7 @@ class AppSettingsActivity: AppCompatActivity() {
                     )
 
                     AppSettings_UserInterface(
-                        theme = model.settings.getIntLive(Settings.PREFERRED_THEME).observeAsState().value ?: Settings.PREFERRED_THEME_DEFAULT,
+                        theme = model.settings.getIntFlow(Settings.PREFERRED_THEME).collectAsStateWithLifecycle(null).value ?: Settings.PREFERRED_THEME_DEFAULT,
                         onThemeSelected = {
                             model.settings.putInt(Settings.PREFERRED_THEME, it)
                             UiUtils.updateTheme(context)
@@ -184,7 +186,7 @@ class AppSettingsActivity: AppCompatActivity() {
                     )
 
                     AppSettings_Integration(
-                        taskProvider = TaskUtils.currentProviderLive(context).observeAsState().value
+                        taskProvider = TaskUtils.currentProviderFlow(context, lifecycleScope).collectAsStateWithLifecycle().value
                     )
                 }
             }

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/TasksActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/TasksActivity.kt
@@ -41,6 +41,8 @@ import androidx.compose.ui.unit.dp
 import androidx.core.text.HtmlCompat
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -103,7 +105,7 @@ class TasksActivity: AppCompatActivity() {
 
         }
 
-        val showAgain = settings.getBooleanLive(HINT_OPENTASKS_NOT_INSTALLED)
+        val showAgain = settings.getBooleanFlow(HINT_OPENTASKS_NOT_INSTALLED)
         fun setShowAgain(showAgain: Boolean) {
             if (showAgain)
                 settings.remove(HINT_OPENTASKS_NOT_INSTALLED)
@@ -111,7 +113,7 @@ class TasksActivity: AppCompatActivity() {
                 settings.putBoolean(HINT_OPENTASKS_NOT_INSTALLED, false)
         }
 
-        val currentProvider = TaskUtils.currentProviderLive(context)
+        val currentProvider = TaskUtils.currentProviderFlow(context, viewModelScope).asLiveData()
         val jtxSelected = currentProvider.map { it == TaskProvider.ProviderName.JtxBoard }
         val tasksOrgSelected = currentProvider.map { it == TaskProvider.ProviderName.TasksOrg }
         val openTasksSelected = currentProvider.map { it == TaskProvider.ProviderName.OpenTasks }
@@ -171,7 +173,7 @@ fun TasksCard(
     val openTasksInstalled by model.openTasksInstalled.observeAsState(false)
     val openTasksSelected by model.openTasksSelected.observeAsState(false)
 
-    val showAgain = model.showAgain.observeAsState().value ?: true
+    val showAgain = model.showAgain.collectAsStateWithLifecycle(null).value ?: false
 
     fun installApp(packageName: String) {
         val uri = Uri.parse("market://details?id=$packageName&referrer=" +

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/intro/BatteryOptimizationsPage.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/intro/BatteryOptimizationsPage.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.content.getSystemService
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import at.bitfire.davdroid.BuildConfig
 import at.bitfire.davdroid.Constants
@@ -102,7 +103,7 @@ class BatteryOptimizationsPage: IntroPage {
             model.checkBatteryOptimizations()
         }
 
-        val hintBatteryOptimizations by model.hintBatteryOptimizations.observeAsState()
+        val hintBatteryOptimizations by model.hintBatteryOptimizations.collectAsStateWithLifecycle(false)
         val shouldBeExempted by model.shouldBeExempted.observeAsState(false)
         val isExempted by model.isExempted.observeAsState(false)
         LaunchedEffect(shouldBeExempted, isExempted) {
@@ -110,7 +111,7 @@ class BatteryOptimizationsPage: IntroPage {
                 ignoreBatteryOptimizationsResultLauncher.launch(BuildConfig.APPLICATION_ID)
         }
 
-        val hintAutostartPermission by model.hintAutostartPermission.observeAsState()
+        val hintAutostartPermission by model.hintAutostartPermission.collectAsStateWithLifecycle(false)
         BatteryOptimizationsContent(
             dontShowBattery = hintBatteryOptimizations == false,
             onChangeDontShowBattery = {
@@ -178,14 +179,14 @@ class BatteryOptimizationsPage: IntroPage {
 
         val shouldBeExempted = MutableLiveData<Boolean>()
         val isExempted = MutableLiveData<Boolean>()
-        val hintBatteryOptimizations = settings.getBooleanLive(HINT_BATTERY_OPTIMIZATIONS)
+        val hintBatteryOptimizations = settings.getBooleanFlow(HINT_BATTERY_OPTIMIZATIONS)
         private val batteryOptimizationsReceiver = object: BroadcastReceiver() {
             override fun onReceive(context: Context, intent: Intent) {
                 checkBatteryOptimizations()
             }
         }
 
-        val hintAutostartPermission = settings.getBooleanLive(HINT_AUTOSTART_PERMISSION)
+        val hintAutostartPermission = settings.getBooleanFlow(HINT_AUTOSTART_PERMISSION)
 
         init {
             val intentFilter = IntentFilter(PermissionUtils.ACTION_POWER_SAVE_WHITELIST_CHANGED)

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/intro/OpenSourcePage.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/intro/OpenSourcePage.kt
@@ -21,7 +21,6 @@ import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
@@ -31,6 +30,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import at.bitfire.davdroid.Constants
 import at.bitfire.davdroid.Constants.withStatParams
@@ -68,7 +68,7 @@ class OpenSourcePage : IntroPage {
 
     @Composable
     private fun Page(model: Model = viewModel()) {
-        val dontShow by model.dontShow.observeAsState(false)
+        val dontShow by model.dontShow.collectAsStateWithLifecycle(false)
         PageContent(
             dontShow = dontShow,
             onChangeDontShow = {
@@ -147,7 +147,8 @@ class OpenSourcePage : IntroPage {
             const val SETTING_NEXT_DONATION_POPUP = "time_nextDonationPopup"
         }
 
-        val dontShow = settings.containsKeyLive(SETTING_NEXT_DONATION_POPUP)
+        val dontShow = settings.containsKeyFlow(SETTING_NEXT_DONATION_POPUP)
+
         fun setDontShow(dontShowAgain: Boolean) {
             if (dontShowAgain) {
                 val nextReminder = System.currentTimeMillis() + 90*86400000L     // 90 days (~ 3 months)

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/AccountDetailsPage.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/AccountDetailsPage.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.servicedetection.DavResourceFinder
@@ -96,8 +97,9 @@ fun AccountDetailsPage(
     val suggestedAccountNames = foundConfig.calDAV?.emails ?: emptyList()
     var accountName by remember { mutableStateOf(suggestedAccountNames.firstOrNull() ?: "") }
 
-    val forcedGroupMethod by model.forcedGroupMethod.observeAsState()
-    var groupMethod by remember { mutableStateOf(forcedGroupMethod ?: loginInfo.suggestedGroupMethod) }
+    var groupMethod by remember { mutableStateOf(loginInfo.suggestedGroupMethod) }
+    val forcedGroupMethod by model.forcedGroupMethod.collectAsStateWithLifecycle(null)
+    forcedGroupMethod?.let { groupMethod = it }
     AccountDetailsPage_Content(
         suggestedAccountNames = suggestedAccountNames,
         accountName = accountName,

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginModel.kt
@@ -14,7 +14,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.liveData
-import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
 import at.bitfire.davdroid.InvalidAccountException
 import at.bitfire.davdroid.R
@@ -33,6 +32,7 @@ import at.bitfire.davdroid.util.TaskUtils
 import at.bitfire.vcard4android.GroupMethod
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runInterruptible
 import java.util.logging.Level
@@ -45,7 +45,7 @@ class LoginModel @Inject constructor(
     val settingsManager: SettingsManager
 ): ViewModel() {
 
-    val forcedGroupMethod = settingsManager.getStringLive(AccountSettings.KEY_CONTACT_GROUP_METHOD).map { methodName ->
+    val forcedGroupMethod = settingsManager.getStringFlow(AccountSettings.KEY_CONTACT_GROUP_METHOD).map { methodName ->
         methodName?.let {
             try {
                 GroupMethod.valueOf(it)

--- a/app/src/main/kotlin/at/bitfire/davdroid/util/TaskUtils.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/util/TaskUtils.kt
@@ -15,8 +15,6 @@ import android.graphics.drawable.BitmapDrawable
 import android.net.Uri
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.map
 import at.bitfire.davdroid.InvalidAccountException
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.Service
@@ -34,6 +32,11 @@ import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 
 object TaskUtils {
 
@@ -57,16 +60,16 @@ object TaskUtils {
     /**
      * Returns the currently selected tasks provider (if it's still available = installed).
      *
-     * @return the currently selected tasks provider, or null if none is available
+     * @return flow with the currently selected tasks provider
      */
-    fun currentProviderLive(context: Context): LiveData<ProviderName?> {
+    fun currentProviderFlow(context: Context, externalScope: CoroutineScope): StateFlow<ProviderName?> {
         val settingsManager = EntryPointAccessors.fromApplication(context, TaskUtilsEntryPoint::class.java).settingsManager()
-        return settingsManager.getStringLive(Settings.SELECTED_TASKS_PROVIDER).map { preferred ->
+        return settingsManager.getStringFlow(Settings.SELECTED_TASKS_PROVIDER).map { preferred ->
             if (preferred != null)
                 preferredAuthorityToProviderName(preferred, context.packageManager)
             else
                 null
-        }
+        }.stateIn(scope = externalScope, started = SharingStarted.WhileSubscribed(), initialValue = null)
     }
 
     private fun preferredAuthorityToProviderName(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ androidx-constraintLayout = "2.1.4"
 androidx-core = "1.12.0"
 androidx-fragment = "1.6.2"
 androidx-hilt = "1.2.0"
+androidx-lifecycle = "2.7.0"
 androidx-paging = "3.2.1"
 androidx-preference = "1.2.1"
 androidx-security = "1.1.0-alpha06"
@@ -23,7 +24,6 @@ androidx-test-core = "1.5.0"
 androidx-test-runner = "1.5.2"
 androidx-test-rules = "1.5.0"
 androidx-test-junit = "1.1.5"
-androidx-viewmodel = "2.7.0"
 androidx-work = "2.9.0"
 appIntro = "7.0.0-beta02"
 bitfire-cert4android = "f0964cb"
@@ -72,8 +72,9 @@ androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-cor
 androidx-fragment = { module = "androidx.fragment:fragment-ktx", version.ref = "androidx-fragment" }
 androidx-hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "androidx-hilt" }
 androidx-hilt-work = { module = "androidx.hilt:hilt-work", version.ref = "androidx-hilt" }
-androidx-lifecycle-viewmodel-base = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-viewmodel" }
-androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-viewmodel" }
+androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
+androidx-lifecycle-viewmodel-base = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle" }
+androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-paging = { module = "androidx.paging:paging-runtime-ktx", version.ref = "androidx-paging" }
 androidx-paging-compose = { module = "androidx.paging:paging-compose", version.ref = "androidx-paging" }
 androidx-preference = { module = "androidx.preference:preference-ktx", version.ref = "androidx-preference" }


### PR DESCRIPTION
Uses Flow instead of LiveData to provide observable settings.

- `callbackFlow` is used with the `SettingsManager.addOnChangeListener`.
- The flow always emits the current value (even if it's null; so something like #681 won't happen) and then updates
- In the Compose UI, `collectAsStateWithLifecycle` is used to collect the flow lifecycle-aware: if the Activity is paused, the flow will be stopped; if it's resumed, it will be started again.
- At some points, `.asLiveData()` is used so that existing code that uses settings LiveData doesn't have to be rewritten in this PR.

In the `AccountDetailsPage`, there was a problem with the initial value of `groupMethod`: `forcedGroupMethod` may be `null` at the first composition and then be updated. Now updated values of `forcedGroupMethod` are forced into the `groupMethod`. In this context, we're also using `Flow.map`.

In `TaskUtils.currentProviderFlow`, I have used `stateIn` to make the `SELECTED_TASK_PROVIDER` setting flow hot and stateful: the initial value and then incoming updates will be collected to a current state (StateFlow) so that the result always has a correct `value`.

@ArnyminerZ @sunkup I think this is how we could use Flows in the future (as discussed yesterday). Please test / have a look and tell me your thoughts.