### PR TITLE
PreferenceRepository.observeAsFlow: emit initial value

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/repository/PreferenceRepository.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/repository/PreferenceRepository.kt
@@ -51,6 +51,9 @@ class PreferenceRepository @Inject constructor(
             }
             preferences.registerOnSharedPreferenceChangeListener(listener)
 
+            // Emit the initial value
+            trySend(getValue())
+
             awaitClose {
                 preferences.unregisterOnSharedPreferenceChangeListener(listener)
             }


### PR DESCRIPTION
`PreferenceRepository.observeAsFlow` didn't emit an initial value (only observe updates). This causes the "Verbose logging" UI switch to be unchecked when the App Settings are opened even if verbose logging is actually enabled.

Fix: emit initial value