### PR TITLE
Don't overwrite calendar/task list color with default color

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
@@ -43,7 +43,11 @@ class LocalCalendar private constructor(
             get() = Logger.getGlobal()
 
         fun create(account: Account, provider: ContentProviderClient, info: Collection): Uri {
-            val values = valuesFromCollectionInfo(info, true)
+            // If the collection doesn't have a color, use a default color.
+            if (info.color != null)
+                info.color = Constants.DAVDROID_GREEN_RGBA
+
+            val values = valuesFromCollectionInfo(info, withColor = true)
 
             // ACCOUNT_NAME and ACCOUNT_TYPE are required (see docs)! If it's missing, other apps will crash.
             values.put(Calendars.ACCOUNT_NAME, account.name)
@@ -65,8 +69,8 @@ class LocalCalendar private constructor(
             values.put(Calendars.CALENDAR_DISPLAY_NAME,
                 if (info.displayName.isNullOrBlank()) info.url.lastSegment else info.displayName)
 
-            if (withColor)
-                values.put(Calendars.CALENDAR_COLOR, info.color ?: Constants.DAVDROID_GREEN_RGBA)
+            if (withColor && info.color != null)
+                values.put(Calendars.CALENDAR_COLOR, info.color)
 
             if (info.privWriteContent && !info.forceReadOnly) {
                 values.put(Calendars.CALENDAR_ACCESS_LEVEL, Calendars.CAL_ACCESS_OWNER)
@@ -129,11 +133,11 @@ class LocalCalendar private constructor(
     }
 
     fun update(info: Collection, updateColor: Boolean) =
-            update(valuesFromCollectionInfo(info, updateColor))
+        update(valuesFromCollectionInfo(info, updateColor))
 
 
     override fun findDeleted() =
-            queryEvents("${Events.DELETED} AND ${Events.ORIGINAL_ID} IS NULL", null)
+        queryEvents("${Events.DELETED} AND ${Events.ORIGINAL_ID} IS NULL", null)
 
     override fun findDirty(): List<LocalEvent> {
         val dirty = LinkedList<LocalEvent>()

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollection.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollection.kt
@@ -26,7 +26,12 @@ class LocalJtxCollection(account: Account, client: ContentProviderClient, id: Lo
     companion object {
 
         fun create(account: Account, client: ContentProviderClient, info: Collection, owner: Principal?): Uri {
-            val values = valuesFromCollection(info, account, owner, true)
+            // If the collection doesn't have a color, use a default color.
+            if (info.color != null)
+                info.color = Constants.DAVDROID_GREEN_RGBA
+
+            val values = valuesFromCollection(info, account, owner, withColor = true)
+
             return create(account, client, values)
         }
 
@@ -43,8 +48,8 @@ class LocalJtxCollection(account: Account, client: ContentProviderClient, id: Lo
                 else
                     Logger.getGlobal().warning("No collection owner given. Will create jtx collection without owner")
                 put(JtxContract.JtxCollection.OWNER_DISPLAYNAME, owner?.displayName)
-                if (withColor)
-                    put(JtxContract.JtxCollection.COLOR, info.color ?: Constants.DAVDROID_GREEN_RGBA)
+                if (withColor && info.color != null)
+                    put(JtxContract.JtxCollection.COLOR, info.color)
                 put(JtxContract.JtxCollection.SUPPORTSVEVENT, info.supportsVEVENT)
                 put(JtxContract.JtxCollection.SUPPORTSVJOURNAL, info.supportsVJOURNAL)
                 put(JtxContract.JtxCollection.SUPPORTSVTODO, info.supportsVTODO)
@@ -69,8 +74,8 @@ class LocalJtxCollection(account: Account, client: ContentProviderClient, id: Lo
         get() = SyncState.fromString(syncstate)
         set(value) { syncstate = value.toString() }
 
-    fun updateCollection(info: Collection, owner: Principal?, withColor: Boolean) {
-        val values = valuesFromCollection(info, account, owner, withColor)
+    fun updateCollection(info: Collection, owner: Principal?, updateColor: Boolean) {
+        val values = valuesFromCollection(info, account, owner, updateColor)
         update(values)
     }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskList.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskList.kt
@@ -34,7 +34,11 @@ class LocalTaskList private constructor(
     companion object {
 
         fun create(account: Account, provider: TaskProvider, info: Collection): Uri {
-            val values = valuesFromCollectionInfo(info, true)
+            // If the collection doesn't have a color, use a default color.
+            if (info.color != null)
+                info.color = Constants.DAVDROID_GREEN_RGBA
+
+            val values = valuesFromCollectionInfo(info, withColor = true)
             values.put(TaskLists.OWNER, account.name)
             values.put(TaskLists.SYNC_ENABLED, 1)
             values.put(TaskLists.VISIBLE, 1)
@@ -61,8 +65,8 @@ class LocalTaskList private constructor(
             values.put(TaskLists.LIST_NAME,
                 if (info.displayName.isNullOrBlank()) info.url.lastSegment else info.displayName)
 
-            if (withColor)
-                values.put(TaskLists.LIST_COLOR, info.color ?: Constants.DAVDROID_GREEN_RGBA)
+            if (withColor && info.color != null)
+                values.put(TaskLists.LIST_COLOR, info.color)
 
             if (info.privWriteContent && !info.forceReadOnly)
                 values.put(TaskListColumns.ACCESS_LEVEL, TaskListColumns.ACCESS_LEVEL_OWNER)


### PR DESCRIPTION
When a server doesn't provide a calendar/task list color, we assume a default green.

Currently, this default color is set as calendar color at every sync (when the "Manage calendar colors" setting is active [default]).


### Purpose

It's enough to set the calendar color at sync only when the server actually sends a color. So the DAVx5 default color is _not_ set at every sync.

So the when the server doesn't send a color, people can change the calendar color locally in their calendar app (for instance, aCalendar+), and it won't be overwritten at every sync by default.


### Short description

A new condition is added to when calendar colors are updated:

- "Manage calendar colors" must be active (like previously)
- The color must be provided by the server (new condition)

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

