### PR TITLE
Reproducible Builds (for IzzyOnDroid)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,6 @@ jobs:
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.android_keystore_password }}
           ANDROID_KEY_ALIAS: ${{ secrets.android_key_alias }}
           ANDROID_KEY_PASSWORD: ${{ secrets.android_key_password }}
-          # Pass current build date
-          BUILD_DATE: ${{ github.event.repository.updated_at }}
 
       - name: Create Github release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,8 @@ jobs:
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.android_keystore_password }}
           ANDROID_KEY_ALIAS: ${{ secrets.android_key_alias }}
           ANDROID_KEY_PASSWORD: ${{ secrets.android_key_password }}
+          # Pass current build date
+          BUILD_DATE: ${{ github.event.repository.updated_at }}
 
       - name: Create Github release
         uses: softprops/action-gh-release@v2

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,20 +11,6 @@ plugins {
     alias(libs.plugins.ksp)
 }
 
-fun runCommand(vararg command: String): String {
-    val process = ProcessBuilder(*command)
-        .directory(rootDir)
-        .redirectErrorStream(true)
-        .start()
-    val reader = process.inputStream.bufferedReader()
-    val builder = StringBuilder()
-    var line: String?
-    while (reader.readLine().also { line = it } != null) {
-        builder.appendLine(line)
-    }
-    return builder.toString()
-}
-
 // Android configuration
 android {
     compileSdk = 34
@@ -34,9 +20,6 @@ android {
 
         versionCode = 404030000
         versionName = "4.4.3-alpha.1"
-
-        val buildTime = runCommand("git", "log", "-1", "--pretty=%ct").trim()
-        buildConfigField("long", "buildTime", "${buildTime}000L")
 
         setProperty("archivesBaseName", "davx5-ose-$versionName")
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,3 @@
-import java.io.OutputStream
-import java.time.Instant
-
 /***************************************************************************************************
  * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  **************************************************************************************************/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,4 @@
+import java.io.OutputStream
 import java.time.Instant
 
 /***************************************************************************************************
@@ -13,6 +14,20 @@ plugins {
     alias(libs.plugins.ksp)
 }
 
+fun runCommand(vararg command: String): String {
+    val process = ProcessBuilder(*command)
+        .directory(rootDir)
+        .redirectErrorStream(true)
+        .start()
+    val reader = process.inputStream.bufferedReader()
+    val builder = StringBuilder()
+    var line: String?
+    while (reader.readLine().also { line = it } != null) {
+        builder.appendLine(line)
+    }
+    return builder.toString()
+}
+
 // Android configuration
 android {
     compileSdk = 34
@@ -23,15 +38,8 @@ android {
         versionCode = 404030000
         versionName = "4.4.3-alpha.1"
 
-        val buildDate = System.getenv("BUILD_DATE")
-        val buildTime = if (buildDate != null) {
-            // BUILD_DATE is passed by github as ISO 8601. eg. 2021-09-30T12:00:00Z
-            // Convert the string to an epoch timestamp
-            Instant.parse(buildDate).toEpochMilli()
-        } else {
-            System.currentTimeMillis()
-        }
-        buildConfigField("long", "buildTime", "${buildTime}L")
+        val buildTime = runCommand("git", "log", "-1", "--pretty=%ct").trim()
+        buildConfigField("long", "buildTime", "${buildTime}000L")
 
         setProperty("archivesBaseName", "davx5-ose-$versionName")
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.time.Instant
+
 /***************************************************************************************************
  * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  **************************************************************************************************/
@@ -21,7 +23,15 @@ android {
         versionCode = 404030000
         versionName = "4.4.3-alpha.1"
 
-        buildConfigField("long", "buildTime", "${System.currentTimeMillis()}L")
+        val buildDate = System.getenv("BUILD_DATE")
+        val buildTime = if (buildDate != null) {
+            // BUILD_DATE is passed by github as ISO 8601. eg. 2021-09-30T12:00:00Z
+            // Convert the string to an epoch timestamp
+            Instant.parse(buildDate).toEpochMilli()
+        } else {
+            System.currentTimeMillis()
+        }
+        buildConfigField("long", "buildTime", "${buildTime}L")
 
         setProperty("archivesBaseName", "davx5-ose-$versionName")
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -128,6 +128,10 @@ ksp {
     arg("room.schemaLocation", "$projectDir/schemas")
 }
 
+aboutLibraries {
+    excludeFields = arrayOf("generated")
+}
+
 configurations {
     configureEach {
         // exclude modules which are in conflict with system libraries

--- a/app/src/main/kotlin/at/bitfire/davdroid/network/HttpClient.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/network/HttpClient.kt
@@ -22,6 +22,21 @@ import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
+import java.io.File
+import java.net.InetSocketAddress
+import java.net.Proxy
+import java.net.Socket
+import java.security.KeyStore
+import java.security.Principal
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+import java.util.logging.Level
+import java.util.logging.Logger
+import javax.net.ssl.KeyManager
+import javax.net.ssl.SSLContext
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509ExtendedKeyManager
+import javax.net.ssl.X509TrustManager
 import kotlinx.coroutines.flow.MutableStateFlow
 import net.openid.appauth.AuthState
 import net.openid.appauth.AuthorizationService
@@ -36,23 +51,6 @@ import okhttp3.Response
 import okhttp3.brotli.BrotliInterceptor
 import okhttp3.internal.tls.OkHostnameVerifier
 import okhttp3.logging.HttpLoggingInterceptor
-import java.io.File
-import java.net.InetSocketAddress
-import java.net.Proxy
-import java.net.Socket
-import java.security.KeyStore
-import java.security.Principal
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
-import java.util.concurrent.TimeUnit
-import java.util.logging.Level
-import java.util.logging.Logger
-import javax.net.ssl.KeyManager
-import javax.net.ssl.SSLContext
-import javax.net.ssl.TrustManagerFactory
-import javax.net.ssl.X509ExtendedKeyManager
-import javax.net.ssl.X509TrustManager
 
 class HttpClient @AssistedInject constructor(
     @Assisted val okHttpClient: OkHttpClient,
@@ -319,10 +317,7 @@ class HttpClient @AssistedInject constructor(
 
     object UserAgentInterceptor: Interceptor {
 
-        // use Locale.ROOT because numbers may be encoded as non-ASCII characters in other locales
-        private val userAgentDateFormat = SimpleDateFormat("yyyy/MM/dd", Locale.ROOT)
-        private val userAgentDate = userAgentDateFormat.format(Date(BuildConfig.buildTime))
-        val userAgent = "DAVx5/${BuildConfig.VERSION_NAME} ($userAgentDate; dav4jvm; " +
+        val userAgent = "DAVx5/${BuildConfig.VERSION_NAME} (dav4jvm; " +
                 "okhttp/${OkHttp.VERSION}) Android/${Build.VERSION.RELEASE}"
 
         init {

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AboutActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AboutActivity.kt
@@ -284,14 +284,6 @@ fun AboutApp(licenseInfoProvider: AboutActivity.AppLicenseInfoProvider? = null) 
             textAlign = TextAlign.Center,
             modifier = Modifier.fillMaxWidth()
         )
-        val buildTime = LocalDateTime.ofEpochSecond(BuildConfig.buildTime / 1000, 0, ZoneOffset.UTC)
-        val dateFormatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT)
-        Text(
-            stringResource(R.string.about_build_date, dateFormatter.format(buildTime)),
-            style = MaterialTheme.typography.bodyLarge,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.fillMaxWidth()
-        )
 
         Text(
             stringResource(R.string.about_copyright),

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -54,7 +54,6 @@
   <!--AboutActivity-->
   <string name="about_libraries">المكتبات</string>
   <string name="about_version">النسخة %1$s (%2$d)</string>
-  <string name="about_build_date">التجميع على %s</string>
   <string name="about_license_info_no_warranty">يقدَّم هذا البرنامج دون أدنى مسؤولية.  إنه برنامج حر، وندعوك لإعادة توزيعه حسب أحكام محددة.</string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">لا يمكن إنشاء ملف سجل</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -91,7 +91,6 @@
   <string name="about_translations">Преводи</string>
   <string name="about_libraries">Библиотеки</string>
   <string name="about_version">Издание %1$s (%2$d)</string>
-  <string name="about_build_date">Компилирано на %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) и сътрудници</string>
   <string name="about_license_info_no_warranty">Тази програма се предлага с АБСОЛЮТНО НИКАКВА ГАРАНЦИЯ. Тя е свободен софтуер и можете да я разпространявате при определени условия.</string>
   <!--global settings-->

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -96,7 +96,6 @@
   <string name="about_translations">Traduccions</string>
   <string name="about_libraries">Biblioteques</string>
   <string name="about_version">Versió %1$s (%2$d)</string>
-  <string name="about_build_date">Compilat el %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) i col·laboradors</string>
   <string name="about_license_info_no_warranty">Aquest programa és distribuït sense CAP MENA DE GARANTIA. És programari lliure, i està permesa la seva redistribució segons certes condicions.</string>
   <!--global settings-->

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -96,7 +96,6 @@
   <string name="about_translations">Překlady</string>
   <string name="about_libraries">Knihovny</string>
   <string name="about_version">Verze %1$s (%2$d)</string>
-  <string name="about_build_date">Sestaveno %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) a přispěvatelé</string>
   <string name="about_license_info_no_warranty">Na tento program nejsou poskytovány ŽÁDNÉ ZÁRUKY. Jedná se o svobodný software a jeho šíření dál je vítáno, ovšem za podmínky, že stejné svobody zůstanou zachovány i všem dalším příjemcům.</string>
   <!--global settings-->

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -96,7 +96,6 @@
   <string name="about_translations">Oversættelser</string>
   <string name="about_libraries">Biblioteker</string>
   <string name="about_version">Version %1$s (%2$d)</string>
-  <string name="about_build_date">Oversat den %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) og bidragydere</string>
   <string name="about_license_info_no_warranty">Dette program leveres ABSOLUT UDEN GARANTI. Det er fri software, og du er velkommen til at videredistribuere det under visse betingelse.</string>
   <!--global settings-->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -96,7 +96,6 @@
   <string name="about_translations">Übersetzungen</string>
   <string name="about_libraries">Bibliotheken</string>
   <string name="about_version">Version %1$s (%2$d)</string>
-  <string name="about_build_date">Erstellt am %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) und Mitwirkende</string>
   <string name="about_license_info_no_warranty">Dieses Programm wird OHNE JEDE GEWÄHRLEISTUNG bereitgestellt. Es ist freie Software – Sie können es also unter bestimmten Bedingungen weiterverbreiten.</string>
   <!--global settings-->

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -73,7 +73,6 @@
   <string name="about_translations">Μεταφράσεις</string>
   <string name="about_libraries">Βιβλιοθήκες</string>
   <string name="about_version">Έκδοση %1$s (%2$d)</string>
-  <string name="about_build_date">Μεταγλωττισμένο σε %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) και συνεργάτες</string>
   <string name="about_license_info_no_warranty">Αυτό το πρόγραμμα συνοδεύεται χωρις ΚΑΜΙΑ ΕΓΓΥΗΣΗ. Είναι ελεύθερο λογισμικό και είστε ευπρόσδεκτοι να το αναδιανείμετε υπό ορισμένες προϋποθέσεις.</string>
   <!--global settings-->

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -89,7 +89,6 @@
   <string name="about_translations">Translations</string>
   <string name="about_libraries">Libraries</string>
   <string name="about_version">Version %1$s (%2$d)</string>
-  <string name="about_build_date">Compiled on %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) and contributors</string>
   <string name="about_license_info_no_warranty">This program comes with ABSOLUTELY NO WARRANTY. It is free software, and you are welcome to redistribute it under certain conditions.</string>
   <!--global settings-->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -96,7 +96,6 @@
   <string name="about_translations">Traducciones</string>
   <string name="about_libraries">Bibliotecas</string>
   <string name="about_version">Versión %1$s (%2$d)</string>
-  <string name="about_build_date">Compilada en %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) y colaboradores </string>
   <string name="about_license_info_no_warranty">Este programa viene sin NINGÚN TIPO DE GARANTÍA. Es software libre, y cualquier contribución es bienvenida y redistribuida bajo ciertas condiciones.</string>
   <!--global settings-->

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -97,7 +97,6 @@
   <string name="about_translations">Itzulpenak</string>
   <string name="about_libraries">Liburutegiak</string>
   <string name="about_version">%1$s (%2$d) bertsioa</string>
