### PR TITLE
Increased icon size and text size for accounts list

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
@@ -394,12 +394,12 @@ fun AccountList(
                                 contentDescription = null,
                                 modifier = Modifier
                                     .align(Alignment.CenterHorizontally)
-                                    .size(32.dp)
+                                    .size(48.dp)
                             )
 
                             Text(
                                 text = account.name,
-                                style = MaterialTheme.typography.bodyLarge,
+                                style = MaterialTheme.typography.titleLarge,
                                 textAlign = TextAlign.Center,
                                 modifier = Modifier
                                     .padding(top = 4.dp)

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
@@ -388,7 +388,7 @@ fun AccountList(
                                 )
                         }
 
-                        Column(Modifier.padding(8.dp)) {
+                        Column(Modifier.padding(vertical = 12.dp)) {
                             Icon(
                                 imageVector = Icons.Default.AccountCircle,
                                 contentDescription = null,


### PR DESCRIPTION
The PR should be in _Draft_ state during development. As soon as it's finished, it should be marked as _Ready for review_ and a reviewer should be chosen.

See also: [Writing A Great Pull Request Description](https://www.pullrequest.com/blog/writing-a-great-pull-request-description/)


### Purpose

See #809. Increases the icon and text size of the accounts list items.

![image](https://github.com/bitfireAT/davx5-ose/assets/12086466/36cc3645-6c7b-4615-afae-a82492784a6c)

### Short description

- Increased icon size from `32dp` to `48dp`
- Increased text style from `bodyLarge` to `titleLarge`.

> [!NOTE]
> We might need to consider setting some text overflow if we don't want the title to take multiple lines.

![image](https://github.com/bitfireAT/davx5-ose/assets/12086466/e9ed4564-7337-4f23-8f3e-b40b618b99ca)

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

