### PR TITLE
Start at LoginDetails page if logging in via intent

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginActivity.kt
@@ -109,9 +109,13 @@ class LoginActivity @Inject constructor(): AppCompatActivity() {
         super.onCreate(savedInstanceState)
 
         // start with login info from Intent
-        model.updateLoginInfo(loginInfoFromIntent(intent))
-        if (intent.data != null)
-            model.navToPage(LoginScreenModel.Page.LoginDetails)
+        if (savedInstanceState == null) {
+            val loginInfo = loginInfoFromIntent(intent)
+            if (loginInfo.baseUri != null) {
+                model.updateLoginInfo(loginInfo)
+                model.navToPage(LoginScreenModel.Page.LoginDetails)
+            }
+        }
 
         setContent {
             LoginScreen(

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginActivity.kt
@@ -110,6 +110,8 @@ class LoginActivity @Inject constructor(): AppCompatActivity() {
 
         // start with login info from Intent
         model.updateLoginInfo(loginInfoFromIntent(intent))
+        if (intent.data != null)
+            model.navToPage(LoginScreenModel.Page.LoginDetails)
 
         setContent {
             LoginScreen(

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
@@ -53,6 +53,10 @@ class LoginScreenModel @Inject constructor(
 
     // navigation events
 
+    fun navToPage(toPage: Page) {
+        page = toPage
+    }
+
     fun navToNextPage() {
         when (page) {
             Page.LoginType -> {


### PR DESCRIPTION
### Purpose

DAVx5 should start with the login details page automatically when the login type is determined by the Intent.

### Short description

When the `intent.data` is not empty a new method `navToPage` is called, which sets the active page to be the login details page. This is by default of type `UrlLogin`, so we currently don't need to set it explicitly. 

### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added reasonable tests or consciously decided to not add tests.