-  <string name="about_build_date">%s(e)an konpilatuta</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) eta kolaboratzaileak</string>
   <string name="about_license_info_no_warranty">Programa hau INOLAKO BERMERIK GABE dator. Software librea da, eta birbanatzeko baimena duzu baldintza batzuk kontuan hartuz.</string>
   <!--global settings-->

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -89,7 +89,6 @@
   <string name="about_translations">ترجمه ها</string>
   <string name="about_libraries">کتابخانه ها</string>
   <string name="about_version">ورژن %1$s (%2$d)</string>
-  <string name="about_build_date">در %s وارد شده است</string>
   <string name="about_license_info_no_warranty">این برنامه کاملاً بدون ضمانت است. این یک نرم افزار رایگان است ، و شما می توانید تحت شرایط خاص توزیع مجدد آن را انجام دهید.</string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">پرونده ثبت ایجاد نشد</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -95,7 +95,6 @@
   <string name="about_translations">Traductions</string>
   <string name="about_libraries">Librairies</string>
   <string name="about_version">Version %1$s (%2$d)</string>
-  <string name="about_build_date">Générée le %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) et les contributeurs</string>
   <string name="about_license_info_no_warranty">Ce programme est fourni sans AUCUNE GARANTIE. C\'est un logiciel libre, et vous êtes en droit de le redistribuer sous certaines conditions.</string>
   <!--global settings-->

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -96,7 +96,6 @@
   <string name="about_translations">Traducións</string>
   <string name="about_libraries">Bibliotecas</string>
   <string name="about_version">Versión  %1$s (%2$d)</string>
