### PR TITLE
Fix sync not running directly after enabling a collection

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollection.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollection.kt
@@ -7,6 +7,7 @@ package at.bitfire.davdroid.resource
 import android.accounts.Account
 import android.content.ContentProviderClient
 import android.content.ContentValues
+import android.net.Uri
 import at.bitfire.davdroid.Constants
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Principal
@@ -24,9 +25,9 @@ class LocalJtxCollection(account: Account, client: ContentProviderClient, id: Lo
 
     companion object {
 
-        fun create(account: Account, client: ContentProviderClient, info: Collection, owner: Principal?) {
+        fun create(account: Account, client: ContentProviderClient, info: Collection, owner: Principal?): Uri {
             val values = valuesFromCollection(info, account, owner, true)
-            create(account, client, values)
+            return create(account, client, values)
         }
 
         fun valuesFromCollection(info: Collection, account: Account, owner: Principal?, withColor: Boolean) =

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
@@ -63,9 +63,9 @@ class AddressBookSyncer @AssistedInject constructor(
         }
     }
 
-    override fun create(provider: ContentProviderClient, remoteCollection: Collection) {
+    override fun create(provider: ContentProviderClient, remoteCollection: Collection): LocalAddressBook {
         logger.log(Level.INFO, "Adding local address book", remoteCollection)
-        LocalAddressBook.create(context, provider, account, remoteCollection, forceAllReadOnly)
+        return LocalAddressBook.create(context, provider, account, remoteCollection, forceAllReadOnly)
     }
 
     override fun syncCollection(provider: ContentProviderClient, localCollection: LocalAddressBook, remoteCollection: Collection) {

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncer.kt
@@ -6,6 +6,7 @@ package at.bitfire.davdroid.sync
 
 import android.accounts.Account
 import android.content.ContentProviderClient
+import android.content.ContentUris
 import android.content.SyncResult
 import android.provider.CalendarContract
 import at.bitfire.davdroid.db.Collection
@@ -74,9 +75,10 @@ class CalendarSyncer @AssistedInject constructor(
         localCollection.update(remoteCollection, accountSettings.getManageCalendarColors())
     }
 
-    override fun create(provider: ContentProviderClient, remoteCollection: Collection) {
+    override fun create(provider: ContentProviderClient, remoteCollection: Collection): LocalCalendar {
         logger.log(Level.INFO, "Adding local calendar", remoteCollection)
-        LocalCalendar.create(account, provider, remoteCollection)
+        val uri = LocalCalendar.create(account, provider, remoteCollection)
+        return AndroidCalendar.findByID(account, provider, LocalCalendar.Factory, ContentUris.parseId(uri))
     }
 
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
@@ -100,8 +100,8 @@ abstract class Syncer<CollectionType: LocalCollection<*>>(
         }
 
         // Update/delete local collections and determine new (unknown) remote collections
-        val localSyncCollections = localSyncCollections(provider)
         val newDbCollections = HashMap(dbCollections)   // create a copy
+        val localSyncCollections = localSyncCollections(provider).toMutableList()
         for (localCollection in localSyncCollections) {
             val dbCollection = dbCollections[localCollection.collectionUrl?.toHttpUrlOrNull()]
             if (dbCollection == null)
@@ -116,7 +116,7 @@ abstract class Syncer<CollectionType: LocalCollection<*>>(
 
         // 3. create new local collections for newly found remote collections
         for ((_, collection) in newDbCollections)
-            create(provider, collection)
+            localSyncCollections += create(provider, collection)
 
         // 4. sync local collection contents (events, contacts, tasks)
         for (localCollection in localSyncCollections)
@@ -162,7 +162,7 @@ abstract class Syncer<CollectionType: LocalCollection<*>>(
      * @param provider The content provider client to create the local collection
      * @param remoteCollection The remote collection to be created locally
      */
-    abstract fun create(provider: ContentProviderClient, remoteCollection: Collection)
+    abstract fun create(provider: ContentProviderClient, remoteCollection: Collection): CollectionType
 
     /**
      * Synchronise local with remote collection contents

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/TaskSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/TaskSyncer.kt
@@ -7,6 +7,7 @@ package at.bitfire.davdroid.sync
 import android.accounts.Account
 import android.accounts.AccountManager
 import android.content.ContentProviderClient
+import android.content.ContentUris
 import android.content.SyncResult
 import android.os.Build
 import at.bitfire.davdroid.db.Collection
@@ -17,7 +18,7 @@ import at.bitfire.ical4android.TaskProvider
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import org.dmfs.tasks.contract.TaskContract
+import org.dmfs.tasks.contract.TaskContract.TaskLists
 import java.util.logging.Level
 
 /**
@@ -44,7 +45,7 @@ class TaskSyncer @AssistedInject constructor(
 
 
     override fun localSyncCollections(provider: ContentProviderClient): List<LocalTaskList>
-        = DmfsTaskList.find(account, taskProvider, LocalTaskList.Factory, "${TaskContract.TaskLists.SYNC_ENABLED}!=0", null)
+        = DmfsTaskList.find(account, taskProvider, LocalTaskList.Factory, "${TaskLists.SYNC_ENABLED}!=0", null)
 
     override fun prepare(provider: ContentProviderClient): Boolean {
         // Acquire task provider
@@ -77,9 +78,10 @@ class TaskSyncer @AssistedInject constructor(
         localCollection.update(remoteCollection, accountSettings.getManageCalendarColors())
     }
 
-    override fun create(provider: ContentProviderClient, remoteCollection: Collection) {
+    override fun create(provider: ContentProviderClient, remoteCollection: Collection): LocalTaskList {
         logger.log(Level.INFO, "Adding local task list", remoteCollection)
-        LocalTaskList.create(account, taskProvider, remoteCollection)
+        val uri = LocalTaskList.create(account, taskProvider, remoteCollection)
+        return DmfsTaskList.findByID(account, taskProvider, LocalTaskList.Factory, ContentUris.parseId(uri))
     }
 
     override fun syncCollection(provider: ContentProviderClient, localCollection: LocalTaskList, remoteCollection: Collection) {


### PR DESCRIPTION
### Purpose

Fix sync not running directly after enabling a collection. 

### Short description

Return local collections on creation and add them to the sync collections list, so they will be synced directly after enabling.

### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [ ] I have added documentation to complex functions and functions that can be used by other modules.
- [ ] I have added reasonable tests or consciously decided to not add tests.

