### PR TITLE
Define toolchain version; update dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,12 +33,15 @@ android {
         testInstrumentationRunner = "at.bitfire.davdroid.CustomTestRunner"
     }
 
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(17)
+        }
+    }
+
     compileOptions {
         // enable because ical4android requires desugaring
         isCoreLibraryDesugaringEnabled = true
-
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
     }
 
     buildFeatures {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,7 +47,7 @@ kotlin = "2.0.0"
 kotlinx-coroutines = "1.8.1"
 # see https://github.com/google/ksp/releases for version numbers
 ksp = "2.0.0-1.0.21"
-mikepenz-aboutLibraries = "11.2.0"
+mikepenz-aboutLibraries = "11.2.1"
 nsk90-kstatemachine = "0.30.0"
 mockk = "1.13.11"
 okhttp = "4.12.0"


### PR DESCRIPTION
### Purpose

Instead of defining `sourceCompatibility` and `targetCompatibility`, we should now [define the toolchain version](https://developer.android.com/build/jdks#toolchain).
