### PR TITLE
More compatible processing of multiget responses

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
@@ -196,6 +196,19 @@ class CalendarSyncManager @AssistedInject constructor(
         logger.info("Downloading ${bunch.size} iCalendars: $bunch")
         SyncException.wrapWithRemoteResource(collection.url) {
             davCollection.multiget(bunch) { response, _ ->
+                /*
+                 * Real-world servers may return:
+                 *
+                 * - unrelated resources
+                 * - the collection itself
+                 * - the requested resources, but with a different collection URL (for instance, `/cal/1.ics` instead of `/shared-cal/1.ics`).
+                 *
+                 * So we:
+                 *
+                 * - ignore unsuccessful responses,
+                 * - ignore responses without requested calendar data (should also ignore collections and hopefully unrelated resources), and
+                 * - take the last segment of the href as the file name and assume that it's in the requested collection.
+                 */
                 SyncException.wrapWithRemoteResource(response.href) wrapResource@ {
                     if (!response.isSuccess()) {
                         logger.warning("Ignoring non-successful multi-get response for ${response.href}")

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
@@ -196,19 +196,21 @@ class CalendarSyncManager @AssistedInject constructor(
         logger.info("Downloading ${bunch.size} iCalendars: $bunch")
         SyncException.wrapWithRemoteResource(collection.url) {
             davCollection.multiget(bunch) { response, _ ->
-                SyncException.wrapWithRemoteResource(response.href) wrapResponse@ {
+                SyncException.wrapWithRemoteResource(response.href) wrapResource@ {
                     if (!response.isSuccess()) {
-                        logger.warning("Received non-successful multiget response for ${response.href}")
-                        return@wrapResponse
+                        logger.warning("Ignoring non-successful multi-get response for ${response.href}")
+                        return@wrapResource
+                    }
+
+                    val iCal = response[CalendarData::class.java]?.iCalendar
+                    if (iCal == null) {
+                        logger.warning("Ignoring multi-get response without calendar-data")
+                        return@wrapResource
                     }
 
                     val eTag = response[GetETag::class.java]?.eTag
-                            ?: throw DavException("Received multi-get response without ETag")
+                        ?: throw DavException("Received multi-get response without ETag")
                     val scheduleTag = response[ScheduleTag::class.java]?.scheduleTag
-
-                    val calendarData = response[CalendarData::class.java]
-                    val iCal = calendarData?.iCalendar
-                            ?: throw DavException("Received multi-get response without calendar data")
 
                     processVEvent(
                         response.href.lastSegment,

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
@@ -320,6 +320,7 @@ class ContactsSyncManager @AssistedInject constructor(
                 }
             }
             davCollection.multiget(bunch, contentType, version) { response, _ ->
+                // See CalendarSyncManager for more information about the multi-get response
                 SyncException.wrapWithRemoteResource(response.href) wrapResource@ {
                     if (!response.isSuccess()) {
                         logger.warning("Ignoring non-successful multi-get response for ${response.href}")

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
@@ -322,21 +322,23 @@ class ContactsSyncManager @AssistedInject constructor(
             davCollection.multiget(bunch, contentType, version) { response, _ ->
                 SyncException.wrapWithRemoteResource(response.href) wrapResource@ {
                     if (!response.isSuccess()) {
-                        logger.warning("Received non-successful multiget response for ${response.href}")
+                        logger.warning("Ignoring non-successful multi-get response for ${response.href}")
+                        return@wrapResource
+                    }
+
+                    val card = response[AddressData::class.java]?.card
+                    if (card == null) {
+                        logger.warning("Ignoring multi-get response without address-data")
                         return@wrapResource
                     }
 
                     val eTag = response[GetETag::class.java]?.eTag
-                            ?: throw DavException("Received multi-get response without ETag")
+                        ?: throw DavException("Received multi-get response without ETag")
 
                     var isJCard = hasJCard      // assume that server has sent what we have requested (we ask for jCard only when the server advertises it)
                     response[GetContentType::class.java]?.type?.let { type ->
                         isJCard = type.sameTypeAs(DavUtils.MEDIA_TYPE_JCARD)
                     }
-
-                    val addressData = response[AddressData::class.java]
-                    val card = addressData?.card
-                            ?: throw DavException("Received multi-get response without address data")
 
                     processCard(
                         response.href.lastSegment,

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
@@ -123,6 +123,7 @@ class JtxSyncManager @AssistedInject constructor(
         // multiple iCalendars, use calendar-multi-get
         SyncException.wrapWithRemoteResource(collection.url) {
             davCollection.multiget(bunch) { response, _ ->
+                // See CalendarSyncManager for more information about the multi-get response
                 SyncException.wrapWithRemoteResource(response.href) wrapResource@ {
                     if (!response.isSuccess()) {
                         logger.warning("Ignoring non-successful multi-get response for ${response.href}")

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
@@ -125,16 +125,18 @@ class JtxSyncManager @AssistedInject constructor(
             davCollection.multiget(bunch) { response, _ ->
                 SyncException.wrapWithRemoteResource(response.href) wrapResource@ {
                     if (!response.isSuccess()) {
-                        logger.warning("Received non-successful multiget response for ${response.href}")
+                        logger.warning("Ignoring non-successful multi-get response for ${response.href}")
+                        return@wrapResource
+                    }
+
+                    val iCal = response[CalendarData::class.java]?.iCalendar
+                    if (iCal == null) {
+                        logger.warning("Ignoring multi-get response without calendar-data")
                         return@wrapResource
                     }
 
                     val eTag = response[GetETag::class.java]?.eTag
                         ?: throw DavException("Received multi-get response without ETag")
-
-                    val calendarData = response[CalendarData::class.java]
-                    val iCal = calendarData?.iCalendar
-                        ?: throw DavException("Received multi-get response without task data")
 
                     processICalObject(response.href.lastSegment, eTag, StringReader(iCal))
                 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
@@ -123,6 +123,7 @@ class TasksSyncManager @AssistedInject constructor(
         // multiple iCalendars, use calendar-multi-get
         SyncException.wrapWithRemoteResource(collection.url) {
             davCollection.multiget(bunch) { response, _ ->
+                // See CalendarSyncManager for more information about the multi-get response
                 SyncException.wrapWithRemoteResource(response.href) wrapResource@ {
                     if (!response.isSuccess()) {
                         logger.warning("Ignoring non-successful multi-get response for ${response.href}")

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
@@ -125,16 +125,18 @@ class TasksSyncManager @AssistedInject constructor(
             davCollection.multiget(bunch) { response, _ ->
                 SyncException.wrapWithRemoteResource(response.href) wrapResource@ {
                     if (!response.isSuccess()) {
-                        logger.warning("Received non-successful multiget response for ${response.href}")
+                        logger.warning("Ignoring non-successful multi-get response for ${response.href}")
+                        return@wrapResource
+                    }
+
+                    val iCal = response[CalendarData::class.java]?.iCalendar
+                    if (iCal == null) {
+                        logger.warning("Ignoring multi-get response without calendar-data")
                         return@wrapResource
                     }
 
                     val eTag = response[GetETag::class.java]?.eTag
-                            ?: throw DavException("Received multi-get response without ETag")
-
-                    val calendarData = response[CalendarData::class.java]
-                    val iCal = calendarData?.iCalendar
-                            ?: throw DavException("Received multi-get response without task data")
+                        ?: throw DavException("Received multi-get response without ETag")
 
                     processVTodo(response.href.lastSegment, eTag, StringReader(iCal))
                 }


### PR DESCRIPTION
Ignores multi-get responses without data.

Confirmed by user that it now works with CPanel (which sometimes added a multiget response for the collection itself, without data).