### PR TITLE
`LocalAddressBook`: move contacts when renaming the address book account

### DIFF
--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookTest.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.resource
+
+import android.Manifest
+import android.accounts.Account
+import android.content.ContentProviderClient
+import android.content.Context
+import android.provider.ContactsContract
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.rule.GrantPermissionRule
+import at.bitfire.vcard4android.Contact
+import at.bitfire.vcard4android.GroupMethod
+import at.bitfire.vcard4android.LabeledProperty
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import ezvcard.property.Telephone
+import org.junit.AfterClass
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.ClassRule
+import org.junit.Rule
+import org.junit.Test
+import java.util.LinkedList
+import javax.inject.Inject
+
+@HiltAndroidTest
+class LocalAddressBookTest {
+
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+
+    @Inject
+    lateinit var addressbookFactory: LocalTestAddressBook.Factory
+
+    @Inject
+    @ApplicationContext
+    lateinit var context: Context
+
+
+    @Before
+    fun setup() {
+        hiltRule.inject()
+    }
+
+
+    /**
+     * Tests whether contacts are moved (and not lost) when an address book is renamed.
+     */
+    @Test
+    fun test_renameAccount_retainsContacts() {
+        val addressBook = addressbookFactory.create(provider, GroupMethod.CATEGORIES)
+        LocalTestAddressBook.createAccount(context)
+        try {
+            // insert contact with data row
+            val uid = "12345"
+            val contact = Contact(
+                uid = uid,
+                displayName = "Test Contact",
+                phoneNumbers = LinkedList(listOf(LabeledProperty(Telephone("1234567890"))))
+            )
+            LocalContact(addressBook, contact, null, null, 0).add()
+
+            // rename address book
+            val newAccount = Account("New Name", addressBook.account.type)
+            LocalAddressBook.renameAccount(context, provider, addressBook.account, newAccount.name)
+            addressBook.account = newAccount
+
+            // check whether contact is still there
+            val result = addressBook.findContactByUid(uid)!!.getContact()
+            assertEquals(uid, result.uid)
+            assertEquals(contact.displayName, result.displayName)
+            assertEquals(contact.phoneNumbers.first().component1().text, result.phoneNumbers.first().component1().text)
+
+        } finally {
+            // clean up / remove address book
+            addressBook.deleteCollection()
+        }
+    }
+
+
+    companion object {
+
+        @JvmField
+        @ClassRule
+        val permissionRule = GrantPermissionRule.grant(Manifest.permission.READ_CONTACTS, Manifest.permission.WRITE_CONTACTS)!!
+
+        private lateinit var provider: ContentProviderClient
+
+        @BeforeClass
+        @JvmStatic
+        fun connect() {
+            val context = InstrumentationRegistry.getInstrumentation().targetContext
+            provider = context.contentResolver.acquireContentProviderClient(ContactsContract.AUTHORITY)!!
+            assertNotNull(provider)
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun disconnect() {
+            provider.close()
+        }
+    }
+
+}

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookTest.kt
@@ -70,7 +70,7 @@ class LocalAddressBookTest {
             val id = ContentUris.parseId(uri)
             val localContact = addressBook.findContactById(id)
             localContact.resetDirty()
-            assertFalse("Contact is dirty before moving", localContact.isDirty())
+            assertFalse("Contact is dirty before moving", addressBook.isContactDirty(id))
 
             // rename address book
             val newName = "New Name"
@@ -79,7 +79,7 @@ class LocalAddressBookTest {
 
             // check whether contact is still here (including data rows) and not dirty
             val result = addressBook.findContactById(id)
-            assertFalse("Contact is dirty after moving", result.isDirty())
+            assertFalse("Contact is dirty after moving", addressBook.isContactDirty(id))
 
             val contact2 = result.getContact()
             assertEquals(uid, contact2.uid)

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalTestAddressBook.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalTestAddressBook.kt
@@ -66,6 +66,22 @@ class LocalTestAddressBook @AssistedInject constructor(
         throw FileNotFoundException()
     }
 
+    /**
+     * Returns the dirty flag of the given contact group.
+     *
+     * @return true if the group is dirty, false otherwise
+     *
+     * @throws FileNotFoundException if the group can't be found
+     */
+    fun isGroupDirty(id: Long): Boolean {
+        val uri = ContentUris.withAppendedId(groupsSyncUri(), id)
+        provider!!.query(uri, arrayOf(ContactsContract.Groups.DIRTY), null, null, null)?.use { cursor ->
+            if (cursor.moveToFirst())
+                return cursor.getInt(0) != 0
+        }
+        throw FileNotFoundException()
+    }
+
 
     companion object {
 

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalTestAddressBook.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalTestAddressBook.kt
@@ -7,7 +7,9 @@ package at.bitfire.davdroid.resource
 import android.accounts.Account
 import android.accounts.AccountManager
 import android.content.ContentProviderClient
+import android.content.ContentUris
 import android.content.Context
+import android.provider.ContactsContract
 import at.bitfire.davdroid.repository.DavCollectionRepository
 import at.bitfire.davdroid.repository.DavServiceRepository
 import at.bitfire.davdroid.settings.AccountSettings
@@ -17,6 +19,7 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.qualifiers.ApplicationContext
 import org.junit.Assert.assertTrue
+import java.io.FileNotFoundException
 import java.util.logging.Logger
 
 class LocalTestAddressBook @AssistedInject constructor(
@@ -44,6 +47,23 @@ class LocalTestAddressBook @AssistedInject constructor(
             contact.delete()
         for (group in queryGroups(null, null))
             group.delete()
+    }
+
+
+    /**
+     * Returns the dirty flag of the given contact.
+     *
+     * @return true if the contact is dirty, false otherwise
+     *
+     * @throws FileNotFoundException if the contact can't be found
+     */
+    fun isContactDirty(id: Long): Boolean {
+        val uri = ContentUris.withAppendedId(rawContactsSyncUri(), id)
+        provider!!.query(uri, arrayOf(ContactsContract.RawContacts.DIRTY), null, null, null)?.use { cursor ->
+            if (cursor.moveToFirst())
+                return cursor.getInt(0) != 0
+        }
+        throw FileNotFoundException()
     }
 
 

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalTestAddressBook.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalTestAddressBook.kt
@@ -5,6 +5,7 @@
 package at.bitfire.davdroid.resource
 
 import android.accounts.Account
+import android.accounts.AccountManager
 import android.content.ContentProviderClient
 import android.content.Context
 import at.bitfire.davdroid.repository.DavCollectionRepository
@@ -15,6 +16,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.qualifiers.ApplicationContext
+import org.junit.Assert.assertTrue
 import java.util.logging.Logger
 
 class LocalTestAddressBook @AssistedInject constructor(
@@ -26,10 +28,6 @@ class LocalTestAddressBook @AssistedInject constructor(
     logger: Logger,
     serviceRepository: DavServiceRepository
 ): LocalAddressBook(ACCOUNT, provider, context, accountSettingsFactory, collectionRepository, logger, serviceRepository) {
-
-    companion object {
-        val ACCOUNT = Account("LocalTestAddressBook", "at.bitfire.davdroid.test")
-    }
 
     @AssistedFactory
     interface Factory {
@@ -46,6 +44,18 @@ class LocalTestAddressBook @AssistedInject constructor(
             contact.delete()
         for (group in queryGroups(null, null))
             group.delete()
+    }
+
+
+    companion object {
+
+        val ACCOUNT = Account("LocalTestAddressBook", "at.bitfire.davdroid.test")
+
+        fun createAccount(context: Context) {
+            val am = AccountManager.get(context)
+            assertTrue("Couldn't create account for local test address-book", am.addAccountExplicitly(ACCOUNT, null, null))
+        }
+
     }
 
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -214,11 +214,9 @@ open class LocalAddressBook @AssistedInject constructor(
         val oldAccount = account
         logger.info("Renaming address book from \"${oldAccount.name}\" to \"$newName\"")
 
-        // copy user data to new account
-        val accountManager = AccountManager.get(context)
+        // create new account
         val newAccount = Account(newName, oldAccount.type)
         if (!SystemAccountUtils.createAccount(context, newAccount, Bundle()))
-            // Couldn't rename account
             return false
 
         // move contacts and groups to new account
@@ -239,6 +237,7 @@ open class LocalAddressBook @AssistedInject constructor(
         account = newAccount
 
         // delete old account
+        val accountManager = AccountManager.get(context)
         accountManager.removeAccountExplicitly(oldAccount)
 
         return true

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -18,6 +18,7 @@ import android.provider.ContactsContract.CommonDataKinds.GroupMembership
 import android.provider.ContactsContract.Groups
 import android.provider.ContactsContract.RawContacts
 import androidx.annotation.OpenForTesting
+import androidx.annotation.VisibleForTesting
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.SyncState
@@ -30,6 +31,7 @@ import at.bitfire.davdroid.util.setAndVerifyUserData
 import at.bitfire.vcard4android.AndroidAddressBook
 import at.bitfire.vcard4android.AndroidContact
 import at.bitfire.vcard4android.AndroidGroup
+import at.bitfire.vcard4android.BatchOperation
 import at.bitfire.vcard4android.GroupMethod
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -61,125 +63,6 @@ open class LocalAddressBook @AssistedInject constructor(
     private val logger: Logger,
     private val serviceRepository: DavServiceRepository
 ): AndroidAddressBook<LocalContact, LocalGroup>(addressBookAccount, provider, LocalContact.Factory, LocalGroup.Factory), LocalCollection<LocalAddress> {
-
-    companion object {
-
-        @EntryPoint
-        @InstallIn(SingletonComponent::class)
-        interface LocalAddressBookCompanionEntryPoint {
-            fun localAddressBookFactory(): Factory
-            fun serviceRepository(): DavServiceRepository
-            fun logger(): Logger
-        }
-
-        const val USER_DATA_URL = "url"
-        const val USER_DATA_COLLECTION_ID = "collection_id"
-        const val USER_DATA_READ_ONLY = "read_only"
-
-        /**
-         * Creates a new local address book.
-         *
-         * @param context        app context to resolve string resources
-         * @param provider       contacts provider client
-         * @param info           collection where to take the name and settings from
-         * @param forceReadOnly  `true`: set the address book to "force read-only"; `false`: determine read-only flag from [info]
-         */
-        fun create(context: Context, provider: ContentProviderClient, info: Collection, forceReadOnly: Boolean): LocalAddressBook {
-            val entryPoint = EntryPointAccessors.fromApplication<LocalAddressBookCompanionEntryPoint>(context)
-            val logger = entryPoint.logger()
-
-            val account = Account(accountName(context, info), context.getString(R.string.account_type_address_book))
-            val userData = initialUserData(info.url.toString(), info.id.toString())
-            logger.log(Level.INFO, "Creating local address book $account", userData)
-            if (!SystemAccountUtils.createAccount(context, account, userData))
-                throw IllegalStateException("Couldn't create address book account")
-
-            val factory = entryPoint.localAddressBookFactory()
-            val addressBook = factory.create(account, provider)
-            addressBook.updateSyncFrameworkSettings()
-
-            // initialize Contacts Provider Settings
-            val values = ContentValues(2)
-            values.put(ContactsContract.Settings.SHOULD_SYNC, 1)
-            values.put(ContactsContract.Settings.UNGROUPED_VISIBLE, 1)
-            addressBook.settings = values
-            addressBook.readOnly = forceReadOnly || !info.privWriteContent || info.forceReadOnly
-
-            return addressBook
-        }
-
-        /**
-         * Finds a [LocalAddressBook] based on its corresponding collection.
-         *
-         * @param id    collection ID to look for
-         *
-         * @return The [LocalAddressBook] for the given collection or *null* if not found
-         */
-        fun findByCollection(context: Context, provider: ContentProviderClient, id: Long): LocalAddressBook? {
-            val entryPoint = EntryPointAccessors.fromApplication<LocalAddressBookCompanionEntryPoint>(context)
-            val factory = entryPoint.localAddressBookFactory()
-
-            val accountManager = AccountManager.get(context)
-            return accountManager
-                .getAccountsByType(context.getString(R.string.account_type_address_book))
-                .filter { account ->
-                    accountManager.getUserData(account, USER_DATA_COLLECTION_ID)?.toLongOrNull() == id
-                }
-                .map { account -> factory.create(account, provider) }
-                .firstOrNull()
-        }
-
-        /**
-         * Deletes a [LocalAddressBook] based on its corresponding database collection.
-         *
-         * @param id    collection ID to look for
-         */
-        fun deleteByCollection(context: Context, id: Long) {
-            val accountManager = AccountManager.get(context)
-            val addressBookAccount = accountManager.getAccountsByType(context.getString(R.string.account_type_address_book)).firstOrNull { account ->
-                accountManager.getUserData(account, USER_DATA_COLLECTION_ID)?.toLongOrNull() == id
-            }
-            if (addressBookAccount != null)
-                accountManager.removeAccountExplicitly(addressBookAccount)
-        }
-
-        /**
-         * Creates a name for the address book account from its corresponding db collection info.
-         *
-         * The address book account name contains
-         * - the collection display name or last URL path segment
-         * - the actual account name
-         * - the collection ID, to make it unique.
-         *
-         * @param info The corresponding collection
-         */
-        fun accountName(context: Context, info: Collection): String {
-            // Name the address book after given collection display name, otherwise use last URL path segment
-            val sb = StringBuilder(info.displayName.let {
-                if (it.isNullOrEmpty())
-                    info.url.lastSegment
-                else
-                    it
-            })
-            // Add the actual account name to the address book account name
-            val entryPoint = EntryPointAccessors.fromApplication<LocalAddressBookCompanionEntryPoint>(context)
-            val serviceRepository = entryPoint.serviceRepository()
-            serviceRepository.get(info.serviceId)?.let { service ->
-                sb.append(" (${service.accountName})")
-            }
-            // Add the collection ID for uniqueness
-            sb.append(" #${info.id}")
-            return sb.toString()
-        }
-
-        private fun initialUserData(url: String, collectionId: String): Bundle {
-            val bundle = Bundle(3)
-            bundle.putString(USER_DATA_COLLECTION_ID, collectionId)
-            bundle.putString(USER_DATA_URL, url)
-            return bundle
-        }
-
-    }
 
     @AssistedFactory
     interface Factory {
@@ -274,11 +157,8 @@ open class LocalAddressBook @AssistedInject constructor(
 
         // Update the account name
         val newAccountName = accountName(context, info)
-        if (account.name != newAccountName) {
-            // no need to re-assign contacts to new account, because they will be deleted by contacts provider in any case
-            val future = accountManager.renameAccount(account, newAccountName, null, null)
-            account = future.result
-        }
+        if (account.name != newAccountName)
+            account = renameAccount(context, provider!!, account, newAccountName)
 
         // Update the account user data
         accountManager.setAndVerifyUserData(account, USER_DATA_COLLECTION_ID, info.id.toString())
@@ -474,6 +354,176 @@ open class LocalAddressBook @AssistedInject constructor(
             logger.log(Level.FINE, "Deleting group", group)
             group.delete()
         }
+    }
+
+
+    companion object {
+
+        @EntryPoint
+        @InstallIn(SingletonComponent::class)
+        interface LocalAddressBookCompanionEntryPoint {
+            fun localAddressBookFactory(): Factory
+            fun serviceRepository(): DavServiceRepository
+            fun logger(): Logger
+        }
+
+        const val USER_DATA_URL = "url"
+        const val USER_DATA_COLLECTION_ID = "collection_id"
+        const val USER_DATA_READ_ONLY = "read_only"
+
+        // create/query/delete
+
+        /**
+         * Creates a new local address book.
+         *
+         * @param context        app context to resolve string resources
+         * @param provider       contacts provider client
+         * @param info           collection where to take the name and settings from
+         * @param forceReadOnly  `true`: set the address book to "force read-only"; `false`: determine read-only flag from [info]
+         */
+        fun create(context: Context, provider: ContentProviderClient, info: Collection, forceReadOnly: Boolean): LocalAddressBook {
+            val entryPoint = EntryPointAccessors.fromApplication<LocalAddressBookCompanionEntryPoint>(context)
+            val logger = entryPoint.logger()
+
+            val account = Account(accountName(context, info), context.getString(R.string.account_type_address_book))
+            val userData = initialUserData(info.url.toString(), info.id.toString())
+            logger.log(Level.INFO, "Creating local address book $account", userData)
+            if (!SystemAccountUtils.createAccount(context, account, userData))
+                throw IllegalStateException("Couldn't create address book account")
+
+            val factory = entryPoint.localAddressBookFactory()
+            val addressBook = factory.create(account, provider)
+            addressBook.updateSyncFrameworkSettings()
+
+            // initialize Contacts Provider Settings
+            val values = ContentValues(2)
+            values.put(ContactsContract.Settings.SHOULD_SYNC, 1)
+            values.put(ContactsContract.Settings.UNGROUPED_VISIBLE, 1)
+            addressBook.settings = values
+            addressBook.readOnly = forceReadOnly || !info.privWriteContent || info.forceReadOnly
+
+            return addressBook
+        }
+
+        /**
+         * Finds a [LocalAddressBook] based on its corresponding collection.
+         *
+         * @param id    collection ID to look for
+         *
+         * @return The [LocalAddressBook] for the given collection or *null* if not found
+         */
+        fun findByCollection(context: Context, provider: ContentProviderClient, id: Long): LocalAddressBook? {
+            val entryPoint = EntryPointAccessors.fromApplication<LocalAddressBookCompanionEntryPoint>(context)
+            val factory = entryPoint.localAddressBookFactory()
+
+            val accountManager = AccountManager.get(context)
+            return accountManager
+                .getAccountsByType(context.getString(R.string.account_type_address_book))
+                .filter { account ->
+                    accountManager.getUserData(account, USER_DATA_COLLECTION_ID)?.toLongOrNull() == id
+                }
+                .map { account -> factory.create(account, provider) }
+                .firstOrNull()
+        }
+
+        /**
+         * Deletes a [LocalAddressBook] based on its corresponding database collection.
+         *
+         * @param id    collection ID to look for
+         */
+        fun deleteByCollection(context: Context, id: Long) {
+            val accountManager = AccountManager.get(context)
+            val addressBookAccount = accountManager.getAccountsByType(context.getString(R.string.account_type_address_book)).firstOrNull { account ->
+                accountManager.getUserData(account, USER_DATA_COLLECTION_ID)?.toLongOrNull() == id
+            }
+            if (addressBookAccount != null)
+                accountManager.removeAccountExplicitly(addressBookAccount)
+        }
+
+
+        // helpers
+
+        /**
+         * Creates a name for the address book account from its corresponding db collection info.
+         *
+         * The address book account name contains
+         * - the collection display name or last URL path segment
+         * - the actual account name
+         * - the collection ID, to make it unique.
+         *
+         * @param info The corresponding collection
+         */
+        fun accountName(context: Context, info: Collection): String {
+            // Name the address book after given collection display name, otherwise use last URL path segment
+            val sb = StringBuilder(info.displayName.let {
+                if (it.isNullOrEmpty())
+                    info.url.lastSegment
+                else
+                    it
+            })
+            // Add the actual account name to the address book account name
+            val entryPoint = EntryPointAccessors.fromApplication<LocalAddressBookCompanionEntryPoint>(context)
+            val serviceRepository = entryPoint.serviceRepository()
+            serviceRepository.get(info.serviceId)?.let { service ->
+                sb.append(" (${service.accountName})")
+            }
+            // Add the collection ID for uniqueness
+            sb.append(" #${info.id}")
+            return sb.toString()
+        }
+
+        private fun initialUserData(url: String, collectionId: String): Bundle {
+            val bundle = Bundle(3)
+            bundle.putString(USER_DATA_COLLECTION_ID, collectionId)
+            bundle.putString(USER_DATA_URL, url)
+            return bundle
+        }
+
+        /**
+         * Renames an address book account and moves the contacts.
+         *
+         * @param provider    used to move the contacts
+         * @param oldAccount  the account to rename
+         * @param newName     the new account name (will have same account type)
+         *
+         * Previously, we had used [AccountManager.renameAccount], but then the contacts can't be moved because there's never
+         * a moment when both accounts are available.
+         *
+         * @return the resulting account name (new name if successful, old name otherwise)
+         */
+        @VisibleForTesting
+        internal fun renameAccount(context: Context, provider: ContentProviderClient, oldAccount: Account, newName: String): Account {
+            val newAccount = Account(newName, oldAccount.type)
+
+            //val future = accountManager.renameAccount(oldAccount, newName, null, null)
+            val accountManager = AccountManager.get(context)
+
+            // copy user data to new account
+            val data = Bundle(2).apply {
+                putString(USER_DATA_COLLECTION_ID, accountManager.getUserData(oldAccount, USER_DATA_COLLECTION_ID))
+                putString(USER_DATA_URL, accountManager.getUserData(oldAccount, USER_DATA_URL))
+            }
+
+            if (!SystemAccountUtils.createAccount(context, newAccount, data))
+                // Couldn't rename account
+                return oldAccount
+
+            // move contacts to new account
+            val batch = BatchOperation(provider)
+            batch.enqueue(BatchOperation.CpoBuilder
+                .newUpdate(RawContacts.CONTENT_URI)
+                .withSelection(RawContacts.ACCOUNT_NAME + "=? AND " + RawContacts.ACCOUNT_TYPE + "=?", arrayOf(oldAccount.name, oldAccount.type))
+                .withValue(RawContacts.ACCOUNT_NAME, newAccount.name)
+                .withValue(RawContacts.ACCOUNT_TYPE, newAccount.type)
+            )
+            batch.commit()
+
+            // delete old account
+            accountManager.removeAccountExplicitly(oldAccount)
+
+            return newAccount
+        }
+
     }
 
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -159,7 +159,7 @@ open class LocalAddressBook @AssistedInject constructor(
         // Update the account name
         val newAccountName = accountName(context, info)
         if (account.name != newAccountName)
-            // rename and update AndroidAddressBook.account
+            // rename, move contacts/groups and update [AndroidAddressBook.]account
             renameAccount(newAccountName)
 
         // Update the account user data
@@ -197,14 +197,15 @@ open class LocalAddressBook @AssistedInject constructor(
     }
 
     /**
-     * Renames an address book account and moves the contacts.
+     * Renames an address book account and moves the contacts and groups (without making them dirty).
+     * Does not keep user data of the old account, so these have to be set again.
      *
      * On success, [account] will be updated to the new account name.
      *
      * _Note:_ Previously, we had used [AccountManager.renameAccount], but then the contacts can't be moved because there's never
      * a moment when both accounts are available.
      *
-     * @param newName   the new account name (will have same account type as [account])
+     * @param newName   the new account name (account type is taken from [account])
      *
      * @return whether the account was renamed successfully
      */
@@ -215,13 +216,8 @@ open class LocalAddressBook @AssistedInject constructor(
 
         // copy user data to new account
         val accountManager = AccountManager.get(context)
-        val userData = Bundle(2).apply {
-            putString(USER_DATA_COLLECTION_ID, accountManager.getUserData(oldAccount, USER_DATA_COLLECTION_ID))
-            putString(USER_DATA_URL, accountManager.getUserData(oldAccount, USER_DATA_URL))
-        }
-
         val newAccount = Account(newName, oldAccount.type)
-        if (!SystemAccountUtils.createAccount(context, newAccount, userData))
+        if (!SystemAccountUtils.createAccount(context, newAccount, Bundle()))
             // Couldn't rename account
             return false
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalContact.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalContact.kt
@@ -115,6 +115,21 @@ class LocalContact: AndroidContact, LocalAddress {
         this.eTag = eTag
     }
 
+    /**
+     * Returns the dirty flag of the current contact.
+     *
+     * @return true if the contact is dirty, false otherwise
+     *
+     * @throws FileNotFoundException if the current contact can't be found
+     */
+    fun isDirty(): Boolean {
+        addressBook.provider!!.query(rawContactSyncURI(), arrayOf(ContactsContract.RawContacts.DIRTY), null, null, null)?.use { cursor ->
+            if (cursor.moveToFirst())
+                return cursor.getInt(0) != 0
+        }
+        throw FileNotFoundException()
+    }
+
     override fun resetDeleted() {
         val values = ContentValues(1)
         values.put(ContactsContract.Groups.DELETED, 0)

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalContact.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalContact.kt
@@ -115,21 +115,6 @@ class LocalContact: AndroidContact, LocalAddress {
         this.eTag = eTag
     }
 
-    /**
-     * Returns the dirty flag of the current contact.
-     *
-     * @return true if the contact is dirty, false otherwise
-     *
-     * @throws FileNotFoundException if the current contact can't be found
-     */
-    fun isDirty(): Boolean {
-        addressBook.provider!!.query(rawContactSyncURI(), arrayOf(ContactsContract.RawContacts.DIRTY), null, null, null)?.use { cursor ->
-            if (cursor.moveToFirst())
-                return cursor.getInt(0) != 0
-        }
-        throw FileNotFoundException()
-    }
-
     override fun resetDeleted() {
         val values = ContentValues(1)
         values.put(ContactsContract.Groups.DELETED, 0)

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
@@ -74,7 +74,7 @@ class AddressBookSyncer @AssistedInject constructor(
     }
 
     override fun syncCollection(provider: ContentProviderClient, localCollection: LocalAddressBook, remoteCollection: Collection) {
-        logger.info("Synchronizing address book $localCollection")
+        logger.info("Synchronizing address book: ${localCollection.account.name}")
         syncAddressBook(
             account = account,
             addressBook = localCollection,
@@ -123,8 +123,6 @@ class AddressBookSyncer @AssistedInject constructor(
                 }
             }
             accountSettings.accountManager.setAndVerifyUserData(addressBook.account, PREVIOUS_GROUP_METHOD, groupMethod)
-
-            logger.info("Synchronizing address book: ${addressBook.collectionUrl}")
 
             val syncManager = contactsSyncManagerFactory.contactsSyncManager(account, accountSettings, httpClient.value, extras, authority, syncResult, provider, addressBook, collection)
             syncManager.performSync()


### PR DESCRIPTION
### Purpose

Previously, renaming an address book (= address book account) resulted in all local contacts being dropped and re-synced.

However, contacts (and groups) should be kept when an address book account is renamed so that there are as little possibilities for errors as possible. For instance, at re-sync the server could be not available or there could be (temporary) problems with specific contacts which would not appear without re-sync etc.


### Short description

Instead of renaming the account with `AccountManager.renameAccount()`:

1. a new account with the desired name is created,
2. the contacts and groups are moved to the new account (without touching their dirty flag),
3. the old account is deleted.


### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