-  <string name="about_build_date">Compilada en %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) e colaboradoras</string>
   <string name="about_license_info_no_warranty">Este programa non proporciona NINGUNHA GARANTÍA. É software libre, e convidámoste a redistribuílo baixo certas condicións.</string>
   <!--global settings-->

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -74,7 +74,6 @@
   <string name="about_translations">Prijevodi</string>
   <string name="about_libraries">Bibiloteke</string>
   <string name="about_version">Verzija %1$s(%2$d)</string>
-  <string name="about_build_date">Kompilirano na %s</string>
   <string name="about_license_info_no_warranty">Ovaj program dolazi BEZ APSOLUTNO BILO KAKVOG JAMSTVA. To je besplatni softver i možete ga distribuirati pod određenim uvjetima. </string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Couldn\'t create log file</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -95,7 +95,6 @@
   <string name="about_translations">Fordítások</string>
   <string name="about_libraries">Programkönyvtárak</string>
   <string name="about_version">Verziószám:%1$s (%2$d)</string>
-  <string name="about_build_date">Fordítás ideje: %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) és a közreműködők</string>
   <string name="about_license_info_no_warranty">Ehhez a program SEMMIFÉLE GARANCIA NEM JÁR. Szabad szoftver, amely bizonyos feltételek mellett szabadon terjeszthető.</string>
   <!--global settings-->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -85,7 +85,6 @@
   <string name="about_translations">Traduzioni</string>
   <string name="about_libraries">Librerie</string>
   <string name="about_version">Versione %1$s (%2$d)</string>
