### PR TITLE
Replaced "Create" by "Add" when creating accounts

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
@@ -194,8 +194,8 @@ fun AccountsScreen(
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
                         if (showAddAccount == AccountsModel.FABStyle.WithText)
                             ExtendedFloatingActionButton(
-                                text = { Text(stringResource(R.string.login_create_account)) },
-                                icon = { Icon(Icons.Filled.Add, stringResource(R.string.login_create_account)) },
+                                text = { Text(stringResource(R.string.login_add_account)) },
+                                icon = { Icon(Icons.Filled.Add, stringResource(R.string.login_add_account)) },
                                 containerColor = MaterialTheme.colorScheme.primary,
                                 contentColor = MaterialTheme.colorScheme.onPrimary,
                                 onClick = onAddAccount
@@ -206,7 +206,7 @@ fun AccountsScreen(
                                 containerColor = MaterialTheme.colorScheme.secondary,
                                 contentColor = MaterialTheme.colorScheme.onSecondary
                             ) {
-                                Icon(Icons.Filled.Add, stringResource(R.string.login_create_account))
+                                Icon(Icons.Filled.Add, stringResource(R.string.login_add_account))
                             }
 
                         if (showSyncAll)

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/AccountDetailsPage.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/AccountDetailsPage.kt
@@ -59,7 +59,7 @@ fun AccountDetailsPage(
     val context = LocalContext.current
     LaunchedEffect(uiState.couldNotCreateAccount) {
         if (uiState.couldNotCreateAccount) {
-            snackbarHostState.showSnackbar(context.getString(R.string.login_account_not_created))
+            snackbarHostState.showSnackbar(context.getString(R.string.login_account_not_added))
             model.resetCouldNotCreateAccount()
         }
     }
@@ -93,7 +93,7 @@ fun AccountDetailsPageContent(
     creatingAccount: Boolean
 ) {
     Assistant(
-        nextLabel = stringResource(R.string.login_create_account),
+        nextLabel = stringResource(R.string.login_add_account),
         onNext = onCreateAccount,
         nextEnabled = !creatingAccount && accountName.isNotBlank() && !accountNameAlreadyExists
     ) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -263,14 +263,14 @@
     <string name="login_base_url">Base URL</string>
     <string name="login_base_url_info"><![CDATA[The base URL will be checked directly, but <a href="%s">services are also discovered</a> using DNS records and well-known URLs.]]></string>
     <string name="login_select_certificate">Select certificate</string>
-    <string name="login_create_account">Create account</string>
+    <string name="login_add_account">Add account</string>
     <string name="login_account_name">Account name</string>
     <string name="login_account_avoid_apostrophe">Usage of apostrophes (\') seems to cause problems on some devices.</string>
     <string name="login_account_name_info">Use your email address as account name because Android will use the account name as ORGANIZER field for events you create. You can\'t have two accounts with the same name.</string>
     <string name="login_account_contact_group_method">Contact group method:</string>
     <string name="login_account_name_required">Account name required</string>
     <string name="login_account_name_already_taken">Account name already taken</string>
-    <string name="login_account_not_created">Account could not be created</string>
+    <string name="login_account_not_added">Account could not be added</string>
     <string name="login_type_advanced">Advanced login</string>
     <string name="login_no_client_certificate_optional">No client certificate*</string>
     <string name="login_client_certificate_selected">Client certificate: %s</string>


### PR DESCRIPTION
### Purpose

"Create account" could be interpreted as that it would create the account on the server.

### Short description

- Replaced "Create cccount" by "Add account"
- Replaced "Account could not be added" by "Account could not be created"

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

