### PR TITLE
lint fails in AboutActivity

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -87,7 +87,7 @@ android {
     }
 
     lint {
-        disable += arrayOf("GoogleAppIndexingWarning", "ImpliedQuantity", "MissingQuantity", "MissingTranslation", "ExtraTranslation", "RtlEnabled", "RtlHardcoded", "Typos", "NullSafeMutableLiveData")
+        disable += arrayOf("GoogleAppIndexingWarning", "ImpliedQuantity", "MissingQuantity", "MissingTranslation", "ExtraTranslation", "RtlEnabled", "RtlHardcoded", "Typos", "NullSafeMutableLiveData", "CoroutineCreationDuringComposition")
     }
 
     packaging {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -87,7 +87,10 @@ android {
     }
 
     lint {
-        disable += arrayOf("GoogleAppIndexingWarning", "ImpliedQuantity", "MissingQuantity", "MissingTranslation", "ExtraTranslation", "RtlEnabled", "RtlHardcoded", "Typos", "NullSafeMutableLiveData", "CoroutineCreationDuringComposition")
+        disable += arrayOf("GoogleAppIndexingWarning", "ImpliedQuantity", "MissingQuantity", "MissingTranslation", "ExtraTranslation", "RtlEnabled", "RtlHardcoded", "Typos", "NullSafeMutableLiveData")
+        // TODO: Remove on the next Compose release, should be fixed
+        // Maybe related to https://issuetracker.google.com/issues/298483892
+        disable += "CoroutineCreationDuringComposition"
     }
 
     packaging {


### PR DESCRIPTION
### Purpose

lint fails with:

```
 /home/runner/work/davx5-ose/davx5-ose/app/src/main/kotlin/at/bitfire/davdroid/ui/AboutActivity.kt: Error: Unexpected failure during lint analysis of AboutActivity.kt (this is a bug in lint or one of the libraries it depends on)
```

https://github.com/bitfireAT/davx5-ose/actions/runs/10698537347/job/29663348020

### Short description

It _looks like_ a bug in lint directly, it's crashing in `AboutActivity`, but for example, in ICSx5 fails in `EnterUrlComposable` ([see](https://github.com/bitfireAT/icsx5/actions/runs/10620217450/job/29469650938)). I think it all comes from the same place. I couldn't find anything on Google, but I guess it's related to Compose, maybe it will get fixed in a future version.

I've disabled `CoroutineCreationDuringComposition`, which of course doesn't solve anything, but at least compiles correctly.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

