### PR TITLE
Replace android sync framework result class with our own

### DIFF
--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncManagerTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncManagerTest.kt
@@ -6,7 +6,6 @@ package at.bitfire.davdroid.sync
 
 import android.accounts.Account
 import android.content.Context
-import android.content.SyncResult
 import android.util.Log
 import androidx.core.app.NotificationManagerCompat
 import androidx.hilt.work.HiltWorkerFactory

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncerTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncerTest.kt
@@ -6,7 +6,6 @@ package at.bitfire.davdroid.sync
 
 import android.accounts.Account
 import android.content.ContentProviderClient
-import android.content.SyncResult
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.sync.account.TestAccountAuthenticator
 import dagger.assisted.Assisted

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/TestSyncManager.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/TestSyncManager.kt
@@ -5,7 +5,6 @@
 package at.bitfire.davdroid.sync
 
 import android.accounts.Account
-import android.content.SyncResult
 import at.bitfire.dav4jvm.DavCollection
 import at.bitfire.dav4jvm.MultiResponseCallback
 import at.bitfire.dav4jvm.Response

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
@@ -6,7 +6,6 @@ package at.bitfire.davdroid.sync
 
 import android.accounts.Account
 import android.content.ContentProviderClient
-import android.content.SyncResult
 import android.provider.ContactsContract
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
@@ -5,7 +5,6 @@
 package at.bitfire.davdroid.sync
 
 import android.accounts.Account
-import android.content.SyncResult
 import android.text.format.Formatter
 import at.bitfire.dav4jvm.DavCalendar
 import at.bitfire.dav4jvm.MultiResponseCallback

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncer.kt
@@ -7,7 +7,6 @@ package at.bitfire.davdroid.sync
 import android.accounts.Account
 import android.content.ContentProviderClient
 import android.content.ContentUris
-import android.content.SyncResult
 import android.provider.CalendarContract
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
@@ -7,7 +7,6 @@ package at.bitfire.davdroid.sync
 import android.accounts.Account
 import android.content.ContentProviderClient
 import android.content.ContentResolver
-import android.content.SyncResult
 import android.os.Build
 import android.text.format.Formatter
 import at.bitfire.dav4jvm.DavAddressBook

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
@@ -5,7 +5,6 @@
 package at.bitfire.davdroid.sync
 
 import android.accounts.Account
-import android.content.SyncResult
 import android.text.format.Formatter
 import at.bitfire.dav4jvm.DavCalendar
 import at.bitfire.dav4jvm.MultiResponseCallback

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncer.kt
@@ -8,7 +8,6 @@ import android.accounts.Account
 import android.accounts.AccountManager
 import android.content.ContentProviderClient
 import android.content.ContentUris
-import android.content.SyncResult
 import android.os.Build
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service
@@ -54,7 +53,7 @@ class JtxSyncer @AssistedInject constructor(
             TaskProvider.checkVersion(context, TaskProvider.ProviderName.JtxBoard)
         } catch (e: TaskProvider.ProviderTooOldException) {
             tasksAppManager.get().notifyProviderTooOld(e)
-            syncResult.databaseError = true
+            syncResult.contentProviderError = true
             return false // Don't sync
         }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncResult.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncResult.kt
