### PR TITLE
Fix padding for show only personal

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.LocalMinimumInteractiveComponentEnforcement
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
@@ -45,6 +46,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.pulltorefresh.PullToRefreshContainer
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -429,6 +431,7 @@ fun AccountScreen(
 }
 
 @Composable
+@OptIn(ExperimentalMaterial3Api::class)
 fun AccountScreen_Actions(
     accountName: String,
     canCreateAddressBook: Boolean,
@@ -504,14 +507,18 @@ fun AccountScreen_Actions(
         // show only personal
         DropdownMenuItem(
             leadingIcon = {
-                Checkbox(
-                    checked = showOnlyPersonal.onlyPersonal,
-                    enabled = !showOnlyPersonal.locked,
-                    onCheckedChange = {
-                        onSetShowOnlyPersonal(it)
-                        overflowOpen = false
-                    }
-                )
+                CompositionLocalProvider(
+                    LocalMinimumInteractiveComponentEnforcement provides false
+                ) {
+                    Checkbox(
+                        checked = showOnlyPersonal.onlyPersonal,
+                        enabled = !showOnlyPersonal.locked,
+                        onCheckedChange = {
+                            onSetShowOnlyPersonal(it)
+                            overflowOpen = false
+                        }
+                    )
+                }
             },
             text = {
                 Text(stringResource(R.string.account_only_personal))

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreen.kt
@@ -516,7 +516,8 @@ fun AccountScreen_Actions(
                         onCheckedChange = {
                             onSetShowOnlyPersonal(it)
                             overflowOpen = false
-                        }
+                        },
+                        modifier = Modifier.padding(end = 8.dp)
                     )
                 }
             },


### PR DESCRIPTION
The PR should be in _Draft_ state during development. As soon as it's finished, it should be marked as _Ready for review_ and a reviewer should be chosen.

See also: [Writing A Great Pull Request Description](https://www.pullrequest.com/blog/writing-a-great-pull-request-description/)


### Purpose

Fix the misaligned checkbox for the "Show only personal" checkbox in the account screen's dropdown menu.


### Short description

- Disabled `LocalMinimumInteractiveComponentEnforcement` for the checkbox.
- Added more padding to the right to align with the padding of the icons.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

