### PR TITLE
Fix: Syncer synchronizes only once

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncer.kt
@@ -101,6 +101,5 @@ class CalendarSyncer @Inject constructor(
                 syncManager.performSync()
             }
         }
-
     }
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
@@ -121,6 +121,10 @@ abstract class Syncer(
         } finally {
             if (httpClient.isInitialized())
                 httpClient.value.close()
+
+            // close content provider client which is acquired above
+            provider.close()
+
             Logger.log.log(
                 Level.INFO,
                 "$contentAuthority sync of $account finished",


### PR DESCRIPTION
### Purpose

Fix the Syncer not synchronizing anymore after the first initial sync.

For more see #909

### Short description

In #881 we used the same hashmap (`remoteCalendars`, `remoteAddressbooks`, ...) for supplying collections to the sync manager and to determine whether a new local resource (calendar, address book, task list, jtx collection) should be created for a new found remote collection. This PR introduces a second hashmap (`newCollections`), copying from the initial one (`remoteCollections`) to determine new remote collections by subtraction. The original hashmap (`remoteCollections`) will then be used to provide the collection to the sync manager when syncing.

This PR will also close the acquired provider in the abstract syncer, which was forgotten in #881.
     
- Rename the different remoteCalendars, remoteAddressBooks, etc. collection HashMaps to generic `remoteCollections`
- Use a separate HashMap `newCollections` to determine new remote collections
- Create new local resources (calendar, address book, task list, jtx collection) from `newCollections`
- Use `remoteCollections` to provide collections when syncing to sync manager.
- Close content provider after sync in syncer 

### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.

