### PR TITLE
Updated debug builds configuration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -82,6 +82,9 @@ android {
 
             signingConfig = signingConfigs.findByName("bitfire")
         }
+        getByName("debug") {
+            applicationIdSuffix = ".debug"
+        }
     }
 
     lint {

--- a/app/src/debug/res/values/colors.xml
+++ b/app/src/debug/res/values/colors.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="primaryColor">#E07C25</color>
+    <color name="primaryLightColor">#E5A371</color>
+    <color name="primaryDarkColor">#7C3E07</color>
+</resources>

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name" translatable="false">DAVx⁵ Debug</string>
+</resources>


### PR DESCRIPTION
### Purpose

Right now is hard to test DAVx⁵ in a "production device". You have to reinstall (because the signing key is different), and clear all the app data.

My laptop is having serious issues with the emulator lately, so I've been having to use my personal device, which without this changes, makes me have to reconfigure DAVx⁵ a lot of times.

### Short description

- Added a `.debug` suffix to the package name, that way "two DAVx⁵s" can be installed at the same time.
- Changed the icon color to orange. This only applies to the adaptive icon, just to be quicker, but it's needed in order  to differentiate the production and debug builds in the apps drawer.
- Added a " Debug" suffix to the app name, to differentiate it even more.

The rest of the app is exactly the same.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

