### PR TITLE
[Google] Allow login with custom domains again

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/GoogleLoginModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/GoogleLoginModel.kt
@@ -57,7 +57,7 @@ class GoogleLoginModel @AssistedInject constructor(
         val result: LoginInfo? = null
     ) {
         val canContinue = email.isNotEmpty()
-        val emailWithDomain = StringUtils.appendIfMissing(email, "@gmail.com")
+        val emailWithDomain = if (email.contains("@")) email else "$email@gmail.com"
     }
 
     var uiState by mutableStateOf(UiState())


### PR DESCRIPTION
The PR should be in _Draft_ state during development. As soon as it's finished, it should be marked as _Ready for review_ and a reviewer should be chosen.

See also: [Writing A Great Pull Request Description](https://www.pullrequest.com/blog/writing-a-great-pull-request-description/)


### Purpose

Allows introducing non-gmail accounts in the Google account creation screen.

### Short description

Replaces the suffixation with a simple check that will add `@gmail.com` if the introduced email doesn't have any hostname (aka doesn't contain `@`).

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