-  <string name="about_build_date">Compilato su %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) e contibutori</string>
   <string name="about_license_info_no_warranty">Il programma è distribuito SENZA ALCUNA GARANZIA. È software libero e può essere redistribuito sotto alcune condizioni.</string>
   <!--global settings-->

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -96,7 +96,6 @@
   <string name="about_translations">翻訳</string>
   <string name="about_libraries">ライブラリー</string>
   <string name="about_version">バージョン %1$s (%2$d)</string>
-  <string name="about_build_date">コンパイル日時 %s</string>
   <string name="about_copyright">© Ricki Hirner、Bernhard Stockmann (bitfire web engineering GmbH) と貢献者</string>
   <string name="about_license_info_no_warranty">このプログラムは完全に無保証で提供されます。これはフリーソフトウェアで、特定の条件下での再頒布を歓迎します。</string>
   <!--global settings-->

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -95,7 +95,6 @@
   <string name="about_translations">თარგმანი</string>
   <string name="about_libraries">ბიბლიოთეკები</string>
   <string name="about_version">ვერსია %1$s (%2$d)</string>
-  <string name="about_build_date">კომპილირებულია %s-ს</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) და მონაწილეები</string>
   <string name="about_license_info_no_warranty">ამ პროგრამას არ აქვს არანაირი გარანტია. იგი არის უფასო პროგრამული უზრუნველყოფა, ხოლო თქვენ შეგეძლეიათ იგი გაავრცელოთ გარკვეული პირობების გათვალისწინებით.</string>
   <!--global settings-->

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -82,7 +82,6 @@
   <string name="about_translations">번역</string>
   <string name="about_libraries">라이브러리</string>
   <string name="about_version">버전 %1$s (%2$d)</string>
