### PR TITLE
Fix setup through nextcloud app (intent) not working

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginActivity.kt
@@ -8,7 +8,6 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import androidx.activity.compose.setContent
-import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import at.bitfire.davdroid.db.Credentials
 import at.bitfire.davdroid.ui.account.AccountActivity
@@ -109,24 +108,23 @@ class LoginActivity @Inject constructor(): AppCompatActivity() {
 
     }
 
-    val model: LoginScreenModel by viewModels()
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // start with login info from Intent
-        if (savedInstanceState == null) {
-            val loginInfo = loginInfoFromIntent(intent)
-            if (loginInfo.baseUri != null) {
-                val initialLoginType = model.loginTypesProvider.intentToInitialLoginType(intent)
-                model.selectLoginType(initialLoginType)
-                model.updateLoginInfo(loginInfo)
-                model.navToPage(LoginScreenModel.Page.LoginDetails)
-            }
+        var initialLoginType: LoginType = UrlLogin
+        var startPage: LoginScreenModel.Page = LoginScreenModel.Page.LoginType
+
+        // Login flow from nextcloud app, via intent
+        if (intent.hasExtra(EXTRA_LOGIN_FLOW)) {
+            initialLoginType = NextcloudLogin
+            startPage = LoginScreenModel.Page.LoginDetails
         }
 
         setContent {
             LoginScreen(
+                startPage = startPage,
+                initialLoginType = initialLoginType,
+                initialLoginInfo = loginInfoFromIntent(intent),
                 onNavUp = { onSupportNavigateUp() },
                 onFinish = { newAccount ->
                     finish()
@@ -136,8 +134,7 @@ class LoginActivity @Inject constructor(): AppCompatActivity() {
                         intent.putExtra(AccountActivity.EXTRA_ACCOUNT, newAccount)
                         startActivity(intent)
                     }
-                },
-                model = model
+                }
             )
         }
     }

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginActivity.kt
@@ -112,6 +112,8 @@ class LoginActivity @Inject constructor(): AppCompatActivity() {
         if (savedInstanceState == null) {
             val loginInfo = loginInfoFromIntent(intent)
             if (loginInfo.baseUri != null) {
+                val initialLoginType = model.loginTypesProvider.intentToInitialLoginType(intent)
+                model.selectLoginType(initialLoginType)
                 model.updateLoginInfo(loginInfo)
                 model.navToPage(LoginScreenModel.Page.LoginDetails)
             }

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginActivity.kt
@@ -108,22 +108,17 @@ class LoginActivity @Inject constructor(): AppCompatActivity() {
 
     }
 
+    @Inject lateinit var loginTypesProvider: LoginTypesProvider
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        var initialLoginType: LoginType = UrlLogin
-        var startPage: LoginScreenModel.Page = LoginScreenModel.Page.LoginType
-
-        // Login flow from nextcloud app, via intent
-        if (intent.hasExtra(EXTRA_LOGIN_FLOW)) {
-            initialLoginType = NextcloudLogin
-            startPage = LoginScreenModel.Page.LoginDetails
-        }
+        val (initialLoginType, skipLoginTypePage) = loginTypesProvider.intentToInitialLoginType(intent)
 
         setContent {
             LoginScreen(
-                startPage = startPage,
                 initialLoginType = initialLoginType,
+                skipLoginTypePage = skipLoginTypePage,
                 initialLoginInfo = loginInfoFromIntent(intent),
                 onNavUp = { onSupportNavigateUp() },
                 onFinish = { newAccount ->

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginActivity.kt
@@ -48,6 +48,12 @@ class LoginActivity @Inject constructor(): AppCompatActivity() {
         const val EXTRA_LOGIN_FLOW = "loginFlow"
 
 
+        /**
+         * Extracts login information from given intent, validates it and returns it in [LoginInfo].
+         *
+         * @param intent Contains base url, username and password.
+         * @return Extracted login info. Contains null values if given info is invalid.
+         */
         fun loginInfoFromIntent(intent: Intent): LoginInfo {
             var givenUri: String? = null
             var givenUsername: String? = null

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreen.kt
@@ -25,7 +25,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import at.bitfire.davdroid.Constants
 import at.bitfire.davdroid.Constants.withStatParams
 import at.bitfire.davdroid.R
@@ -33,10 +33,16 @@ import at.bitfire.davdroid.ui.AppTheme
 
 @Composable
 fun LoginScreen(
+    startPage: LoginScreenModel.Page = LoginScreenModel.Page.LoginType,
+    initialLoginInfo: LoginInfo = LoginInfo(),
+    initialLoginType: LoginType = UrlLogin,
     onNavUp: () -> Unit,
-    onFinish: (Account?) -> Unit,
-    model: LoginScreenModel = viewModel()
+    onFinish: (Account?) -> Unit
 ) {
+    val model: LoginScreenModel = hiltViewModel { factory: LoginScreenModel.Factory ->
+        factory.create(startPage, initialLoginInfo, initialLoginType)
+    }
+
     // handle back/up navigation
     BackHandler {
         model.navBack()

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreen.kt
@@ -40,7 +40,7 @@ fun LoginScreen(
     onFinish: (Account?) -> Unit
 ) {
     val model: LoginScreenModel = hiltViewModel { factory: LoginScreenModel.Factory ->
-        factory.create(skipLoginTypePage, initialLoginInfo, initialLoginType)
+        factory.create(initialLoginType, skipLoginTypePage, initialLoginInfo)
     }
 
     // handle back/up navigation

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreen.kt
@@ -33,14 +33,14 @@ import at.bitfire.davdroid.ui.AppTheme
 
 @Composable
 fun LoginScreen(
-    startPage: LoginScreenModel.Page = LoginScreenModel.Page.LoginType,
     initialLoginInfo: LoginInfo = LoginInfo(),
+    skipLoginTypePage: Boolean = false,
     initialLoginType: LoginType = UrlLogin,
     onNavUp: () -> Unit,
     onFinish: (Account?) -> Unit
 ) {
     val model: LoginScreenModel = hiltViewModel { factory: LoginScreenModel.Factory ->
-        factory.create(startPage, initialLoginInfo, initialLoginType)
+        factory.create(skipLoginTypePage, initialLoginInfo, initialLoginType)
     }
 
     // handle back/up navigation

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
@@ -33,9 +33,9 @@ import kotlinx.coroutines.withContext
 
 @HiltViewModel(assistedFactory = LoginScreenModel.Factory::class)
 class LoginScreenModel @AssistedInject constructor(
+    @Assisted val initialLoginType: LoginType,
     @Assisted val skipLoginTypePage: Boolean,
     @Assisted val initialLoginInfo: LoginInfo,
-    @Assisted val initialLoginType: LoginType,
     val context: Application,
     val loginTypesProvider: LoginTypesProvider,
     private val accountRepository: AccountRepository,
@@ -45,9 +45,9 @@ class LoginScreenModel @AssistedInject constructor(
     @AssistedFactory
     interface Factory {
         fun create(
+            initialLoginType: LoginType,
             skipLoginTypePage: Boolean,
-            initialLoginInfo: LoginInfo,
-            initialLoginType: LoginType
+            initialLoginInfo: LoginInfo
         ): LoginScreenModel
     }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
@@ -18,6 +18,9 @@ import at.bitfire.davdroid.servicedetection.DavResourceFinder
 import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.settings.SettingsManager
 import at.bitfire.vcard4android.GroupMethod
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -27,15 +30,26 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withContext
-import javax.inject.Inject
 
-@HiltViewModel
-class LoginScreenModel @Inject constructor(
+@HiltViewModel(assistedFactory = LoginScreenModel.Factory::class)
+class LoginScreenModel @AssistedInject constructor(
+    @Assisted val startPage: Page,
+    @Assisted val initialLoginInfo: LoginInfo,
+    @Assisted val initialLoginType: LoginType,
     val context: Application,
     val loginTypesProvider: LoginTypesProvider,
     private val accountRepository: AccountRepository,
     settingsManager: SettingsManager
 ): ViewModel() {
+
+    @AssistedFactory
+    interface Factory {
+        fun create(
+            startPage: Page,
+            initialLoginInfo: LoginInfo,
+            initialLoginType: LoginType
+        ): LoginScreenModel
+    }
 
     enum class Page {
         LoginType,
@@ -44,7 +58,7 @@ class LoginScreenModel @Inject constructor(
         AccountDetails
     }
 
-    var page by mutableStateOf(Page.LoginType)
+    var page by mutableStateOf(startPage)
         private set
 
     var finish by mutableStateOf(false)
@@ -52,10 +66,6 @@ class LoginScreenModel @Inject constructor(
 
 
     // navigation events
-
-    fun navToPage(toPage: Page) {
-        page = toPage
-    }
 
     fun navToNextPage() {
         when (page) {
@@ -122,7 +132,7 @@ class LoginScreenModel @Inject constructor(
         val loginType: LoginType
     )
 
-    var loginTypeUiState by mutableStateOf(LoginTypeUiState(loginType = loginTypesProvider.defaultLoginType))
+    var loginTypeUiState by mutableStateOf(LoginTypeUiState(loginType = initialLoginType))
         private set
 
     fun selectLoginType(loginType: LoginType) {
@@ -134,7 +144,7 @@ class LoginScreenModel @Inject constructor(
     // UI element state – second page: login details
 
     // base URI and credentials
-    private var loginInfo: LoginInfo = LoginInfo()
+    private var loginInfo: LoginInfo = initialLoginInfo
 
     data class LoginDetailsUiState(
         val loginType: LoginType,
@@ -142,7 +152,7 @@ class LoginScreenModel @Inject constructor(
     )
 
     var loginDetailsUiState by mutableStateOf(LoginDetailsUiState(
-        loginType = loginTypesProvider.defaultLoginType,
+        loginType = initialLoginType,
         loginInfo = loginInfo
     ))
         private set

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
@@ -127,6 +127,7 @@ class LoginScreenModel @Inject constructor(
 
     fun selectLoginType(loginType: LoginType) {
         loginTypeUiState = loginTypeUiState.copy(loginType = loginType)
+        loginDetailsUiState = loginDetailsUiState.copy(loginType = loginType)
     }
 
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
@@ -34,7 +34,7 @@ class LoginScreenModel @Inject constructor(
     val context: Application,
     val loginTypesProvider: LoginTypesProvider,
     private val accountRepository: AccountRepository,
-    private val settingsManager: SettingsManager
+    settingsManager: SettingsManager
 ): ViewModel() {
 
     enum class Page {

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
@@ -33,7 +33,7 @@ import kotlinx.coroutines.withContext
 
 @HiltViewModel(assistedFactory = LoginScreenModel.Factory::class)
 class LoginScreenModel @AssistedInject constructor(
-    @Assisted val startPage: Page,
+    @Assisted val skipLoginTypePage: Boolean,
     @Assisted val initialLoginInfo: LoginInfo,
     @Assisted val initialLoginType: LoginType,
     val context: Application,
@@ -45,7 +45,7 @@ class LoginScreenModel @AssistedInject constructor(
     @AssistedFactory
     interface Factory {
         fun create(
-            startPage: Page,
+            skipLoginTypePage: Boolean,
             initialLoginInfo: LoginInfo,
             initialLoginType: LoginType
         ): LoginScreenModel
@@ -57,6 +57,11 @@ class LoginScreenModel @AssistedInject constructor(
         DetectResources,
         AccountDetails
     }
+
+    private val startPage = if (skipLoginTypePage)
+        Page.LoginDetails
+    else
+        Page.LoginType
 
     var page by mutableStateOf(startPage)
         private set

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginTypesProvider.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginTypesProvider.kt
@@ -12,7 +12,11 @@ interface LoginTypesProvider {
 
     val defaultLoginType: LoginType
 
-    fun intentToInitialLoginType(intent: Intent): LoginType
+    /**
+     * Which login type to use and whether to skip the login type selection page. Used for Nextcloud
+     * login flow. May be used by other login flows.
+     */
+    fun intentToInitialLoginType(intent: Intent): Pair<LoginType, Boolean> = Pair(defaultLoginType, false)
 
     /** Whether the [LoginTypePage] may be non-interactive. This causes it to be skipped in back navigation. */
     val maybeNonInteractive: Boolean

--- a/app/src/ose/kotlin/at/bitfire/davdroid/OseFlavorModule.kt
+++ b/app/src/ose/kotlin/at/bitfire/davdroid/OseFlavorModule.kt
@@ -8,8 +8,6 @@ import at.bitfire.davdroid.ui.AboutActivity
 import at.bitfire.davdroid.ui.AccountsDrawerHandler
 import at.bitfire.davdroid.ui.OpenSourceLicenseInfoProvider
 import at.bitfire.davdroid.ui.OseAccountsDrawerHandler
-import at.bitfire.davdroid.ui.intro.BatteryOptimizationsPage
-import at.bitfire.davdroid.ui.intro.IntroPage
 import at.bitfire.davdroid.ui.intro.IntroPageFactory
 import at.bitfire.davdroid.ui.setup.LoginTypesProvider
 import at.bitfire.davdroid.ui.setup.StandardLoginTypesProvider
@@ -19,7 +17,6 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ActivityComponent
 import dagger.hilt.android.components.ViewModelComponent
 import dagger.hilt.components.SingletonComponent
-import dagger.multibindings.IntoSet
 
 interface OseFlavorModules {
 
@@ -28,6 +25,9 @@ interface OseFlavorModules {
     interface ForActivities {
         @Binds
         fun accountsDrawerHandler(impl: OseAccountsDrawerHandler): AccountsDrawerHandler
+
+        @Binds
+        fun loginTypesProvider(impl: StandardLoginTypesProvider): LoginTypesProvider
     }
 
     @Module

--- a/app/src/ose/kotlin/at/bitfire/davdroid/ui/setup/StandardLoginTypesProvider.kt
+++ b/app/src/ose/kotlin/at/bitfire/davdroid/ui/setup/StandardLoginTypesProvider.kt
@@ -28,9 +28,9 @@ class StandardLoginTypesProvider @Inject constructor() : LoginTypesProvider {
 
     override fun intentToInitialLoginType(intent: Intent) =
         if (intent.hasExtra(LoginActivity.EXTRA_LOGIN_FLOW))
-            NextcloudLogin
+            Pair(NextcloudLogin, true)
         else
-            UrlLogin
+            Pair(defaultLoginType, false)
 
     @Composable
     override fun LoginTypePage(


### PR DESCRIPTION
### Purpose

The nextcloud login/setup flow [could not be started via intent](https://github.com/bitfireAT/davx5-ose/issues/773). This fixes it.

### Short description

LoginActivity:
- Now using previously unused `intentToInitialLoginType()` to determine login type from intent.
- Use `selectLoginType()` to change the login type accordingly

LoginScreenModel:
- Alter `selectLoginType()` to also update the ui state of the login details page. Previously it only updated the ui state of the login type page.  
- Small lint fix

See also: [Creation of intent in nextcloud app](https://github.com/nextcloud/android/blob/48a67334d82cd99f440515f3f51c2fbace3a4a25/app/src/main/java/com/owncloud/android/ui/activity/SettingsActivity.java#L874).

### Testing

Intent for testing:

```
adb shell am start -e url "https://davtest.dev001.net/nextcloud" -e loginFlow 1  at.bitfire.davdroid/at.bitfire.davdroid.ui.setup.LoginActivity
```

### Checklist

- [X] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.

