### PR TITLE
Increase SDK level to 35

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 
 // Android configuration
 android {
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "at.bitfire.davdroid"
@@ -26,7 +26,7 @@ android {
         setProperty("archivesBaseName", "davx5-ose-$versionName")
 
         minSdk = 24        // Android 7.0
-        targetSdk = 34     // Android 14
+        targetSdk = 35     // Android 15
 
         testInstrumentationRunner = "at.bitfire.davdroid.HiltTestRunner"
     }


### PR DESCRIPTION
### Purpose

Increase target SDK level to 35 in order to support Android 15.

### Short description

See #997

### Checklist

- [ ] The PR has a proper title, description and label.
- [ ] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [ ] I have added documentation to complex functions and functions that can be used by other modules.
- [ ] I have added reasonable tests or consciously decided to not add tests.

