### PR TITLE
Fix color picker size

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateCalendarScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateCalendarScreen.kt
@@ -9,10 +9,14 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -173,7 +177,8 @@ fun CreateCalendarScreen(
                         .padding(8.dp)
                 ) {
                     Row(
-                        verticalAlignment = Alignment.CenterVertically
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.height(IntrinsicSize.Min)
                     ) {
                         val focusRequester = remember { FocusRequester() }
                         OutlinedTextField(
@@ -195,11 +200,14 @@ fun CreateCalendarScreen(
 
                         var showColorPicker by remember { mutableStateOf(false) }
                         Box(Modifier
+                            .padding(top = 8.dp)
                             .background(color = Color(color), shape = RoundedCornerShape(4.dp))
                             .clickable {
                                 showColorPicker = true
                             }
-                            .size(48.dp)
+                            // .size(48.dp)
+                            .fillMaxHeight()
+                            .aspectRatio(1f)
                             .semantics {
                                 contentDescription =
                                     context.getString(R.string.create_collection_color)


### PR DESCRIPTION
The PR should be in _Draft_ state during development. As soon as it's finished, it should be marked as _Ready for review_ and a reviewer should be chosen.

See also: [Writing A Great Pull Request Description](https://www.pullrequest.com/blog/writing-a-great-pull-request-description/)


### Purpose

Fix color picker size so it matches the text field.

Before:

![Screenshot_20240522_154950](https://github.com/bitfireAT/davx5-ose/assets/12086466/7cd58430-ac37-4f6c-8346-e46d750e9320)

After:

![image](https://github.com/bitfireAT/davx5-ose/assets/12086466/bbf7b2c9-17c2-4f96-a25e-4a71f852142f)

_Note that the guidelines have been added to demonstrate the result, they don't appear on the app obviously._

### Short description

- Forced size to have aspect ratio 1, and fill max height.
- Added `8dp` of padding to the top, so it matches the field's border and not the label's text above.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

Closes #806