-  <string name="about_build_date">%s에서 컴파일</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) and contributors</string>
   <string name="about_license_info_no_warranty">이 프로그램은 보증 없이 제공됩니다. 그것은 무료 소프트웨어이며, 특정한 조건 하에서 재배포하는 것을 환영합니다.</string>
   <!--global settings-->

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -22,7 +22,6 @@
   <!--AboutActivity-->
   <string name="about_libraries">Bibliotek</string>
   <string name="about_version">Versjon %1$s(%2$d)</string>
-  <string name="about_build_date">Kompilert på %s</string>
   <string name="about_license_info_no_warranty">Dette programmet kommer uten NOEN FORM FOR GARANTI. Det er fri programvare, og du er velkommen til å redistribuere det under gitte forhold.</string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Kan ikke opprette loggfil</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -96,7 +96,6 @@
   <string name="about_translations">Vertalingen</string>
   <string name="about_libraries">Bibliotheken</string>
   <string name="about_version">Versie%1$s (%2$d)</string>
-  <string name="about_build_date">Gecompileerd op %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) en bijdragers</string>
   <string name="about_license_info_no_warranty">Dit programma wordt geleverd met ABSOLUUT GEEN GARANTIE. Het is gratis software, en mag opnieuw worden verspreid onder bepaalde voorwaarden.</string>
   <!--global settings-->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -90,7 +90,6 @@
   <string name="about_translations">Tłumaczenia</string>
   <string name="about_libraries">Biblioteki</string>
   <string name="about_version">Wersja %1$s (%2$d)</string>
