### PR TITLE
Log stop reason when sync worker is cancelled

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
@@ -8,6 +8,7 @@ import android.accounts.Account
 import android.content.ContentResolver
 import android.content.Context
 import android.content.SyncResult
+import android.os.Build
 import android.provider.CalendarContract
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
@@ -194,6 +195,9 @@ abstract class BaseSyncWorker(
         } finally {
             logger.info("${javaClass.simpleName} finished for $syncTag")
             runningSyncs -= syncTag
+
+            if (Build.VERSION.SDK_INT >= 31 && stopReason != WorkInfo.STOP_REASON_NOT_STOPPED)
+                logger.warning("Worker was stopped with reason: $stopReason")
         }
     }
 


### PR DESCRIPTION
### Purpose

When a sync worker is cancelled, we should log the cancellation reason.

### Short description

It's only possible since API lvl 31.

Since `BaseSyncWorker` is a CoroutineWorker it's stopped by a CancellationException. We can get and log the stop reason inside of its `doWork()` method with a try-finally block. 

Further information:
[Why stopped?](https://developer.android.com/develop/background-work/background-tasks/optimize-battery#why-stopped )
[2.9.0](https://developer.android.com/jetpack/androidx/releases/work#2.9.0)
[Cancellation and exceptions](https://kotlinlang.org/docs/exception-handling.html#cancellation-and-exceptions)

### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [ ] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.

