### PR TITLE
Show CalDAV/CardDAV tab when the respective service is present

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreen.kt
@@ -46,7 +46,6 @@ import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -98,13 +97,15 @@ fun AccountScreen(
         }
     )
 
-    val addressBooksPager by model.addressBooksPager.collectAsState(null)
+    val cardDavService by model.cardDavSvc.collectAsStateWithLifecycle()
+    val addressBooksPager by model.addressBooksPager.collectAsStateWithLifecycle(null)
     val addressBooks = addressBooksPager?.flow?.collectAsLazyPagingItems()
 
-    val calendarsPager by model.calendarsPager.collectAsState(null)
+    val calDavService by model.calDavSvc.collectAsStateWithLifecycle()
+    val calendarsPager by model.calendarsPager.collectAsStateWithLifecycle(null)
     val calendars = calendarsPager?.flow?.collectAsLazyPagingItems()
 
-    val subscriptionsPager by model.webcalPager.collectAsState(null)
+    val subscriptionsPager by model.webcalPager.collectAsStateWithLifecycle(null)
     val subscriptions = subscriptionsPager?.flow?.collectAsLazyPagingItems()
 
     val context = LocalContext.current
@@ -117,11 +118,11 @@ fun AccountScreen(
             initialValue = AccountSettings.ShowOnlyPersonal(onlyPersonal = false, locked = false)
         ).value,
         onSetShowOnlyPersonal = model::setShowOnlyPersonal,
-        hasCardDav = addressBooks?.itemCount != 0,
+        hasCardDav = cardDavService != null,
         canCreateAddressBook = model.canCreateAddressBook.collectAsStateWithLifecycle(false).value,
         cardDavProgress = model.cardDavProgress.collectAsStateWithLifecycle(AccountProgress.Idle).value,
         addressBooks = addressBooks,
-        hasCalDav = calendars?.itemCount != 0,
+        hasCalDav = calDavService != null,
         canCreateCalendar = model.canCreateCalendar.collectAsStateWithLifecycle(false).value,
         calDavProgress = model.calDavProgress.collectAsStateWithLifecycle(AccountProgress.Idle).value,
         calendars = calendars,

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreenModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreenModel.kt
@@ -79,7 +79,7 @@ class AccountScreenModel @AssistedInject constructor(
         refreshSettingsSignal.postValue(Unit)
     }
 
-    private val cardDavSvc = serviceRepository
+    val cardDavSvc = serviceRepository
         .getCardDavServiceFlow(account.name)
         .stateIn(viewModelScope, initialValue = null, started = SharingStarted.Eagerly)
     private val bindableAddressBookHomesets = getBindableHomesetsFromServiceUseCase(cardDavSvc)
@@ -93,7 +93,7 @@ class AccountScreenModel @AssistedInject constructor(
     )
     val addressBooksPager = getServiceCollectionPagerUseCase(cardDavSvc, Collection.TYPE_ADDRESSBOOK, showOnlyPersonal)
 
-    private val calDavSvc = serviceRepository
+    val calDavSvc = serviceRepository
         .getCalDavServiceFlow(account.name)
         .stateIn(viewModelScope, initialValue = null, started = SharingStarted.Eagerly)
     private val bindableCalendarHomesets = getBindableHomesetsFromServiceUseCase(calDavSvc)


### PR DESCRIPTION
### Purpose

Previously, we showed the

- CardDAV tab when there's at least one address book (or if there are `null` address books, which happens when there is no CardDAV service, which caused #864).
- Same for CalDAV.


### Short description

This PR uses the existence of a CalDAV/CardDAV service as a condition for whether to show the respective tab.

This may cause confusion for users who use servers that report a CalDAV/CardDAV service without providing a Web interface for it. However, they can sometimes still create a collection, which may be want they want.

An alternative would be to just check for `null` and then hide the tab, too. However as said above, they may then never be able to create the first collection on an empty server.


### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

