### PR TITLE
Don't use AccountSettings on main thread

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettings.kt
@@ -8,6 +8,7 @@ import android.accounts.AccountManager
 import android.content.ContentResolver
 import android.content.Context
 import android.os.Bundle
+import android.os.Looper
 import android.provider.CalendarContract
 import androidx.annotation.WorkerThread
 import at.bitfire.davdroid.InvalidAccountException
@@ -142,6 +143,10 @@ class AccountSettings @AssistedInject constructor(
 
     }
 
+    init {
+        if (Looper.getMainLooper() == Looper.myLooper())
+            throw IllegalThreadStateException("AccountSettings may not be used on main thread")
+    }
 
     val accountManager: AccountManager = AccountManager.get(context)
     init {

--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettings.kt
@@ -30,11 +30,15 @@ import java.util.logging.Logger
 /**
  * Manages settings of an account.
  *
+ * Must not be called from main thread as it uses blocking I/O
+ * and may run migrations.
+ *
  * @param account   account to take settings from
  *
  * @throws InvalidAccountException      on construction when the account doesn't exist (anymore)
  * @throws IllegalArgumentException     when the account is not a DAVx5 account
  */
+@WorkerThread   
 class AccountSettings @AssistedInject constructor(
     @Assisted val account: Account,
     @ApplicationContext val context: Context,
@@ -45,6 +49,11 @@ class AccountSettings @AssistedInject constructor(
 
     @AssistedFactory
     interface Factory {
+        /**
+         * Must not be called from main thread as AccountSettings uses blocking I/O and may run
+         * migrations.
+         */
+        @WorkerThread
         fun create(account: Account): AccountSettings
     }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoModel.kt
@@ -24,6 +24,7 @@ import android.provider.CalendarContract
 import android.provider.ContactsContract
 import android.text.format.DateUtils
 import android.text.format.Formatter
+import androidx.annotation.WorkerThread
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -127,7 +128,7 @@ class DebugInfoModel @AssistedInject constructor(
         // create debug info directory
         val debugDir = LogFileHandler.debugDir(context) ?: throw IOException("Couldn't create debug info directory")
 
-        viewModelScope.launch(Dispatchers.Main) {
+        viewModelScope.launch(Dispatchers.Default) {
             // create log file from EXTRA_LOGS or log file
             if (details.logs != null) {
                 val file = File(debugDir, FILE_LOGS)
@@ -148,7 +149,6 @@ class DebugInfoModel @AssistedInject constructor(
                 localResource = details.localResource,
                 remoteResource = details.remoteResource
             )
-
             generateDebugInfo(
                 syncAccount = details.account,
                 syncAuthority = details.authority,
@@ -164,6 +164,7 @@ class DebugInfoModel @AssistedInject constructor(
      *
      * Note: Part of this method and all of it's helpers (listed below) should probably be extracted in the future
      */
+    @WorkerThread
     private fun generateDebugInfo(syncAccount: Account?, syncAuthority: String?, cause: Throwable?, localResource: String?, remoteResource: String?) {
         val debugInfoFile = File(LogFileHandler.debugDir(context), FILE_DEBUG_INFO)
         debugInfoFile.printWriter().use { writer ->
@@ -460,6 +461,7 @@ class DebugInfoModel @AssistedInject constructor(
      *
      * Note: Helper method of [generateDebugInfo].
      */
+    @WorkerThread
     private fun dumpAccount(account: Account, writer: Writer) {
         writer.append("\n\n - Account: ${account.name}\n")
         val accountSettings = accountSettingsFactory.create(account)
@@ -488,10 +490,10 @@ class DebugInfoModel @AssistedInject constructor(
             }
             writer.append(
                 "\n  Contact group method: ${accountSettings.getGroupMethod()}\n" +
-                        "  Time range (past days): ${accountSettings.getTimeRangePastDays()}\n" +
-                        "  Default alarm (min before): ${accountSettings.getDefaultAlarm()}\n" +
-                        "  Manage calendar colors: ${accountSettings.getManageCalendarColors()}\n" +
-                        "  Use event colors: ${accountSettings.getEventColors()}\n"
+                    "  Time range (past days): ${accountSettings.getTimeRangePastDays()}\n" +
+                    "  Default alarm (min before): ${accountSettings.getDefaultAlarm()}\n" +
+                    "  Manage calendar colors: ${accountSettings.getManageCalendarColors()}\n" +
+                    "  Use event colors: ${accountSettings.getEventColors()}\n"
             )
 
             writer.append("\nSync workers:\n")

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreenModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreenModel.kt
@@ -47,7 +47,7 @@ class AccountScreenModel @AssistedInject constructor(
     @Assisted val account: Account,
     private val accountRepository: AccountRepository,
     accountProgressUseCase: AccountProgressUseCase,
-    accountSettingsFactory: AccountSettings.Factory,
+    private val accountSettingsFactory: AccountSettings.Factory,
     private val collectionRepository: DavCollectionRepository,
     @ApplicationContext val context: Context,
     getBindableHomesetsFromService: GetBindableHomeSetsFromServiceUseCase,
@@ -67,18 +67,19 @@ class AccountScreenModel @AssistedInject constructor(
         !accounts.contains(account)
     }
 
-    private val settings = accountSettingsFactory.create(account)
     private val refreshSettingsSignal = MutableLiveData(Unit)
     val showOnlyPersonal = refreshSettingsSignal.switchMap<Unit, AccountSettings.ShowOnlyPersonal> {
         object : LiveData<AccountSettings.ShowOnlyPersonal>() {
             init {
                 viewModelScope.launch(Dispatchers.IO) {
+                    val settings = accountSettingsFactory.create(account)
                     postValue(settings.getShowOnlyPersonal())
                 }
             }
         }
     }.asFlow()
     fun setShowOnlyPersonal(showOnlyPersonal: Boolean) = viewModelScope.launch(Dispatchers.IO) {
+        val settings = accountSettingsFactory.create(account)
         settings.setShowOnlyPersonal(showOnlyPersonal)
         refreshSettingsSignal.postValue(Unit)
     }

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -70,6 +71,7 @@ fun AccountSettingsScreen(
     val model = hiltViewModel { factory: AccountSettingsModel.Factory ->
         factory.create(account)
     }
+    val uiState by model.uiState.collectAsState()
     val canAccessWifiSsid by PermissionUtils.rememberCanAccessWifiSsid()
 
     AppTheme {
@@ -80,35 +82,35 @@ fun AccountSettingsScreen(
             // Sync settings
             canAccessWifiSsid = canAccessWifiSsid,
             onSyncWifiOnlyPermissionsAction = onNavWifiPermissionsScreen,
-            contactsSyncInterval = model.syncIntervalContacts,
+            contactsSyncInterval = uiState.syncIntervalContacts,
             onUpdateContactsSyncInterval = model::updateContactsSyncInterval,
-            calendarSyncInterval = model.syncIntervalCalendars,
+            calendarSyncInterval = uiState.syncIntervalCalendars,
             onUpdateCalendarSyncInterval = model::updateCalendarSyncInterval,
-            tasksSyncInterval = model.syncIntervalTasks,
+            tasksSyncInterval = uiState.syncIntervalTasks,
             onUpdateTasksSyncInterval = model::updateTasksSyncInterval,
-            syncOnlyOnWifi = model.syncWifiOnly,
+            syncOnlyOnWifi = uiState.syncWifiOnly,
             onUpdateSyncOnlyOnWifi = model::updateSyncWifiOnly,
-            onlyOnSsids = model.syncWifiOnlySSIDs,
+            onlyOnSsids = uiState.syncWifiOnlySSIDs,
             onUpdateOnlyOnSsids = model::updateSyncWifiOnlySSIDs,
-            ignoreVpns = model.ignoreVpns,
+            ignoreVpns = uiState.ignoreVpns,
             onUpdateIgnoreVpns = model::updateIgnoreVpns,
 
             // Authentication Settings
-            credentials = model.credentials,
+            credentials = uiState.credentials,
             onUpdateCredentials = model::updateCredentials,
 
             // CalDav Settings
-            timeRangePastDays = model.timeRangePastDays,
+            timeRangePastDays = uiState.timeRangePastDays,
             onUpdateTimeRangePastDays = model::updateTimeRangePastDays,
-            defaultAlarmMinBefore = model.defaultAlarmMinBefore,
+            defaultAlarmMinBefore = uiState.defaultAlarmMinBefore,
             onUpdateDefaultAlarmMinBefore = model::updateDefaultAlarm,
-            manageCalendarColors = model.manageCalendarColors,
+            manageCalendarColors = uiState.manageCalendarColors,
             onUpdateManageCalendarColors = model::updateManageCalendarColors,
-            eventColors = model.eventColors,
+            eventColors = uiState.eventColors,
             onUpdateEventColors = model::updateEventColors,
 
             // CardDav Settings
-            contactGroupMethod = model.contactGroupMethod,
+            contactGroupMethod = uiState.contactGroupMethod,
             onUpdateContactGroupMethod = model::updateContactGroupMethod,
         )
     }


### PR DESCRIPTION
### Purpose

AccountSettings uses blocking I/O and may run migrations. We don't want to block the main thread like that, which is why this PR will stop creating/using AccountSettings on the main thread.

### Short description

- Document that AccountSettings shouldn't be used in the main thread 
- Don't access AccountSettings on the main thread in
  - [X] `AccountSettingsModel`: Switch to state flow, since snapshot was complicated and didn't work well for me on the background thread ...
  - [X] `AccountScreenModel`
  - [X] `DebugInfoModel`

### Resources

https://developer.android.com/topic/architecture/ui-layer/state-production#mutating_the_ui_state_from_background_threads


### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

