### PR TITLE
"Rename account" should use outlined text field

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/RenameAccountDialog.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/RenameAccountDialog.kt
@@ -14,8 +14,8 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -53,7 +53,7 @@ fun RenameAccountDialog(
             )
 
             val focusRequester = remember { FocusRequester() }
-            TextField(
+            OutlinedTextField(
                 value = accountName,
                 onValueChange = { accountName = it },
                 label = { Text(stringResource(R.string.account_rename_new_name)) },


### PR DESCRIPTION
The PR should be in _Draft_ state during development. As soon as it's finished, it should be marked as _Ready for review_ and a reviewer should be chosen.

See also: [Writing A Great Pull Request Description](https://www.pullrequest.com/blog/writing-a-great-pull-request-description/)


### Purpose

To keep consistency along other dialogs, the `RenameAccountDialog` should also be using `OutlinedTextField`.

### Short description

Switched `TextField` usage in `RenameAccountDialog` to `OutlinedTextField`.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

