### PR TITLE
Don't try to sync deleted collections

### DIFF
--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncerTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncerTest.kt
@@ -86,8 +86,12 @@ class SyncerTest {
         every { localCollection.deleteCollection() } returns true
 
         // Should delete the localCollection if dbCollection (remote) does not exist
-        syncer.updateCollections(listOf(localCollection), dbCollections = emptyMap())
+        val (_, deletedLocalCollections) = syncer.updateCollections(
+            localCollections = listOf(localCollection),
+            dbCollections = emptyMap()
+        )
         verify(exactly = 1) { localCollection.deleteCollection() }
+        assertEquals(localCollection, deletedLocalCollections.first())
     }
 
     @Test
@@ -99,7 +103,7 @@ class SyncerTest {
         every { localCollection.collectionUrl } returns "http://update.the/collection"
 
         // Should update the localCollection if it exists ...
-        val newCollections = syncer.updateCollections(listOf(localCollection), dbCollections)
+        val (newCollections, _) = syncer.updateCollections(listOf(localCollection), dbCollections)
         verify(exactly = 1) { syncer.update(localCollection, dbCollection) }
         // ... and remove it from the "new found" collections which are to be created
         assertTrue(newCollections.isEmpty())
@@ -112,7 +116,7 @@ class SyncerTest {
         every { dbCollection.url } returns "http://newly.found/collection".toHttpUrl()
 
         // Should return the new collection, because it was not updated
-        val newCollections = syncer.updateCollections(listOf(), dbCollections)
+        val (newCollections, _) = syncer.updateCollections(listOf(), dbCollections)
         assertEquals(dbCollection, newCollections["http://newly.found/collection".toHttpUrl()])
     }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
@@ -138,7 +138,9 @@ abstract class Syncer<CollectionType: LocalCollection<*>>(
      *
      * @param localCollections The local collections to be updated or deleted
      * @param dbCollections The database collections possibly containing new information
-     * @return New found database collections to be created in provider
+     * @return Pair of:
+     *  1) New found database collections to be created in provider
+     *  2) Local collections which have been deleted
      */
     @VisibleForTesting
     internal fun updateCollections(
@@ -152,7 +154,7 @@ abstract class Syncer<CollectionType: LocalCollection<*>>(
             if (dbCollection == null) {
                 // Collection not available in db = on server (anymore), delete obsolete local collection
                 localCollection.deleteCollection()
-                deletedLocalCollections.add(localCollection)
+                deletedLocalCollections.add(localCollection) // Add to "not to be synced" list
             } else {
                 // Collection exists locally, update local collection and remove it from "to be created" map
                 update(localCollection, dbCollection)


### PR DESCRIPTION
### Purpose
`Syncer` tries to sync collections it deleted causing an exception. The sync algorithm is the heart of DAVx5 and so it should run flawlessly, be easy to understand and well documented. 

### Short description

It would have been possible to simply get the collections anew from the database, after `updateCollections` has run and possibly deleted some local collections. It would, however, not have been as explicit in the sense that we would have relied on a side effect of `updateCollections`.

By returning a pair (which is ugly yes) it is more explicit. We also save a database query and made the deletion test stronger.

Actual changes:
- Return list of deleted local collections from `updateCollections`
- Remove the deleted local collections from the list of collections to be synced 
- Update KDoc
- Update tests

### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.

