### PR TITLE
Ignore lint AppLinkUrlError

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -130,7 +130,9 @@
             <intent-filter>
                 <action android:name="loginFlow" /> <!-- Ensures this filter matches, even if the sending app is not defining an action -->
                 <category android:name="android.intent.category.DEFAULT" />
-                <data android:scheme="http" />
+                <data
+                    tools:ignore="AppLinkUrlError"
+                    android:scheme="http" />
                 <data android:scheme="https" />
             </intent-filter>
         </activity>

--- a/app/src/ose/AndroidManifest.xml
+++ b/app/src/ose/AndroidManifest.xml
@@ -2,7 +2,8 @@
   ~ Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application>
 
@@ -14,7 +15,10 @@
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
-                <data android:scheme="at.bitfire.davdroid" android:path="/oauth2/redirect"/>
+                <data
+                    tools:ignore="AppLinkUrlError"
+                    android:scheme="at.bitfire.davdroid"
+                    android:path="/oauth2/redirect"/>
             </intent-filter>
         </activity>
 


### PR DESCRIPTION
### Purpose

Since https://github.com/bitfireAT/davx5-ose/commit/a1148613e9f31d0adf8915062d57d449868f9001 we are getting the following lint error:

```
   Lint found 2 errors, 71 warnings. First failure:
  
  /home/runner/work/davx5-ose/davx5-ose/app/src/ose/AndroidManifest.xml:17: Error: At least one host must be specified [AppLinkUrlError]
                  <data android:scheme="at.bitfire.davdroid" android:path="/oauth2/redirect"/>
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

### Short description

- Ignore the lint error "AppLinkUrlError" in the app manifest xml file
- Ignore the lint error "AppLinkUrlError" in the project manifest xml file

https://developer.android.com/studio/write/lint#src

https://developer.android.com/training/app-links
https://developer.android.com/studio/write/app-link-indexing
https://developer.android.com/guide/topics/manifest/data-element#host


### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [ ] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