-  <string name="about_build_date">Skompilowano %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) i współpracownicy</string>
   <string name="about_license_info_no_warranty">Ten program jest ABSOLUTNIE BEZ GWARANCJI. To jest wolne oprogramowanie i mile widziane jest dalsze rozpowszechnianie go zgodnie z warunkami licencji.</string>
   <!--global settings-->

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -96,7 +96,6 @@
   <string name="about_translations">Traduções</string>
   <string name="about_libraries">Bibliotecas</string>
   <string name="about_version">Versão %1$s (%2$d)</string>
-  <string name="about_build_date">Compilado em %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) e contribuidores</string>
   <string name="about_license_info_no_warranty">Este programa é distribuído SEM NENHUMA GARANTIA. Ele é software livre e pode ser redistribuído sob algumas condições.</string>
   <!--global settings-->

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -96,7 +96,6 @@
   <string name="about_translations">Traduceri</string>
   <string name="about_libraries">Biblioteci</string>
   <string name="about_version">Versiune %1$s (%2$d)</string>
-  <string name="about_build_date">Compilată la %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (inginerie web bitfire GmbH) și contribuitori</string>
   <string name="about_license_info_no_warranty">Acest program vine cu ABSOLUT NICIO GARANȚIE. Este software gratuit și ești binevenit să îl redistribui în anumite condiții.</string>
   <!--global settings-->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -96,7 +96,6 @@
   <string name="about_translations">Переводы</string>
   <string name="about_libraries">Библиотеки</string>
   <string name="about_version">Версия %1$s (%2$d)</string>
-  <string name="about_build_date">Скомпилировано %s</string>
   <string name="about_copyright">© Рикки Хирнер (Ricki Hirner), Бернхард Штокманн (Bernhard Stockmann) (bitfire web engineering GmbH) и контрибьюторы</string>
   <string name="about_license_info_no_warranty">Эта программа поставляется БЕЗ КАКИХ-ЛИБО ГАРАНТИЙ. Это свободное программное обеспечение и вы можете распространять его при соблюдении определенных условий.</string>
   <!--global settings-->

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -21,7 +21,6 @@
   <!--AboutActivity-->
   <string name="about_libraries">Knižnice</string>
   <string name="about_version">Verzia %1$s (%2$d)</string>
-  <string name="about_build_date">Preložené na %s</string>
   <string name="about_license_info_no_warranty">Tento program sa poskytuje BEZ AKEJKOĽVEK ZÁRUKY. Je to slobodný softvér a môžete ho ďalej šíriť pri splnení určitých podmienok.</string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Nie je možné vytvoriť súbor protokolu</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -52,7 +52,6 @@
   <!--AboutActivity-->
   <string name="about_libraries">Knjižnice </string>
   <string name="about_version">Verzija %1$s (%2$d)</string>
-  <string name="about_build_date">Združeno na %s</string>
   <string name="about_license_info_no_warranty">Ta program ne vsebuje NIČ garancije. To je brezplačna programska oprema in jo lahko pod določenimi pogoji delite naprej.</string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Ni bilo mogoče ustvariti zapisnika</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -84,7 +84,6 @@
   <string name="about_translations">Преводи</string>
   <string name="about_libraries">Библиотеке</string>
   <string name="about_version">Издање %1$s (%2$d)</string>
-  <string name="about_build_date">Компилован %s</string>
   <string name="about_license_info_no_warranty">Овај програм НЕМА НИКАКВЕ ГАРАНЦИЈЕ. Бесплатан је софтвер којег можете слободно да делите под одређеним условима.</string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Није се могла направити датотека записа</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -95,7 +95,6 @@
   <string name="about_translations">Översättningar</string>
   <string name="about_libraries">Bibliotek</string>
   <string name="about_version">Version %1$s (%2$d)</string>
-  <string name="about_build_date">Kompilerad på %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) och bidragsgivare</string>
   <string name="about_license_info_no_warranty">Detta program levereras med ABSOLUT INGEN GARANTI. Det är fri programvara, och du kan vidaredistribuera den under vissa förutsättningar.</string>
   <!--global settings-->

