### PR TITLE
Inject SyncDispatcher over Hilt

### DIFF
--- a/app/src/androidTestOse/kotlin/at/bitfire/davdroid/syncadapter/PeriodicSyncWorkerTest.kt
+++ b/app/src/androidTestOse/kotlin/at/bitfire/davdroid/syncadapter/PeriodicSyncWorkerTest.kt
@@ -25,6 +25,7 @@ import at.bitfire.davdroid.TestUtils.workScheduledOrRunning
 import at.bitfire.davdroid.db.Credentials
 import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.ui.NotificationUtils
+import dagger.assisted.AssistedFactory
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import io.mockk.junit4.MockKRule
@@ -77,13 +78,18 @@ class PeriodicSyncWorkerTest {
 
     }
 
+    @AssistedFactory
+    interface PeriodicSyncWorkerFactory {
+        fun create(appContext: Context, workerParams: WorkerParameters): PeriodicSyncWorker
+    }
+
     @get:Rule
     val hiltRule = HiltAndroidRule(this)
     @get:Rule
     val mockkRule = MockKRule(this)
 
     @Inject
-    lateinit var syncDispatcher: SyncDispatcher
+    lateinit var syncWorkerFactory: PeriodicSyncWorkerFactory
 
     @Before
     fun inject() {
@@ -125,7 +131,7 @@ class PeriodicSyncWorkerTest {
         val testWorker = TestListenableWorkerBuilder<PeriodicSyncWorker>(context, inputData)
             .setWorkerFactory(object: WorkerFactory() {
                 override fun createWorker(appContext: Context, workerClassName: String, workerParameters: WorkerParameters) =
-                    PeriodicSyncWorker(appContext, workerParameters, syncDispatcher)
+                    syncWorkerFactory.create(appContext, workerParameters)
             })
             .build()
         val result = runBlocking {

--- a/app/src/main/kotlin/at/bitfire/davdroid/syncadapter/BaseSyncWorker.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/syncadapter/BaseSyncWorker.kt
@@ -31,6 +31,7 @@ import at.bitfire.davdroid.ui.NotificationUtils.notifyIfPossible
 import at.bitfire.davdroid.ui.account.WifiPermissionsActivity
 import at.bitfire.davdroid.util.PermissionUtils
 import at.bitfire.ical4android.TaskProvider
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -41,7 +42,8 @@ import java.util.logging.Level
 
 abstract class BaseSyncWorker(
     appContext: Context,
-    val workerParams: WorkerParameters
+    val workerParams: WorkerParameters,
+    private val syncDispatcher: CoroutineDispatcher,
 ) : CoroutineWorker(appContext, workerParams) {
 
     companion object {
@@ -178,7 +180,6 @@ abstract class BaseSyncWorker(
     }
 
 
-    private val dispatcher = SyncWorkDispatcher.getInstance(applicationContext)
     private val notificationManager = NotificationManagerCompat.from(applicationContext)
 
 
@@ -240,7 +241,7 @@ abstract class BaseSyncWorker(
         account: Account,
         authority: String,
         accountSettings: AccountSettings
-    ): Result = withContext(dispatcher) {
+    ): Result = withContext(syncDispatcher) {
         Logger.log.info("Running ${javaClass.name}: account=$account, authority=$authority")
 
         // What are we going to sync? Select syncer based on authority

--- a/app/src/main/kotlin/at/bitfire/davdroid/syncadapter/BaseSyncWorker.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/syncadapter/BaseSyncWorker.kt
@@ -42,7 +42,7 @@ import java.util.logging.Level
 
 abstract class BaseSyncWorker(
     appContext: Context,
-    val workerParams: WorkerParameters,
+    private val workerParams: WorkerParameters,
     private val syncDispatcher: CoroutineDispatcher,
 ) : CoroutineWorker(appContext, workerParams) {
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/syncadapter/OneTimeSyncWorker.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/syncadapter/OneTimeSyncWorker.kt
@@ -40,8 +40,9 @@ import java.util.logging.Level
 @HiltWorker
 class OneTimeSyncWorker @AssistedInject constructor(
     @Assisted appContext: Context,
-    @Assisted workerParams: WorkerParameters
-) : BaseSyncWorker(appContext, workerParams) {
+    @Assisted workerParams: WorkerParameters,
+    syncDispatcher: SyncDispatcher
+) : BaseSyncWorker(appContext, workerParams, syncDispatcher.dispatcher) {
 
     companion object {
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/syncadapter/PeriodicSyncWorker.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/syncadapter/PeriodicSyncWorker.kt
@@ -37,8 +37,9 @@ import java.util.concurrent.TimeUnit
 @HiltWorker
 class PeriodicSyncWorker @AssistedInject constructor(
     @Assisted appContext: Context,
-    @Assisted workerParams: WorkerParameters
-) : BaseSyncWorker(appContext, workerParams) {
+    @Assisted workerParams: WorkerParameters,
+    syncDispatcher: SyncDispatcher
+) : BaseSyncWorker(appContext, workerParams, syncDispatcher.dispatcher) {
 
     companion object {
 


### PR DESCRIPTION
SyncDispatcher (previously SyncWorkDispatcher) had code to generate itself as a Singleton, but this can be done by Hilt as well.