### PR TITLE
Switched CalDAV and CardDAV tab positions

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreen.kt
@@ -216,12 +216,12 @@ fun AccountScreen(
         var nextIdx = -1
 
         @Suppress("KotlinConstantConditions")
-        val idxCardDav: Int? = if (hasCardDav) ++nextIdx else null
         val idxCalDav: Int? = if (hasCalDav) ++nextIdx else null
+        val idxCardDav: Int? = if (hasCardDav) ++nextIdx else null
         val idxWebcal: Int? = if (hasWebcal) ++nextIdx else null
         val nrPages =
-            (if (idxCardDav != null) 1 else 0) +
-                    (if (idxCalDav != null) 1 else 0) +
+            (if (idxCalDav != null) 1 else 0) +
+                    (if (idxCardDav != null) 1 else 0) +
                     (if (idxWebcal != null) 1 else 0)
         val pagerState = rememberPagerState(pageCount = { nrPages })
 
@@ -298,21 +298,6 @@ fun AccountScreen(
                 Column {
                     if (nrPages > 0) {
                         TabRow(selectedTabIndex = pagerState.currentPage) {
-                            if (idxCardDav != null)
-                                Tab(
-                                    selected = pagerState.currentPage == idxCardDav,
-                                    onClick = {
-                                        scope.launch {
-                                            pagerState.scrollToPage(idxCardDav)
-                                        }
-                                    }
-                                ) {
-                                    Text(
-                                        stringResource(R.string.account_carddav),
-                                        modifier = Modifier.padding(8.dp)
-                                    )
-                                }
-
                             if (idxCalDav != null) {
                                 Tab(
                                     selected = pagerState.currentPage == idxCalDav,
@@ -324,6 +309,22 @@ fun AccountScreen(
                                 ) {
                                     Text(
                                         stringResource(R.string.account_caldav),
+                                        modifier = Modifier.padding(8.dp)
+                                    )
+                                }
+                            }
+
+                            if (idxCardDav != null) {
+                                Tab(
+                                    selected = pagerState.currentPage == idxCardDav,
+                                    onClick = {
+                                        scope.launch {
+                                            pagerState.scrollToPage(idxCardDav)
+                                        }
+                                    }
+                                ) {
+                                    Text(
+                                        stringResource(R.string.account_carddav),
                                         modifier = Modifier.padding(8.dp)
                                     )
                                 }


### PR DESCRIPTION
The PR should be in _Draft_ state during development. As soon as it's finished, it should be marked as _Ready for review_ and a reviewer should be chosen.

See also: [Writing A Great Pull Request Description](https://www.pullrequest.com/blog/writing-a-great-pull-request-description/)


### Purpose

Full discussion on #766.

TLDR; CalDAV tab is accessed more often than CardDAV, so it's more logical to have it first.


### Short description

Switched the positions of the CalDAV and CardDAV tabs.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

