### PR TITLE
Provide collection to SyncManager

### DIFF
--- a/app/src/androidTestOse/kotlin/at/bitfire/davdroid/sync/SyncManagerTest.kt
+++ b/app/src/androidTestOse/kotlin/at/bitfire/davdroid/sync/SyncManagerTest.kt
@@ -20,6 +20,7 @@ import at.bitfire.dav4jvm.property.webdav.GetETag
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.TestUtils.assertWithin
 import at.bitfire.davdroid.db.AppDatabase
+import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Credentials
 import at.bitfire.davdroid.db.SyncState
 import at.bitfire.davdroid.network.HttpClient
@@ -27,6 +28,7 @@ import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.ui.NotificationUtils
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Protocol
 import okhttp3.internal.http.StatusLine
 import okhttp3.mockwebserver.MockResponse
@@ -98,13 +100,18 @@ class SyncManagerTest {
     }
 
 
-    private fun syncManager(collection: LocalTestCollection, syncResult: SyncResult = SyncResult()) =
+    private fun syncManager(
+        localCollection: LocalTestCollection,
+        syncResult: SyncResult = SyncResult(),
+        collection: Collection = Collection(0,0, type = "", url = "http://a".toHttpUrl())
+    ) =
         TestSyncManager(
             account,
             arrayOf(),
             "TestAuthority",
             HttpClient.Builder(InstrumentationRegistry.getInstrumentation().targetContext).build(),
             syncResult,
+            localCollection,
             collection,
             server,
             context, db

--- a/app/src/androidTestOse/kotlin/at/bitfire/davdroid/sync/SyncManagerTest.kt
+++ b/app/src/androidTestOse/kotlin/at/bitfire/davdroid/sync/SyncManagerTest.kt
@@ -28,7 +28,7 @@ import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.ui.NotificationUtils
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
-import okhttp3.HttpUrl.Companion.toHttpUrl
+import io.mockk.mockk
 import okhttp3.Protocol
 import okhttp3.internal.http.StatusLine
 import okhttp3.mockwebserver.MockResponse
@@ -103,7 +103,7 @@ class SyncManagerTest {
     private fun syncManager(
         localCollection: LocalTestCollection,
         syncResult: SyncResult = SyncResult(),
-        collection: Collection = Collection(0,0, type = "", url = "http://a".toHttpUrl())
+        collection: Collection = mockk<Collection>()
     ) =
         TestSyncManager(
             account,

--- a/app/src/androidTestOse/kotlin/at/bitfire/davdroid/sync/TestSyncManager.kt
+++ b/app/src/androidTestOse/kotlin/at/bitfire/davdroid/sync/TestSyncManager.kt
@@ -12,6 +12,7 @@ import at.bitfire.dav4jvm.MultiResponseCallback
 import at.bitfire.dav4jvm.Response
 import at.bitfire.dav4jvm.property.caldav.GetCTag
 import at.bitfire.davdroid.db.AppDatabase
+import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.SyncState
 import at.bitfire.davdroid.network.HttpClient
 import at.bitfire.davdroid.resource.LocalResource
@@ -30,10 +31,11 @@ class TestSyncManager(
     httpClient: HttpClient,
     syncResult: SyncResult,
     localCollection: LocalTestCollection,
+    collection: Collection,
     val mockWebServer: MockWebServer,
     context: Context,
     db: AppDatabase
-): SyncManager<LocalTestResource, LocalTestCollection, DavCollection>(account, AccountSettings(context, account), httpClient, extras, authority, syncResult, localCollection, context, db) {
+): SyncManager<LocalTestResource, LocalTestCollection, DavCollection>(account, AccountSettings(context, account), httpClient, extras, authority, syncResult, localCollection, collection, context, db) {
 
     override fun prepare(): Boolean {
         collectionURL = mockWebServer.url("/")

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
@@ -118,7 +118,7 @@ class AddressBookSyncer(
 
                 val url = addressBook.url.toHttpUrl()
                 remoteAddressBooks[url]?.let { collection ->
-                    syncAddresBook(
+                    syncAddressBook(
                         addressBook.account,
                         extras,
                         ContactsContract.AUTHORITY,
@@ -132,7 +132,7 @@ class AddressBookSyncer(
         }
     }
 
-    fun syncAddresBook(
+    fun syncAddressBook(
         account: Account,
         extras: Array<String>,
         authority: String,

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
@@ -21,6 +21,7 @@ import at.bitfire.dav4jvm.property.webdav.SupportedReportSet
 import at.bitfire.dav4jvm.property.webdav.SyncToken
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.AppDatabase
+import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.SyncState
 import at.bitfire.davdroid.log.Logger
 import at.bitfire.davdroid.network.HttpClient
@@ -61,6 +62,7 @@ class CalendarSyncManager @AssistedInject constructor(
     @Assisted authority: String,
     @Assisted syncResult: SyncResult,
     @Assisted localCalendar: LocalCalendar,
+    @Assisted collection: Collection,
     @ApplicationContext context: Context,
     db: AppDatabase
 ): SyncManager<LocalEvent, LocalCalendar, DavCalendar>(account, accountSettings, httpClient, extras, authority, syncResult, localCalendar, context, db) {
@@ -74,7 +76,8 @@ class CalendarSyncManager @AssistedInject constructor(
             httpClient: HttpClient,
             authority: String,
             syncResult: SyncResult,
-            localCalendar: LocalCalendar
+            localCalendar: LocalCalendar,
+            collection: Collection
         ): CalendarSyncManager
     }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
@@ -32,6 +32,7 @@ import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.util.lastSegment
 import at.bitfire.ical4android.Event
 import at.bitfire.ical4android.InvalidCalendarException
+import at.bitfire.ical4android.UsesThreadContextClassLoader
 import at.bitfire.ical4android.util.DateUtils
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -52,8 +53,9 @@ import java.time.ZonedDateTime
 import java.util.logging.Level
 
 /**
- * Synchronization manager for CalDAV collections; handles events (VEVENT)
+ * Synchronization manager for CalDAV collections; handles events (VEVENT).
  */
+@UsesThreadContextClassLoader
 class CalendarSyncManager @AssistedInject constructor(
     @Assisted account: Account,
     @Assisted accountSettings: AccountSettings,

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
@@ -65,7 +65,7 @@ class CalendarSyncManager @AssistedInject constructor(
     @Assisted collection: Collection,
     @ApplicationContext context: Context,
     db: AppDatabase
-): SyncManager<LocalEvent, LocalCalendar, DavCalendar>(account, accountSettings, httpClient, extras, authority, syncResult, localCalendar, context, db) {
+): SyncManager<LocalEvent, LocalCalendar, DavCalendar>(account, accountSettings, httpClient, extras, authority, syncResult, localCalendar, collection, context, db) {
 
     @AssistedFactory
     interface Factory {

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncer.kt
@@ -87,8 +87,9 @@ class CalendarSyncer(context: Context): Syncer(context) {
         // Sync local calendars
         val calendars = AndroidCalendar
             .find(account, provider, LocalCalendar.Factory, "${CalendarContract.Calendars.SYNC_EVENTS}!=0", null)
-        for (calendar in calendars)
-            remoteCalendars[calendar.name?.toHttpUrl()]?.let { collection ->
+        for (calendar in calendars) {
+            val url = calendar.name?.toHttpUrl()
+            remoteCalendars[url]?.let { collection ->
                 Logger.log.info("Synchronizing calendar #${calendar.id}, URL: ${calendar.name}")
 
                 val syncManagerFactory = entryPoint.calendarSyncManagerFactory()
@@ -104,6 +105,7 @@ class CalendarSyncer(context: Context): Syncer(context) {
                 )
                 syncManager.performSync()
             }
+        }
 
     }
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
@@ -26,6 +26,7 @@ import at.bitfire.dav4jvm.property.webdav.SupportedReportSet
 import at.bitfire.dav4jvm.property.webdav.SyncToken
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.AppDatabase
+import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.SyncState
 import at.bitfire.davdroid.log.Logger
 import at.bitfire.davdroid.network.HttpClient
@@ -104,6 +105,7 @@ class ContactsSyncManager @AssistedInject constructor(
     @Assisted syncResult: SyncResult,
     @Assisted val provider: ContentProviderClient,
     @Assisted localAddressBook: LocalAddressBook,
+    @Assisted collection: Collection,
     @ApplicationContext context: Context,
     db: AppDatabase
 ): SyncManager<LocalAddress, LocalAddressBook, DavAddressBook>(
@@ -121,7 +123,8 @@ class ContactsSyncManager @AssistedInject constructor(
             authority: String,
             syncResult: SyncResult,
             provider: ContentProviderClient,
-            localAddressBook: LocalAddressBook
+            localAddressBook: LocalAddressBook,
+            collection: Collection
         ): ContactsSyncManager
     }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
@@ -109,7 +109,7 @@ class ContactsSyncManager @AssistedInject constructor(
     @ApplicationContext context: Context,
     db: AppDatabase
 ): SyncManager<LocalAddress, LocalAddressBook, DavAddressBook>(
-    account, accountSettings, httpClient, extras, authority, syncResult, localAddressBook,
+    account, accountSettings, httpClient, extras, authority, syncResult, localAddressBook,  collection,
     context, db
 ) {
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
@@ -54,7 +54,7 @@ class JtxSyncManager @AssistedInject constructor(
     @Assisted collection: Collection,
     @ApplicationContext context: Context,
     db: AppDatabase
-): SyncManager<LocalJtxICalObject, LocalJtxCollection, DavCalendar>(account, accountSettings, httpClient, extras, authority, syncResult, localCollection, context, db) {
+): SyncManager<LocalJtxICalObject, LocalJtxCollection, DavCalendar>(account, accountSettings, httpClient, extras, authority, syncResult, localCollection, collection, context, db) {
 
     @AssistedFactory
     interface Factory {

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
@@ -19,6 +19,7 @@ import at.bitfire.dav4jvm.property.webdav.GetETag
 import at.bitfire.dav4jvm.property.webdav.SyncToken
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.AppDatabase
+import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.SyncState
 import at.bitfire.davdroid.log.Logger
 import at.bitfire.davdroid.network.HttpClient
@@ -50,6 +51,7 @@ class JtxSyncManager @AssistedInject constructor(
     @Assisted authority: String,
     @Assisted syncResult: SyncResult,
     @Assisted localCollection: LocalJtxCollection,
+    @Assisted collection: Collection,
     @ApplicationContext context: Context,
     db: AppDatabase
 ): SyncManager<LocalJtxICalObject, LocalJtxCollection, DavCalendar>(account, accountSettings, httpClient, extras, authority, syncResult, localCollection, context, db) {
@@ -63,7 +65,8 @@ class JtxSyncManager @AssistedInject constructor(
             httpClient: HttpClient,
             authority: String,
             syncResult: SyncResult,
-            localCollection: LocalJtxCollection
+            localCollection: LocalJtxCollection,
+            collection: Collection
         ): JtxSyncManager
     }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
@@ -30,6 +30,7 @@ import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.util.lastSegment
 import at.bitfire.ical4android.InvalidCalendarException
 import at.bitfire.ical4android.JtxICalObject
+import at.bitfire.ical4android.UsesThreadContextClassLoader
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -43,6 +44,7 @@ import java.io.Reader
 import java.io.StringReader
 import java.util.logging.Level
 
+@UsesThreadContextClassLoader
 class JtxSyncManager @AssistedInject constructor(
     @Assisted account: Account,
     @Assisted accountSettings: AccountSettings,

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -78,7 +78,22 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.logging.Level
 import javax.net.ssl.SSLHandshakeException
 
-@UsesThreadContextClassLoader
+/**
+ * Synchronizes a local collection with a remote collection.
+ *
+ * @param ResourceType      type of local resources
+ * @param CollectionType    type of local collection
+ * @param RemoteType        type of remote collection
+ *
+ * @param account           account to synchronize
+ * @param accountSettings   account settings of account to synchronize
+ * @param httpClient        HTTP client to use for network requests, already authenticated with credentials from [account]
+ * @param extras            additional sync parameters
+ * @param authority         authority of the content provider the collection shall be synchronized with
+ * @param syncResult        receiver for result of the synchronization (will be updated by [performSync])
+ * @param localCollection   local collection to synchronize (interface to content provider)
+ * @param collection        collection info in the database
+ */
 abstract class SyncManager<ResourceType: LocalResource<*>, out CollectionType: LocalCollection<ResourceType>, RemoteType: DavCollection>(
     val account: Account,
     val accountSettings: AccountSettings,
@@ -325,10 +340,9 @@ abstract class SyncManager<ResourceType: LocalResource<*>, out CollectionType: L
      */
     private fun saveSyncTime() {
         val serviceType = when (authority) {
-            ContactsContract.AUTHORITY,
-            context.getString(R.string.address_books_authority) ->      // Contacts and Address books
+            ContactsContract.AUTHORITY ->       // contacts
                 Service.TYPE_CARDDAV
-            else ->                                    // Calendars + other (ie. tasks
+            else ->                             // calendars and tasks
                 Service.TYPE_CALDAV
         }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -38,6 +38,7 @@ import at.bitfire.dav4jvm.property.webdav.SyncToken
 import at.bitfire.davdroid.InvalidAccountException
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.AppDatabase
+import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service
 import at.bitfire.davdroid.db.SyncState
 import at.bitfire.davdroid.db.SyncStats
@@ -86,6 +87,7 @@ abstract class SyncManager<ResourceType: LocalResource<*>, out CollectionType: L
     val authority: String,
     val syncResult: SyncResult,
     val localCollection: CollectionType,
+    val collection: Collection,
     // injected
     val context: Context,
     val db: AppDatabase

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
@@ -63,6 +63,11 @@ abstract class Syncer(val context: Context) {
     internal val db = syncAdapterEntryPoint.appDatabase()
 
 
+    /**
+     * Creates and/or deletes local collections (calendars, address books, etc) and updates them
+     * with remote information. Then syncs the actual entries (events, tasks, contacts, etc) of all
+     * collections.
+     */
     abstract fun sync(account: Account, extras: Array<String>, authority: String, httpClient: Lazy<HttpClient>, provider: ContentProviderClient, syncResult: SyncResult)
 
     fun onPerformSync(

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
@@ -30,6 +30,7 @@ import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.util.lastSegment
 import at.bitfire.ical4android.InvalidCalendarException
 import at.bitfire.ical4android.Task
+import at.bitfire.ical4android.UsesThreadContextClassLoader
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -46,6 +47,7 @@ import java.util.logging.Level
 /**
  * Synchronization manager for CalDAV collections; handles tasks (VTODO)
  */
+@UsesThreadContextClassLoader
 class TasksSyncManager @AssistedInject constructor(
     @Assisted account: Account,
     @Assisted accountSettings: AccountSettings,

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
@@ -19,6 +19,7 @@ import at.bitfire.dav4jvm.property.webdav.GetETag
 import at.bitfire.dav4jvm.property.webdav.SyncToken
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.AppDatabase
+import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.SyncState
 import at.bitfire.davdroid.log.Logger
 import at.bitfire.davdroid.network.HttpClient
@@ -53,6 +54,7 @@ class TasksSyncManager @AssistedInject constructor(
     @Assisted authority: String,
     @Assisted syncResult: SyncResult,
     @Assisted localCollection: LocalTaskList,
+    @Assisted collection: Collection,
     @ApplicationContext context: Context,
     db: AppDatabase
 ): SyncManager<LocalTask, LocalTaskList, DavCalendar>(account, accountSettings, httpClient, extras, authority, syncResult, localCollection, context, db) {
@@ -66,7 +68,8 @@ class TasksSyncManager @AssistedInject constructor(
             extras: Array<String>,
             authority: String,
             syncResult: SyncResult,
-            localCollection: LocalTaskList
+            localCollection: LocalTaskList,
+            collection: Collection
         ): TasksSyncManager
     }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
@@ -57,7 +57,7 @@ class TasksSyncManager @AssistedInject constructor(
     @Assisted collection: Collection,
     @ApplicationContext context: Context,
     db: AppDatabase
-): SyncManager<LocalTask, LocalTaskList, DavCalendar>(account, accountSettings, httpClient, extras, authority, syncResult, localCollection, context, db) {
+): SyncManager<LocalTask, LocalTaskList, DavCalendar>(account, accountSettings, httpClient, extras, authority, syncResult, localCollection, collection, context, db) {
 
     @AssistedFactory
     interface Factory {


### PR DESCRIPTION
### Purpose

Provides database Collection to SyncManager. This is a prerequisite for #588 , #876  and #878

### Short description

Provide collection to 
 - `CalendarSyncManager`
 - `ContactsSyncManager`
 - `JtxSyncManager`
 - `TasksSyncManager`
 
by rewriting `sync` method in respective syncer classes 
and finally provide collection to `SyncManager`.

Also: 
- adapt `TestSyncManager`


### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

