### PR TITLE
Reword login text

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
@@ -343,12 +343,19 @@ fun AccountList(
 ) {
     Column(modifier) {
         if (accounts.isEmpty())
-            Box(
-                contentAlignment = Alignment.Center,
+            Column(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(8.dp)
             ) {
+                Text(
+                    text = stringResource(R.string.account_list_welcome),
+                    style = MaterialTheme.typography.headlineSmall,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 16.dp, bottom = 32.dp)
+                )
                 Text(
                     text = stringResource(R.string.account_list_empty),
                     style = MaterialTheme.typography.headlineSmall,

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/AccountDetailsPage.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/AccountDetailsPage.kt
@@ -93,7 +93,7 @@ fun AccountDetailsPageContent(
     creatingAccount: Boolean
 ) {
     Assistant(
-        nextLabel = stringResource(R.string.login_add_account),
+        nextLabel = stringResource(R.string.login_finish),
         onNext = onCreateAccount,
         nextEnabled = !creatingAccount && accountName.isNotBlank() && !accountNameAlreadyExists
     ) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -142,7 +142,8 @@
     <string name="account_list_manage_battery_saver">Manage battery saver</string>
     <string name="account_list_low_storage">Storage space low. Android will not sync local changes immediately, but during the next regular sync.</string>
     <string name="account_list_manage_storage">Manage storage</string>
-    <string name="account_list_empty">Welcome to DAVx⁵!\n\nYou can add a CalDAV/CardDAV account now.</string>
+    <string name="account_list_welcome">Welcome to DAVx⁵!</string>
+    <string name="account_list_empty">Connect to your server and keep your calendars and contacts synchronized.</string>
     <string name="accounts_sync_all">Sync all accounts</string>
 
     <!-- RefreshCollectionsWorker -->
@@ -244,6 +245,7 @@
 
     <!-- AddAccountActivity -->
     <string name="login_title">Add account</string>
+    <string name="login_privacy_hint"><![CDATA[All data will only be transferred between your server and your device. %1$s will not send them anywhere else. See <a href=\"%2$s\">privacy policy</a>.]]></string>
     <string name="login_generic_login">Generic login</string>
     <string name="login_provider_login">Provider-specific login</string>
     <string name="login_continue">Continue</string>
@@ -270,6 +272,7 @@
     <string name="login_account_name_required">Account name required</string>
     <string name="login_account_name_already_taken">Account name already taken</string>
     <string name="login_account_not_added">Account could not be added</string>
+    <string name="login_finish">Finish</string>
     <string name="login_type_advanced">Advanced login</string>
     <string name="login_no_client_certificate_optional">No client certificate*</string>
     <string name="login_client_certificate_selected">Client certificate: %s</string>

--- a/app/src/ose/kotlin/at/bitfire/davdroid/ui/setup/StandardLoginTypePage.kt
+++ b/app/src/ose/kotlin/at/bitfire/davdroid/ui/setup/StandardLoginTypePage.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.DividerDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
@@ -17,14 +19,22 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.text.HtmlCompat
+import at.bitfire.davdroid.Constants
+import at.bitfire.davdroid.Constants.withStatParams
 import at.bitfire.davdroid.R
+import at.bitfire.davdroid.ui.UiUtils.toAnnotatedString
 import at.bitfire.davdroid.ui.composable.Assistant
+import at.bitfire.davdroid.ui.widget.ClickableTextWithLink
 
 @Composable
 fun StandardLoginTypePage(
     selectedLoginType: LoginType,
     onSelectLoginType: (LoginType) -> Unit,
+
+    @Suppress("UNUSED_PARAMETER")   // for build variants
     setInitialLoginInfo: (LoginInfo) -> Unit,
+    
     onContinue: () -> Unit = {}
 ) {
     Assistant(
@@ -56,6 +66,20 @@ fun StandardLoginTypePage(
                     selected = type == selectedLoginType,
                     onSelect = { onSelectLoginType(type) }
                 )
+
+            HorizontalDivider(Modifier.padding(vertical = 12.dp))
+
+            val privacyPolicy = Constants.HOMEPAGE_URL.buildUpon()
+                .appendPath(Constants.HOMEPAGE_PATH_PRIVACY)
+                .withStatParams("StandardLoginTypePage")
+                .build().toString()
+            val privacy = HtmlCompat.fromHtml(
+                stringResource(R.string.login_privacy_hint, stringResource(R.string.app_name), privacyPolicy),
+                HtmlCompat.FROM_HTML_MODE_COMPACT)
+            ClickableTextWithLink(
+                privacy.toAnnotatedString(),
+                style = MaterialTheme.typography.bodyMedium
+            )
         }
     }
 }
@@ -89,9 +113,11 @@ fun LoginTypeSelector(
 
 @Composable
 @Preview
-fun LoginScreen_Preview() {
-    /*LoginScreen(
-        loginTypesProvider = StandardLoginTypesProvider(),
-        initialLoginType = LoginTypeUrl
-    )*/
+fun StandardLoginTypePage_Preview() {
+    StandardLoginTypePage(
+        selectedLoginType = StandardLoginTypesProvider.genericLoginTypes.first(),
+        onSelectLoginType = {},
+        setInitialLoginInfo = {},
+        onContinue = {}
+    )
 }


### PR DESCRIPTION
### Purpose

It was not clear what "Add account" does, especially that it doesn't just sign in to an app-proprietary hosted account like for 99.9% of the apps. This was also the reason that Google had sometimes rejected the app because they didn't "get a test account on our server".

We

- split _Welcome_ and the welcome text for easier translations,
- make it clear that it's about a user server → empty accounts text, privacy note
- decided to keep the words
  - _Add account_ for the whole process of adding an account and
  - _Login_ for the first step of this process
- changed the last button to _Finish_ to distinguish between the title of the whole process (_Add account_) and the specific step.


### Short description

- Change empty accounts text
- Add privacy note to Login screen
- Changed last button text


### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

