### PR TITLE
Add account name to address book account name

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -68,6 +68,7 @@ open class LocalAddressBook @AssistedInject constructor(
         @InstallIn(SingletonComponent::class)
         interface LocalAddressBookCompanionEntryPoint {
             fun localAddressBookFactory(): Factory
+            fun serviceRepository(): DavServiceRepository
             fun logger(): Logger
         }
 
@@ -87,7 +88,7 @@ open class LocalAddressBook @AssistedInject constructor(
             val entryPoint = EntryPointAccessors.fromApplication<LocalAddressBookCompanionEntryPoint>(context)
             val logger = entryPoint.logger()
 
-            val account = Account(accountName(info), context.getString(R.string.account_type_address_book))
+            val account = Account(accountName(context, info), context.getString(R.string.account_type_address_book))
             val userData = initialUserData(info.url.toString(), info.id.toString())
             logger.log(Level.INFO, "Creating local address book $account", userData)
             if (!AccountUtils.createAccount(context, account, userData))
@@ -145,18 +146,28 @@ open class LocalAddressBook @AssistedInject constructor(
         /**
          * Creates a name for the address book account from its corresponding db collection info.
          *
-         * The address book account name contains the collection display name or last URL segment as
-         * well as the collection ID, to make the name unique.
+         * The address book account name contains
+         * - the collection display name or last URL path segment
+         * - the actual account name
+         * - the collection ID, to make it unique.
          *
          * @param info The corresponding collection
          */
-        fun accountName(info: Collection): String {
+        fun accountName(context: Context, info: Collection): String {
+            val entryPoint = EntryPointAccessors.fromApplication<LocalAddressBookCompanionEntryPoint>(context)
+            val serviceRepository = entryPoint.serviceRepository()
+            // Name the address book after given collection display name, otherwise use last URL path segment
             val sb = StringBuilder(info.displayName.let {
                 if (it.isNullOrEmpty())
                     info.url.lastSegment
                 else
                     it
             })
+            // Add the actual account name to the address book account name
+            serviceRepository.get(info.id)?.let { service ->
+                sb.append(" ${service.accountName}")
+            }
+            // Add the collection ID for uniqueness
             sb.append(" (${info.id})")
             return sb.toString()
         }
@@ -256,7 +267,7 @@ open class LocalAddressBook @AssistedInject constructor(
      * @param forceReadOnly  `true`: set the address book to "force read-only"; `false`: determine read-only flag from [info]
      */
     fun update(info: Collection, forceReadOnly: Boolean) {
-        val newAccountName = accountName(info)
+        val newAccountName = accountName(context, info)
 
         if (account.name != newAccountName) {
             // no need to re-assign contacts to new account, because they will be deleted by contacts provider in any case

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -154,8 +154,6 @@ open class LocalAddressBook @AssistedInject constructor(
          * @param info The corresponding collection
          */
         fun accountName(context: Context, info: Collection): String {
-            val entryPoint = EntryPointAccessors.fromApplication<LocalAddressBookCompanionEntryPoint>(context)
-            val serviceRepository = entryPoint.serviceRepository()
             // Name the address book after given collection display name, otherwise use last URL path segment
             val sb = StringBuilder(info.displayName.let {
                 if (it.isNullOrEmpty())
@@ -164,6 +162,8 @@ open class LocalAddressBook @AssistedInject constructor(
                     it
             })
             // Add the actual account name to the address book account name
+            val entryPoint = EntryPointAccessors.fromApplication<LocalAddressBookCompanionEntryPoint>(context)
+            val serviceRepository = entryPoint.serviceRepository()
             serviceRepository.get(info.serviceId)?.let { service ->
                 sb.append(" (${service.accountName})")
             }

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -165,10 +165,10 @@ open class LocalAddressBook @AssistedInject constructor(
             })
             // Add the actual account name to the address book account name
             serviceRepository.get(info.id)?.let { service ->
-                sb.append(" ${service.accountName}")
+                sb.append(" (${service.accountName})")
             }
             // Add the collection ID for uniqueness
-            sb.append(" (${info.id})")
+            sb.append(" #${info.id}")
             return sb.toString()
         }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -164,7 +164,7 @@ open class LocalAddressBook @AssistedInject constructor(
                     it
             })
             // Add the actual account name to the address book account name
-            serviceRepository.get(info.id)?.let { service ->
+            serviceRepository.get(info.serviceId)?.let { service ->
                 sb.append(" (${service.accountName})")
             }
             // Add the collection ID for uniqueness


### PR DESCRIPTION
### Purpose

https://github.com/bitfireAT/davx5-ose/pull/989 has renamed address book accounts. Now address book accounts don't include the actual account name anymore. This is desireable for usability though. This PR adds the actual account name back to the address book account name.

### Short description

- Add the actual account name to the address book account name.
- Add some explaining comments

### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.

