### PR TITLE
Use DI for AccountSettings and Android tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,7 +30,7 @@ android {
 
         buildConfigField("String", "userAgent", "\"DAVx5\"")
 
-        testInstrumentationRunner = "at.bitfire.davdroid.CustomTestRunner"
+        testInstrumentationRunner = "at.bitfire.davdroid.HiltTestRunner"
     }
 
     java {

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/HiltTestRunner.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/HiltTestRunner.kt
@@ -4,14 +4,14 @@
 
 package at.bitfire.davdroid
 
+import android.app.Application
 import android.content.Context
 import androidx.test.runner.AndroidJUnitRunner
-import dagger.hilt.android.HiltAndroidApp
 import dagger.hilt.android.testing.HiltTestApplication
 
-class CustomTestRunner : AndroidJUnitRunner() {
+class HiltTestRunner : AndroidJUnitRunner() {
 
-    override fun newApplication(cl: ClassLoader, name: String, context: Context) =
+    override fun newApplication(cl: ClassLoader, name: String, context: Context): Application =
         super.newApplication(cl, HiltTestApplication::class.java.name, context)
 
 }

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/InitCalendarProviderRule.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/InitCalendarProviderRule.kt
@@ -10,7 +10,6 @@ import android.content.ContentUris
 import android.content.ContentValues
 import android.os.Build
 import android.provider.CalendarContract
-import androidx.annotation.RequiresApi
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
 import at.bitfire.davdroid.log.Logger

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/TestModules.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/TestModules.kt
@@ -1,13 +1,8 @@
 package at.bitfire.davdroid
 
-import android.content.Context
-import androidx.test.platform.app.InstrumentationRegistry
 import at.bitfire.davdroid.push.PushRegistrationWorker
 import at.bitfire.davdroid.repository.DavCollectionRepository
 import dagger.Module
-import dagger.Provides
-import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.hilt.testing.TestInstallIn
 import dagger.multibindings.Multibinds

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/TestModules.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/TestModules.kt
@@ -1,11 +1,16 @@
 package at.bitfire.davdroid
 
-import at.bitfire.davdroid.repository.DavCollectionRepository
+import android.content.Context
+import androidx.test.platform.app.InstrumentationRegistry
 import at.bitfire.davdroid.push.PushRegistrationWorker
+import at.bitfire.davdroid.repository.DavCollectionRepository
 import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
-import dagger.multibindings.Multibinds
 import dagger.hilt.testing.TestInstallIn
+import dagger.multibindings.Multibinds
 
 interface TestModules {
 
@@ -14,9 +19,10 @@ interface TestModules {
         components = [SingletonComponent::class],
         replaces = [PushRegistrationWorker.PushRegistrationWorkerModule::class]
     )
-    abstract class FakePushRegistrationWorkerModule {
-        // Provides empty set of listeners
+    abstract class TestPushRegistrationWorkerModule {
+        // provides empty set of listeners
         @Multibinds
         abstract fun defaultOnChangeListeners(): Set<DavCollectionRepository.OnChangeListener>
     }
+
 }

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/db/CollectionTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/db/CollectionTest.kt
@@ -4,13 +4,14 @@
 
 package at.bitfire.davdroid.db
 
+import android.content.Context
 import android.security.NetworkSecurityPolicy
 import androidx.test.filters.SmallTest
-import androidx.test.platform.app.InstrumentationRegistry
 import at.bitfire.dav4jvm.DavResource
 import at.bitfire.dav4jvm.property.webdav.ResourceType
 import at.bitfire.davdroid.network.HttpClient
 import at.bitfire.davdroid.settings.SettingsManager
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -34,25 +35,25 @@ class CollectionTest {
     val hiltRule = HiltAndroidRule(this)
 
     @Inject
+    @ApplicationContext
+    lateinit var context: Context
+
+    @Inject
     lateinit var settingsManager: SettingsManager
-
-    @Before
-    fun inject() {
-        hiltRule.inject()
-    }
-
 
     private lateinit var httpClient: HttpClient
     private val server = MockWebServer()
 
     @Before
-    fun setUp() {
-        httpClient = HttpClient.Builder(InstrumentationRegistry.getInstrumentation().targetContext).build()
+    fun setup() {
+        hiltRule.inject()
+
+        httpClient = HttpClient.Builder(context).build()
         Assume.assumeTrue(NetworkSecurityPolicy.getInstance().isCleartextTrafficPermitted)
     }
 
     @After
-    fun shutDown() {
+    fun teardown() {
         httpClient.close()
     }
 

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/network/ConnectionUtilsTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/network/ConnectionUtilsTest.kt
@@ -11,7 +11,6 @@ import android.net.NetworkCapabilities.NET_CAPABILITY_INTERNET
 import android.net.NetworkCapabilities.NET_CAPABILITY_NOT_VPN
 import android.net.NetworkCapabilities.NET_CAPABILITY_VALIDATED
 import android.net.NetworkCapabilities.TRANSPORT_WIFI
-import dagger.hilt.android.testing.HiltAndroidTest
 import io.mockk.every
 import io.mockk.junit4.MockKRule
 import io.mockk.mockk
@@ -21,7 +20,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
-@HiltAndroidTest
 class ConnectionUtilsTest {
 
     @get:Rule

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientTest.kt
@@ -4,8 +4,9 @@
 
 package at.bitfire.davdroid.network
 
+import android.content.Context
 import android.security.NetworkSecurityPolicy
-import androidx.test.platform.app.InstrumentationRegistry
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import okhttp3.Request
@@ -19,6 +20,7 @@ import org.junit.Assume
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import javax.inject.Inject
 
 @HiltAndroidTest
 class HttpClientTest {
@@ -29,11 +31,15 @@ class HttpClientTest {
     @get:Rule
     var hiltRule = HiltAndroidRule(this)
 
+    @Inject
+    @ApplicationContext
+    lateinit var context: Context
+
     @Before
     fun setUp() {
         hiltRule.inject()
 
-        httpClient = HttpClient.Builder(InstrumentationRegistry.getInstrumentation().targetContext).build()
+        httpClient = HttpClient.Builder(context).build()
 
         server = MockWebServer()
         server.start(30000)

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/repository/DavCollectionRepositoryTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/repository/DavCollectionRepositoryTest.kt
@@ -4,6 +4,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service
+import at.bitfire.davdroid.settings.AccountSettings
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import io.mockk.mockk
@@ -21,6 +22,9 @@ class DavCollectionRepositoryTest {
 
     @get:Rule
     var hiltRule = HiltAndroidRule(this)
+
+    @Inject
+    lateinit var accountSettingsFactory: AccountSettings.Factory
 
     @Inject
     lateinit var serviceRepository: DavServiceRepository
@@ -55,7 +59,7 @@ class DavCollectionRepositoryTest {
             )
         )
         val testObserver = mockk<DavCollectionRepository.OnChangeListener>(relaxed = true)
-        val collectionRepository = DavCollectionRepository(context, mutableSetOf(testObserver), serviceRepository, db)
+        val collectionRepository = DavCollectionRepository(accountSettingsFactory, context, db, mutableSetOf(testObserver), serviceRepository)
 
         assert(db.collectionDao().get(collectionId)?.forceReadOnly == false)
         verify(exactly = 0) {
@@ -76,4 +80,5 @@ class DavCollectionRepositoryTest {
         val serviceId = serviceRepository.insertOrReplace(service)
         return serviceRepository.get(serviceId)
     }
+
 }

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/repository/DavCollectionRepositoryTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/repository/DavCollectionRepositoryTest.kt
@@ -1,10 +1,11 @@
 package at.bitfire.davdroid.repository
 
-import androidx.test.platform.app.InstrumentationRegistry
+import android.content.Context
 import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service
 import at.bitfire.davdroid.settings.AccountSettings
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import io.mockk.mockk
@@ -27,12 +28,14 @@ class DavCollectionRepositoryTest {
     lateinit var accountSettingsFactory: AccountSettings.Factory
 
     @Inject
-    lateinit var serviceRepository: DavServiceRepository
+    @ApplicationContext
+    lateinit var context: Context
 
     @Inject
     lateinit var db: AppDatabase
 
-    val context = InstrumentationRegistry.getInstrumentation().targetContext
+    @Inject
+    lateinit var serviceRepository: DavServiceRepository
 
     var service: Service? = null
 
@@ -47,6 +50,7 @@ class DavCollectionRepositoryTest {
         db.close()
         serviceRepository.deleteAll()
     }
+
 
     @Test
     fun testOnChangeListener_setForceReadOnly() = runBlocking {

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookTest.kt
@@ -6,15 +6,16 @@ package at.bitfire.davdroid.resource
 
 import android.accounts.Account
 import android.accounts.AccountManager
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import androidx.test.platform.app.InstrumentationRegistry
+import android.content.Context
 import at.bitfire.davdroid.R
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import javax.inject.Inject
 
 @HiltAndroidTest
 class LocalAddressBookTest {
@@ -22,18 +23,20 @@ class LocalAddressBookTest {
     @get:Rule
     val hiltRule = HiltAndroidRule(this)
 
-    val context = InstrumentationRegistry.getInstrumentation().targetContext
+    @Inject
+    @ApplicationContext
+    lateinit var context: Context
 
-    val mainAccountType = context.getString(R.string.account_type)
-    val mainAccount = Account("main", mainAccountType)
+    private val mainAccountType by lazy { context.getString(R.string.account_type) }
+    private val mainAccount by lazy { Account("main", mainAccountType) }
 
-    val addressBookAccountType = context.getString(R.string.account_type_address_book)
-    val addressBookAccount = Account("sub", addressBookAccountType)
+    private val addressBookAccountType by lazy { context.getString(R.string.account_type_address_book) }
+    private val addressBookAccount by lazy { Account("sub", addressBookAccountType) }
 
-    val accountManager = AccountManager.get(context)
+    private val accountManager by lazy { AccountManager.get(context) }
 
     @Before
-    fun setUp() {
+    fun setup() {
         hiltRule.inject()
 
         // TODO DOES NOT WORK: the account immediately starts to sync, which creates the sync adapter services.
@@ -42,7 +45,7 @@ class LocalAddressBookTest {
     }
 
     @After
-    fun cleanup() {
+    fun teardown() {
         accountManager.removeAccount(addressBookAccount, null, null)
         accountManager.removeAccount(mainAccount, null, null)
     }

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalCalendarTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalCalendarTest.kt
@@ -15,14 +15,19 @@ import androidx.test.platform.app.InstrumentationRegistry
 import at.bitfire.davdroid.InitCalendarProviderRule
 import at.bitfire.ical4android.AndroidCalendar
 import at.bitfire.ical4android.Event
-import at.bitfire.ical4android.util.MiscUtils.closeCompat
 import at.bitfire.ical4android.util.MiscUtils.asSyncAdapter
+import at.bitfire.ical4android.util.MiscUtils.closeCompat
 import net.fortuna.ical4j.model.property.DtStart
 import net.fortuna.ical4j.model.property.RRule
 import net.fortuna.ical4j.model.property.RecurrenceId
 import net.fortuna.ical4j.model.property.Status
-import org.junit.*
+import org.junit.After
+import org.junit.AfterClass
 import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.ClassRule
+import org.junit.Test
 import org.junit.rules.TestRule
 
 class LocalCalendarTest {

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalEventTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalEventTest.kt
@@ -21,11 +21,22 @@ import at.techbee.jtx.JtxContract.asSyncAdapter
 import net.fortuna.ical4j.model.Date
 import net.fortuna.ical4j.model.DateList
 import net.fortuna.ical4j.model.parameter.Value
-import net.fortuna.ical4j.model.property.*
-import org.junit.*
-import org.junit.Assert.*
+import net.fortuna.ical4j.model.property.DtStart
+import net.fortuna.ical4j.model.property.ExDate
+import net.fortuna.ical4j.model.property.RRule
+import net.fortuna.ical4j.model.property.RecurrenceId
+import net.fortuna.ical4j.model.property.Status
+import org.junit.After
+import org.junit.AfterClass
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.ClassRule
+import org.junit.Test
 import org.junit.rules.TestRule
-import java.util.*
+import java.util.UUID
 
 class LocalEventTest {
 

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalGroupTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalGroupTest.kt
@@ -8,6 +8,7 @@ import android.Manifest
 import android.content.ContentProviderClient
 import android.content.ContentUris
 import android.content.ContentValues
+import android.content.Context
 import android.provider.ContactsContract
 import android.provider.ContactsContract.CommonDataKinds.GroupMembership
 import androidx.test.platform.app.InstrumentationRegistry
@@ -17,6 +18,7 @@ import at.bitfire.vcard4android.BatchOperation
 import at.bitfire.vcard4android.CachedGroupMembership
 import at.bitfire.vcard4android.Contact
 import at.bitfire.vcard4android.GroupMethod
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.AfterClass
@@ -37,8 +39,6 @@ class LocalGroupTest {
 
     companion object {
 
-        val context = InstrumentationRegistry.getInstrumentation().targetContext
-
         @JvmField
         @ClassRule
         val permissionRule = GrantPermissionRule.grant(Manifest.permission.READ_CONTACTS, Manifest.permission.WRITE_CONTACTS)!!
@@ -48,6 +48,7 @@ class LocalGroupTest {
         @BeforeClass
         @JvmStatic
         fun connect() {
+            val context = InstrumentationRegistry.getInstrumentation().targetContext
             provider = context.contentResolver.acquireContentProviderClient(ContactsContract.AUTHORITY)!!
             assertNotNull(provider)
         }
@@ -61,6 +62,10 @@ class LocalGroupTest {
 
     @get:Rule
     val hiltRule = HiltAndroidRule(this)
+
+    @Inject
+    @ApplicationContext
+    lateinit var context: Context
 
     @Inject
     lateinit var settingsManager: SettingsManager

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/contactrow/CachedGroupMembershipHandlerTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/contactrow/CachedGroupMembershipHandlerTest.kt
@@ -15,37 +15,55 @@ import at.bitfire.davdroid.resource.LocalTestAddressBook
 import at.bitfire.vcard4android.CachedGroupMembership
 import at.bitfire.vcard4android.Contact
 import at.bitfire.vcard4android.GroupMethod
-import org.junit.*
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.AfterClass
+import org.junit.Assert
 import org.junit.Assert.assertArrayEquals
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.ClassRule
+import org.junit.Rule
+import org.junit.Test
 
+@HiltAndroidTest
 class CachedGroupMembershipHandlerTest {
 
     companion object {
+
+        val context = InstrumentationRegistry.getInstrumentation().context
 
         @JvmField
         @ClassRule
         val permissionRule = GrantPermissionRule.grant(Manifest.permission.READ_CONTACTS, Manifest.permission.WRITE_CONTACTS)!!
 
         private lateinit var provider: ContentProviderClient
-        private lateinit var addressBook: LocalTestAddressBook
 
         @BeforeClass
         @JvmStatic
         fun connect() {
-            val context = InstrumentationRegistry.getInstrumentation().context
             provider = context.contentResolver.acquireContentProviderClient(ContactsContract.AUTHORITY)!!
             Assert.assertNotNull(provider)
-
-            addressBook = LocalTestAddressBook(context, provider, GroupMethod.GROUP_VCARDS)
         }
 
         @AfterClass
         @JvmStatic
         fun disconnect() {
-            @Suppress("DEPRECATION")
-            provider.release()
+            provider.close()
         }
 
+    }
+
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+
+    private lateinit var addressBook: LocalTestAddressBook
+
+    @Before
+    fun setup() {
+        hiltRule.inject()
+
+        addressBook = LocalTestAddressBook(context, provider, GroupMethod.GROUP_VCARDS)
     }
 
 

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/contactrow/CachedGroupMembershipHandlerTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/contactrow/CachedGroupMembershipHandlerTest.kt
@@ -7,6 +7,7 @@ package at.bitfire.davdroid.resource.contactrow
 import android.Manifest
 import android.content.ContentProviderClient
 import android.content.ContentValues
+import android.content.Context
 import android.provider.ContactsContract
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
@@ -15,23 +16,22 @@ import at.bitfire.davdroid.resource.LocalTestAddressBook
 import at.bitfire.vcard4android.CachedGroupMembership
 import at.bitfire.vcard4android.Contact
 import at.bitfire.vcard4android.GroupMethod
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.AfterClass
-import org.junit.Assert
 import org.junit.Assert.assertArrayEquals
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.ClassRule
 import org.junit.Rule
 import org.junit.Test
+import javax.inject.Inject
 
 @HiltAndroidTest
 class CachedGroupMembershipHandlerTest {
 
     companion object {
-
-        val context = InstrumentationRegistry.getInstrumentation().context
 
         @JvmField
         @ClassRule
@@ -42,8 +42,8 @@ class CachedGroupMembershipHandlerTest {
         @BeforeClass
         @JvmStatic
         fun connect() {
+            val context = InstrumentationRegistry.getInstrumentation().context
             provider = context.contentResolver.acquireContentProviderClient(ContactsContract.AUTHORITY)!!
-            Assert.assertNotNull(provider)
         }
 
         @AfterClass
@@ -54,21 +54,24 @@ class CachedGroupMembershipHandlerTest {
 
     }
 
+
+    @Inject
+    @ApplicationContext
+    lateinit var context: Context
+
     @get:Rule
     val hiltRule = HiltAndroidRule(this)
 
-    private lateinit var addressBook: LocalTestAddressBook
-
     @Before
-    fun setup() {
+    fun inject() {
         hiltRule.inject()
-
-        addressBook = LocalTestAddressBook(context, provider, GroupMethod.GROUP_VCARDS)
     }
 
 
     @Test
     fun testMembership() {
+        val addressBook = LocalTestAddressBook(context, provider, GroupMethod.GROUP_VCARDS)
+
         val contact = Contact()
         val localContact = LocalContact(addressBook, contact, null, null, 0)
         CachedGroupMembershipHandler(localContact).handle(ContentValues().apply {

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/contactrow/GroupMembershipBuilderTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/contactrow/GroupMembershipBuilderTest.kt
@@ -14,9 +14,18 @@ import androidx.test.rule.GrantPermissionRule
 import at.bitfire.davdroid.resource.LocalTestAddressBook
 import at.bitfire.vcard4android.Contact
 import at.bitfire.vcard4android.GroupMethod
-import org.junit.*
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.AfterClass
+import org.junit.Assert
 import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.ClassRule
+import org.junit.Rule
+import org.junit.Test
 
+@HiltAndroidTest
 class GroupMembershipBuilderTest {
 
     companion object {
@@ -46,6 +55,14 @@ class GroupMembershipBuilderTest {
             @Suppress("DEPRECATION")
             provider.release()
         }
+    }
+
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+
+    @Before
+    fun setup() {
+        hiltRule.inject()
     }
 
 

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/contactrow/GroupMembershipBuilderTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/contactrow/GroupMembershipBuilderTest.kt
@@ -6,6 +6,7 @@ package at.bitfire.davdroid.resource.contactrow
 
 import android.Manifest
 import android.content.ContentProviderClient
+import android.content.Context
 import android.net.Uri
 import android.provider.ContactsContract
 import android.provider.ContactsContract.CommonDataKinds.GroupMembership
@@ -17,7 +18,6 @@ import at.bitfire.vcard4android.GroupMethod
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.AfterClass
-import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.BeforeClass
@@ -29,39 +29,34 @@ import org.junit.Test
 class GroupMembershipBuilderTest {
 
     companion object {
+
+        val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
+
         @JvmField
         @ClassRule
         val permissionRule = GrantPermissionRule.grant(Manifest.permission.READ_CONTACTS, Manifest.permission.WRITE_CONTACTS)!!
 
         private lateinit var provider: ContentProviderClient
 
-        private lateinit var addressBookGroupsAsCategories: LocalTestAddressBook
-        private lateinit var addressBookGroupsAsVCards: LocalTestAddressBook
-
         @BeforeClass
         @JvmStatic
         fun connect() {
-            val context = InstrumentationRegistry.getInstrumentation().targetContext
             provider = context.contentResolver.acquireContentProviderClient(ContactsContract.AUTHORITY)!!
-            Assert.assertNotNull(provider)
-
-            addressBookGroupsAsCategories = LocalTestAddressBook(context, provider, GroupMethod.CATEGORIES)
-            addressBookGroupsAsVCards = LocalTestAddressBook(context, provider, GroupMethod.GROUP_VCARDS)
         }
 
         @AfterClass
         @JvmStatic
         fun disconnect() {
-            @Suppress("DEPRECATION")
-            provider.release()
+            provider.close()
         }
+
     }
 
     @get:Rule
     val hiltRule = HiltAndroidRule(this)
 
     @Before
-    fun setup() {
+    fun inject() {
         hiltRule.inject()
     }
 
@@ -71,6 +66,7 @@ class GroupMembershipBuilderTest {
         val contact = Contact().apply {
             categories += "TEST GROUP"
         }
+        val addressBookGroupsAsCategories = LocalTestAddressBook(context, provider, GroupMethod.CATEGORIES)
         GroupMembershipBuilder(Uri.EMPTY, null, contact, addressBookGroupsAsCategories, false).build().also { result ->
             assertEquals(1, result.size)
             assertEquals(GroupMembership.CONTENT_ITEM_TYPE, result[0].values[GroupMembership.MIMETYPE])
@@ -83,6 +79,7 @@ class GroupMembershipBuilderTest {
         val contact = Contact().apply {
             categories += "TEST GROUP"
         }
+        val addressBookGroupsAsVCards = LocalTestAddressBook(context, provider, GroupMethod.GROUP_VCARDS)
         GroupMembershipBuilder(Uri.EMPTY, null, contact, addressBookGroupsAsVCards, false).build().also { result ->
             // group membership is constructed during post-processing
             assertEquals(0, result.size)

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/contactrow/GroupMembershipBuilderTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/contactrow/GroupMembershipBuilderTest.kt
@@ -15,6 +15,7 @@ import androidx.test.rule.GrantPermissionRule
 import at.bitfire.davdroid.resource.LocalTestAddressBook
 import at.bitfire.vcard4android.Contact
 import at.bitfire.vcard4android.GroupMethod
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.AfterClass
@@ -24,13 +25,12 @@ import org.junit.BeforeClass
 import org.junit.ClassRule
 import org.junit.Rule
 import org.junit.Test
+import javax.inject.Inject
 
 @HiltAndroidTest
 class GroupMembershipBuilderTest {
 
     companion object {
-
-        val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
 
         @JvmField
         @ClassRule
@@ -41,6 +41,7 @@ class GroupMembershipBuilderTest {
         @BeforeClass
         @JvmStatic
         fun connect() {
+            val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
             provider = context.contentResolver.acquireContentProviderClient(ContactsContract.AUTHORITY)!!
         }
 
@@ -54,6 +55,10 @@ class GroupMembershipBuilderTest {
 
     @get:Rule
     val hiltRule = HiltAndroidRule(this)
+
+    @Inject
+    @ApplicationContext
+    lateinit var context: Context
 
     @Before
     fun inject() {

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/contactrow/GroupMembershipHandlerTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/contactrow/GroupMembershipHandlerTest.kt
@@ -15,11 +15,21 @@ import at.bitfire.davdroid.resource.LocalTestAddressBook
 import at.bitfire.vcard4android.CachedGroupMembership
 import at.bitfire.vcard4android.Contact
 import at.bitfire.vcard4android.GroupMethod
-import org.junit.*
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.After
+import org.junit.Assert
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
 
+@HiltAndroidTest
 class GroupMembershipHandlerTest {
+
+    @get:Rule
+    var hiltRule = HiltAndroidRule(this)
 
     @JvmField
     @Rule
@@ -33,7 +43,9 @@ class GroupMembershipHandlerTest {
     private lateinit var addressBookGroupsAsVCards: LocalTestAddressBook
 
     @Before
-    fun connect() {
+    fun setup() {
+        hiltRule.inject()
+
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         provider = context.contentResolver.acquireContentProviderClient(ContactsContract.AUTHORITY)!!
         Assert.assertNotNull(provider)
@@ -45,9 +57,8 @@ class GroupMembershipHandlerTest {
     }
 
     @After
-    fun disconnect() {
-        @Suppress("DEPRECATION")
-        provider.release()
+    fun teardown() {
+        provider.close()
     }
 
 

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/contactrow/GroupMembershipHandlerTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/contactrow/GroupMembershipHandlerTest.kt
@@ -17,25 +17,46 @@ import at.bitfire.vcard4android.Contact
 import at.bitfire.vcard4android.GroupMethod
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
-import org.junit.After
+import org.junit.AfterClass
 import org.junit.Assert
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.ClassRule
 import org.junit.Rule
 import org.junit.Test
 
 @HiltAndroidTest
 class GroupMembershipHandlerTest {
 
+    companion object {
+
+        val context = InstrumentationRegistry.getInstrumentation().context
+
+        @JvmField
+        @ClassRule
+        val permissionRule = GrantPermissionRule.grant(Manifest.permission.READ_CONTACTS, Manifest.permission.WRITE_CONTACTS)!!
+
+        private lateinit var provider: ContentProviderClient
+
+        @BeforeClass
+        @JvmStatic
+        fun connect() {
+            provider = context.contentResolver.acquireContentProviderClient(ContactsContract.AUTHORITY)!!
+            Assert.assertNotNull(provider)
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun disconnect() {
+            provider.close()
+        }
+
+    }
+
     @get:Rule
     var hiltRule = HiltAndroidRule(this)
-
-    @JvmField
-    @Rule
-    val permissionRule = GrantPermissionRule.grant(Manifest.permission.READ_CONTACTS, Manifest.permission.WRITE_CONTACTS)!!
-
-    private lateinit var provider: ContentProviderClient
 
     private lateinit var addressBookGroupsAsCategories: LocalTestAddressBook
     private var addressBookGroupsAsCategoriesGroup: Long = -1
@@ -46,19 +67,10 @@ class GroupMembershipHandlerTest {
     fun setup() {
         hiltRule.inject()
 
-        val context = InstrumentationRegistry.getInstrumentation().targetContext
-        provider = context.contentResolver.acquireContentProviderClient(ContactsContract.AUTHORITY)!!
-        Assert.assertNotNull(provider)
-
         addressBookGroupsAsCategories = LocalTestAddressBook(context, provider, GroupMethod.CATEGORIES)
         addressBookGroupsAsCategoriesGroup = addressBookGroupsAsCategories.findOrCreateGroup("TEST GROUP")
 
         addressBookGroupsAsVCards = LocalTestAddressBook(context, provider, GroupMethod.GROUP_VCARDS)
-    }
-
-    @After
-    fun teardown() {
-        provider.close()
     }
 
 

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/servicedetection/CollectionListRefresherTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/servicedetection/CollectionListRefresherTest.kt
@@ -6,7 +6,6 @@ package at.bitfire.davdroid.servicedetection
 
 import android.content.Context
 import android.security.NetworkSecurityPolicy
-import androidx.test.platform.app.InstrumentationRegistry
 import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.HomeSet
@@ -16,6 +15,7 @@ import at.bitfire.davdroid.log.Logger
 import at.bitfire.davdroid.network.HttpClient
 import at.bitfire.davdroid.settings.Settings
 import at.bitfire.davdroid.settings.SettingsManager
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import io.mockk.every
@@ -36,22 +36,6 @@ import javax.inject.Inject
 
 @HiltAndroidTest
 class CollectionListRefresherTest {
-    
-    @get:Rule
-    var hiltRule = HiltAndroidRule(this)
-
-    val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
-
-    @Inject
-    lateinit var settings: SettingsManager
-
-    @Before
-    fun setUp() {
-        hiltRule.inject()
-    }
-
-    
-    // Test dependencies
 
     companion object {
         private const val PATH_CALDAV = "/caldav"
@@ -66,28 +50,40 @@ class CollectionListRefresherTest {
         private const val SUBPATH_ADDRESSBOOK_INACCESSIBLE = "/addressbooks/inaccessible-contacts"
     }
 
+    @get:Rule
+    var hiltRule = HiltAndroidRule(this)
+
+    @Inject
+    @ApplicationContext
+    lateinit var context: Context
+
     @Inject
     lateinit var db: AppDatabase
 
     @Inject
     lateinit var refresherFactory: CollectionListRefresher.Factory
 
+    @Inject
+    lateinit var settings: SettingsManager
+
     private val mockServer = MockWebServer()
     private lateinit var client: HttpClient
 
     @Before
-    fun mockServerSetup() {
+    fun setup() {
+        hiltRule.inject()
+
         // Start mock web server
         mockServer.dispatcher = TestDispatcher()
         mockServer.start()
 
-        client = HttpClient.Builder(InstrumentationRegistry.getInstrumentation().targetContext).build()
+        client = HttpClient.Builder(context).build()
 
         Assume.assumeTrue(NetworkSecurityPolicy.getInstance().isCleartextTrafficPermitted)
     }
 
     @After
-    fun cleanUp() {
+    fun teardown() {
         mockServer.shutdown()
         db.close()
     }

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/webdav/DavDocumentsProviderTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/webdav/DavDocumentsProviderTest.kt
@@ -6,13 +6,13 @@ package at.bitfire.davdroid.webdav
 
 import android.content.Context
 import android.security.NetworkSecurityPolicy
-import androidx.test.platform.app.InstrumentationRegistry
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.WebDavDocument
 import at.bitfire.davdroid.db.WebDavMount
 import at.bitfire.davdroid.log.Logger
 import at.bitfire.davdroid.network.HttpClient
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import okhttp3.CookieJar
@@ -31,10 +31,16 @@ import javax.inject.Inject
 @HiltAndroidTest
 class DavDocumentsProviderTest {
 
+    companion object {
+        private const val PATH_WEBDAV_ROOT = "/webdav"
+    }
+
     @get:Rule
     val hiltRule = HiltAndroidRule(this)
 
-    val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
+    @Inject
+    @ApplicationContext
+    lateinit var context: Context
 
     @Inject lateinit var db: AppDatabase
 
@@ -43,13 +49,11 @@ class DavDocumentsProviderTest {
         hiltRule.inject()
     }
 
+
     private var mockServer =  MockWebServer()
 
     private lateinit var client: HttpClient
 
-    companion object {
-        private const val PATH_WEBDAV_ROOT = "/webdav"
-    }
 
     @Before
     fun mockServerSetup() {
@@ -57,7 +61,7 @@ class DavDocumentsProviderTest {
         mockServer.dispatcher = TestDispatcher()
         mockServer.start()
 
-        client = HttpClient.Builder(InstrumentationRegistry.getInstrumentation().targetContext).build()
+        client = HttpClient.Builder(context).build()
 
         // mock server delivers HTTP without encryption
         assertTrue(NetworkSecurityPolicy.getInstance().isCleartextTrafficPermitted)

--- a/app/src/androidTestOse/kotlin/at/bitfire/davdroid/OkhttpClientTest.kt
+++ b/app/src/androidTestOse/kotlin/at/bitfire/davdroid/OkhttpClientTest.kt
@@ -4,9 +4,10 @@
 
 package at.bitfire.davdroid
 
-import androidx.test.platform.app.InstrumentationRegistry
+import android.content.Context
 import at.bitfire.davdroid.network.HttpClient
 import at.bitfire.davdroid.settings.SettingsManager
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import okhttp3.Request
@@ -22,6 +23,10 @@ class OkhttpClientTest {
     val hiltRule = HiltAndroidRule(this)
 
     @Inject
+    @ApplicationContext
+    lateinit var context: Context
+
+    @Inject
     lateinit var settingsManager: SettingsManager
 
     @Before
@@ -32,8 +37,7 @@ class OkhttpClientTest {
 
     @Test
     fun testIcloudWithSettings() {
-        val client = HttpClient.Builder(InstrumentationRegistry.getInstrumentation().targetContext)
-                .build()
+        val client = HttpClient.Builder(context).build()
         client.okHttpClient.newCall(Request.Builder()
                 .get()
                 .url("https://icloud.com")

--- a/app/src/androidTestOse/kotlin/at/bitfire/davdroid/sync/SyncManagerTest.kt
+++ b/app/src/androidTestOse/kotlin/at/bitfire/davdroid/sync/SyncManagerTest.kt
@@ -76,6 +76,9 @@ class SyncManagerTest {
     val hiltRule = HiltAndroidRule(this)
 
     @Inject
+    lateinit var accountSettingsFactory: AccountSettings.Factory
+
+    @Inject
     lateinit var db: AppDatabase
 
     @Inject
@@ -107,6 +110,7 @@ class SyncManagerTest {
     ) =
         TestSyncManager(
             account,
+            accountSettingsFactory.forAccount(account),
             arrayOf(),
             "TestAuthority",
             HttpClient.Builder(InstrumentationRegistry.getInstrumentation().targetContext).build(),

--- a/app/src/androidTestOse/kotlin/at/bitfire/davdroid/sync/SyncManagerTest.kt
+++ b/app/src/androidTestOse/kotlin/at/bitfire/davdroid/sync/SyncManagerTest.kt
@@ -6,6 +6,7 @@ package at.bitfire.davdroid.sync
 
 import android.accounts.Account
 import android.accounts.AccountManager
+import android.content.Context
 import android.content.SyncResult
 import android.util.Log
 import androidx.core.app.NotificationManagerCompat
@@ -26,6 +27,7 @@ import at.bitfire.davdroid.db.SyncState
 import at.bitfire.davdroid.network.HttpClient
 import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.ui.NotificationUtils
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import io.mockk.mockk
@@ -79,6 +81,10 @@ class SyncManagerTest {
     lateinit var accountSettingsFactory: AccountSettings.Factory
 
     @Inject
+    @ApplicationContext
+    lateinit var context: Context
+
+    @Inject
     lateinit var db: AppDatabase
 
     @Inject
@@ -113,7 +119,7 @@ class SyncManagerTest {
             accountSettingsFactory.forAccount(account),
             arrayOf(),
             "TestAuthority",
-            HttpClient.Builder(InstrumentationRegistry.getInstrumentation().targetContext).build(),
+            HttpClient.Builder(context).build(),
             syncResult,
             localCollection,
             collection,

--- a/app/src/androidTestOse/kotlin/at/bitfire/davdroid/sync/SyncerTest.kt
+++ b/app/src/androidTestOse/kotlin/at/bitfire/davdroid/sync/SyncerTest.kt
@@ -8,11 +8,11 @@ import android.accounts.Account
 import android.content.ContentProviderClient
 import android.content.Context
 import android.content.SyncResult
-import androidx.test.platform.app.InstrumentationRegistry
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.network.HttpClient
 import at.bitfire.davdroid.settings.AccountSettings
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Assert.assertEquals
@@ -28,7 +28,9 @@ class SyncerTest {
     @get:Rule
     val hiltRule = HiltAndroidRule(this)
 
-    val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
+    @Inject
+    @ApplicationContext
+    lateinit var context: Context
 
     @Inject
     lateinit var accountSettingsFactory: AccountSettings.Factory
@@ -37,15 +39,15 @@ class SyncerTest {
     lateinit var db: AppDatabase
 
     /** use our WebDAV provider as a mock provider because it's our own and we don't need any permissions for it */
-    private val mockAuthority = context.getString(R.string.webdav_authority)
+    private val mockAuthority by lazy { context.getString(R.string.webdav_authority) }
 
-    val account = Account(javaClass.canonicalName, context.getString(R.string.account_type))
-
+    val account by lazy { Account(javaClass.canonicalName, context.getString(R.string.account_type)) }
 
     @Before
     fun setUp() {
         hiltRule.inject()
     }
+
 
     @Test
     fun testOnPerformSync_runsSyncAndSetsClassLoader() {

--- a/app/src/androidTestOse/kotlin/at/bitfire/davdroid/sync/SyncerTest.kt
+++ b/app/src/androidTestOse/kotlin/at/bitfire/davdroid/sync/SyncerTest.kt
@@ -12,6 +12,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.network.HttpClient
+import at.bitfire.davdroid.settings.AccountSettings
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Assert.assertEquals
@@ -30,6 +31,9 @@ class SyncerTest {
     val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
 
     @Inject
+    lateinit var accountSettingsFactory: AccountSettings.Factory
+
+    @Inject
     lateinit var db: AppDatabase
 
     /** use our WebDAV provider as a mock provider because it's our own and we don't need any permissions for it */
@@ -45,7 +49,7 @@ class SyncerTest {
 
     @Test
     fun testOnPerformSync_runsSyncAndSetsClassLoader() {
-        val syncer = TestSyncer(context, db)
+        val syncer = TestSyncer(accountSettingsFactory, context, db)
         syncer.onPerformSync(account, arrayOf(), mockAuthority, SyncResult())
 
         // check whether onPerformSync() actually calls sync()
@@ -56,7 +60,11 @@ class SyncerTest {
     }
 
 
-    class TestSyncer(context: Context, db: AppDatabase) : Syncer(context, db) {
+    class TestSyncer(
+        accountSettingsFactory: AccountSettings.Factory,
+        context: Context,
+        db: AppDatabase
+    ) : Syncer(accountSettingsFactory, context, db) {
 
         val syncCalled = AtomicInteger()
 

--- a/app/src/androidTestOse/kotlin/at/bitfire/davdroid/sync/TestSyncManager.kt
+++ b/app/src/androidTestOse/kotlin/at/bitfire/davdroid/sync/TestSyncManager.kt
@@ -26,6 +26,7 @@ import org.junit.Assert.assertEquals
 
 class TestSyncManager(
     account: Account,
+    accountSettings: AccountSettings,
     extras: Array<String>,
     authority: String,
     httpClient: HttpClient,
@@ -35,7 +36,7 @@ class TestSyncManager(
     val mockWebServer: MockWebServer,
     context: Context,
     db: AppDatabase
-): SyncManager<LocalTestResource, LocalTestCollection, DavCollection>(account, AccountSettings(context, account), httpClient, extras, authority, syncResult, localCollection, collection, context, db) {
+): SyncManager<LocalTestResource, LocalTestCollection, DavCollection>(account, accountSettings, httpClient, extras, authority, syncResult, localCollection, collection, context, db) {
 
     override fun prepare(): Boolean {
         collectionURL = mockWebServer.url("/")

--- a/app/src/androidTestOse/kotlin/at/bitfire/davdroid/sync/account/AccountUtilsTest.kt
+++ b/app/src/androidTestOse/kotlin/at/bitfire/davdroid/sync/account/AccountUtilsTest.kt
@@ -6,10 +6,11 @@ package at.bitfire.davdroid.sync.account
 
 import android.accounts.Account
 import android.accounts.AccountManager
+import android.content.Context
 import android.os.Bundle
-import androidx.test.platform.app.InstrumentationRegistry
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.settings.SettingsManager
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Assert.assertEquals
@@ -27,6 +28,10 @@ class AccountUtilsTest {
     val hiltRule = HiltAndroidRule(this)
 
     @Inject
+    @ApplicationContext
+    lateinit var context: Context
+
+    @Inject
     lateinit var settingsManager: SettingsManager
 
     @Before
@@ -35,8 +40,8 @@ class AccountUtilsTest {
     }
 
 
-    val context by lazy { InstrumentationRegistry.getInstrumentation().targetContext }
     val account by lazy { Account("Test Account", context.getString(R.string.account_type)) }
+
 
     @Test
     fun testCreateAccount() {

--- a/app/src/androidTestOse/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorkerTest.kt
+++ b/app/src/androidTestOse/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorkerTest.kt
@@ -7,13 +7,13 @@ package at.bitfire.davdroid.sync.worker
 import android.accounts.Account
 import android.accounts.AccountManager
 import android.content.ContentResolver
+import android.content.Context
 import android.net.wifi.WifiInfo
 import android.net.wifi.WifiManager
 import android.provider.CalendarContract
 import android.provider.ContactsContract
 import android.util.Log
 import androidx.core.content.getSystemService
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.work.Configuration
 import androidx.work.testing.WorkManagerTestInitHelper
 import at.bitfire.davdroid.R
@@ -23,6 +23,7 @@ import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.sync.account.AccountUtils
 import at.bitfire.davdroid.ui.NotificationUtils
 import at.bitfire.davdroid.util.PermissionUtils
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import io.mockk.every
@@ -41,26 +42,26 @@ import javax.inject.Inject
 @HiltAndroidTest
 class BaseSyncWorkerTest {
 
-    private val context = InstrumentationRegistry.getInstrumentation().targetContext
-
-    @Inject
-    lateinit var accountSettingsFactory: AccountSettings.Factory
-
-    private val accountManager = AccountManager.get(context)
-    private val account = Account("Test Account", context.getString(R.string.account_type))
-    private val fakeCredentials = Credentials("test", "test")
-
     @get:Rule
     val hiltRule = HiltAndroidRule(this)
     @get:Rule
     val mockkRule = MockKRule(this)
 
-    @Before
-    fun inject() = hiltRule.inject()
+    @Inject
+    lateinit var accountSettingsFactory: AccountSettings.Factory
 
+    @Inject
+    @ApplicationContext
+    lateinit var context: Context
+
+    private val accountManager by lazy { AccountManager.get(context) }
+    private val account by lazy { Account("Test Account", context.getString(R.string.account_type)) }
+    private val fakeCredentials = Credentials("test", "test")
 
     @Before
-    fun setUp() {
+    fun setup() {
+        hiltRule.inject()
+
         assertTrue(AccountUtils.createAccount(context, account, AccountSettings.initialUserData(fakeCredentials)))
         ContentResolver.setIsSyncable(account, CalendarContract.AUTHORITY, 1)
         ContentResolver.setIsSyncable(account, ContactsContract.AUTHORITY, 0)
@@ -77,7 +78,7 @@ class BaseSyncWorkerTest {
     }
 
     @After
-    fun removeAccount() {
+    fun teardown() {
         accountManager.removeAccountExplicitly(account)
     }
 

--- a/app/src/androidTestOse/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorkerTest.kt
+++ b/app/src/androidTestOse/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorkerTest.kt
@@ -36,11 +36,15 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import javax.inject.Inject
 
 @HiltAndroidTest
 class BaseSyncWorkerTest {
 
-    val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Inject
+    lateinit var accountSettingsFactory: AccountSettings.Factory
 
     private val accountManager = AccountManager.get(context)
     private val account = Account("Test Account", context.getString(R.string.account_type))
@@ -87,7 +91,7 @@ class BaseSyncWorkerTest {
     
     @Test
     fun testWifiConditionsMet_anyWifi_wifiEnabled() {
-        val accountSettings = AccountSettings(context, account)
+        val accountSettings = accountSettingsFactory.forAccount(account)
         accountSettings.setSyncWiFiOnly(true)
 
         mockkObject(ConnectionUtils)
@@ -100,7 +104,7 @@ class BaseSyncWorkerTest {
 
     @Test
     fun testWifiConditionsMet_anyWifi_wifiDisabled() {
-        val accountSettings = AccountSettings(context, account)
+        val accountSettings = accountSettingsFactory.forAccount(account)
         accountSettings.setSyncWiFiOnly(true)
 
         mockkObject(ConnectionUtils)
@@ -114,7 +118,7 @@ class BaseSyncWorkerTest {
 
     @Test
     fun testCorrectWifiSsid_CorrectWiFiSsid() {
-        val accountSettings = AccountSettings(context, account)
+        val accountSettings = accountSettingsFactory.forAccount(account)
         mockkObject(accountSettings)
         every { accountSettings.getSyncWifiOnlySSIDs() } returns listOf("SampleWiFi1","ConnectedWiFi")
 
@@ -132,7 +136,7 @@ class BaseSyncWorkerTest {
 
     @Test
     fun testCorrectWifiSsid_WrongWiFiSsid() {
-        val accountSettings = AccountSettings(context, account)
+        val accountSettings = accountSettingsFactory.forAccount(account)
         mockkObject(accountSettings)
         every { accountSettings.getSyncWifiOnlySSIDs() } returns listOf("SampleWiFi1","SampleWiFi2")
 

--- a/app/src/androidTestOse/kotlin/at/bitfire/davdroid/sync/worker/OneTimeSyncWorkerTest.kt
+++ b/app/src/androidTestOse/kotlin/at/bitfire/davdroid/sync/worker/OneTimeSyncWorkerTest.kt
@@ -6,17 +6,31 @@ package at.bitfire.davdroid.sync.worker
 
 import android.content.Context
 import android.provider.CalendarContract
-import androidx.test.platform.app.InstrumentationRegistry
 import at.bitfire.davdroid.TestUtils
 import at.bitfire.davdroid.sync.SyncManagerTest.Companion.account
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import javax.inject.Inject
 
 @HiltAndroidTest
 class OneTimeSyncWorkerTest {
 
-    val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
+    @Inject
+    @ApplicationContext
+    lateinit var context: Context
+
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+
+    @Before
+    fun setup() {
+        hiltRule.inject()
+    }
 
     @Test
     fun testEnqueue_enqueuesWorker() {

--- a/app/src/androidTestOse/kotlin/at/bitfire/davdroid/sync/worker/PeriodicSyncWorkerTest.kt
+++ b/app/src/androidTestOse/kotlin/at/bitfire/davdroid/sync/worker/PeriodicSyncWorkerTest.kt
@@ -27,6 +27,7 @@ import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.sync.account.AccountUtils
 import at.bitfire.davdroid.ui.NotificationUtils
 import dagger.assisted.AssistedFactory
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import io.mockk.junit4.MockKRule
@@ -47,7 +48,7 @@ class PeriodicSyncWorkerTest {
 
     companion object {
 
-        val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
+        private val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
 
         private val accountManager = AccountManager.get(context)
         private val account = Account("Test Account", context.getString(R.string.account_type))
@@ -84,13 +85,17 @@ class PeriodicSyncWorkerTest {
         fun create(appContext: Context, workerParams: WorkerParameters): PeriodicSyncWorker
     }
 
+    @Inject
+    @ApplicationContext
+    lateinit var context: Context
+
+    @Inject
+    lateinit var syncWorkerFactory: PeriodicSyncWorkerFactory
+
     @get:Rule
     val hiltRule = HiltAndroidRule(this)
     @get:Rule
     val mockkRule = MockKRule(this)
-
-    @Inject
-    lateinit var syncWorkerFactory: PeriodicSyncWorkerFactory
 
     @Before
     fun inject() {

--- a/app/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationWorker.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationWorker.kt
@@ -55,6 +55,7 @@ import javax.inject.Inject
 class PushRegistrationWorker @AssistedInject constructor(
     @Assisted context: Context,
     @Assisted workerParameters: WorkerParameters,
+    private val accountSettingsFactory: AccountSettings.Factory,
     private val collectionRepository: DavCollectionRepository,
     private val preferenceRepository: PreferenceRepository,
     private val serviceRepository: DavServiceRepository
@@ -84,7 +85,7 @@ class PushRegistrationWorker @AssistedInject constructor(
 
 
     private suspend fun requestPushRegistration(collection: Collection, account: Account, endpoint: String) {
-        val settings = AccountSettings(applicationContext, account)
+        val settings = accountSettingsFactory.forAccount(account)
 
         runInterruptible {
             HttpClient.Builder(applicationContext, settings)

--- a/app/src/main/kotlin/at/bitfire/davdroid/repository/DavSyncStatsRepository.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/repository/DavSyncStatsRepository.kt
@@ -4,17 +4,18 @@
 
 package at.bitfire.davdroid.repository
 
-import android.app.Application
+import android.content.Context
 import android.content.pm.PackageManager
 import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.log.Logger
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import java.text.Collator
 import javax.inject.Inject
 
 class DavSyncStatsRepository @Inject constructor(
-    val context: Application,
+    @ApplicationContext val context: Context,
     db: AppDatabase
 ) {
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -31,6 +31,10 @@ import at.bitfire.vcard4android.AndroidContact
 import at.bitfire.vcard4android.AndroidGroup
 import at.bitfire.vcard4android.Constants
 import at.bitfire.vcard4android.GroupMethod
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
 import java.io.ByteArrayOutputStream
 import java.util.LinkedList
 import java.util.logging.Level
@@ -42,9 +46,9 @@ import java.util.logging.Level
  * DAVx5 main account.
  */
 open class LocalAddressBook(
-        private val context: Context,
-        account: Account,
-        provider: ContentProviderClient?
+    private val context: Context,
+    account: Account,
+    provider: ContentProviderClient?
 ): AndroidAddressBook<LocalContact, LocalGroup>(account, provider, LocalContact.Factory, LocalGroup.Factory), LocalCollection<LocalAddress> {
 
     companion object {
@@ -154,6 +158,15 @@ open class LocalAddressBook(
 
     }
 
+    @EntryPoint
+    @InstallIn(SingletonComponent::class)
+    interface LocalAddressBookEntryPoint {
+        fun accountSettingsFactory(): AccountSettings.Factory
+    }
+    private val entryPoint = EntryPointAccessors.fromApplication<LocalAddressBookEntryPoint>(context)
+    private val accountSettingsFactory = entryPoint.accountSettingsFactory()
+
+
     override val tag: String
         get() = "contacts-${account.name}"
 
@@ -167,7 +180,7 @@ open class LocalAddressBook(
      * but if it is enabled, [findDirty] will find dirty [LocalContact]s and [LocalGroup]s.
      */
     open val groupMethod: GroupMethod by lazy {
-        val accountSettings = AccountSettings(context, requireMainAccount())
+        val accountSettings = accountSettingsFactory.forAccount(requireMainAccount())
         accountSettings.getGroupMethod()
     }
     val includeGroups

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -38,6 +38,7 @@ import dagger.hilt.components.SingletonComponent
 import java.io.ByteArrayOutputStream
 import java.util.LinkedList
 import java.util.logging.Level
+import javax.inject.Inject
 
 /**
  * A local address book. Requires an own Android account, because Android manages contacts per
@@ -45,7 +46,7 @@ import java.util.logging.Level
  * address book" account for every CardDAV address book. These accounts are bound to a
  * DAVx5 main account.
  */
-open class LocalAddressBook(
+open class LocalAddressBook @Inject constructor(
     private val context: Context,
     account: Account,
     provider: ContentProviderClient?
@@ -163,7 +164,7 @@ open class LocalAddressBook(
     interface LocalAddressBookEntryPoint {
         fun accountSettingsFactory(): AccountSettings.Factory
     }
-    private val entryPoint = EntryPointAccessors.fromApplication<LocalAddressBookEntryPoint>(context)
+    private val entryPoint = EntryPointAccessors.fromApplication(context, LocalAddressBookEntryPoint::class.java)
     private val accountSettingsFactory = entryPoint.accountSettingsFactory()
 
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/servicedetection/RefreshCollectionsWorker.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/servicedetection/RefreshCollectionsWorker.kt
@@ -74,8 +74,9 @@ import java.util.logging.Level
 class RefreshCollectionsWorker @AssistedInject constructor(
     @Assisted appContext: Context,
     @Assisted workerParams: WorkerParameters,
+    private val accountSettingsFactory: AccountSettings.Factory,
     serviceRepository: DavServiceRepository,
-    val collectionListRefresherFactory: CollectionListRefresher.Factory
+    private val collectionListRefresherFactory: CollectionListRefresher.Factory
 ): CoroutineWorker(appContext, workerParams) {
 
     companion object {
@@ -179,7 +180,7 @@ class RefreshCollectionsWorker @AssistedInject constructor(
 
             // create authenticating OkHttpClient (credentials taken from account settings)
             runInterruptible {
-                HttpClient.Builder(applicationContext, AccountSettings(applicationContext, account))
+                HttpClient.Builder(applicationContext, accountSettingsFactory.forAccount(account))
                     .setForeground(true)
                     .build().use { client ->
                         val httpClient = client.okHttpClient

--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettingsMigrations.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettingsMigrations.kt
@@ -7,10 +7,10 @@ package at.bitfire.davdroid.settings
 import android.accounts.Account
 import android.accounts.AccountManager
 import android.annotation.SuppressLint
-import android.app.Application
 import android.content.ContentResolver
 import android.content.ContentUris
 import android.content.ContentValues
+import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Parcel
 import android.os.RemoteException
@@ -43,6 +43,7 @@ import at.techbee.jtx.JtxContract.asSyncAdapter
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import dagger.hilt.android.qualifiers.ApplicationContext
 import net.fortuna.ical4j.model.Property
 import net.fortuna.ical4j.model.property.Url
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
@@ -55,7 +56,7 @@ class AccountSettingsMigrations @AssistedInject constructor(
     @Assisted val account: Account,
     @Assisted val accountSettings: AccountSettings,
     val accountRepository: AccountRepository,
-    val context: Application,
+    @ApplicationContext val context: Context,
     val db: AppDatabase,
     val settings: SettingsManager
 ) {

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
@@ -32,11 +32,12 @@ import javax.inject.Inject
  * Sync logic for address books
  */
 class AddressBookSyncer @Inject constructor(
+    accountSettingsFactory: AccountSettings.Factory,
     @ApplicationContext context: Context,
     db: AppDatabase,
     private val contactsSyncManagerFactory: ContactsSyncManager.Factory,
     private val settingsManager: SettingsManager
-) : Syncer(context, db) {
+) : Syncer(accountSettingsFactory, context, db) {
 
     companion object {
         const val PREVIOUS_GROUP_METHOD = "previous_group_method"
@@ -134,7 +135,7 @@ class AddressBookSyncer @Inject constructor(
         collection: Collection
     ) {
         try {
-            val accountSettings = AccountSettings(context, account)
+            val accountSettings = accountSettingsFactory.forAccount(account)
             val addressBook = LocalAddressBook(context, account, provider)
 
             // handle group method change

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncer.kt
@@ -27,10 +27,11 @@ import javax.inject.Inject
  * Sync logic for calendars
  */
 class CalendarSyncer @Inject constructor(
+    accountSettingsFactory: AccountSettings.Factory,
     @ApplicationContext context: Context,
     db: AppDatabase,
     private val calendarSyncManagerFactory: CalendarSyncManager.Factory
-): Syncer(context, db) {
+): Syncer(accountSettingsFactory, context, db) {
 
     override fun sync(
         account: Account,
@@ -42,7 +43,7 @@ class CalendarSyncer @Inject constructor(
     ) {
 
         // 0. preparations
-        val accountSettings = AccountSettings(context, account)
+        val accountSettings = accountSettingsFactory.forAccount(account)
         if (accountSettings.getEventColors())
             AndroidCalendar.insertColors(provider, account)
         else

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncer.kt
@@ -30,10 +30,11 @@ import javax.inject.Inject
  * Sync logic for jtx board
  */
 class JtxSyncer @Inject constructor(
+    accountSettingsFactory: AccountSettings.Factory,
     @ApplicationContext context: Context,
     db: AppDatabase,
     private val jtxSyncManagerFactory: JtxSyncManager.Factory
-): Syncer(context, db) {
+): Syncer(accountSettingsFactory, context, db) {
 
     override fun sync(
         account: Account,
@@ -57,7 +58,7 @@ class JtxSyncer @Inject constructor(
                     am.setAccountVisibility(account, TaskProvider.ProviderName.JtxBoard.packageName, AccountManager.VISIBILITY_VISIBLE)
             }
 
-            val accountSettings = AccountSettings(context, account)
+            val accountSettings = accountSettingsFactory.forAccount(account)
 
             // 1. find jtxCollection collections to be synced
             val remoteCollections = mutableMapOf<HttpUrl, Collection>()

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
@@ -27,6 +27,7 @@ import java.util.logging.Level
  * Also provides useful methods that can be used by derived syncers ie [CalendarSyncer], etc.
  */
 abstract class Syncer(
+    protected val accountSettingsFactory: AccountSettings.Factory,
     val context: Context,
     val db: AppDatabase
 ) {
@@ -77,7 +78,7 @@ abstract class Syncer(
             else
                 authority
 
-        val accountSettings by lazy { AccountSettings(context, account) }
+        val accountSettings by lazy { accountSettingsFactory.forAccount(account) }
         val httpClient = lazy { HttpClient.Builder(context, accountSettings).build() }
 
         // acquire ContentProviderClient of authority to be synced

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/TaskSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/TaskSyncer.kt
@@ -31,10 +31,11 @@ import javax.inject.Inject
  * Sync logic for tasks in CalDAV collections ({@code VTODO}).
  */
 class TaskSyncer @Inject constructor(
+    accountSettingsFactory: AccountSettings.Factory,
     @ApplicationContext context: Context,
     db: AppDatabase,
     private val tasksSyncManagerFactory: TasksSyncManager.Factory
-): Syncer(context, db) {
+): Syncer(accountSettingsFactory, context, db) {
 
     override fun sync(
         account: Account,
@@ -58,7 +59,7 @@ class TaskSyncer @Inject constructor(
                     am.setAccountVisibility(account, providerName.packageName, AccountManager.VISIBILITY_VISIBLE)
             }
 
-            val accountSettings = AccountSettings(context, account)
+            val accountSettings = accountSettingsFactory.forAccount(account)
 
             // 1. find task collections to be synced
             val remoteCollections = mutableMapOf<HttpUrl, Collection>()

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
@@ -48,12 +48,12 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withContext
 import java.util.Collections
-import java.util.logging.Level
 
 abstract class BaseSyncWorker(
     context: Context,
     private val workerParams: WorkerParameters,
-    private val syncDispatcher: CoroutineDispatcher,
+    private val accountSettingsFactory: AccountSettings.Factory,
+    private val syncDispatcher: CoroutineDispatcher
 ) : CoroutineWorker(context, workerParams) {
 
     companion object {
@@ -222,7 +222,7 @@ abstract class BaseSyncWorker(
 
         try {
             val accountSettings = try {
-                AccountSettings(applicationContext, account)
+                accountSettingsFactory.forAccount(account)
             } catch (e: InvalidAccountException) {
                 val workId = workerParams.id
                 Logger.log.warning("Account $account doesn't exist anymore, cancelling worker $workId")

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/OneTimeSyncWorker.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/OneTimeSyncWorker.kt
@@ -24,6 +24,7 @@ import androidx.work.WorkRequest
 import androidx.work.WorkerParameters
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.log.Logger
+import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.sync.SyncDispatcher
 import at.bitfire.davdroid.sync.SyncUtils
 import at.bitfire.davdroid.ui.NotificationUtils
@@ -43,8 +44,9 @@ import java.util.logging.Level
 class OneTimeSyncWorker @AssistedInject constructor(
     @Assisted appContext: Context,
     @Assisted workerParams: WorkerParameters,
+    accountSettingsFactory: AccountSettings.Factory,
     syncDispatcher: SyncDispatcher
-) : BaseSyncWorker(appContext, workerParams, syncDispatcher.dispatcher) {
+) : BaseSyncWorker(appContext, workerParams, accountSettingsFactory, syncDispatcher.dispatcher) {
 
     companion object {
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/PeriodicSyncWorker.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/PeriodicSyncWorker.kt
@@ -16,6 +16,7 @@ import androidx.work.Operation
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
+import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.sync.SyncDispatcher
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -41,8 +42,9 @@ import java.util.concurrent.TimeUnit
 class PeriodicSyncWorker @AssistedInject constructor(
     @Assisted appContext: Context,
     @Assisted workerParams: WorkerParameters,
+    accountSettingsFactory: AccountSettings.Factory,
     syncDispatcher: SyncDispatcher
-) : BaseSyncWorker(appContext, workerParams, syncDispatcher.dispatcher) {
+) : BaseSyncWorker(appContext, workerParams, accountSettingsFactory, syncDispatcher.dispatcher) {
 
     companion object {
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsModel.kt
@@ -1,7 +1,7 @@
 package at.bitfire.davdroid.ui
 
 import android.accounts.Account
-import android.app.Application
+import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.net.ConnectivityManager
@@ -30,6 +30,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -43,8 +44,8 @@ import java.text.Collator
 @HiltViewModel(assistedFactory = AccountsModel.Factory::class)
 class AccountsModel @AssistedInject constructor(
     @Assisted val syncAccountsOnInit: Boolean,
-    private val context: Application,
     private val accountRepository: AccountRepository,
+    @ApplicationContext val context: Context,
     private val db: AppDatabase,
     introPageFactory: IntroPageFactory
 ): ViewModel() {

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsModel.kt
@@ -1,6 +1,6 @@
 package at.bitfire.davdroid.ui
 
-import android.app.Application
+import android.content.Context
 import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.os.PowerManager
@@ -18,6 +18,7 @@ import at.bitfire.davdroid.util.PermissionUtils
 import at.bitfire.davdroid.util.TaskUtils
 import at.bitfire.davdroid.util.broadcastReceiverFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -25,7 +26,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class AppSettingsModel @Inject constructor(
-    val context: Application,
+    @ApplicationContext val context: Context,
     private val preference: PreferenceRepository,
     private val settings: SettingsManager
 ) : ViewModel() {

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/PermissionsModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/PermissionsModel.kt
@@ -1,6 +1,6 @@
 package at.bitfire.davdroid.ui
 
-import android.app.Application
+import android.content.Context
 import android.os.Build
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -10,12 +10,13 @@ import androidx.lifecycle.viewModelScope
 import at.bitfire.davdroid.util.packageChangedFlow
 import at.bitfire.ical4android.TaskProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class PermissionsModel @Inject constructor(
-    val context: Application
+    @ApplicationContext val context: Context,
 ): ViewModel() {
 
     var needKeepPermissions by mutableStateOf(false)

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/TasksModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/TasksModel.kt
@@ -1,6 +1,6 @@
 package at.bitfire.davdroid.ui
 
-import android.app.Application
+import android.content.Context
 import android.content.pm.PackageManager
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -12,6 +12,7 @@ import at.bitfire.davdroid.util.TaskUtils
 import at.bitfire.davdroid.util.packageChangedFlow
 import at.bitfire.ical4android.TaskProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -19,8 +20,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class TasksModel @Inject constructor(
-    val context: Application,
-    val settings: SettingsManager
+    @ApplicationContext val context: Context,
+    private val settings: SettingsManager
 ) : ViewModel() {
 
     companion object {

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountProgressUseCase.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountProgressUseCase.kt
@@ -5,12 +5,13 @@
 package at.bitfire.davdroid.ui.account
 
 import android.accounts.Account
-import android.app.Application
+import android.content.Context
 import androidx.work.WorkInfo
 import at.bitfire.davdroid.db.Service
 import at.bitfire.davdroid.servicedetection.RefreshCollectionsWorker
 import at.bitfire.davdroid.sync.worker.BaseSyncWorker
 import at.bitfire.davdroid.sync.worker.OneTimeSyncWorker
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
@@ -19,7 +20,7 @@ import kotlinx.coroutines.flow.flowOf
 import javax.inject.Inject
 
 class AccountProgressUseCase @Inject constructor(
-    val context: Application
+    @ApplicationContext val context: Context
 ) {
 
     operator fun invoke(

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreenModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreenModel.kt
@@ -46,6 +46,7 @@ class AccountScreenModel @AssistedInject constructor(
     @Assisted val account: Account,
     val context: Application,
     private val accountRepository: AccountRepository,
+    private val accountSettingsFactory: AccountSettings.Factory,
     private val collectionRepository: DavCollectionRepository,
     serviceRepository: DavServiceRepository,
     accountProgressUseCase: AccountProgressUseCase,
@@ -63,7 +64,7 @@ class AccountScreenModel @AssistedInject constructor(
         !accounts.contains(account)
     }
 
-    private val settings = AccountSettings(context, account)
+    private val settings = accountSettingsFactory.forAccount(account)
     private val refreshSettingsSignal = MutableLiveData(Unit)
     val showOnlyPersonal = refreshSettingsSignal.switchMap<Unit, AccountSettings.ShowOnlyPersonal> {
         object : LiveData<AccountSettings.ShowOnlyPersonal>() {

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreenModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreenModel.kt
@@ -5,7 +5,7 @@
 package at.bitfire.davdroid.ui.account
 
 import android.accounts.Account
-import android.app.Application
+import android.content.Context
 import android.provider.CalendarContract
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -30,6 +30,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -44,10 +45,10 @@ import java.util.logging.Level
 @HiltViewModel(assistedFactory = AccountScreenModel.Factory::class)
 class AccountScreenModel @AssistedInject constructor(
     @Assisted val account: Account,
-    val context: Application,
     private val accountRepository: AccountRepository,
-    private val accountSettingsFactory: AccountSettings.Factory,
+    accountSettingsFactory: AccountSettings.Factory,
     private val collectionRepository: DavCollectionRepository,
+    @ApplicationContext val context: Context,
     serviceRepository: DavServiceRepository,
     accountProgressUseCase: AccountProgressUseCase,
     getBindableHomesetsFromService: GetBindableHomeSetsFromServiceUseCase,

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsModel.kt
@@ -1,7 +1,7 @@
 package at.bitfire.davdroid.ui.account
 
 import android.accounts.Account
-import android.app.Application
+import android.content.Context
 import android.provider.CalendarContract
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -22,15 +22,17 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 @HiltViewModel(assistedFactory = AccountSettingsModel.Factory::class)
 class AccountSettingsModel @AssistedInject constructor(
-    val context: Application,
-    val settings: SettingsManager,
-    @Assisted val account: Account
+    @Assisted val account: Account,
+    private val accountSettingsFactory: AccountSettings.Factory,
+    @ApplicationContext val context: Context,
+    private val settings: SettingsManager
 ): ViewModel(), SettingsManager.OnChangeListener {
 
     @AssistedFactory
@@ -38,7 +40,7 @@ class AccountSettingsModel @AssistedInject constructor(
         fun create(account: Account): AccountSettingsModel
     }
 
-    private val accountSettings = AccountSettings(context, account)
+    private val accountSettings = accountSettingsFactory.forAccount(account)
 
     // settings
     var syncIntervalContacts by mutableStateOf<Long?>(null)

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/intro/BatteryOptimizationsPageModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/intro/BatteryOptimizationsPageModel.kt
@@ -1,6 +1,5 @@
 package at.bitfire.davdroid.ui.intro
 
-import android.app.Application
 import android.content.Context
 import android.content.IntentFilter
 import android.os.Build
@@ -16,13 +15,14 @@ import at.bitfire.davdroid.settings.SettingsManager
 import at.bitfire.davdroid.util.PermissionUtils
 import at.bitfire.davdroid.util.broadcastReceiverFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.launch
 import java.util.Locale
 import javax.inject.Inject
 
 @HiltViewModel
 class BatteryOptimizationsPageModel @Inject constructor(
-    val context: Application,
+    @ApplicationContext val context: Context,
     private val settings: SettingsManager
 ): ViewModel() {
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/GoogleLoginModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/GoogleLoginModel.kt
@@ -5,7 +5,6 @@
 package at.bitfire.davdroid.ui.setup
 
 import android.accounts.AccountManager
-import android.app.Application
 import android.content.Context
 import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
@@ -22,6 +21,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.launch
 import net.openid.appauth.AuthorizationRequest
 import net.openid.appauth.AuthorizationResponse
@@ -32,8 +32,8 @@ import java.util.logging.Level
 @HiltViewModel(assistedFactory = GoogleLoginModel.Factory::class)
 class GoogleLoginModel @AssistedInject constructor(
     @Assisted val initialLoginInfo: LoginInfo,
-    val context: Application,
-    val authService: AuthorizationService
+    val authService: AuthorizationService,
+    @ApplicationContext val context: Context
 ): ViewModel() {
 
     @AssistedFactory

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
@@ -5,7 +5,7 @@
 package at.bitfire.davdroid.ui.setup
 
 import android.accounts.Account
-import android.app.Application
+import android.content.Context
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -22,6 +22,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.SharingStarted
@@ -36,9 +37,9 @@ class LoginScreenModel @AssistedInject constructor(
     @Assisted val initialLoginType: LoginType,
     @Assisted val skipLoginTypePage: Boolean,
     @Assisted val initialLoginInfo: LoginInfo,
-    val context: Application,
-    val loginTypesProvider: LoginTypesProvider,
     private val accountRepository: AccountRepository,
+    @ApplicationContext val context: Context,
+    val loginTypesProvider: LoginTypesProvider,
     settingsManager: SettingsManager
 ): ViewModel() {
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/NextcloudLoginModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/NextcloudLoginModel.kt
@@ -4,7 +4,7 @@
 
 package at.bitfire.davdroid.ui.setup
 
-import android.app.Application
+import android.content.Context
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -16,6 +16,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.launch
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
@@ -24,7 +25,7 @@ import java.util.logging.Level
 @HiltViewModel(assistedFactory = NextcloudLoginModel.Factory::class)
 class NextcloudLoginModel @AssistedInject constructor(
     @Assisted val initialLoginInfo: LoginInfo,
-    val context: Application
+    @ApplicationContext val context: Context
     //val state: SavedStateHandle
 ): ViewModel() {
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/webdav/AddWebdavMountModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/webdav/AddWebdavMountModel.kt
@@ -4,7 +4,7 @@
 
 package at.bitfire.davdroid.ui.webdav
 
-import android.app.Application
+import android.content.Context
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -15,13 +15,14 @@ import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.Credentials
 import at.bitfire.davdroid.webdav.WebDavMountRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.launch
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import javax.inject.Inject
 
 @HiltViewModel
 class AddWebdavMountModel @Inject constructor(
-    val context: Application,
+    @ApplicationContext val context: Context,
     val db: AppDatabase,
     private val mountRepository: WebDavMountRepository
 ): ViewModel() {

--- a/app/src/main/kotlin/at/bitfire/davdroid/util/TaskUtils.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/util/TaskUtils.kt
@@ -22,8 +22,8 @@ import at.bitfire.davdroid.log.Logger
 import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.settings.Settings
 import at.bitfire.davdroid.settings.SettingsManager
-import at.bitfire.davdroid.sync.worker.PeriodicSyncWorker
 import at.bitfire.davdroid.sync.SyncUtils
+import at.bitfire.davdroid.sync.worker.PeriodicSyncWorker
 import at.bitfire.davdroid.ui.NotificationUtils
 import at.bitfire.davdroid.ui.NotificationUtils.notifyIfPossible
 import at.bitfire.ical4android.TaskProvider
@@ -43,6 +43,7 @@ object TaskUtils {
     @EntryPoint
     @InstallIn(SingletonComponent::class)
     interface TaskUtilsEntryPoint {
+        fun accountSettingsFactory(): AccountSettings.Factory
         fun settingsManager(): SettingsManager
     }
 
@@ -175,7 +176,8 @@ object TaskUtils {
     private fun setSyncable(context: Context, account: Account, authority: String, syncable: Boolean) {
         val settingsManager by lazy { EntryPointAccessors.fromApplication(context, SyncUtils.SyncUtilsEntryPoint::class.java).settingsManager() }
         try {
-            val settings = AccountSettings(context, account)
+            val entryPoint = EntryPointAccessors.fromApplication<TaskUtilsEntryPoint>(context)
+            val settings = entryPoint.accountSettingsFactory().forAccount(account)
             if (syncable) {
                 Logger.log.info("Enabling $authority sync for $account")
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/webdav/WebDavMountRepository.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/webdav/WebDavMountRepository.kt
@@ -4,7 +4,7 @@
 
 package at.bitfire.davdroid.webdav
 
-import android.app.Application
+import android.content.Context
 import android.provider.DocumentsContract
 import androidx.annotation.VisibleForTesting
 import at.bitfire.dav4jvm.DavResource
@@ -13,6 +13,7 @@ import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.Credentials
 import at.bitfire.davdroid.db.WebDavMount
 import at.bitfire.davdroid.network.HttpClient
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runInterruptible
@@ -21,7 +22,7 @@ import okhttp3.HttpUrl
 import javax.inject.Inject
 
 class WebDavMountRepository @Inject constructor(
-    val context: Application,
+    @ApplicationContext val context: Context,
     val db: AppDatabase
 ) {
 


### PR DESCRIPTION
- Use Hilt for `AccountSettings`.
- Use Hilt for Android tests when things need to be injected.

Findings:

- There's no guaranteed order for multiple `@Before` methods in JUnit tests, so we should only have one `@Before fun setup()` per test class. This setup method runs `AndroidHiltRule.inject()` first and can then initialize other things. Test variables that depend on the `Context` need to be declared `by lazy` because the `Context` will only be available after the Hilt rule is run.
- In Android tests using Hilt (`@HiltAndroidTest`), we should always inject the application context instead of getting it from the instrumentation. Otherwise Hilt may have stored another (wrapped or whatever) Application as application context and then things like `EntryPointAccessors.fromApplication` won't work properly.
- We should always inject `@ApplicationContext val context: Context` instead of an `Application` for the same reason.