@@ -1,11 +1,9 @@
 package at.bitfire.davdroid.sync
 
 /**
- * This class is used to communicate the results of a sync operation from [Syncer]s to the
- * [at.bitfire.davdroid.sync.worker.BaseSyncWorker]. Based on the values here the
- * [at.bitfire.davdroid.sync.worker.BaseSyncWorker] will determine the run ability of the sync and
- * whether or not there will be retries. See the implementation of
- * [at.bitfire.davdroid.sync.worker.BaseSyncWorker.doSyncWork] for details.
+ * This class represents the results of a sync operation from [Syncer].
+ *
+ * Used by [at.bitfire.davdroid.sync.worker.BaseSyncWorker] to determine whether or not there will be retries etc.
  */
 data class SyncResult(
     var contentProviderError: Boolean = false,
@@ -60,4 +58,5 @@ data class SyncResult(
         var numIoExceptions: Long = 0,
         var numServiceUnavailableExceptions: Long = 0
     )
+
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncResult.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncResult.kt
@@ -1,0 +1,63 @@
+package at.bitfire.davdroid.sync
+
+/**
+ * This class is used to communicate the results of a sync operation from [Syncer]s to the
+ * [at.bitfire.davdroid.sync.worker.BaseSyncWorker]. Based on the values here the
+ * [at.bitfire.davdroid.sync.worker.BaseSyncWorker] will determine the run ability of the sync and
+ * whether or not there will be retries. See the implementation of
+ * [at.bitfire.davdroid.sync.worker.BaseSyncWorker.doSyncWork] for details.
+ */
+data class SyncResult(
+    var contentProviderError: Boolean = false,
+    var localStorageError: Boolean = false,
+    var delayUntil: Long = 0,
+    val stats: SyncStats = SyncStats()
+) {
+
+    /**
+     * Whether a hard error occurred.
+     */
+    fun hasHardError(): Boolean =
+        contentProviderError
+            || localStorageError
+            || stats.numAuthExceptions > 0
+            || stats.numHttpExceptions > 0
+            || stats.numUnclassifiedErrors > 0
+
+    /**
+     * Whether a soft error occurred.
+     */
+    fun hasSoftError(): Boolean =
+        stats.numDeadObjectExceptions > 0
+            || stats.numIoExceptions > 0
+            || stats.numServiceUnavailableExceptions > 0
+
+    /**
+     * Whether a hard or a soft error occurred.
+     */
+    fun hasError(): Boolean =
+        hasHardError() || hasSoftError()
+
+    /**
+     * Holds statistics about the sync operation. Used to determine retries. Also useful for
+     * debugging and customer support when logged.
+     */
+    data class SyncStats(
+        // Stats
+        var numDeletes: Long = 0,
+        var numEntries: Long = 0,
+        var numInserts: Long = 0,
+        var numSkippedEntries: Long = 0,
+        var numUpdates: Long = 0,
+
+        // Hard errors
+        var numAuthExceptions: Long = 0,
+        var numHttpExceptions: Long = 0,
+        var numUnclassifiedErrors: Long = 0,
+
+        // Soft errors
+        var numDeadObjectExceptions: Long = 0,
+        var numIoExceptions: Long = 0,
+        var numServiceUnavailableExceptions: Long = 0
+    )
+}

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/TaskSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/TaskSyncer.kt
@@ -8,7 +8,6 @@ import android.accounts.Account
 import android.accounts.AccountManager
 import android.content.ContentProviderClient
 import android.content.ContentUris
-import android.content.SyncResult
 import android.os.Build
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service
@@ -52,7 +51,7 @@ class TaskSyncer @AssistedInject constructor(
             TaskProvider.checkVersion(context, providerName)
         } catch (e: TaskProvider.ProviderTooOldException) {
             tasksAppManager.get().notifyProviderTooOld(e)
-            syncResult.databaseError = true
+            syncResult.contentProviderError = true
             return false // Don't sync
         }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
@@ -5,7 +5,6 @@
 package at.bitfire.davdroid.sync
 
 import android.accounts.Account
-import android.content.SyncResult
 import android.text.format.Formatter
 import at.bitfire.dav4jvm.DavCalendar
 import at.bitfire.dav4jvm.MultiResponseCallback

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
@@ -7,7 +7,6 @@ package at.bitfire.davdroid.sync.worker
 import android.accounts.Account
 import android.content.ContentResolver
 import android.content.Context
-import android.content.SyncResult
 import android.os.Build
 import android.provider.CalendarContract
 import androidx.annotation.IntDef
@@ -27,20 +26,21 @@ import at.bitfire.davdroid.sync.AddressBookSyncer
 import at.bitfire.davdroid.sync.CalendarSyncer
 import at.bitfire.davdroid.sync.JtxSyncer
 import at.bitfire.davdroid.sync.SyncConditions
+import at.bitfire.davdroid.sync.SyncResult
 import at.bitfire.davdroid.sync.SyncUtils
 import at.bitfire.davdroid.sync.Syncer
 import at.bitfire.davdroid.sync.TaskSyncer
 import at.bitfire.davdroid.ui.NotificationRegistry
 import at.bitfire.ical4android.TaskProvider
-import java.util.Collections
-import java.util.logging.Logger
-import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withContext
+import java.util.Collections
+import java.util.logging.Logger
+import javax.inject.Inject
 
 abstract class BaseSyncWorker(
     context: Context,


### PR DESCRIPTION
### Purpose

More control over the sync result and less dependency on android.

### Short description

1) Add our own `SyncResult` data class with the following differences: 
- Not parcelable
- Replaced `databaseError` with `localStorageError` and `contentProviderError`; Updated it's usages.
- dropped methods, because unused: 
  - madeSomeProgress()
  - clear()
  - describeContents()
  - writeToParcel()
  - toDebugString()
- dropped properties, because unused:
  - fullSyncRequested
  - moreRecordsToGet
  - partialSyncUnavailable
  - syncAlreadyInProgress
  - tooManyDeletions
  - tooManyRetries

2) Add our own `SyncStats` data class with the following differences: 
  - Not parcelable
  - dropped properties, because unused or replaced:
    - numConflictDetectedExceptions (unused)
    - numParseExceptions (replaced by numDeadObjectExceptions and numServiceUnavailableExceptions)
  - added properties, to avoid overloading existing properties:
    - numHttpExceptions
    - numUnclassifiedErrors
    - numDeadObjectExceptions
    - numServiceUnavailableExceptions

3) Tests ... to be added after first review

**Note**

- I have not added `SyncResult` to `BaseSyncWorker` even though it's the only place where it's used, bacause `BaseSyncWorker` is a damn long file already. 

- I have not added tests yet because I am afraid there will be wishes for changes in the design.

**Further Information**
https://developer.android.com/reference/android/content/SyncResult

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [ ] I have added reasonable tests or consciously decided to not add tests.

