### PR TITLE
AccountsScreen: move navigation drawer to foreground so that it overlays FABs when open

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
@@ -139,76 +139,76 @@ fun AccountsScreen(
 
     val snackbarHostState = remember { SnackbarHostState() }
     AppTheme {
-        Scaffold(
-            topBar = {
-                TopAppBar(
-                    navigationIcon = {
-                        IconToggleButton(false, onCheckedChange = { openDrawer ->
+        ModalNavigationDrawer(
+            drawerState = drawerState,
+            drawerContent = {
+                ModalDrawerSheet {
+                    accountsDrawerHandler.AccountsDrawer(
+                        snackbarHostState = snackbarHostState,
+                        onCloseDrawer = {
                             scope.launch {
-                                if (openDrawer)
-                                    drawerState.open()
-                                else
-                                    drawerState.close()
+                                drawerState.close()
                             }
-                        }) {
-                            Icon(
-                                Icons.Filled.Menu,
-                                stringResource(androidx.compose.ui.R.string.navigation_menu)
-                            )
                         }
-                    },
-                    title = {
-                        Text(stringResource(R.string.app_name))
-                    }
-                )
-            },
-            floatingActionButton = {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    if (showSyncAll)
-                        FloatingActionButton(
-                            containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                            onClick = onSyncAll
-                        ) {
-                            Icon(
-                                Icons.Default.Sync,
-                                contentDescription = stringResource(R.string.accounts_sync_all)
-                            )
-                        }
-
-                    if (showAddAccount == AccountsModel.FABStyle.WithText)
-                        ExtendedFloatingActionButton(
-                            text = { Text(stringResource(R.string.login_create_account)) },
-                            icon = { Icon(Icons.Filled.Add, stringResource(R.string.login_create_account)) },
-                            onClick = onAddAccount
-                        )
-                    else if (showAddAccount == AccountsModel.FABStyle.Standard)
-                        FloatingActionButton(
-                            onClick = onAddAccount,
-                            modifier = Modifier.padding(top = 24.dp)
-                        ) {
-                            Icon(Icons.Filled.Add, stringResource(R.string.login_create_account))
-                        }
+                    )
                 }
-            },
-            snackbarHost = { SnackbarHost(snackbarHostState) }
-        ) { padding ->
-            Box(Modifier.padding(padding)) {
-                ModalNavigationDrawer(
-                    drawerState = drawerState,
-                    drawerContent = {
-                        ModalDrawerSheet {
-                            accountsDrawerHandler.AccountsDrawer(
-                                snackbarHostState = snackbarHostState,
-                                onCloseDrawer = {
-                                    scope.launch {
+            }
+        ) {
+            Scaffold(
+                topBar = {
+                    TopAppBar(
+                        navigationIcon = {
+                            IconToggleButton(false, onCheckedChange = { openDrawer ->
+                                scope.launch {
+                                    if (openDrawer)
+                                        drawerState.open()
+                                    else
                                         drawerState.close()
-                                    }
                                 }
-                            )
+                            }) {
+                                Icon(
+                                    Icons.Filled.Menu,
+                                    stringResource(androidx.compose.ui.R.string.navigation_menu)
+                                )
+                            }
+                        },
+                        title = {
+                            Text(stringResource(R.string.app_name))
                         }
+                    )
+                },
+                floatingActionButton = {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        if (showSyncAll)
+                            FloatingActionButton(
+                                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                                onClick = onSyncAll
+                            ) {
+                                Icon(
+                                    Icons.Default.Sync,
+                                    contentDescription = stringResource(R.string.accounts_sync_all)
+                                )
+                            }
+
+                        if (showAddAccount == AccountsModel.FABStyle.WithText)
+                            ExtendedFloatingActionButton(
+                                text = { Text(stringResource(R.string.login_create_account)) },
+                                icon = { Icon(Icons.Filled.Add, stringResource(R.string.login_create_account)) },
+                                onClick = onAddAccount
+                            )
+                        else if (showAddAccount == AccountsModel.FABStyle.Standard)
+                            FloatingActionButton(
+                                onClick = onAddAccount,
+                                modifier = Modifier.padding(top = 24.dp)
+                            ) {
+                                Icon(Icons.Filled.Add, stringResource(R.string.login_create_account))
+                            }
                     }
-                ) {
+                },
+                snackbarHost = { SnackbarHost(snackbarHostState) }
+            ) { padding ->
+                Box(Modifier.padding(padding)) {
                     Box(
                         Modifier
                             .fillMaxSize()


### PR DESCRIPTION
The PR should be in _Draft_ state during development. As soon as it's finished, it should be marked as _Ready for review_ and a reviewer should be chosen.

See also: [Writing A Great Pull Request Description](https://www.pullrequest.com/blog/writing-a-great-pull-request-description/)


### Purpose

Solves #763 by switching the order of the Composables, which places the FABs correctly, below the side drawer.


### Short description

Moved `Scaffold` inside of `ModalNavigationDrawer` instead of the other way around.

See:

![Screenshot_20240430_124524](https://github.com/bitfireAT/davx5-ose/assets/12086466/be88eb52-df0c-492e-9a04-ece67a564221)


### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

