### PR TITLE
[Nextcloud login flow] No login after returning from custom tabs when on low memory

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.hilt)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.ksp)
 }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/db/Credentials.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/db/Credentials.kt
@@ -4,16 +4,20 @@
 
 package at.bitfire.davdroid.db
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.RawValue
 import net.openid.appauth.AuthState
 
+@Parcelize
 data class Credentials(
     val username: String? = null,
     val password: String? = null,
 
     val certificateAlias: String? = null,
 
-    val authState: AuthState? = null
-) {
+    val authState: @RawValue AuthState? = null
+): Parcelable {
 
     override fun toString(): String {
         val s = mutableListOf<String>()

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/AdvancedLogin.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/AdvancedLogin.kt
@@ -39,8 +39,10 @@ import at.bitfire.davdroid.ui.UiUtils.toAnnotatedString
 import at.bitfire.davdroid.ui.composable.Assistant
 import at.bitfire.davdroid.ui.composable.PasswordTextField
 import at.bitfire.davdroid.ui.composable.SelectClientCertificateCard
+import kotlinx.parcelize.Parcelize
 
-object AdvancedLogin : LoginType {
+@Parcelize
+data object AdvancedLogin : LoginType {
 
     override val title: Int
         get() = R.string.login_type_advanced

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/EmailLogin.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/EmailLogin.kt
@@ -36,8 +36,10 @@ import at.bitfire.davdroid.R
 import at.bitfire.davdroid.ui.UiUtils.toAnnotatedString
 import at.bitfire.davdroid.ui.composable.Assistant
 import at.bitfire.davdroid.ui.composable.PasswordTextField
+import kotlinx.parcelize.Parcelize
 
-object EmailLogin : LoginType {
+@Parcelize
+data object EmailLogin : LoginType {
 
     override val title: Int
         get() = R.string.login_type_email

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/GoogleLogin.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/GoogleLogin.kt
@@ -52,8 +52,11 @@ import at.bitfire.davdroid.ui.UiUtils.toAnnotatedString
 import at.bitfire.davdroid.ui.setup.GoogleLogin.GOOGLE_POLICY_URL
 import java.util.logging.Level
 import java.util.logging.Logger
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
 
-object GoogleLogin : LoginType {
+@Parcelize
+data object GoogleLogin : LoginType {
 
     override val title: Int
         get() = R.string.login_type_google
@@ -67,10 +70,12 @@ object GoogleLogin : LoginType {
 
 
     // Google API Services User Data Policy
+    @IgnoredOnParcel
     const val GOOGLE_POLICY_URL =
         "https://developers.google.com/terms/api-services-user-data-policy#additional_requirements_for_specific_api_scopes"
 
     // Support site
+    @IgnoredOnParcel
     val URI_TESTED_WITH_GOOGLE: Uri =
         Constants.HOMEPAGE_URL.buildUpon()
             .appendPath(Constants.HOMEPAGE_PATH_TESTED_SERVICES)

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginInfo.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginInfo.kt
@@ -4,10 +4,13 @@
 
 package at.bitfire.davdroid.ui.setup
 
+import android.os.Parcelable
 import at.bitfire.davdroid.db.Credentials
 import at.bitfire.vcard4android.GroupMethod
 import java.net.URI
+import kotlinx.parcelize.Parcelize
 
+@Parcelize
 data class LoginInfo(
     val baseUri: URI? = null,
     val credentials: Credentials? = null,
@@ -16,4 +19,4 @@ data class LoginInfo(
 
     /** group method that should be pre-selected */
     val suggestedGroupMethod: GroupMethod = GroupMethod.GROUP_VCARDS
-)
+): Parcelable

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
@@ -37,8 +37,10 @@ import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
 
+@OptIn(SavedStateHandleSaveableApi::class)
 @HiltViewModel(assistedFactory = LoginScreenModel.Factory::class)
 class LoginScreenModel @AssistedInject constructor(
+    savedStateHandle: SavedStateHandle,
     @Assisted val initialLoginType: LoginType,
     @Assisted val skipLoginTypePage: Boolean,
     @Assisted val initialLoginInfo: LoginInfo,
@@ -71,10 +73,14 @@ class LoginScreenModel @AssistedInject constructor(
     else
         Page.LoginType
 
-    var page by mutableStateOf(startPage)
+    var page by savedStateHandle.saveable {
+        mutableStateOf(startPage)
+    }
         private set
 
-    var finish by mutableStateOf(false)
+    var finish by savedStateHandle.saveable {
+        mutableStateOf(false)
+    }
         private set
 
 
@@ -146,7 +152,9 @@ class LoginScreenModel @AssistedInject constructor(
         val loginType: LoginType
     ): Parcelable
 
-    var loginTypeUiState by mutableStateOf(LoginTypeUiState(loginType = initialLoginType))
+    var loginTypeUiState by savedStateHandle.saveable {
+        mutableStateOf(LoginTypeUiState(loginType = initialLoginType))
+    }
         private set
 
     fun selectLoginType(loginType: LoginType) {
@@ -166,10 +174,14 @@ class LoginScreenModel @AssistedInject constructor(
         val loginInfo: LoginInfo
     ): Parcelable
 
-    var loginDetailsUiState by mutableStateOf(LoginDetailsUiState(
-        loginType = initialLoginType,
-        loginInfo = loginInfo
-    ))
+    var loginDetailsUiState by savedStateHandle.saveable {
+        mutableStateOf(
+            LoginDetailsUiState(
+                loginType = initialLoginType,
+                loginInfo = loginInfo
+            )
+        )
+    }
         private set
 
     fun updateLoginInfo(loginInfo: LoginInfo) {
@@ -187,7 +199,9 @@ class LoginScreenModel @AssistedInject constructor(
         val logs: String? = null
     ): Parcelable
 
-    var detectResourcesUiState by mutableStateOf(DetectResourcesUiState())
+    var detectResourcesUiState by savedStateHandle.saveable {
+        mutableStateOf(DetectResourcesUiState())
+    }
         private set
 
     private var foundConfig: DavResourceFinder.Configuration? = null

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
@@ -6,11 +6,13 @@ package at.bitfire.davdroid.ui.setup
 
 import android.accounts.Account
 import android.content.Context
-import androidx.compose.runtime.getValue
+import android.os.Parcelable
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.compose.SavedStateHandleSaveableApi
+import androidx.lifecycle.viewmodel.compose.saveable
 import at.bitfire.davdroid.repository.AccountRepository
 import at.bitfire.davdroid.servicedetection.DavResourceFinder
 import at.bitfire.davdroid.settings.AccountSettings
@@ -21,6 +23,7 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.logging.Logger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -32,7 +35,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withContext
-import java.util.logging.Logger
+import kotlinx.parcelize.Parcelize
 
 @HiltViewModel(assistedFactory = LoginScreenModel.Factory::class)
 class LoginScreenModel @AssistedInject constructor(
@@ -138,9 +141,10 @@ class LoginScreenModel @AssistedInject constructor(
 
     // UI element state – first page: login type
 
+    @Parcelize
     data class LoginTypeUiState(
         val loginType: LoginType
-    )
+    ): Parcelable
 
     var loginTypeUiState by mutableStateOf(LoginTypeUiState(loginType = initialLoginType))
         private set
@@ -156,10 +160,11 @@ class LoginScreenModel @AssistedInject constructor(
     // base URI and credentials
     private var loginInfo: LoginInfo = initialLoginInfo
 
+    @Parcelize
     data class LoginDetailsUiState(
         val loginType: LoginType,
         val loginInfo: LoginInfo
-    )
+    ): Parcelable
 
     var loginDetailsUiState by mutableStateOf(LoginDetailsUiState(
         loginType = initialLoginType,
@@ -174,12 +179,13 @@ class LoginScreenModel @AssistedInject constructor(
 
     // UI element state – third page: detect resources
 
+    @Parcelize
     data class DetectResourcesUiState(
         val loading: Boolean = false,
         val foundNothing: Boolean = false,
         val encountered401: Boolean = false,
         val logs: String? = null
-    )
+    ): Parcelable
 
     var detectResourcesUiState by mutableStateOf(DetectResourcesUiState())
         private set

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginType.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginType.kt
@@ -5,10 +5,13 @@
 package at.bitfire.davdroid.ui.setup
 
 import android.net.Uri
+import android.os.Parcelable
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
+import kotlinx.parcelize.Parcelize
 
-interface LoginType {
+@Parcelize
+sealed interface LoginType: Parcelable {
 
     val title: Int
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/NextcloudLogin.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/NextcloudLogin.kt
@@ -49,8 +49,10 @@ import at.bitfire.davdroid.ui.UiUtils.haveCustomTabs
 import at.bitfire.davdroid.ui.composable.Assistant
 import at.bitfire.davdroid.ui.composable.ProgressBar
 import kotlinx.coroutines.launch
+import kotlinx.parcelize.Parcelize
 
-object NextcloudLogin : LoginType {
+@Parcelize
+data object NextcloudLogin : LoginType {
 
     override val title: Int
         get() = R.string.login_type_nextcloud

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/UrlLogin.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/UrlLogin.kt
@@ -37,8 +37,10 @@ import at.bitfire.davdroid.R
 import at.bitfire.davdroid.ui.UiUtils.toAnnotatedString
 import at.bitfire.davdroid.ui.composable.Assistant
 import at.bitfire.davdroid.ui.composable.PasswordTextField
+import kotlinx.parcelize.Parcelize
 
-object UrlLogin : LoginType {
+@Parcelize
+data object UrlLogin : LoginType {
 
     override val title
         get() = R.string.login_type_url

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.kotlin.parcelize) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.mikepenz.aboutLibraries) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -106,5 +106,6 @@ android-application = { id = "com.android.application", version.ref = "android-a
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 mikepenz-aboutLibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "mikepenz-aboutLibraries" }


### PR DESCRIPTION
### Purpose

See #552. When low memory, Android closes DAVx⁵ in the background after opening custom tabs, so state is not restored, and the login process is reset.

### Short description

- Stored all relevant states in `SavedInstanceHandle`
- Passing `pollUrl` and `token` back from state to `NextcloudLoginFlow`.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

