### PR TITLE
Replace `DavUtils.lastSegmentOfUrl` by `UrlUtils.lastSegment`

### DIFF
--- a/app/src/androidTestOse/kotlin/at/bitfire/davdroid/syncadapter/TestSyncManager.kt
+++ b/app/src/androidTestOse/kotlin/at/bitfire/davdroid/syncadapter/TestSyncManager.kt
@@ -16,6 +16,7 @@ import at.bitfire.davdroid.network.HttpClient
 import at.bitfire.davdroid.resource.LocalResource
 import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.util.DavUtils
+import at.bitfire.davdroid.util.lastSegment
 import okhttp3.HttpUrl
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -81,7 +82,7 @@ class TestSyncManager(
         assertEquals(assertDownloadRemote.keys.toList(), bunch)
 
         for ((url, eTag) in assertDownloadRemote) {
-            val fileName = DavUtils.lastSegmentOfUrl(url)
+            val fileName = url.lastSegment()
             var localEntry = localCollection.entries.firstOrNull { it.fileName == fileName }
             if (localEntry == null) {
                 val newEntry = LocalTestResource().also {

--- a/app/src/androidTestOse/kotlin/at/bitfire/davdroid/syncadapter/TestSyncManager.kt
+++ b/app/src/androidTestOse/kotlin/at/bitfire/davdroid/syncadapter/TestSyncManager.kt
@@ -82,7 +82,7 @@ class TestSyncManager(
         assertEquals(assertDownloadRemote.keys.toList(), bunch)
 
         for ((url, eTag) in assertDownloadRemote) {
-            val fileName = url.lastSegment()
+            val fileName = url.lastSegment
             var localEntry = localCollection.entries.firstOrNull { it.fileName == fileName }
             if (localEntry == null) {
                 val newEntry = LocalTestResource().also {

--- a/app/src/main/kotlin/at/bitfire/davdroid/db/Collection.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/db/Collection.kt
@@ -212,7 +212,7 @@ data class Collection(
     }
 
     // calculated properties
-    fun title() = displayName ?: url.lastSegment()
+    fun title() = displayName ?: url.lastSegment
     fun readOnly() = forceReadOnly || !privWriteContent
 
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/db/Collection.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/db/Collection.kt
@@ -23,6 +23,7 @@ import at.bitfire.dav4jvm.property.webdav.CurrentUserPrivilegeSet
 import at.bitfire.dav4jvm.property.webdav.DisplayName
 import at.bitfire.dav4jvm.property.webdav.ResourceType
 import at.bitfire.davdroid.util.DavUtils
+import at.bitfire.davdroid.util.lastSegment
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.apache.commons.lang3.StringUtils
@@ -211,7 +212,7 @@ data class Collection(
     }
 
     // calculated properties
-    fun title() = displayName ?: DavUtils.lastSegmentOfUrl(url)
+    fun title() = displayName ?: url.lastSegment()
     fun readOnly() = forceReadOnly || !privWriteContent
 
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/db/HomeSet.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/db/HomeSet.kt
@@ -38,6 +38,6 @@ data class HomeSet(
     var displayName: String? = null
 ) {
 
-    fun title() = displayName ?: url.lastSegment()
+    fun title() = displayName ?: url.lastSegment
 
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -109,7 +109,7 @@ open class LocalAddressBook(
 
             val sb = StringBuilder(info.displayName.let {
                 if (it.isNullOrEmpty())
-                    info.url.lastSegment()
+                    info.url.lastSegment
                 else
                     it
             })

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -25,6 +25,7 @@ import at.bitfire.davdroid.log.Logger
 import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.syncadapter.AccountUtils
 import at.bitfire.davdroid.util.DavUtils
+import at.bitfire.davdroid.util.lastSegment
 import at.bitfire.davdroid.util.setAndVerifyUserData
 import at.bitfire.vcard4android.AndroidAddressBook
 import at.bitfire.vcard4android.AndroidContact
@@ -108,7 +109,7 @@ open class LocalAddressBook(
 
             val sb = StringBuilder(info.displayName.let {
                 if (it.isNullOrEmpty())
-                    DavUtils.lastSegmentOfUrl(info.url)
+                    info.url.lastSegment()
                 else
                     it
             })

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
@@ -16,6 +16,7 @@ import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.SyncState
 import at.bitfire.davdroid.log.Logger
 import at.bitfire.davdroid.util.DavUtils
+import at.bitfire.davdroid.util.lastSegment
 import at.bitfire.ical4android.AndroidCalendar
 import at.bitfire.ical4android.AndroidCalendarFactory
 import at.bitfire.ical4android.BatchOperation
@@ -54,7 +55,8 @@ class LocalCalendar private constructor(
         private fun valuesFromCollectionInfo(info: Collection, withColor: Boolean): ContentValues {
             val values = ContentValues()
             values.put(Calendars.NAME, info.url.toString())
-            values.put(Calendars.CALENDAR_DISPLAY_NAME, if (info.displayName.isNullOrBlank()) DavUtils.lastSegmentOfUrl(info.url) else info.displayName)
+            values.put(Calendars.CALENDAR_DISPLAY_NAME,
+                if (info.displayName.isNullOrBlank()) info.url.lastSegment() else info.displayName)
 
             if (withColor)
                 values.put(Calendars.CALENDAR_COLOR, info.color ?: Constants.DAVDROID_GREEN_RGBA)

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
@@ -56,7 +56,7 @@ class LocalCalendar private constructor(
             val values = ContentValues()
             values.put(Calendars.NAME, info.url.toString())
             values.put(Calendars.CALENDAR_DISPLAY_NAME,
-                if (info.displayName.isNullOrBlank()) info.url.lastSegment() else info.displayName)
+                if (info.displayName.isNullOrBlank()) info.url.lastSegment else info.displayName)
 
             if (withColor)
                 values.put(Calendars.CALENDAR_COLOR, info.color ?: Constants.DAVDROID_GREEN_RGBA)

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollection.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollection.kt
@@ -36,7 +36,7 @@ class LocalJtxCollection(account: Account, client: ContentProviderClient, id: Lo
                 put(JtxContract.JtxCollection.URL, info.url.toString())
                 put(
                     JtxContract.JtxCollection.DISPLAYNAME,
-                    info.displayName ?: info.url.lastSegment()
+                    info.displayName ?: info.url.lastSegment
                 )
                 put(JtxContract.JtxCollection.DESCRIPTION, info.description)
                 if (owner != null)

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollection.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollection.kt
@@ -13,6 +13,7 @@ import at.bitfire.davdroid.db.Principal
 import at.bitfire.davdroid.db.SyncState
 import at.bitfire.davdroid.log.Logger
 import at.bitfire.davdroid.util.DavUtils
+import at.bitfire.davdroid.util.lastSegment
 import at.bitfire.ical4android.JtxCollection
 import at.bitfire.ical4android.JtxCollectionFactory
 import at.bitfire.ical4android.JtxICalObject
@@ -33,7 +34,10 @@ class LocalJtxCollection(account: Account, client: ContentProviderClient, id: Lo
         fun valuesFromCollection(info: Collection, account: Account, owner: Principal?, withColor: Boolean) =
             ContentValues().apply {
                 put(JtxContract.JtxCollection.URL, info.url.toString())
-                put(JtxContract.JtxCollection.DISPLAYNAME, info.displayName ?: DavUtils.lastSegmentOfUrl(info.url))
+                put(
+                    JtxContract.JtxCollection.DISPLAYNAME,
+                    info.displayName ?: info.url.lastSegment()
+                )
                 put(JtxContract.JtxCollection.DESCRIPTION, info.description)
                 if (owner != null)
                     put(JtxContract.JtxCollection.OWNER, owner.url.toString())

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskList.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskList.kt
@@ -14,6 +14,7 @@ import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.SyncState
 import at.bitfire.davdroid.log.Logger
 import at.bitfire.davdroid.util.DavUtils
+import at.bitfire.davdroid.util.lastSegment
 import at.bitfire.ical4android.DmfsTaskList
 import at.bitfire.ical4android.DmfsTaskListFactory
 import at.bitfire.ical4android.TaskProvider
@@ -53,7 +54,8 @@ class LocalTaskList private constructor(
         private fun valuesFromCollectionInfo(info: Collection, withColor: Boolean): ContentValues {
             val values = ContentValues(3)
             values.put(TaskLists._SYNC_ID, info.url.toString())
-            values.put(TaskLists.LIST_NAME, if (info.displayName.isNullOrBlank()) DavUtils.lastSegmentOfUrl(info.url) else info.displayName)
+            values.put(TaskLists.LIST_NAME,
+                if (info.displayName.isNullOrBlank()) info.url.lastSegment() else info.displayName)
 
             if (withColor)
                 values.put(TaskLists.LIST_COLOR, info.color ?: Constants.DAVDROID_GREEN_RGBA)

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskList.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskList.kt
@@ -55,7 +55,7 @@ class LocalTaskList private constructor(
             val values = ContentValues(3)
             values.put(TaskLists._SYNC_ID, info.url.toString())
             values.put(TaskLists.LIST_NAME,
-                if (info.displayName.isNullOrBlank()) info.url.lastSegment() else info.displayName)
+                if (info.displayName.isNullOrBlank()) info.url.lastSegment else info.displayName)
 
             if (withColor)
                 values.put(TaskLists.LIST_COLOR, info.color ?: Constants.DAVDROID_GREEN_RGBA)

--- a/app/src/main/kotlin/at/bitfire/davdroid/syncadapter/CalendarSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/syncadapter/CalendarSyncManager.kt
@@ -27,6 +27,7 @@ import at.bitfire.davdroid.resource.LocalEvent
 import at.bitfire.davdroid.resource.LocalResource
 import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.util.DavUtils
+import at.bitfire.davdroid.util.lastSegment
 import at.bitfire.ical4android.Event
 import at.bitfire.ical4android.InvalidCalendarException
 import at.bitfire.ical4android.util.DateUtils
@@ -182,7 +183,12 @@ class CalendarSyncManager(
                     val iCal = calendarData?.iCalendar
                             ?: throw DavException("Received multi-get response without calendar data")
 
-                    processVEvent(DavUtils.lastSegmentOfUrl(response.href), eTag, scheduleTag, StringReader(iCal))
+                    processVEvent(
+                        response.href.lastSegment(),
+                        eTag,
+                        scheduleTag,
+                        StringReader(iCal)
+                    )
                 }
             }
         }

--- a/app/src/main/kotlin/at/bitfire/davdroid/syncadapter/CalendarSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/syncadapter/CalendarSyncManager.kt
@@ -184,7 +184,7 @@ class CalendarSyncManager(
                             ?: throw DavException("Received multi-get response without calendar data")
 
                     processVEvent(
-                        response.href.lastSegment(),
+                        response.href.lastSegment,
                         eTag,
                         scheduleTag,
                         StringReader(iCal)

--- a/app/src/main/kotlin/at/bitfire/davdroid/syncadapter/ContactsSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/syncadapter/ContactsSyncManager.kt
@@ -37,6 +37,7 @@ import at.bitfire.davdroid.syncadapter.groups.CategoriesStrategy
 import at.bitfire.davdroid.syncadapter.groups.VCard4Strategy
 import at.bitfire.davdroid.util.DavUtils
 import at.bitfire.davdroid.util.DavUtils.sameTypeAs
+import at.bitfire.davdroid.util.lastSegment
 import at.bitfire.vcard4android.Contact
 import at.bitfire.vcard4android.GroupMethod
 import ezvcard.VCardVersion
@@ -304,7 +305,13 @@ class ContactsSyncManager(
                     val card = addressData?.card
                             ?: throw DavException("Received multi-get response without address data")
 
-                    processCard(DavUtils.lastSegmentOfUrl(response.href), eTag, StringReader(card), isJCard, resourceDownloader)
+                    processCard(
+                        response.href.lastSegment(),
+                        eTag,
+                        StringReader(card),
+                        isJCard,
+                        resourceDownloader
+                    )
                 }
             }
         }

--- a/app/src/main/kotlin/at/bitfire/davdroid/syncadapter/ContactsSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/syncadapter/ContactsSyncManager.kt
@@ -306,7 +306,7 @@ class ContactsSyncManager(
                             ?: throw DavException("Received multi-get response without address data")
 
                     processCard(
-                        response.href.lastSegment(),
+                        response.href.lastSegment,
                         eTag,
                         StringReader(card),
                         isJCard,

--- a/app/src/main/kotlin/at/bitfire/davdroid/syncadapter/JtxSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/syncadapter/JtxSyncManager.kt
@@ -112,7 +112,7 @@ class JtxSyncManager(
                     val iCal = calendarData?.iCalendar
                         ?: throw DavException("Received multi-get response without task data")
 
-                    processICalObject(response.href.lastSegment(), eTag, StringReader(iCal))
+                    processICalObject(response.href.lastSegment, eTag, StringReader(iCal))
                 }
             }
         }

--- a/app/src/main/kotlin/at/bitfire/davdroid/syncadapter/JtxSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/syncadapter/JtxSyncManager.kt
@@ -25,6 +25,7 @@ import at.bitfire.davdroid.resource.LocalJtxICalObject
 import at.bitfire.davdroid.resource.LocalResource
 import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.util.DavUtils
+import at.bitfire.davdroid.util.lastSegment
 import at.bitfire.ical4android.InvalidCalendarException
 import at.bitfire.ical4android.JtxICalObject
 import okhttp3.HttpUrl
@@ -111,7 +112,7 @@ class JtxSyncManager(
                     val iCal = calendarData?.iCalendar
                         ?: throw DavException("Received multi-get response without task data")
 
-                    processICalObject(DavUtils.lastSegmentOfUrl(response.href), eTag, StringReader(iCal))
+                    processICalObject(response.href.lastSegment(), eTag, StringReader(iCal))
                 }
             }
         }

--- a/app/src/main/kotlin/at/bitfire/davdroid/syncadapter/TasksSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/syncadapter/TasksSyncManager.kt
@@ -25,6 +25,7 @@ import at.bitfire.davdroid.resource.LocalTask
 import at.bitfire.davdroid.resource.LocalTaskList
 import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.util.DavUtils
+import at.bitfire.davdroid.util.lastSegment
 import at.bitfire.ical4android.InvalidCalendarException
 import at.bitfire.ical4android.Task
 import okhttp3.HttpUrl
@@ -111,7 +112,7 @@ class TasksSyncManager(
                     val iCal = calendarData?.iCalendar
                             ?: throw DavException("Received multi-get response without task data")
 
-                    processVTodo(DavUtils.lastSegmentOfUrl(response.href), eTag, StringReader(iCal))
+                    processVTodo(response.href.lastSegment(), eTag, StringReader(iCal))
                 }
             }
         }

--- a/app/src/main/kotlin/at/bitfire/davdroid/syncadapter/TasksSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/syncadapter/TasksSyncManager.kt
@@ -112,7 +112,7 @@ class TasksSyncManager(
                     val iCal = calendarData?.iCalendar
                             ?: throw DavException("Received multi-get response without task data")
 
-                    processVTodo(response.href.lastSegment(), eTag, StringReader(iCal))
+                    processVTodo(response.href.lastSegment, eTag, StringReader(iCal))
                 }
             }
         }

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionScreenModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionScreenModel.kt
@@ -59,7 +59,7 @@ class CollectionScreenModel @AssistedInject constructor(
     val owner: Flow<String?> = collection.map { collection ->
         collection?.ownerId?.let { ownerId ->
             val principal = principalDao.getAsync(ownerId)
-            principal.displayName ?: principal.url.lastSegment()
+            principal.displayName ?: principal.url.lastSegment
         }
     }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/util/DavUtils.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/util/DavUtils.kt
@@ -60,7 +60,13 @@ object DavUtils {
         return String.format(Locale.ROOT, "#%06X%02X", color, alpha)
     }
 
-    @Deprecated("Use HttpUrl.lastSegment in UrlUtils")
+    @Deprecated(
+        message = "Use HttpUrl.lastSegment in UrlUtils",
+        replaceWith = ReplaceWith(
+            "url.lastSegment()",
+            "at.bitfire.davdroid.util.lastSegment"
+        )
+    )
     fun lastSegmentOfUrl(url: HttpUrl): String {
         // the list returned by HttpUrl.pathSegments() is unmodifiable, so we have to create a copy
         val segments = LinkedList(url.pathSegments)

--- a/app/src/main/kotlin/at/bitfire/davdroid/util/DavUtils.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/util/DavUtils.kt
@@ -60,21 +60,6 @@ object DavUtils {
         return String.format(Locale.ROOT, "#%06X%02X", color, alpha)
     }
 
-    @Deprecated(
-        message = "Use HttpUrl.lastSegment in UrlUtils",
-        replaceWith = ReplaceWith(
-            "url.lastSegment()",
-            "at.bitfire.davdroid.util.lastSegment"
-        )
-    )
-    fun lastSegmentOfUrl(url: HttpUrl): String {
-        // the list returned by HttpUrl.pathSegments() is unmodifiable, so we have to create a copy
-        val segments = LinkedList(url.pathSegments)
-        segments.reverse()
-
-        return segments.firstOrNull { it.isNotEmpty() } ?: "/"
-    }
-
     fun prepareLookup(context: Context, lookup: Lookup) {
         if (Build.VERSION.SDK_INT >= 29) {
             /* Since Android 10, there's a native DnsResolver API that allows to send SRV queries without

--- a/app/src/main/kotlin/at/bitfire/davdroid/util/UrlUtils.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/util/UrlUtils.kt
@@ -6,5 +6,5 @@ package at.bitfire.davdroid.util
 
 import okhttp3.HttpUrl
 
-fun HttpUrl.lastSegment(): String =
-    pathSegments.lastOrNull { it.isNotEmpty() } ?: "/"
+val HttpUrl.lastSegment: String
+    get() = pathSegments.lastOrNull { it.isNotEmpty() } ?: "/"

--- a/app/src/test/kotlin/at/bitfire/davdroid/DavUtilsTest.kt
+++ b/app/src/test/kotlin/at/bitfire/davdroid/DavUtilsTest.kt
@@ -18,9 +18,6 @@ import org.xbill.DNS.SRVRecord
 
 class DavUtilsTest {
 
-    val exampleURL = "http://example.com/"
-
-
     @Test
     fun testAcceptAnything() {
         assertEquals("*/*", DavUtils.acceptAnything(null))
@@ -32,14 +29,6 @@ class DavUtilsTest {
         assertEquals("#00000000", DavUtils.ARGBtoCalDAVColor(0))
         assertEquals("#123456FF", DavUtils.ARGBtoCalDAVColor(0xFF123456.toInt()))
         assertEquals("#000000FF", DavUtils.ARGBtoCalDAVColor(0xFF000000.toInt()))
-    }
-
-    @Test
-    fun testLastSegmentOfUrl() {
-        assertEquals("/", DavUtils.lastSegmentOfUrl(exampleURL.toHttpUrl()))
-        assertEquals("dir", DavUtils.lastSegmentOfUrl((exampleURL + "dir").toHttpUrl()))
-        assertEquals("dir", DavUtils.lastSegmentOfUrl((exampleURL + "dir/").toHttpUrl()))
-        assertEquals("file.html", DavUtils.lastSegmentOfUrl((exampleURL + "dir/file.html").toHttpUrl()))
     }
 
     @Test

--- a/app/src/test/kotlin/at/bitfire/davdroid/DavUtilsTest.kt
+++ b/app/src/test/kotlin/at/bitfire/davdroid/DavUtilsTest.kt
@@ -6,7 +6,6 @@ package at.bitfire.davdroid
 
 import at.bitfire.davdroid.util.DavUtils
 import at.bitfire.davdroid.util.DavUtils.parent
-import at.bitfire.davdroid.util.lastSegment
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import org.junit.Assert.assertEquals
@@ -37,10 +36,10 @@ class DavUtilsTest {
 
     @Test
     fun testLastSegmentOfUrl() {
-        assertEquals("/", exampleURL.toHttpUrl().lastSegment())
-        assertEquals("dir", (exampleURL + "dir").toHttpUrl().lastSegment())
-        assertEquals("dir", (exampleURL + "dir/").toHttpUrl().lastSegment())
-        assertEquals("file.html", (exampleURL + "dir/file.html").toHttpUrl().lastSegment())
+        assertEquals("/", DavUtils.lastSegmentOfUrl(exampleURL.toHttpUrl()))
+        assertEquals("dir", DavUtils.lastSegmentOfUrl((exampleURL + "dir").toHttpUrl()))
+        assertEquals("dir", DavUtils.lastSegmentOfUrl((exampleURL + "dir/").toHttpUrl()))
+        assertEquals("file.html", DavUtils.lastSegmentOfUrl((exampleURL + "dir/file.html").toHttpUrl()))
     }
 
     @Test

--- a/app/src/test/kotlin/at/bitfire/davdroid/DavUtilsTest.kt
+++ b/app/src/test/kotlin/at/bitfire/davdroid/DavUtilsTest.kt
@@ -6,6 +6,7 @@ package at.bitfire.davdroid
 
 import at.bitfire.davdroid.util.DavUtils
 import at.bitfire.davdroid.util.DavUtils.parent
+import at.bitfire.davdroid.util.lastSegment
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import org.junit.Assert.assertEquals
@@ -36,10 +37,10 @@ class DavUtilsTest {
 
     @Test
     fun testLastSegmentOfUrl() {
-        assertEquals("/", DavUtils.lastSegmentOfUrl(exampleURL.toHttpUrl()))
-        assertEquals("dir", DavUtils.lastSegmentOfUrl((exampleURL + "dir").toHttpUrl()))
-        assertEquals("dir", DavUtils.lastSegmentOfUrl((exampleURL + "dir/").toHttpUrl()))
-        assertEquals("file.html", DavUtils.lastSegmentOfUrl((exampleURL + "dir/file.html").toHttpUrl()))
+        assertEquals("/", exampleURL.toHttpUrl().lastSegment())
+        assertEquals("dir", (exampleURL + "dir").toHttpUrl().lastSegment())
+        assertEquals("dir", (exampleURL + "dir/").toHttpUrl().lastSegment())
+        assertEquals("file.html", (exampleURL + "dir/file.html").toHttpUrl().lastSegment())
     }
 
     @Test

--- a/app/src/test/kotlin/at/bitfire/davdroid/UrlUtilsTest.kt
+++ b/app/src/test/kotlin/at/bitfire/davdroid/UrlUtilsTest.kt
@@ -10,9 +10,9 @@ class UrlUtilsTest {
 
     @Test
     fun testLastSegmentOfUrl() {
-        Assert.assertEquals("/", exampleURL.toHttpUrl().lastSegment())
-        Assert.assertEquals("dir", (exampleURL + "dir").toHttpUrl().lastSegment())
-        Assert.assertEquals("dir", (exampleURL + "dir/").toHttpUrl().lastSegment())
-        Assert.assertEquals("file.html", (exampleURL + "dir/file.html").toHttpUrl().lastSegment())
+        Assert.assertEquals("/", exampleURL.toHttpUrl().lastSegment)
+        Assert.assertEquals("dir", (exampleURL + "dir").toHttpUrl().lastSegment)
+        Assert.assertEquals("dir", (exampleURL + "dir/").toHttpUrl().lastSegment)
+        Assert.assertEquals("file.html", (exampleURL + "dir/file.html").toHttpUrl().lastSegment)
     }
 }

--- a/app/src/test/kotlin/at/bitfire/davdroid/UrlUtilsTest.kt
+++ b/app/src/test/kotlin/at/bitfire/davdroid/UrlUtilsTest.kt
@@ -1,0 +1,18 @@
+package at.bitfire.davdroid
+
+import at.bitfire.davdroid.util.lastSegment
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.junit.Assert
+import org.junit.Test
+
+class UrlUtilsTest {
+    private val exampleURL = "http://example.com/"
+
+    @Test
+    fun testLastSegmentOfUrl() {
+        Assert.assertEquals("/", exampleURL.toHttpUrl().lastSegment())
+        Assert.assertEquals("dir", (exampleURL + "dir").toHttpUrl().lastSegment())
+        Assert.assertEquals("dir", (exampleURL + "dir/").toHttpUrl().lastSegment())
+        Assert.assertEquals("file.html", (exampleURL + "dir/file.html").toHttpUrl().lastSegment())
+    }
+}


### PR DESCRIPTION
The PR should be in _Draft_ state during development. As soon as it's finished, it should be marked as _Ready for review_ and a reviewer should be chosen.

See also: [Writing A Great Pull Request Description](https://www.pullrequest.com/blog/writing-a-great-pull-request-description/)


### Purpose

Replaces all the usages of the deprecated `DavUtils.lastSegmentOfUrl` by the extension function of `Url` (`lastSegment()`).


### Short description

- Added `replaceWith` to the annotation.
- Replaced all usages

`DavUtils.lastSegmentOfUrl` may be removed if desired.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

