### PR TITLE
Orange progress indicator bar

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
@@ -35,7 +35,6 @@ import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconToggleButton
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.ModalNavigationDrawer
@@ -56,7 +55,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
@@ -71,6 +69,7 @@ import at.bitfire.davdroid.BuildConfig
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.ui.account.AccountProgress
 import at.bitfire.davdroid.ui.composable.ActionCard
+import at.bitfire.davdroid.ui.composable.ProgressBar
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
@@ -374,18 +373,18 @@ fun AccountList(
                         val progressAlpha = progress.rememberAlpha()
                         when (progress) {
                             AccountProgress.Active ->
-                                LinearProgressIndicator(
+                                ProgressBar(
                                     modifier = Modifier
                                         .alpha(progressAlpha)
                                         .fillMaxWidth()
                                 )
                             AccountProgress.Pending,
                             AccountProgress.Idle ->
-                                LinearProgressIndicator(
-                                    progress = 1f,
+                                ProgressBar(
+                                    progress = { 1f },
                                     modifier = Modifier
                                         .alpha(progressAlpha)
-                                        .fillMaxWidth()
+                                        .fillMaxWidth(),
                                 )
                         }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
@@ -384,7 +384,7 @@ fun AccountList(
                                     progress = { 1f },
                                     modifier = Modifier
                                         .alpha(progressAlpha)
-                                        .fillMaxWidth(),
+                                        .fillMaxWidth()
                                 )
                         }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
@@ -42,6 +41,7 @@ import at.bitfire.dav4jvm.exception.DavException
 import at.bitfire.dav4jvm.exception.HttpException
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.ui.composable.CardWithImage
+import at.bitfire.davdroid.ui.composable.ProgressBar
 import java.io.File
 import java.io.IOError
 import java.io.IOException
@@ -185,7 +185,7 @@ fun DebugInfoScreen(
                     .verticalScroll(rememberScrollState())
             ) {
                 if (!showDebugInfo || zipProgress)
-                    LinearProgressIndicator()
+                    ProgressBar()
 
                 if (showModelCause) {
                     CardWithImage(

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
@@ -40,7 +39,6 @@ import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.pulltorefresh.PullToRefreshContainer
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
@@ -76,6 +74,7 @@ import at.bitfire.davdroid.ui.account.AccountScreenModel
 import at.bitfire.davdroid.ui.account.CollectionsList
 import at.bitfire.davdroid.ui.account.RenameAccountDialog
 import at.bitfire.davdroid.ui.composable.ActionCard
+import at.bitfire.davdroid.ui.composable.ProgressBar
 import at.bitfire.davdroid.util.TaskUtils
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.rememberMultiplePermissionsState
@@ -593,13 +592,13 @@ fun AccountScreen_ServiceTab(
         // progress indicator
         val progressAlpha = progress.rememberAlpha()
         when (progress) {
-            AccountProgress.Active -> LinearProgressIndicator(
+            AccountProgress.Active -> ProgressBar(
                 modifier = Modifier
                     .alpha(progressAlpha)
                     .fillMaxWidth()
             )
             AccountProgress.Pending,
-            AccountProgress.Idle -> LinearProgressIndicator(
+            AccountProgress.Idle -> ProgressBar(
                 progress = { 1f },
                 modifier = Modifier
                     .alpha(progressAlpha)

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionScreen.kt
@@ -29,14 +29,12 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MediumTopAppBar
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -57,6 +55,7 @@ import at.bitfire.davdroid.R
 import at.bitfire.davdroid.repository.DavSyncStatsRepository
 import at.bitfire.davdroid.ui.AppTheme
 import at.bitfire.davdroid.ui.composable.ExceptionInfoDialog
+import at.bitfire.davdroid.ui.composable.ProgressBar
 import java.time.Instant
 import java.time.ZoneId
 import java.time.ZonedDateTime
@@ -175,7 +174,7 @@ fun CollectionScreen(
                     .verticalScroll(rememberScrollState())
             ) {
                 if (inProgress)
-                    LinearProgressIndicator(
+                    ProgressBar(
                         Modifier
                             .fillMaxWidth()
                             .padding(bottom = 8.dp))

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateAddressBookScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateAddressBookScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -40,6 +39,7 @@ import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.HomeSet
 import at.bitfire.davdroid.ui.AppTheme
 import at.bitfire.davdroid.ui.composable.ExceptionInfoDialog
+import at.bitfire.davdroid.ui.composable.ProgressBar
 import okhttp3.HttpUrl.Companion.toHttpUrl
 
 @Composable
@@ -117,7 +117,7 @@ fun CreateAddressBookScreen(
                     .verticalScroll(rememberScrollState())
             ) {
                 if (isCreating)
-                    LinearProgressIndicator(
+                    ProgressBar(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(bottom = 8.dp)

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateCalendarScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateCalendarScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -58,6 +57,7 @@ import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.HomeSet
 import at.bitfire.davdroid.ui.AppTheme
 import at.bitfire.davdroid.ui.composable.ExceptionInfoDialog
+import at.bitfire.davdroid.ui.composable.ProgressBar
 import at.bitfire.davdroid.ui.widget.CalendarColorPickerDialog
 import at.bitfire.ical4android.Css3Color
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -161,7 +161,7 @@ fun CreateCalendarScreen(
                     .verticalScroll(rememberScrollState())
             ) {
                 if (isCreating)
-                    LinearProgressIndicator(
+                    ProgressBar(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(bottom = 8.dp)

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/composable/ProgressBar.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/composable/ProgressBar.kt
@@ -5,14 +5,15 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ProgressIndicatorDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 
 
 @Composable
 fun ProgressBar(
     modifier: Modifier = Modifier,
-    color: androidx.compose.ui.graphics.Color = MaterialTheme.colorScheme.secondary,
-    trackColor: androidx.compose.ui.graphics.Color = ProgressIndicatorDefaults.linearTrackColor,
+    color: Color = MaterialTheme.colorScheme.secondary,
+    trackColor: Color = ProgressIndicatorDefaults.linearTrackColor,
     strokeCap: StrokeCap = ProgressIndicatorDefaults.LinearStrokeCap
 ) {
     LinearProgressIndicator(
@@ -27,8 +28,8 @@ fun ProgressBar(
 fun ProgressBar(
     progress: () -> Float,
     modifier: Modifier = Modifier,
-    color: androidx.compose.ui.graphics.Color = MaterialTheme.colorScheme.secondary,
-    trackColor: androidx.compose.ui.graphics.Color = ProgressIndicatorDefaults.linearTrackColor,
+    color: Color = MaterialTheme.colorScheme.secondary,
+    trackColor: Color = ProgressIndicatorDefaults.linearTrackColor,
     strokeCap: StrokeCap = ProgressIndicatorDefaults.LinearStrokeCap
 ) {
     LinearProgressIndicator(

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/composable/ProgressBar.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/composable/ProgressBar.kt
@@ -1,0 +1,41 @@
+package at.bitfire.davdroid.ui.composable
+
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ProgressIndicatorDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.StrokeCap
+
+
+@Composable
+fun ProgressBar(
+    modifier: Modifier = Modifier,
+    color: androidx.compose.ui.graphics.Color = MaterialTheme.colorScheme.secondary,
+    trackColor: androidx.compose.ui.graphics.Color = ProgressIndicatorDefaults.linearTrackColor,
+    strokeCap: StrokeCap = ProgressIndicatorDefaults.LinearStrokeCap
+) {
+    LinearProgressIndicator(
+        modifier = modifier,
+        color = color,
+        trackColor = trackColor,
+        strokeCap = strokeCap
+    )
+}
+
+@Composable
+fun ProgressBar(
+    progress: () -> Float,
+    modifier: Modifier = Modifier,
+    color: androidx.compose.ui.graphics.Color = MaterialTheme.colorScheme.secondary,
+    trackColor: androidx.compose.ui.graphics.Color = ProgressIndicatorDefaults.linearTrackColor,
+    strokeCap: StrokeCap = ProgressIndicatorDefaults.LinearStrokeCap
+) {
+    LinearProgressIndicator(
+        progress = progress,
+        modifier = modifier,
+        color = color,
+        trackColor = trackColor,
+        strokeCap = strokeCap
+    )
+}

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/AccountDetailsPage.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/AccountDetailsPage.kt
@@ -20,7 +20,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
@@ -44,6 +43,7 @@ import androidx.compose.ui.window.PopupProperties
 import androidx.lifecycle.viewmodel.compose.viewModel
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.ui.composable.Assistant
+import at.bitfire.davdroid.ui.composable.ProgressBar
 import at.bitfire.vcard4android.GroupMethod
 
 @Composable
@@ -99,7 +99,7 @@ fun AccountDetailsPageContent(
     ) {
         Column(Modifier.padding(8.dp)) {
             if (creatingAccount)
-                LinearProgressIndicator(
+                ProgressBar(
                     Modifier
                         .fillMaxWidth()
                         .padding(bottom = 8.dp))

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/DetectResourcesPage.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/DetectResourcesPage.kt
@@ -15,7 +15,6 @@ import androidx.compose.material.icons.filled.CloudOff
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -32,6 +31,7 @@ import at.bitfire.davdroid.Constants.withStatParams
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.ui.DebugInfoActivity
 import at.bitfire.davdroid.ui.UiUtils.toAnnotatedString
+import at.bitfire.davdroid.ui.composable.ProgressBar
 import at.bitfire.davdroid.ui.widget.ClickableTextWithLink
 
 @Composable
@@ -72,7 +72,7 @@ fun DetectResourcesPageContent(
 @Preview
 fun DetectResourcesPageContent_InProgress() {
     Column(Modifier.fillMaxWidth()) {
-        LinearProgressIndicator(
+        ProgressBar(
             //color = MaterialTheme.colors.secondary,
             modifier = Modifier
                 .fillMaxWidth()

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/NextcloudLogin.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/NextcloudLogin.kt
@@ -21,7 +21,6 @@ import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SnackbarHostState
@@ -48,6 +47,7 @@ import at.bitfire.davdroid.Constants.withStatParams
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.ui.UiUtils.haveCustomTabs
 import at.bitfire.davdroid.ui.composable.Assistant
+import at.bitfire.davdroid.ui.composable.ProgressBar
 import kotlinx.coroutines.launch
 
 object NextcloudLogin : LoginType {
@@ -146,7 +146,7 @@ fun NextcloudLoginScreen(
         onNext = onLogin
     ) {
         if (inProgress)
-            LinearProgressIndicator(
+            ProgressBar(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(bottom = 8.dp)

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/webdav/AddWebdavMountScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/webdav/AddWebdavMountScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -44,6 +43,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.ui.AppTheme
 import at.bitfire.davdroid.ui.composable.PasswordTextField
+import at.bitfire.davdroid.ui.composable.ProgressBar
 import at.bitfire.davdroid.ui.composable.SelectClientCertificateCard
 
 @Composable
@@ -143,7 +143,7 @@ fun AddWebDavMountScreen(
                 .verticalScroll(rememberScrollState())
         ) {
             if (isLoading)
-                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                ProgressBar(modifier = Modifier.fillMaxWidth())
 
             Column(
                 modifier = Modifier

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/webdav/WebdavMountsScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/webdav/WebdavMountsScreen.kt
@@ -34,12 +34,10 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.pulltorefresh.PullToRefreshContainer
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
@@ -69,6 +67,7 @@ import at.bitfire.davdroid.db.WebDavMount
 import at.bitfire.davdroid.db.WebDavMountWithRootDocument
 import at.bitfire.davdroid.ui.AppTheme
 import at.bitfire.davdroid.ui.UiUtils.toAnnotatedString
+import at.bitfire.davdroid.ui.composable.ProgressBar
 import at.bitfire.davdroid.ui.widget.ClickableTextWithLink
 import at.bitfire.davdroid.util.DavUtils
 import okhttp3.HttpUrl
@@ -168,9 +167,10 @@ fun WebdavMountsScreen(
             else {
                 Column {
                     if (refreshingQuota)
-                        LinearProgressIndicator(Modifier
-                            .fillMaxWidth()
-                            .height(4.dp))
+                        ProgressBar(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(4.dp))
                     else
                         Spacer(Modifier.height(4.dp))
 
@@ -287,7 +287,7 @@ fun WebdavMountsItem(
             if (quotaUsed != null && quotaAvailable != null) {
                 val quotaTotal = quotaUsed + quotaAvailable
                 val progress = quotaUsed.toFloat() / quotaTotal
-                LinearProgressIndicator(
+                ProgressBar(
                     progress = { progress },
                     modifier = Modifier
                         .fillMaxWidth()


### PR DESCRIPTION
### Purpose

This is an addition/fix to the M3 rewrite. The progress bar was still green - like the account cards in the accounts overview, and so the pending state very hard to see.

The progress bar was orange before the rewrite to M3, this reverts it to the old state. 

### Short description

Change the progress indicator bar color to orange everywhere in the app.

- Creates reusable ProgressBar composable with secondary theme color as default color
- Replaces the usages of LinearProgressIndicator with ProgressBar.

### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.