--- a/app/src/main/res/values-szl/strings.xml
+++ b/app/src/main/res/values-szl/strings.xml
@@ -37,7 +37,6 @@
   <string name="about_translations">Przekłady</string>
   <string name="about_libraries">Bibliotyki</string>
   <string name="about_version">Wersyjo %1$s (%2$d)</string>
-  <string name="about_build_date">Skōmpilowano %s</string>
   <string name="about_license_info_no_warranty">Tyn program przichodzi BEZ ŻODNYJ GWARANCYJE. To je wolne ôprogramowanie i możesz je rozkludzać pod ôkryślōnymi warōnkami.</string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Niy szło stworzić zbioru dziynnika</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -49,7 +49,6 @@
   <string name="about_translations">Переклади</string>
   <string name="about_libraries">Бібліотеки</string>
   <string name="about_version">Версія %1$s (%2$d)</string>
-  <string name="about_build_date">Складено на %s</string>
   <string name="about_license_info_no_warranty">Цей програмний засіб постачається АБСОЛЮТНО БЕЗ БУДЬ-ЯКИХ ГАРАНТІЙ. Це вільне програмне забезпечення, і ви можете поширювати її, за деякими умовами.</string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">Не вдалося створити файл звіту</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -84,7 +84,6 @@
   <string name="about_translations">Bản dịch</string>
   <string name="about_libraries">Thư viện</string>
   <string name="about_version">Phiên bản %1$s (%2$d)</string>
-  <string name="about_build_date">Biên dịch vào %s</string>
   <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) và những người đóng góp</string>
   <string name="about_license_info_no_warranty">Chương trình này KHÔNG CÓ SỰ ĐẢM BẢO NÀO. Nó là phần mềm tự do, và bạn có thể tuỳ ý phân phối lại nó dưới các điều kiện cụ thể. </string>
   <!--global settings-->

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -44,7 +44,6 @@
   <!--AboutActivity-->
   <string name="about_libraries">函式庫</string>
   <string name="about_version">版本號 %1$s（%2$d）</string>
-  <string name="about_build_date">編譯於 %s</string>
   <string name="about_license_info_no_warranty">我們｢完全不保證｣本程式無瑕疵。這是個自由軟體，歡迎您在符合公用授權條款的情況下任意散布它。</string>
   <!--global settings-->
   <string name="logging_couldnt_create_file">無法創建事項記錄文檔</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -96,7 +96,6 @@
   <string name="about_translations">翻译</string>
   <string name="about_libraries">程序库</string>
   <string name="about_version">版本 %1$s (%2$d)</string>
-  <string name="about_build_date">编译于 %s</string>
   <string name="about_copyright">©Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) 及贡献者</string>
   <string name="about_license_info_no_warranty">本程序不附带任何担保。这是一款自由软件，你可以有条件地传播它。</string>
   <!--global settings-->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,7 +108,6 @@
     <string name="about_translations">Translations</string>
     <string name="about_libraries">Libraries</string>
     <string name="about_version">Version %1$s (%2$d)</string>
-    <string name="about_build_date">Compiled on %s</string>
     <string name="about_copyright">© Ricki Hirner, Bernhard Stockmann (bitfire web engineering GmbH) and contributors</string>
     <string name="about_license_info_no_warranty">This program comes with ABSOLUTELY NO WARRANTY. It is free software, and you are welcome to redistribute it under certain conditions.</string>
 


### PR DESCRIPTION
### Purpose

Followed instructions by @obfusk. See #991

### Short description

~By default, the `BuildConfig.buildTime` field is still always `System.currentTimeMillis()`, but an environment variable can be passed (`BUILD_DATE`) with an ISO 8601 date, that will override this value if set. This allows the Github's workflow to pass a more "deterministic" date than the moment at which the project is built, which may differ a lot between runs.~

Edit: Got rid of `BuildConfig.buildTime`

Also disabled the `generated` field from About Libraries as requested.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

