### PR TITLE
Pre-select per-contact categories for login type NextcloudLogin

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/network/NextcloudLoginFlow.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/network/NextcloudLoginFlow.kt
@@ -9,6 +9,7 @@ import at.bitfire.dav4jvm.exception.DavException
 import at.bitfire.dav4jvm.exception.HttpException
 import at.bitfire.davdroid.db.Credentials
 import at.bitfire.davdroid.ui.setup.LoginInfo
+import at.bitfire.vcard4android.GroupMethod
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withContext
@@ -107,7 +108,8 @@ class NextcloudLoginFlow(
             credentials = Credentials(
                 username = json.getString("loginName"),
                 password = json.getString("appPassword")
-            )
+            ),
+            suggestedGroupMethod = GroupMethod.CATEGORIES
         )
     }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
@@ -80,8 +80,7 @@ class LoginScreenModel @Inject constructor(
                     ?: loginInfo.baseUri?.host
                     ?: ""
                 updateAccountNameAndEmails(initialAccountName, emails)
-                if (loginTypeUiState.loginType == NextcloudLogin)
-                    updateGroupMethod(GroupMethod.CATEGORIES)
+                updateGroupMethod(loginInfo.suggestedGroupMethod)
                 page = Page.AccountDetails
             }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
@@ -80,6 +80,8 @@ class LoginScreenModel @Inject constructor(
                     ?: loginInfo.baseUri?.host
                     ?: ""
                 updateAccountNameAndEmails(initialAccountName, emails)
+                if (loginTypeUiState.loginType == NextcloudLogin)
+                    updateGroupMethod(GroupMethod.CATEGORIES)
                 page = Page.AccountDetails
             }
 


### PR DESCRIPTION
### Purpose

The Nextcloud login method doesn't pre-select the categories group type. This fixes it.

### Short description

Pre-select per-contact categories for login type NextcloudLogin in the `LoginScreenModel` when navigation from `DetectResources` to `AccountDetails` page.


### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added reasonable tests or consciously decided to not add tests.

