### PR TITLE
Replace green tones with grey

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsDrawerHandler.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsDrawerHandler.kt
@@ -28,6 +28,8 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationDrawerItem
+import androidx.compose.material3.NavigationDrawerItemColors
+import androidx.compose.material3.NavigationDrawerItemDefaults
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
@@ -205,7 +207,17 @@ abstract class AccountsDrawerHandler {
             onClick = {
                 onClick()
                 closeHandler.closeDrawer()
-            }
+            },
+            colors = NavigationDrawerItemDefaults.colors(
+                selectedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                unselectedContainerColor = MaterialTheme.colorScheme.background,
+                selectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                unselectedIconColor = MaterialTheme.colorScheme.onBackground,
+                selectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                unselectedTextColor = MaterialTheme.colorScheme.onBackground,
+                selectedBadgeColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                unselectedBadgeColor = MaterialTheme.colorScheme.onBackground
+            )
         )
     }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DrawerDefaults
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
@@ -156,7 +157,10 @@ fun AccountsScreen(
         ModalNavigationDrawer(
             drawerState = drawerState,
             drawerContent = {
-                ModalDrawerSheet {
+                ModalDrawerSheet(
+                    drawerContainerColor = MaterialTheme.colorScheme.background,
+                    drawerContentColor = MaterialTheme.colorScheme.onBackground
+                ) {
                     accountsDrawerHandler.AccountsDrawer(
                         snackbarHostState = snackbarHostState,
                         onCloseDrawer = {
@@ -166,7 +170,8 @@ fun AccountsScreen(
                         }
                     )
                 }
-            }
+            },
+//            scrimColor = MaterialTheme.colorScheme.secondary
         ) {
             Scaffold(
                 topBar = {

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.DrawerDefaults
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
@@ -57,7 +56,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
@@ -170,8 +168,7 @@ fun AccountsScreen(
                         }
                     )
                 }
-            },
-//            scrimColor = MaterialTheme.colorScheme.secondary
+            }
         ) {
             Scaffold(
                 topBar = {

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreen.kt
@@ -4,6 +4,7 @@ import android.accounts.Account
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -40,7 +41,6 @@ import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.pulltorefresh.PullToRefreshContainer
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
@@ -456,7 +456,8 @@ fun AccountScreen_Actions(
     }
     DropdownMenu(
         expanded = overflowOpen,
-        onDismissRequest = { overflowOpen = false }
+        onDismissRequest = { overflowOpen = false },
+        modifier = Modifier.background(MaterialTheme.colorScheme.surfaceVariant)
     ) {
         // TAB-SPECIFIC ACTIONS
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionsList.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionsList.kt
@@ -29,6 +29,7 @@ import androidx.compose.material.icons.filled.Contacts
 import androidx.compose.material.icons.filled.RemoveCircle
 import androidx.compose.material.icons.filled.Task
 import androidx.compose.material.icons.filled.Today
+import androidx.compose.material3.CardColors
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -112,7 +113,13 @@ fun CollectionList_Item(
         modifier = modifier.clickable(onClick = onShowDetails)
 
     ElevatedCard(
-        modifier = modifier
+        modifier = modifier,
+        colors = CardColors(
+            MaterialTheme.colorScheme.surfaceVariant,
+            MaterialTheme.colorScheme.onSurfaceVariant,
+            MaterialTheme.colorScheme.surfaceVariant,
+            MaterialTheme.colorScheme.onSurfaceVariant
+        )
     ) {
         Row(Modifier.height(IntrinsicSize.Max)) {
             Box(

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateCalendarScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateCalendarScreen.kt
@@ -254,7 +254,9 @@ fun CreateCalendarScreen(
                         ExposedDropdownMenu(
                             expanded = expanded,
                             onDismissRequest = { expanded = false },
-                            modifier = Modifier.fillMaxHeight()
+                            modifier = Modifier
+                                .fillMaxHeight()
+                                .background(MaterialTheme.colorScheme.surfaceVariant)
                         ) {
                             Text(
                                 text = stringResource(R.string.create_calendar_time_zone_none),

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/HomeSetSelection.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/HomeSetSelection.kt
@@ -4,6 +4,7 @@
 
 package at.bitfire.davdroid.ui.account
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -66,7 +67,8 @@ fun HomeSetSelection(
 
             ExposedDropdownMenu(
                 expanded = expanded,
-                onDismissRequest = { expanded = false }
+                onDismissRequest = { expanded = false },
+                modifier = Modifier.background(MaterialTheme.colorScheme.surfaceVariant)
             ) {
                 Column(Modifier.padding(horizontal = 8.dp)
                 ) {

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/AccountDetailsPage.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/AccountDetailsPage.kt
@@ -5,6 +5,7 @@
 package at.bitfire.davdroid.ui.setup
 
 import android.accounts.Account
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -136,6 +137,7 @@ fun AccountDetailsPageContent(
                     DropdownMenu(   // ExposedDropdownMenu takes focus away from the text field when expanded
                         expanded = expanded,
                         onDismissRequest = { expanded = false },
+                        modifier = Modifier.background(MaterialTheme.colorScheme.surfaceVariant),
                         properties = PopupProperties(focusable = false)     // prevent focus from being taken away
                     ) {
                         for (name in suggestedAccountNames)


### PR DESCRIPTION
### Purpose

Staying true to the original design, this PR replaces the M3 green pastel tones used in different UI elements with a grey hue (surfaceVariant) and its black'ish dark mode counterpart. In any case the the green hue of most elements is removed so everything looks more crisp.


<details>

<summary>Before/After images</summary>

Navigation drawer
![image](https://github.com/bitfireAT/davx5-ose/assets/8227414/1b23597b-f322-4221-aa4e-4e3695633e8a)
![image](https://github.com/bitfireAT/davx5-ose/assets/8227414/fd332e0c-26a7-48b5-9a6b-e96977d41a50)


Collection cards and dropdown menu
![image](https://github.com/bitfireAT/davx5-ose/assets/8227414/65709838-3c0c-41c6-8667-939d27cc23aa)
![image](https://github.com/bitfireAT/davx5-ose/assets/8227414/5dc6ffd3-9bbc-42c8-8c64-a85a0dde9901)

</details>


### Short description

Replaces the green pastel tones of:
- drop down menus,
- collection cards (account screen) and
- navigation drawer background and items (selected/unselected) (accounts screen)

... with the theme colors "surfaceVariant" and "background" which seems to be a true grey in light mode and (true?) black in dark mode. The text color has been accordingly changed to "onSurfaceVariant".

Note: I believe there might still be a green hue in the text colors, especially in dark mode. But I feel it's not disturbing at all. 

### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.

---

Added by @rfc2822 on 2024/05/26: Depends on #811