### PR TITLE
Update dnsjava, use desugaring with nio, refactor DNS resolving

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,7 +40,9 @@ android {
     }
 
     compileOptions {
-        // enable because ical4android requires desugaring
+        // required for
+        // - dnsjava 3.x: java.nio.file.Path
+        // - ical4android: time API
         isCoreLibraryDesugaringEnabled = true
     }
 

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/network/Android10ResolverTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/network/Android10ResolverTest.kt
@@ -21,10 +21,10 @@ class Android10ResolverTest {
     @Test
     @SdkSuppress(minSdkVersion = Build.VERSION_CODES.Q)
     fun testResolveA() {
-        val www = InetAddress.getAllByName(FQDN_DAVX5).filterIsInstance(Inet4Address::class.java).first()
+        val www = InetAddress.getAllByName(FQDN_DAVX5).filterIsInstance<Inet4Address>().first()
 
         val srvLookup = Lookup(FQDN_DAVX5, Type.A)
-        srvLookup.setResolver(Android10Resolver)
+        srvLookup.setResolver(Android10Resolver())
         val resultGeneric = srvLookup.run()
         assertEquals(1, resultGeneric.size)
 

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/network/DnsRecordResolverTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/network/DnsRecordResolverTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.network
+
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.xbill.DNS.DClass
+import org.xbill.DNS.Name
+import org.xbill.DNS.SRVRecord
+import javax.inject.Inject
+
+@HiltAndroidTest
+class DnsRecordResolverTest {
+
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+
+    @Inject
+    lateinit var dnsRecordResolver: DnsRecordResolver
+
+    @Before
+    fun setup() {
+        hiltRule.inject()
+    }
+
+
+    @Test
+    fun testBestSRVRecord_Empty() {
+        assertNull(dnsRecordResolver.bestSRVRecord(emptyArray()))
+    }
+
+    @Test
+    fun testBestSRVRecord_MultipleRecords_Priority_Different() {
+        val dns1010 = SRVRecord(
+            Name.fromString("_caldavs._tcp.example.com."),
+            DClass.IN, 3600, 10, 10, 8443, Name.fromString("dav1010.example.com.")
+        )
+        val dns2010 = SRVRecord(
+            Name.fromString("_caldavs._tcp.example.com."),
+            DClass.IN, 3600, 20, 20, 8443, Name.fromString("dav2010.example.com.")
+        )
+
+        // lowest priority first
+        val result = dnsRecordResolver.bestSRVRecord(arrayOf(dns1010, dns2010))
+        assertEquals(dns1010, result)
+    }
+
+    @Test
+    fun testBestSRVRecord_MultipleRecords_Priority_Same() {
+        val dns1010 = SRVRecord(
+            Name.fromString("_caldavs._tcp.example.com."),
+            DClass.IN, 3600, 10, 10, 8443, Name.fromString("dav1010.example.com.")
+        )
+        val dns1020 = SRVRecord(
+            Name.fromString("_caldavs._tcp.example.com."),
+            DClass.IN, 3600, 10, 20, 8443, Name.fromString("dav1020.example.com.")
+        )
+
+        // entries are selected randomly (for load balancing)
+        // run 1000 times to get a good distribution
+        val counts = IntArray(2)
+        for (i in 0 until 1000) {
+            val result = dnsRecordResolver.bestSRVRecord(arrayOf(dns1010, dns1020))
+
+            when (result) {
+                dns1010 -> counts[0]++
+                dns1020 -> counts[1]++
+            }
+        }
+
+        /* We had weights 10 and 20, so the distribution of 1000 tries should be roughly
+            weight 10       fraction 1/3    expected count 333
+            weight 20       fraction 2/3    expected count 667
+         */
+        assertTrue(counts[0] in 300..366)
+        assertTrue(counts[1] in 633..700)
+    }
+
+    @Test
+    fun testBestSRVRecord_OneRecord() {
+        val dns1010 = SRVRecord(
+            Name.fromString("_caldavs._tcp.example.com."),
+            DClass.IN, 3600, 10, 10, 8443, Name.fromString("dav1010.example.com.")
+        )
+        val result = dnsRecordResolver.bestSRVRecord(arrayOf(dns1010))
+        assertEquals(dns1010, result)
+    }
+
+}

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/network/DnsRecordResolverTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/network/DnsRecordResolverTest.kt
@@ -6,6 +6,7 @@ package at.bitfire.davdroid.network
 
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -15,6 +16,7 @@ import org.junit.Test
 import org.xbill.DNS.DClass
 import org.xbill.DNS.Name
 import org.xbill.DNS.SRVRecord
+import org.xbill.DNS.TXTRecord
 import javax.inject.Inject
 
 @HiltAndroidTest
@@ -92,6 +94,29 @@ class DnsRecordResolverTest {
         )
         val result = dnsRecordResolver.bestSRVRecord(arrayOf(dns1010))
         assertEquals(dns1010, result)
+    }
+
+
+    @Test
+    fun testPathsFromTXTRecords_Empty() {
+        assertTrue(dnsRecordResolver.pathsFromTXTRecords(arrayOf()).isEmpty())
+    }
+
+    @Test
+    fun testPathsFromTXTRecords_OnePath() {
+        val result = dnsRecordResolver.pathsFromTXTRecords(arrayOf(
+            TXTRecord(Name.fromString("example.com."), 0, 0L, listOf("something=else", "path=/path1"))
+        )).toTypedArray()
+        assertArrayEquals(arrayOf("/path1"), result)
+    }
+
+    @Test
+    fun testPathsFromTXTRecords_TwoPaths() {
+        val result = dnsRecordResolver.pathsFromTXTRecords(arrayOf(
+            TXTRecord(Name.fromString("example.com."), 0, 0L, listOf("path=/path1", "something-else", "path=/path2"))
+        )).toTypedArray()
+        result.sort()
+        assertArrayEquals(arrayOf("/path1", "/path2"), result)
     }
 
 }

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/network/DnsRecordResolverTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/network/DnsRecordResolverTest.kt
@@ -79,11 +79,11 @@ class DnsRecordResolverTest {
         }
 
         /* We had weights 10 and 20, so the distribution of 1000 tries should be roughly
-            weight 10       fraction 1/3    expected count 333
-            weight 20       fraction 2/3    expected count 667
+            weight 10   fraction 1/3   expected count 333   binomial distribution (p=1/3) with 99.99% in [275..393]
+            weight 20   fraction 2/3   expected count 667   binomial distribution (p=2/3) with 99.99% in [607..725]
          */
