### PR TITLE
Fix login detail pages loosing user changes on rotation / re-creation (closes #775)

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/AdvancedLogin.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/AdvancedLogin.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.text.HtmlCompat
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import at.bitfire.davdroid.Constants
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.ui.UiUtils.toAnnotatedString
@@ -56,10 +56,11 @@ object AdvancedLogin : LoginType {
         initialLoginInfo: LoginInfo,
         onLogin: (LoginInfo) -> Unit
     ) {
-        val model = viewModel<AdvancedLoginModel>()
-        LaunchedEffect(Unit) {
-            model.initialize(initialLoginInfo)
-        }
+        val model: AdvancedLoginModel = hiltViewModel(
+            creationCallback = { factory: AdvancedLoginModel.Factory ->
+                factory.create(loginInfo = initialLoginInfo)
+            }
+        )
 
         val uiState = model.uiState
         AdvancedLoginScreen(

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/AdvancedLoginModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/AdvancedLoginModel.kt
@@ -10,9 +10,21 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import at.bitfire.davdroid.db.Credentials
 import at.bitfire.davdroid.util.DavUtils.toURIorNull
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
 import org.apache.commons.lang3.StringUtils
 
-class AdvancedLoginModel: ViewModel() {
+@HiltViewModel(assistedFactory = AdvancedLoginModel.Factory::class)
+class AdvancedLoginModel @AssistedInject constructor(
+    @Assisted val initialLoginInfo: LoginInfo,
+): ViewModel() {
+
+    @AssistedFactory
+    interface Factory {
+        fun create(loginInfo: LoginInfo): AdvancedLoginModel
+    }
 
     data class UiState(
         val url: String = "",
@@ -44,12 +56,12 @@ class AdvancedLoginModel: ViewModel() {
     var uiState by mutableStateOf(UiState())
         private set
 
-    fun initialize(loginInfo: LoginInfo) {
+    init {
         uiState = uiState.copy(
-            url = loginInfo.baseUri?.toString()?.removePrefix("https://") ?: "",
-            username = loginInfo.credentials?.username ?: "",
-            password = loginInfo.credentials?.password ?: "",
-            certAlias = loginInfo.credentials?.certificateAlias ?: ""
+            url = initialLoginInfo.baseUri?.toString()?.removePrefix("https://") ?: "",
+            username = initialLoginInfo.credentials?.username ?: "",
+            password = initialLoginInfo.credentials?.password ?: "",
+            certAlias = initialLoginInfo.credentials?.certificateAlias ?: ""
         )
     }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/EmailLogin.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/EmailLogin.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.text.HtmlCompat
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import at.bitfire.davdroid.Constants
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.ui.UiUtils.toAnnotatedString
@@ -53,10 +53,11 @@ object EmailLogin : LoginType {
         initialLoginInfo: LoginInfo,
         onLogin: (LoginInfo) -> Unit
     ) {
-        val model = viewModel<EmailLoginModel>()
-        LaunchedEffect(initialLoginInfo) {
-            model.initialize(initialLoginInfo)
-        }
+        val model: EmailLoginModel = hiltViewModel(
+            creationCallback = { factory: EmailLoginModel.Factory ->
+                factory.create(loginInfo = initialLoginInfo)
+            }
+        )
 
         val uiState = model.uiState
         EmailLoginScreen(

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/EmailLoginModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/EmailLoginModel.kt
@@ -10,8 +10,20 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import at.bitfire.davdroid.db.Credentials
 import at.bitfire.davdroid.util.DavUtils.toURIorNull
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
 
-class EmailLoginModel: ViewModel() {
+@HiltViewModel(assistedFactory = EmailLoginModel.Factory::class)
+class EmailLoginModel @AssistedInject constructor(
+    @Assisted val initialLoginInfo: LoginInfo
+): ViewModel() {
+
+    @AssistedFactory
+    interface Factory {
+        fun create(loginInfo: LoginInfo): EmailLoginModel
+    }
 
     data class UiState(
         val email: String = "",
@@ -35,7 +47,7 @@ class EmailLoginModel: ViewModel() {
     var uiState by mutableStateOf(UiState())
         private set
 
-    fun initialize(initialLoginInfo: LoginInfo) {
+    init {
         uiState = uiState.copy(
             email = initialLoginInfo.credentials?.username ?: "",
             password = initialLoginInfo.credentials?.password ?: ""

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/GoogleLogin.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/GoogleLogin.kt
@@ -45,7 +45,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.text.HtmlCompat
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import at.bitfire.davdroid.Constants
 import at.bitfire.davdroid.Constants.withStatParams
 import at.bitfire.davdroid.R
@@ -86,10 +86,11 @@ object GoogleLogin : LoginType {
         initialLoginInfo: LoginInfo,
         onLogin: (LoginInfo) -> Unit
     ) {
-        val model = viewModel<GoogleLoginModel>()
-        LaunchedEffect(initialLoginInfo) {
-            model.initialize(initialLoginInfo)
-        }
+        val model: GoogleLoginModel = hiltViewModel(
+            creationCallback = { factory: GoogleLoginModel.Factory ->
+                factory.create(loginInfo = initialLoginInfo)
+            }
+        )
 
         val uiState = model.uiState
         LaunchedEffect(uiState.result) {

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/GoogleLoginModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/GoogleLoginModel.kt
@@ -17,6 +17,9 @@ import androidx.lifecycle.viewModelScope
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.log.Logger
 import at.bitfire.davdroid.network.GoogleLogin
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import net.openid.appauth.AuthorizationRequest
@@ -25,13 +28,18 @@ import net.openid.appauth.AuthorizationService
 import org.apache.commons.lang3.StringUtils
 import java.util.Locale
 import java.util.logging.Level
-import javax.inject.Inject
 
-@HiltViewModel
-class GoogleLoginModel @Inject constructor(
+@HiltViewModel(assistedFactory = GoogleLoginModel.Factory::class)
+class GoogleLoginModel @AssistedInject constructor(
+    @Assisted val initialLoginInfo: LoginInfo,
     val context: Application,
     val authService: AuthorizationService
 ): ViewModel() {
+
+    @AssistedFactory
+    interface Factory {
+        fun create(loginInfo: LoginInfo): GoogleLoginModel
+    }
 
     val googleLogin = GoogleLogin(authService)
 
@@ -55,9 +63,9 @@ class GoogleLoginModel @Inject constructor(
     var uiState by mutableStateOf(UiState())
         private set
 
-    fun initialize(loginInfo: LoginInfo) {
+    init {
         uiState = uiState.copy(
-            email = loginInfo.credentials?.username ?: findGoogleAccount() ?: "",
+            email = initialLoginInfo.credentials?.username ?: findGoogleAccount() ?: "",
             error = null,
             result = null
         )

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/NextcloudLogin.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/NextcloudLogin.kt
@@ -42,7 +42,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.core.os.bundleOf
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import at.bitfire.davdroid.Constants
 import at.bitfire.davdroid.Constants.withStatParams
 import at.bitfire.davdroid.R
@@ -69,10 +69,11 @@ object NextcloudLogin : LoginType {
         initialLoginInfo: LoginInfo,
         onLogin: (LoginInfo) -> Unit
     ) {
-        val model = viewModel<NextcloudLoginModel>()
-        LaunchedEffect(initialLoginInfo) {
-            model.initialize(initialLoginInfo)
-        }
+        val model: NextcloudLoginModel = hiltViewModel(
+            creationCallback = { factory: NextcloudLoginModel.Factory ->
+                factory.create(loginInfo = initialLoginInfo)
+            }
+        )
 
         val context = LocalContext.current
         val checkResultCallback = rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/NextcloudLoginModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/NextcloudLoginModel.kt
@@ -12,18 +12,26 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import at.bitfire.davdroid.log.Logger
 import at.bitfire.davdroid.network.NextcloudLoginFlow
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import java.util.logging.Level
-import javax.inject.Inject
 
-@HiltViewModel
-class NextcloudLoginModel @Inject constructor(
+@HiltViewModel(assistedFactory = NextcloudLoginModel.Factory::class)
+class NextcloudLoginModel @AssistedInject constructor(
+    @Assisted val initialLoginInfo: LoginInfo,
     val context: Application
     //val state: SavedStateHandle
 ): ViewModel() {
+
+    @AssistedFactory
+    interface Factory {
+        fun create(loginInfo: LoginInfo): NextcloudLoginModel
+    }
 
     /*companion object {
         const val STATE_POLL_URL = "poll_url"
@@ -59,8 +67,8 @@ class NextcloudLoginModel @Inject constructor(
     var uiState by mutableStateOf(UiState())
         private set
 
-    fun initialize(loginInfo: LoginInfo) {
-        val baseUri = loginInfo.baseUri
+    init {
+        val baseUri = initialLoginInfo.baseUri
         if (baseUri != null)
             uiState = uiState.copy(
                 baseUrl = baseUri.toString()

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/UrlLogin.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/UrlLogin.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.text.HtmlCompat
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import at.bitfire.davdroid.Constants
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.ui.UiUtils.toAnnotatedString
@@ -53,10 +53,11 @@ object UrlLogin : LoginType {
         initialLoginInfo: LoginInfo,
         onLogin: (LoginInfo) -> Unit
     ) {
-        val model = viewModel<UrlLoginModel>()
-        LaunchedEffect(initialLoginInfo) {
-            model.initialize(initialLoginInfo)
-        }
+        val model: UrlLoginModel = hiltViewModel(
+            creationCallback = { factory: UrlLoginModel.Factory ->
+                factory.create(loginInfo = initialLoginInfo)
+            }
+        )
 
         val uiState = model.uiState
         UrlLoginScreen(

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/UrlLoginModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/UrlLoginModel.kt
@@ -10,9 +10,21 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import at.bitfire.davdroid.db.Credentials
 import at.bitfire.davdroid.util.DavUtils.toURIorNull
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
 import org.apache.commons.lang3.StringUtils
 
-class UrlLoginModel: ViewModel() {
+@HiltViewModel(assistedFactory = UrlLoginModel.Factory::class)
+class UrlLoginModel @AssistedInject constructor(
+    @Assisted val initialLoginInfo: LoginInfo
+): ViewModel() {
+
+    @AssistedFactory
+    interface Factory {
+        fun create(loginInfo: LoginInfo): UrlLoginModel
+    }
 
     data class UiState(
         val url: String = "",
@@ -43,11 +55,11 @@ class UrlLoginModel: ViewModel() {
     var uiState by mutableStateOf(UiState())
         private set
 
-    fun initialize(loginInfo: LoginInfo) {
+    init {
         uiState = UiState(
-            url = loginInfo.baseUri?.toString()?.removePrefix("https://") ?: "",
-            username = loginInfo.credentials?.username ?: "",
-            password = loginInfo.credentials?.password ?: ""
+            url = initialLoginInfo.baseUri?.toString()?.removePrefix("https://") ?: "",
+            username = initialLoginInfo.credentials?.username ?: "",
+            password = initialLoginInfo.credentials?.password ?: ""
         )
     }
 


### PR DESCRIPTION
### Purpose

Previously view models of the login details compose screens  were initialized using `LaunchedEffect`, which had 
LoginDetails screens loose user made changes on screen rotation/re-compose. This is because the `LaunchedEffect` was called on every re-composition, even when called with a constant like `LaunchedEffect(true)`.

Injecting the view models with hilt allows to initialize the model directly when created by the hilt factory, thus circumventing the problem. 


### Short description

- Add hilt assisted factories to the view models 
- Inject view models in composables using hilt with factories passing the `initialLoginInfo` along.
- initialize the view models on creation

See also: 
https://developer.android.com/develop/ui/compose/libraries#hilt
https://developer.android.com/develop/ui/compose/libraries#viewmodel

### Checklist

- [X] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.

