### PR TITLE
Unsubscribe push from unsynced collections

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/db/CollectionDao.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/db/CollectionDao.kt
@@ -88,7 +88,7 @@ interface CollectionDao {
     suspend fun updateForceReadOnly(id: Long, forceReadOnly: Boolean)
 
     @Query("UPDATE collection SET pushSubscription=:pushSubscription, pushSubscriptionCreated=:updatedAt WHERE id=:id")
-    suspend fun updatePushSubscription(id: Long, pushSubscription: String, updatedAt: Long = System.currentTimeMillis())
+    fun updatePushSubscription(id: Long, pushSubscription: String?, updatedAt: Long = System.currentTimeMillis())
 
     @Query("UPDATE collection SET sync=:sync WHERE id=:id")
     suspend fun updateSync(id: Long, sync: Boolean)

--- a/app/src/main/kotlin/at/bitfire/davdroid/db/CollectionDao.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/db/CollectionDao.kt
@@ -72,6 +72,9 @@ interface CollectionDao {
     @Query("SELECT * FROM collection WHERE sync AND supportsWebPush AND pushTopic IS NOT NULL")
     suspend fun getPushCapableSyncCollections(): List<Collection>
 
+    @Query("SELECT * FROM collection WHERE pushSubscription IS NOT NULL AND NOT sync")
+    suspend fun getPushRegisteredAndNotSyncable(): List<Collection>
+
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     fun insert(collection: Collection): Long
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
@@ -246,7 +246,7 @@ class DavCollectionRepository @Inject constructor(
         notifyOnChangeListeners()
     }
 
-    suspend fun updatePushSubscription(id: Long, subscriptionUrl: String) {
+    fun updatePushSubscription(id: Long, subscriptionUrl: String?) {
         dao.updatePushSubscription(id, subscriptionUrl)
     }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
@@ -6,8 +6,6 @@ package at.bitfire.davdroid.repository
 
 import android.accounts.Account
 import android.content.Context
-import android.provider.CalendarContract
-import android.provider.ContactsContract
 import at.bitfire.dav4jvm.DavResource
 import at.bitfire.dav4jvm.XmlUtils
 import at.bitfire.dav4jvm.XmlUtils.insertTag
@@ -29,7 +27,6 @@ import at.bitfire.davdroid.network.HttpClient
 import at.bitfire.davdroid.servicedetection.RefreshCollectionsWorker
 import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.util.DavUtils
-import at.bitfire.ical4android.TaskProvider
 import at.bitfire.ical4android.util.DateUtils
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -196,8 +193,11 @@ class DavCollectionRepository @Inject constructor(
     fun getSyncTaskLists(serviceId: Long) = dao.getSyncTaskLists(serviceId)
 
     /** Returns all collections that are both selected for synchronization and push-capable. */
-    suspend fun getSyncableAndPushCapable(): List<Collection> =
+    suspend fun getPushCapableAndSyncable(): List<Collection> =
         dao.getPushCapableSyncCollections()
+
+    suspend fun getPushRegisteredAndNotSyncable(): List<Collection> =
+        dao.getPushRegisteredAndNotSyncable()
 
     /**
      * Inserts or updates the collection. On update it will not update flag values ([Collection.sync],


### PR DESCRIPTION
### Purpose

Adds functionality: when collections are

1. registered for Push and then
2. unselected (and thus not syncable anymore),

they shall be unregistered from the server.


### Short description

`PushRegistrationWorker` scans for collections that are registered for Push, but not selected for synchronization, and unregisters them from Push.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