-        assertTrue(counts[0] in 300..366)
-        assertTrue(counts[1] in 633..700)
+        assertTrue(counts[0] in 275..393)
+        assertTrue(counts[1] in 607..725)
     }
 
     @Test

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/servicedetection/DavResourceFinderTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/servicedetection/DavResourceFinderTest.kt
@@ -57,6 +57,9 @@ class DavResourceFinderTest {
     lateinit var context: Context
 
     @Inject
+    lateinit var resourceFinderFactory: DavResourceFinder.Factory
+
+    @Inject
     lateinit var settingsManager: SettingsManager
 
     private val server = MockWebServer()
@@ -74,7 +77,7 @@ class DavResourceFinderTest {
         val baseURI = URI.create("/")
         val credentials = Credentials("mock", "12345")
 
-        finder = DavResourceFinder(context, baseURI, credentials)
+        finder = resourceFinderFactory.resourceFinder(baseURI, credentials)
         client = HttpClient.Builder(context)
                 .addAuthentication(null, credentials)
                 .build()

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/servicedetection/DavResourceFinderTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/servicedetection/DavResourceFinderTest.kt
@@ -77,7 +77,7 @@ class DavResourceFinderTest {
         val baseURI = URI.create("/")
         val credentials = Credentials("mock", "12345")
 
-        finder = resourceFinderFactory.resourceFinder(baseURI, credentials)
+        finder = resourceFinderFactory.create(baseURI, credentials)
         client = HttpClient.Builder(context)
                 .addAuthentication(null, credentials)
                 .build()

--- a/app/src/main/kotlin/at/bitfire/davdroid/network/Android10Resolver.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/network/Android10Resolver.kt
@@ -19,7 +19,8 @@ import java.io.IOException
 import java.time.Duration
 
 /**
- * dnsjava Resolver that uses Android's [DnsResolver] API, which is available since Android 10.
+ * dnsjava [Resolver] that uses Android's [DnsResolver] API, which can resolve raw queries and
+ * is available since Android 10.
  */
 @RequiresApi(Build.VERSION_CODES.Q)
 class Android10Resolver : Resolver {

--- a/app/src/main/kotlin/at/bitfire/davdroid/network/Android10Resolver.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/network/Android10Resolver.kt
@@ -11,21 +11,21 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asExecutor
 import kotlinx.coroutines.runBlocking
+import org.xbill.DNS.EDNSOption
 import org.xbill.DNS.Message
 import org.xbill.DNS.Resolver
-import org.xbill.DNS.ResolverListener
 import org.xbill.DNS.TSIG
 import java.io.IOException
+import java.time.Duration
 
 /**
  * dnsjava Resolver that uses Android's [DnsResolver] API, which is available since Android 10.
  */
 @RequiresApi(Build.VERSION_CODES.Q)
-object Android10Resolver: Resolver {
+class Android10Resolver : Resolver {
 
     private val executor = Dispatchers.IO.asExecutor()
     private val resolver = DnsResolver.getInstance()
-
 
     override fun send(query: Message): Message = runBlocking {
         val future = CompletableDeferred<Message>()
@@ -44,10 +44,6 @@ object Android10Resolver: Resolver {
         future.await()
     }
 
-    override fun sendAsync(query: Message, listener: ResolverListener) =
-        // currently not used by dnsjava, so no need to implement it
-        throw NotImplementedError()
-
 
     override fun setPort(port: Int) {
         // not applicable
@@ -61,11 +57,7 @@ object Android10Resolver: Resolver {
         // not applicable
     }
 
-    override fun setEDNS(level: Int) {
-        // not applicable
-    }
-
-    override fun setEDNS(level: Int, payloadSize: Int, flags: Int, options: MutableList<Any?>?) {
+    override fun setEDNS(version: Int, payloadSize: Int, flags: Int, options: MutableList<EDNSOption>?) {
         // not applicable
     }
 
@@ -73,11 +65,7 @@ object Android10Resolver: Resolver {
         // not applicable
     }
 
-    override fun setTimeout(secs: Int, msecs: Int) {
-        // not applicable
-    }
-
-    override fun setTimeout(secs: Int) {
+    override fun setTimeout(timeout: Duration?) {
         // not applicable
     }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/network/DnsRecordResolver.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/network/DnsRecordResolver.kt
@@ -1,0 +1,137 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.network
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.os.Build
+import androidx.core.content.getSystemService
+import dagger.hilt.android.qualifiers.ApplicationContext
+import org.xbill.DNS.ExtendedResolver
+import org.xbill.DNS.Lookup
+import org.xbill.DNS.Record
+import org.xbill.DNS.Resolver
+import org.xbill.DNS.SRVRecord
+import org.xbill.DNS.SimpleResolver
+import org.xbill.DNS.TXTRecord
+import java.net.InetAddress
+import java.util.LinkedList
+import java.util.TreeMap
+import java.util.logging.Logger
+import javax.inject.Inject
+
+class DnsRecordResolver @Inject constructor(
+    @ApplicationContext val context: Context,
+    private val logger: Logger
+) {
+
+    // resolving
+
+    private val DNS_QUAD9 = InetAddress.getByAddress(byteArrayOf(9,9,9,9))
+
+    private val resolver by lazy { chooseResolver() }
+
+    private fun chooseResolver(): Resolver =
+        if (Build.VERSION.SDK_INT >= 29) {
+            /* Since Android 10, there's a native DnsResolver API that allows to send SRV queries without
+               knowing which DNS servers have to be used. DNS over TLS is now also supported. */
+            logger.fine("Using Android 10+ DnsResolver")
+            Android10Resolver()
+
+        } else {
+            /* Since Android 8, the system properties net.dns1, net.dns2, ... are not available anymore.
+               The current version of dnsjava relies on these properties to find the default name servers,
+               so we have to add the servers explicitly (fortunately, there's an Android API to
+               get the DNS servers of the network connections). */
+            val dnsServers = LinkedList<InetAddress>()
+
+            val connectivity = context.getSystemService<ConnectivityManager>()!!
+            connectivity.allNetworks.forEach { network ->
+                val active = connectivity.getNetworkInfo(network)?.isConnected ?: false
+                connectivity.getLinkProperties(network)?.let { link ->
+                    if (active)
+                    // active connection, insert at top of list
+                        dnsServers.addAll(0, link.dnsServers)
+                    else
+                    // inactive connection, insert at end of list
+                        dnsServers.addAll(link.dnsServers)
+                }
+            }
+
+            // fallback: add Quad9 DNS in case that no other DNS works
+            dnsServers.add(DNS_QUAD9)
+
+            val uniqueDnsServers = LinkedHashSet<InetAddress>(dnsServers)
+            val simpleResolvers = uniqueDnsServers.map { dns ->
+                logger.fine("Adding DNS server ${dns.hostAddress}")
+                SimpleResolver(dns)
+            }
+
+            // combine SimpleResolvers which query one DNS server each to an ExtendedResolver
+            ExtendedResolver(simpleResolvers.toTypedArray())
+        }
+
+    fun resolve(query: String, type: Int): Array<out Record> {
+        val lookup = Lookup(query, type)
+        lookup.setResolver(resolver)
+        return lookup.run().orEmpty()
+    }
+
+
+    // record selection
+
+    fun bestSRVRecord(records: Array<out Record>): SRVRecord? {
+        val srvRecords = records.filterIsInstance(SRVRecord::class.java)
+        if (srvRecords.size <= 1)
+            return srvRecords.firstOrNull()
+
+        /* RFC 2782
+           Priority
+                The priority of this target host.  A client MUST attempt to
+                contact the target host with the lowest-numbered priority it can
+                reach; target hosts with the same priority SHOULD be tried in an
+                order defined by the weight field. [...]
+           Weight
+                A server selection mechanism.  The weight field specifies a
+                relative weight for entries with the same priority. [...]
+                To select a target to be contacted next, arrange all SRV RRs
+                (that have not been ordered yet) in any order, except that all
+                those with weight 0 are placed at the beginning of the list.
+                Compute the sum of the weights of those RRs, and with each RR
+                associate the running sum in the selected order. Then choose a
+                uniform random number between 0 and the sum computed
+                (inclusive), and select the RR whose running sum value is the
+                first in the selected order which is greater than or equal to
+                the random number selected. The target host specified in the
+                selected SRV RR is the next one to be contacted by the client.
+        */
+        val minPriority = srvRecords.minOfOrNull { it.priority }
+        val useableRecords = srvRecords.filter { it.priority == minPriority }.sortedBy { it.weight != 0 }
+
+        val map = TreeMap<Int, SRVRecord>()
+        var runningWeight = 0
+        for (record in useableRecords) {
+            val weight = record.weight
+            runningWeight += weight
+            map[runningWeight] = record
+        }
+
+        val selector = (0..runningWeight).random()
+        return map.ceilingEntry(selector)!!.value
+    }
+
+    fun pathsFromTXTRecords(records: Array<out Record>): List<String> {
+        val paths = LinkedList<String>()
+        records.filterIsInstance<TXTRecord>().forEach { txt ->
+            for (segment in txt.strings as List<String>)
+                if (segment.startsWith("path=")) {
+                    paths.add(segment.substring(5))
+                    break
+                }
+        }
+        return paths
+    }
+
+}

--- a/app/src/main/kotlin/at/bitfire/davdroid/network/DnsRecordResolver.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/network/DnsRecordResolver.kt
@@ -142,10 +142,8 @@ class DnsRecordResolver @Inject constructor(
         val paths = LinkedList<String>()
         records.filterIsInstance<TXTRecord>().forEach { txt ->
             for (segment in txt.strings as List<String>)
-                if (segment.startsWith("path=")) {
+                if (segment.startsWith("path="))
                     paths.add(segment.substring(5))
-                    break
-                }
         }
         return paths
     }

--- a/app/src/main/kotlin/at/bitfire/davdroid/network/DnsRecordResolver.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/network/DnsRecordResolver.kt
@@ -96,7 +96,7 @@ class DnsRecordResolver @Inject constructor(
     // record selection
 
     fun bestSRVRecord(records: Array<out Record>): SRVRecord? {
-        val srvRecords = records.filterIsInstance(SRVRecord::class.java)
+        val srvRecords = records.filterIsInstance<SRVRecord>()
         if (srvRecords.size <= 1)
             return srvRecords.firstOrNull()
 
@@ -120,8 +120,11 @@ class DnsRecordResolver @Inject constructor(
                 the random number selected. The target host specified in the
                 selected SRV RR is the next one to be contacted by the client.
         */
+
+        // Select records which have the minimum priority
         val minPriority = srvRecords.minOfOrNull { it.priority }
-        val useableRecords = srvRecords.filter { it.priority == minPriority }.sortedBy { it.weight != 0 }
+        val useableRecords = srvRecords.filter { it.priority == minPriority }
+            .sortedBy { it.weight != 0 }    // and put those with weight 0 first
 
         val map = TreeMap<Int, SRVRecord>()
         var runningWeight = 0

--- a/app/src/main/kotlin/at/bitfire/davdroid/servicedetection/DavResourceFinder.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/servicedetection/DavResourceFinder.kt
@@ -68,7 +68,7 @@ class DavResourceFinder @AssistedInject constructor(
 
     @AssistedFactory
     interface Factory {
-        fun resourceFinder(baseURI: URI, credentials: Credentials?): DavResourceFinder
+        fun create(baseURI: URI, credentials: Credentials?): DavResourceFinder
     }
 
     enum class Service(val wellKnownName: String) {

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
@@ -40,6 +40,7 @@ class LoginScreenModel @AssistedInject constructor(
     private val accountRepository: AccountRepository,
     @ApplicationContext val context: Context,
     val loginTypesProvider: LoginTypesProvider,
+    private val resourceFinderFactory: DavResourceFinder.Factory,
     settingsManager: SettingsManager
 ): ViewModel() {
 
@@ -188,10 +189,10 @@ class LoginScreenModel @AssistedInject constructor(
         detectResourcesJob = viewModelScope.launch {
             val result = withContext(Dispatchers.IO) {
                  runInterruptible {
-                    DavResourceFinder(context, loginInfo.baseUri!!, loginInfo.credentials).use { finder ->
-                        finder.findInitialConfiguration()
-                    }
-                }
+                     resourceFinderFactory.resourceFinder(loginInfo.baseUri!!, loginInfo.credentials).use { finder ->
+                         finder.findInitialConfiguration()
+                     }
+                 }
             }
 
             if (result.calDAV != null || result.cardDAV != null) {

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
@@ -189,7 +189,7 @@ class LoginScreenModel @AssistedInject constructor(
         detectResourcesJob = viewModelScope.launch {
             val result = withContext(Dispatchers.IO) {
                  runInterruptible {
-                     resourceFinderFactory.resourceFinder(loginInfo.baseUri!!, loginInfo.credentials).use { finder ->
+                     resourceFinderFactory.create(loginInfo.baseUri!!, loginInfo.credentials).use { finder ->
                          finder.findInitialConfiguration()
                      }
                  }

--- a/app/src/main/kotlin/at/bitfire/davdroid/util/DavUtils.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/util/DavUtils.kt
@@ -4,34 +4,17 @@
 
 package at.bitfire.davdroid.util
 
-import android.content.Context
-import android.net.ConnectivityManager
-import android.os.Build
-import androidx.core.content.getSystemService
-import at.bitfire.davdroid.log.Logger
-import at.bitfire.davdroid.network.Android10Resolver
 import okhttp3.HttpUrl
 import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaType
-import org.xbill.DNS.ExtendedResolver
-import org.xbill.DNS.Lookup
-import org.xbill.DNS.Record
-import org.xbill.DNS.SRVRecord
-import org.xbill.DNS.SimpleResolver
-import org.xbill.DNS.TXTRecord
-import java.net.InetAddress
 import java.net.URI
 import java.net.URISyntaxException
-import java.util.LinkedList
 import java.util.Locale
-import java.util.TreeMap
 
 /**
  * Some WebDAV and HTTP network utility methods.
   */
 object DavUtils {
-
-    val DNS_QUAD9 = InetAddress.getByAddress(byteArrayOf(9,9,9,9))
 
     const val MIME_TYPE_ACCEPT_ALL = "*/*"
 
@@ -58,108 +41,6 @@ object DavUtils {
         val alpha = (colorWithAlpha shr 24) and 0xFF
         val color = colorWithAlpha and 0xFFFFFF
         return String.format(Locale.ROOT, "#%06X%02X", color, alpha)
-    }
-
-    fun prepareLookup(context: Context, lookup: Lookup) {
-        if (Build.VERSION.SDK_INT >= 29) {
-            /* Since Android 10, there's a native DnsResolver API that allows to send SRV queries without
-               knowing which DNS servers have to be used. DNS over TLS is now also supported. */
-            Logger.log.fine("Using Android 10+ DnsResolver")
-            lookup.setResolver(Android10Resolver)
-
-        } else if (Build.VERSION.SDK_INT >= 26) {
-            /* Since Android 8, the system properties net.dns1, net.dns2, ... are not available anymore.
-               The current version of dnsjava relies on these properties to find the default name servers,
-               so we have to add the servers explicitly (fortunately, there's an Android API to
-               get the DNS servers of the network connections). */
-           val dnsServers = LinkedList<InetAddress>()
-
-            val connectivity = context.getSystemService<ConnectivityManager>()!!
-            connectivity.allNetworks.forEach { network ->
-                val active = connectivity.getNetworkInfo(network)?.isConnected ?: false
-                connectivity.getLinkProperties(network)?.let { link ->
-                    if (active)
-                        // active connection, insert at top of list
-                        dnsServers.addAll(0, link.dnsServers)
-                    else
-                        // inactive connection, insert at end of list
-                        dnsServers.addAll(link.dnsServers)
-                }
-            }
-
-            // fallback: add Quad9 DNS in case that no other DNS works
-            dnsServers.add(DNS_QUAD9)
-
-            val uniqueDnsServers = LinkedHashSet<InetAddress>(dnsServers)
-            val simpleResolvers = uniqueDnsServers.map { dns ->
-                Logger.log.fine("Adding DNS server ${dns.hostAddress}")
-                SimpleResolver().apply {
-                    setAddress(dns)
-                }
-            }
-            val resolver = ExtendedResolver(simpleResolvers.toTypedArray())
-            lookup.setResolver(resolver)
-        }
-    }
-
-    fun selectSRVRecord(records: Array<out Record>?): SRVRecord? {
-        if (records == null)
-            return null
-
-        val srvRecords = records.filterIsInstance(SRVRecord::class.java)
-        if (srvRecords.size <= 1)
-            return srvRecords.firstOrNull()
-
-        /* RFC 2782
-
-           Priority
-                The priority of this target host.  A client MUST attempt to
-                contact the target host with the lowest-numbered priority it can
-                reach; target hosts with the same priority SHOULD be tried in an
-                order defined by the weight field. [...]
-
-           Weight
-                A server selection mechanism.  The weight field specifies a
-                relative weight for entries with the same priority. [...]
-
-                To select a target to be contacted next, arrange all SRV RRs
-                (that have not been ordered yet) in any order, except that all
-                those with weight 0 are placed at the beginning of the list.
-
-                Compute the sum of the weights of those RRs, and with each RR
-                associate the running sum in the selected order. Then choose a
-                uniform random number between 0 and the sum computed
-                (inclusive), and select the RR whose running sum value is the
-                first in the selected order which is greater than or equal to
-                the random number selected. The target host specified in the
-                selected SRV RR is the next one to be contacted by the client.
-        */
-        val minPriority = srvRecords.minOfOrNull { it.priority }
-        val useableRecords = srvRecords.filter { it.priority == minPriority }.sortedBy { it.weight != 0 }
-
-        val map = TreeMap<Int, SRVRecord>()
-        var runningWeight = 0
-        for (record in useableRecords) {
-            val weight = record.weight
-            runningWeight += weight
-            map[runningWeight] = record
-        }
-
-        val selector = (0..runningWeight).random()
-        return map.ceilingEntry(selector)!!.value
-    }
-
-    fun pathsFromTXTRecords(records: Array<Record>?): List<String> {
-        val paths = LinkedList<String>()
-        records?.filterIsInstance(TXTRecord::class.java)?.forEach { txt ->
-            @Suppress("UNCHECKED_CAST")
-            for (segment in txt.strings as List<String>)
-                if (segment.startsWith("path=")) {
-                    paths.add(segment.substring(5))
-                    break
-                }
-        }
-        return paths
     }
 
 

--- a/app/src/test/kotlin/at/bitfire/davdroid/DavUtilsTest.kt
+++ b/app/src/test/kotlin/at/bitfire/davdroid/DavUtilsTest.kt
@@ -9,12 +9,7 @@ import at.bitfire.davdroid.util.DavUtils.parent
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Test
-import org.xbill.DNS.DClass
-import org.xbill.DNS.Name
-import org.xbill.DNS.SRVRecord
 
 class DavUtilsTest {
 
@@ -44,37 +39,6 @@ class DavUtilsTest {
         assertEquals("http://example.com/1/".toHttpUrl(), "http://example.com/1/2".toHttpUrl().parent())
         assertEquals("http://example.com/".toHttpUrl(), "http://example.com/1".toHttpUrl().parent())
         assertEquals("http://example.com/".toHttpUrl(), "http://example.com".toHttpUrl().parent())
-    }
-
-    @Test
-    fun testSelectSRVRecord() {
-        assertNull(DavUtils.selectSRVRecord(emptyArray()))
-
-        val dns1010 = SRVRecord(
-                Name.fromString("_caldavs._tcp.example.com."),
-                DClass.IN, 3600, 10, 10, 8443, Name.fromString("dav1010.example.com.")
-        )
-        val dns1020 = SRVRecord(
-                Name.fromString("_caldavs._tcp.example.com."),
-                DClass.IN, 3600, 10, 20, 8443, Name.fromString("dav1020.example.com.")
-        )
-        val dns2010 = SRVRecord(
-                Name.fromString("_caldavs._tcp.example.com."),
-                DClass.IN, 3600, 20, 20, 8443, Name.fromString("dav2010.example.com.")
-        )
-
-        assertEquals(dns1010, DavUtils.selectSRVRecord(arrayOf(dns1010)))
-
-        val result = IntArray(2) { 0 }
-        for (i in 0 until 1000) {
-            when (DavUtils.selectSRVRecord(arrayOf(dns1010, dns1020, dns2010))) {
-                dns1010 -> result[0]++
-                dns1020 -> result[1]++
-                else -> throw AssertionError()
-            }
-        }
-        assertTrue(result[0] in 201..499)
-        assertTrue(result[1] in 501..799)
     }
 
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,8 +24,7 @@ bitfire-ical4android = "83cda23ceb"
 bitfire-vcard4android = "03a37a8284"
 compose-accompanist = "0.34.0"
 compose-bom = "2024.06.00"
-# don't update to dnsjava 3.x until API level 26 (Android 8) is the minimum API [https://github.com/bitfireAT/davx5/issues/453]
-dnsjava = "2.1.9"
+dnsjava = "3.5.3"
 glance = "1.1.0"
 guava = "33.2.1-android"
 hilt = "2.51.1"
@@ -44,7 +43,7 @@ room = "2.6.1"
 unifiedpush = "2.4.0"
 
 [libraries]
-android-desugaring = { module = "com.android.tools:desugar_jdk_libs", version.ref = "android-desugaring" }
+android-desugaring = { module = "com.android.tools:desugar_jdk_libs_nio", version.ref = "android-desugaring" }
 androidx-activityCompose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-arch-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "androidx-arch" }


### PR DESCRIPTION
### Purpose

Previously, [we couldn't use dnsjava 3.x because the java.nio.file.Path API was not available](https://github.com/bitfireAT/davx5/issues/453).

Now Android [provides desugaring for that class](https://developer.android.com/studio/write/java11-nio-support-table), so we can use dnsjava 3.x and also refactor DNS detection a bit.


### Short description

Create `DnsRecordResolver` + some tests to handle all DNS lookups.


### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

