### PR TITLE
Move local collection management from companion objects to LocalDataStore

### DIFF
--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStoreTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStoreTest.kt
@@ -1,16 +1,26 @@
 package at.bitfire.davdroid.resource
 
+import android.accounts.Account
+import android.content.ContentProviderClient
+import android.content.Context
+import android.provider.ContactsContract
+import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.SpyK
 import io.mockk.junit4.MockKRule
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.runs
+import io.mockk.verify
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
@@ -19,13 +29,29 @@ class LocalAddressBookStoreTest {
     @get:Rule
     val mockkRule = MockKRule(this)
 
+    val context: Context = mockk(relaxed = true) {
+        every { getString(R.string.account_type_address_book) } returns "com.bitfire.davdroid.addressbook"
+    }
+//    val account = Account("MrRobert@example.com", "com.bitfire.davdroid.addressbook")
+    val account: Account = mockk(relaxed = true) {
+//        every { name } returns "MrRobert@example.com"
+//        every { type } returns "com.bitfire.davdroid.addressbook"
+    }
+    val provider = mockk<ContentProviderClient>(relaxed = true)
+    val addressBook: LocalAddressBook = mockk(relaxed = true) {
+        every { updateSyncFrameworkSettings() } just runs
+        every { addressBookAccount } returns account
+        every { settings } returns LocalAddressBookStore.contactsProviderSettings
+    }
+
     @SpyK
     @InjectMockKs
     var localAddressBookStore = LocalAddressBookStore(
-        addressBookFactory = mockk(relaxed = true),
         collectionRepository = mockk(relaxed = true),
-        context = mockk(relaxed = true),
-        localAddressBookFactory = mockk(relaxed = true),
+        context = context,
+        localAddressBookFactory = mockk(relaxed = true) {
+            every { create(account, provider) } returns addressBook
+        },
         logger = mockk(relaxed = true),
         serviceRepository = mockk(relaxed = true) {
             every { get(any<Long>()) } returns null
@@ -62,13 +88,44 @@ class LocalAddressBookStoreTest {
 
     @Test
     fun test_accountName_missingDisplayNameAndService() {
-        val collection = mockk<Collection> {
+        val collection = mockk<Collection>(relaxed = true) {
             every { id } returns 1
             every { url } returns "https://example.com/addressbook/funnyfriends".toHttpUrl()
             every { displayName } returns null
             every { serviceId } returns 404 // missing service
         }
         assertEquals("funnyfriends #1", localAddressBookStore.accountName(collection))
+    }
+
+
+    @Test
+    fun test_create_createAccountReturnsNull() {
+        val collection = mockk<Collection>(relaxed = true)  {
+            every { id } returns 1
+            every { url } returns "https://example.com/addressbook/funnyfriends".toHttpUrl()
+        }
+        every { localAddressBookStore.createAccount(any(), any(), any()) } returns null
+        assertEquals(null, localAddressBookStore.create(provider, collection))
+    }
+
+    @Test
+    fun test_create_createAccountReturnsAccount() {
+        val collection = mockk<Collection>(relaxed = true)  {
+            every { id } returns 1
+            every { url } returns "https://example.com/addressbook/funnyfriends".toHttpUrl()
+        }
+        every { localAddressBookStore.createAccount(any(), any(), any()) } returns account
+        every { addressBook.readOnly } returns true
+        val addrBook = localAddressBookStore.create(provider, collection)!!
+
+        verify(exactly = 1) { addressBook.updateSyncFrameworkSettings() }
+        assertEquals(account, addrBook.addressBookAccount)
+        assertEquals(LocalAddressBookStore.contactsProviderSettings, addrBook.settings)
+        assertEquals(true, addrBook.readOnly)
+
+        every { addressBook.readOnly } returns false
+        val addrBook2 = localAddressBookStore.create(provider, collection)!!
+        assertEquals(false, addrBook2.readOnly)
     }
 
 

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStoreTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStoreTest.kt
@@ -1,0 +1,26 @@
+package at.bitfire.davdroid.resource
+
+import at.bitfire.davdroid.db.Collection
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LocalAddressBookStoreTest {
+
+    /**
+     * Tests the calculation of read only state is correct
+     */
+    @Test
+    fun test_shouldBeReadOnly() {
+        val collectionReadOnly = mockk<Collection> { every { readOnly() } returns true }
+        assertTrue(LocalAddressBookStore.shouldBeReadOnly(collectionReadOnly, false))
+        assertTrue(LocalAddressBookStore.shouldBeReadOnly(collectionReadOnly, true))
+
+        val collectionNotReadOnly = mockk<Collection> { every { readOnly() } returns false }
+        assertFalse(LocalAddressBookStore.shouldBeReadOnly(collectionNotReadOnly, false))
+        assertTrue(LocalAddressBookStore.shouldBeReadOnly(collectionNotReadOnly, true))
+    }
+
+}

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStoreTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStoreTest.kt
@@ -1,13 +1,76 @@
 package at.bitfire.davdroid.resource
 
 import at.bitfire.davdroid.db.Collection
+import at.bitfire.davdroid.db.Service
 import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.SpyK
+import io.mockk.junit4.MockKRule
 import io.mockk.mockk
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
 
 class LocalAddressBookStoreTest {
+
+    @get:Rule
+    val mockkRule = MockKRule(this)
+
+    @SpyK
+    @InjectMockKs
+    var localAddressBookStore = LocalAddressBookStore(
+        addressBookFactory = mockk(relaxed = true),
+        collectionRepository = mockk(relaxed = true),
+        context = mockk(relaxed = true),
+        localAddressBookFactory = mockk(relaxed = true),
+        logger = mockk(relaxed = true),
+        serviceRepository = mockk(relaxed = true) {
+            every { get(any<Long>()) } returns null
+            every { get(200) } returns mockk<Service> {
+                every { accountName } returns "MrRobert@example.com"
+            }
+        },
+        settings = mockk(relaxed = true)
+    )
+
+
+    @Test
+    fun test_accountName_missingService() {
+        val collection = mockk<Collection> {
+            every { id } returns 42
+            every { url } returns "https://example.com/addressbook/funnyfriends".toHttpUrl()
+            every { displayName } returns null
+            every { serviceId } returns 404
+        }
+        assertEquals("funnyfriends #42", localAddressBookStore.accountName(collection))
+    }
+
+    @Test
+    fun test_accountName_missingDisplayName() {
+        val collection = mockk<Collection> {
+            every { id } returns 42
+            every { url } returns "https://example.com/addressbook/funnyfriends".toHttpUrl()
+            every { displayName } returns null
+            every { serviceId } returns 200
+        }
+        val accountName = localAddressBookStore.accountName(collection)
+        assertEquals("funnyfriends (MrRobert@example.com) #42", accountName)
+    }
+
+    @Test
+    fun test_accountName_missingDisplayNameAndService() {
+        val collection = mockk<Collection> {
+            every { id } returns 1
+            every { url } returns "https://example.com/addressbook/funnyfriends".toHttpUrl()
+            every { displayName } returns null
+            every { serviceId } returns 404 // missing service
+        }
+        assertEquals("funnyfriends #1", localAddressBookStore.accountName(collection))
+    }
+
 
     /**
      * Tests the calculation of read only state is correct

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookTest.kt
@@ -6,13 +6,13 @@ package at.bitfire.davdroid.resource
 
 import android.Manifest
 import android.accounts.Account
+import android.accounts.AccountManager
 import android.content.ContentProviderClient
 import android.content.ContentUris
 import android.content.Context
 import android.provider.ContactsContract
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
-import at.bitfire.davdroid.db.Collection
 import at.bitfire.vcard4android.Contact
 import at.bitfire.vcard4android.GroupMethod
 import at.bitfire.vcard4android.LabeledProperty
@@ -20,21 +20,18 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import ezvcard.property.Telephone
-import io.mockk.every
-import io.mockk.mockk
-import java.util.LinkedList
-import javax.inject.Inject
 import org.junit.After
 import org.junit.AfterClass
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.ClassRule
 import org.junit.Rule
 import org.junit.Test
+import java.util.LinkedList
+import javax.inject.Inject
 
 @HiltAndroidTest
 class LocalAddressBookTest {
@@ -63,7 +60,8 @@ class LocalAddressBookTest {
     @After
     fun tearDown() {
         // remove address book
-        addressBook.deleteCollection()
+        val accountManager = AccountManager.get(context)
+        accountManager.removeAccountExplicitly(addressBook.addressBookAccount)
     }
 
 
@@ -126,21 +124,6 @@ class LocalAddressBookTest {
         val group = result.getContact()
         assertEquals("Test Group", group.displayName)
     }
-
-    /**
-     * Tests the calculation of read only state is correct
-     */
-    @Test
-    fun test_shouldBeReadOnly() {
-        val collectionReadOnly = mockk<Collection> { every { readOnly() } returns true }
-        assertTrue(LocalAddressBook.shouldBeReadOnly(collectionReadOnly, false))
-        assertTrue(LocalAddressBook.shouldBeReadOnly(collectionReadOnly, true))
-
-        val collectionNotReadOnly = mockk<Collection> { every { readOnly() } returns false }
-        assertFalse(LocalAddressBook.shouldBeReadOnly(collectionNotReadOnly, false))
-        assertTrue(LocalAddressBook.shouldBeReadOnly(collectionNotReadOnly, true))
-    }
-
 
     companion object {
 

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalCalendarTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalCalendarTest.kt
@@ -66,7 +66,7 @@ class LocalCalendarTest {
 
     @After
     fun tearDown() {
-        calendar.deleteCollection()
+        calendar.delete()
     }
 
 

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalEventTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalEventTest.kt
@@ -12,6 +12,7 @@ import android.os.Build
 import android.provider.CalendarContract
 import android.provider.CalendarContract.ACCOUNT_TYPE_LOCAL
 import android.provider.CalendarContract.Events
+import androidx.datastore.dataStore
 import androidx.test.platform.app.InstrumentationRegistry
 import at.bitfire.davdroid.InitCalendarProviderRule
 import at.bitfire.ical4android.AndroidCalendar
@@ -74,7 +75,7 @@ class LocalEventTest {
 
     @After
     fun removeCalendar() {
-        calendar.deleteCollection()
+        calendar.delete()
     }
 
 
@@ -282,7 +283,7 @@ class LocalEventTest {
             })
         }
         val localEvent = LocalEvent(calendar, event, "filename.ics", null, null, 0)
-        val uri = localEvent.add()
+        localEvent.add()
 
         calendar.findById(localEvent.id!!)
 

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/LocalTestCollection.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/LocalTestCollection.kt
@@ -21,8 +21,6 @@ class LocalTestCollection(
     override val readOnly: Boolean
         get() = throw NotImplementedError()
 
-    override fun deleteCollection(): Boolean = true
-
     override fun findDeleted() = entries.filter { it.deleted }
     override fun findDirty() = entries.filter { it.dirty }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/repository/AccountRepository.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/repository/AccountRepository.kt
@@ -15,7 +15,7 @@ import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.Credentials
 import at.bitfire.davdroid.db.HomeSet
 import at.bitfire.davdroid.db.Service
-import at.bitfire.davdroid.resource.LocalAddressBook
+import at.bitfire.davdroid.resource.LocalAddressBookStore
 import at.bitfire.davdroid.resource.LocalTaskList
 import at.bitfire.davdroid.servicedetection.DavResourceFinder
 import at.bitfire.davdroid.servicedetection.RefreshCollectionsWorker
@@ -49,6 +49,7 @@ class AccountRepository @Inject constructor(
     @ApplicationContext val context: Context,
     private val collectionRepository: DavCollectionRepository,
     private val homeSetRepository: DavHomeSetRepository,
+    private val localAddressBookStore: Lazy<LocalAddressBookStore>,
     private val logger: Logger,
     private val settingsManager: SettingsManager,
     private val serviceRepository: DavServiceRepository,
@@ -140,7 +141,7 @@ class AccountRepository @Inject constructor(
             // delete address books (= address book accounts)
             serviceRepository.getByAccountAndType(accountName, Service.TYPE_CARDDAV)?.let { service ->
                 collectionRepository.getByService(service.id).forEach { collection ->
-                    LocalAddressBook.deleteByCollection(context, collection.id)
+                    localAddressBookStore.get().deleteByCollectionId(collection.id)
                 }
             }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -315,18 +315,27 @@ open class LocalAddressBook @AssistedInject constructor(
 
     companion object {
 
+        /**
+         * URL of the corresponding CardDAV address book.
+         *
+         * User data of the address book account (String).
+         */
+        @Deprecated("Use the URL of the DB collection instead")
         const val USER_DATA_URL = "url"
+
+        /**
+         * ID of the corresponding database [at.bitfire.davdroid.db.Collection].
+         *
+         * User data of the address book account (Long).
+         */
         const val USER_DATA_COLLECTION_ID = "collection_id"
 
+        /**
+         * Indicates whether the address book is currently set to read-only (i.e. its contacts and groups have the read-only flag).
+         *
+         * User data of the address book account (Boolean).
+         */
         const val USER_DATA_READ_ONLY = "read_only"
-
-        internal fun initialUserData(url: String, collectionId: String): Bundle {
-            val bundle = Bundle(3)
-            bundle.putString(USER_DATA_COLLECTION_ID, collectionId)
-            bundle.putString(USER_DATA_URL, url)
-            // TODO read-only??
-            return bundle
-        }
 
     }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -103,6 +103,18 @@ open class LocalAddressBook @AssistedInject constructor(
                 ?: throw IllegalStateException("Address book has no URL")
         set(url) = AccountManager.get(context).setAndVerifyUserData(addressBookAccount, USER_DATA_URL, url)
 
+    /**
+     * Read-only flag for the address book itself.
+     *
+     * Setting this flag:
+     *
+     * - stores the new value in [USER_DATA_READ_ONLY] and
+     * - sets the read-only flag for all contacts and groups in the address book in the content provider, which will
+     * prevent non-sync-adapter apps from modifying them. However new entries can still be created, so the address book
+     * is not really read-only.
+     *
+     * Reading this flag returns the stored value from [USER_DATA_READ_ONLY].
+     */
     override var readOnly: Boolean
         get() = AccountManager.get(context).getUserData(addressBookAccount, USER_DATA_READ_ONLY) != null
         set(readOnly) {

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
@@ -87,7 +87,7 @@ class LocalAddressBookStore @Inject constructor(
         // update settings
         addressBook.updateSyncFrameworkSettings()
         addressBook.settings = contactsProviderSettings
-        addressBook.readOnly = forceAllReadOnly || fromCollection.readOnly()
+        addressBook.readOnly = shouldBeReadOnly(fromCollection, forceAllReadOnly)
 
         return addressBook
     }
@@ -162,7 +162,6 @@ class LocalAddressBookStore @Inject constructor(
             logger.info("Address book has changed to read-only = $nowReadOnly")
             localCollection.readOnly = nowReadOnly
         }
-
 
         // make sure it will still be synchronized when contacts are updated
         localCollection.updateSyncFrameworkSettings()

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
@@ -20,10 +20,10 @@ import at.bitfire.davdroid.repository.DavCollectionRepository
 import at.bitfire.davdroid.repository.DavServiceRepository
 import at.bitfire.davdroid.resource.LocalAddressBook.Companion.USER_DATA_COLLECTION_ID
 import at.bitfire.davdroid.resource.LocalAddressBook.Companion.USER_DATA_URL
-import at.bitfire.davdroid.resource.LocalAddressBook.Companion.accountName
 import at.bitfire.davdroid.settings.Settings
 import at.bitfire.davdroid.settings.SettingsManager
 import at.bitfire.davdroid.sync.account.SystemAccountUtils
+import at.bitfire.davdroid.util.DavUtils.lastSegment
 import at.bitfire.davdroid.util.setAndVerifyUserData
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.util.logging.Level
@@ -35,18 +35,48 @@ class LocalAddressBookStore @Inject constructor(
     val addressBookFactory: LocalAddressBook.Factory,
     val collectionRepository: DavCollectionRepository,
     @ApplicationContext val context: Context,
+    val localAddressBookFactory: LocalAddressBook.Factory,
     val logger: Logger,
-    val settings: SettingsManager,
-    val serviceRepository: DavServiceRepository
-): LocalDataStore<LocalAddressBook> {
+    val serviceRepository: DavServiceRepository,
+    val settings: SettingsManager
+    ): LocalDataStore<LocalAddressBook> {
 
     /** whether a (usually managed) setting wants all address-books to be read-only **/
     val forceAllReadOnly: Boolean
         get() = settings.getBoolean(Settings.FORCE_READ_ONLY_ADDRESSBOOKS)
 
 
+    /**
+     * Assembles a name for the address book (account) from its corresponding database [Collection].
+     *
+     * The address book account name contains
+     *
+     * - the collection display name or last URL path segment
+     * - the actual account name
+     * - the collection ID, to make it unique.
+     *
+     * @param info  Collection to take info from
+     */
+    fun accountName(info: Collection): String {
+        // Name the address book after given collection display name, otherwise use last URL path segment
+        val sb = StringBuilder(info.displayName.let {
+            if (it.isNullOrEmpty())
+                info.url.lastSegment
+            else
+                it
+        })
+        // Add the actual account name to the address book account name
+        serviceRepository.get(info.serviceId)?.let { service ->
+            sb.append(" (${service.accountName})")
+        }
+        // Add the collection ID for uniqueness
+        sb.append(" #${info.id}")
+        return sb.toString()
+    }
+
+
     override fun create(provider: ContentProviderClient, fromCollection: Collection): LocalAddressBook? {
-        val name = accountName(context, fromCollection)
+        val name = accountName(fromCollection)
         val account = createAccount(
             name = name,
             id = fromCollection.id,
@@ -78,12 +108,41 @@ class LocalAddressBookStore @Inject constructor(
         return account
     }
 
+
+    override fun getAll(account: Account, provider: ContentProviderClient): List<LocalAddressBook> =
+        serviceRepository.getByAccountAndType(account.name, Service.TYPE_CARDDAV)?.let { service ->
+            // get all collections for the CardDAV service
+            collectionRepository.getByService(service.id).mapNotNull { collection ->
+                // and map to a LocalAddressBook, if applicable
+                findByCollection(provider, collection.id)
+            }
+        }.orEmpty()
+
+    /**
+     * Finds a [LocalAddressBook] based on its corresponding collection.
+     *
+     * @param id    collection ID to look for
+     *
+     * @return The [LocalAddressBook] for the given collection or *null* if not found
+     */
+    private fun findByCollection(provider: ContentProviderClient, id: Long): LocalAddressBook? {
+        val accountManager = AccountManager.get(context)
+        return accountManager
+            .getAccountsByType(context.getString(R.string.account_type_address_book))
+            .filter { account ->
+                accountManager.getUserData(account, USER_DATA_COLLECTION_ID)?.toLongOrNull() == id
+            }
+            .map { account -> localAddressBookFactory.create(account, provider) }
+            .firstOrNull()
+    }
+
+
     override fun update(provider: ContentProviderClient, localCollection: LocalAddressBook, fromCollection: Collection) {
         var currentAccount = localCollection.addressBookAccount
         logger.log(Level.INFO, "Updating local address book $currentAccount from collection $fromCollection")
 
         // Update the account name
-        val newAccountName = accountName(context, fromCollection)
+        val newAccountName = accountName(fromCollection)
         if (currentAccount.name != newAccountName) {
             // rename, move contacts/groups and update [AndroidAddressBook.]account
             localCollection.renameAccount(newAccountName)
@@ -130,16 +189,24 @@ class LocalAddressBookStore @Inject constructor(
         localCollection.updateSyncFrameworkSettings()
     }
 
-    override fun getAll(account: Account, provider: ContentProviderClient): List<LocalAddressBook> =
-        serviceRepository.getByAccountAndType(account.name, Service.TYPE_CARDDAV)?.let { service ->
-            collectionRepository.getByService(service.id).mapNotNull { collection ->
-                LocalAddressBook.findByCollection(context, provider, collection.id)
-            }
-        }.orEmpty()
 
     override fun delete(localCollection: LocalAddressBook) {
         val accountManager = AccountManager.get(context)
         accountManager.removeAccountExplicitly(localCollection.addressBookAccount)
+    }
+
+    /**
+     * Deletes a [LocalAddressBook] based on its corresponding database collection.
+     *
+     * @param id    [Collection.id] to look for
+     */
+    fun deleteByCollectionId(id: Long) {
+        val accountManager = AccountManager.get(context)
+        val addressBookAccount = accountManager.getAccountsByType(context.getString(R.string.account_type_address_book)).firstOrNull { account ->
+            accountManager.getUserData(account, USER_DATA_COLLECTION_ID)?.toLongOrNull() == id
+        }
+        if (addressBookAccount != null)
+            accountManager.removeAccountExplicitly(addressBookAccount)
     }
 
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
@@ -31,7 +31,6 @@ import javax.inject.Inject
 import kotlin.collections.orEmpty
 
 class LocalAddressBookStore @Inject constructor(
-    val addressBookFactory: LocalAddressBook.Factory,
     val collectionRepository: DavCollectionRepository,
     @ApplicationContext val context: Context,
     val localAddressBookFactory: LocalAddressBook.Factory,
@@ -82,7 +81,7 @@ class LocalAddressBookStore @Inject constructor(
             url = fromCollection.url.toString()
         ) ?: return null
 
-        val addressBook = addressBookFactory.create(account, provider)
+        val addressBook = localAddressBookFactory.create(account, provider)
 
         // update settings
         addressBook.updateSyncFrameworkSettings()

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
@@ -107,18 +107,21 @@ class LocalAddressBookStore @Inject constructor(
             localCollection.readOnly = nowReadOnly
 
             // update raw contacts
-            val rawContactValues = ContentValues(1)
-            rawContactValues.put(RawContacts.RAW_CONTACT_IS_READ_ONLY, if (nowReadOnly) 1 else 0)
+            val rawContactValues = ContentValues(1).apply {
+                put(RawContacts.RAW_CONTACT_IS_READ_ONLY, if (nowReadOnly) 1 else 0)
+            }
             provider.update(localCollection.rawContactsSyncUri(), rawContactValues, null, null)
 
             // update data rows
-            val dataValues = ContentValues(1)
-            dataValues.put(ContactsContract.Data.IS_READ_ONLY, if (nowReadOnly) 1 else 0)
+            val dataValues = ContentValues(1).apply {
+                put(ContactsContract.Data.IS_READ_ONLY, if (nowReadOnly) 1 else 0)
+            }
             provider.update(localCollection.syncAdapterURI(ContactsContract.Data.CONTENT_URI), dataValues, null, null)
 
             // update group rows
-            val groupValues = ContentValues(1)
-            groupValues.put(Groups.GROUP_IS_READ_ONLY, if (nowReadOnly) 1 else 0)
+            val groupValues = ContentValues(1).apply {
+                put(Groups.GROUP_IS_READ_ONLY, if (nowReadOnly) 1 else 0)
+            }
             provider.update(localCollection.groupsSyncUri(), groupValues, null, null)
         }
 
@@ -145,13 +148,14 @@ class LocalAddressBookStore @Inject constructor(
         /**
          * Contacts Provider Settings (equal for every address book)
          */
-        val contactsProviderSettings = ContentValues(2).apply {
-            // SHOULD_SYNC is just a hint that an account's contacts (the contacts of this local address book) are syncable.
-            put(ContactsContract.Settings.SHOULD_SYNC, 1)
+        val contactsProviderSettings
+            get() = ContentValues(2).apply {
+                // SHOULD_SYNC is just a hint that an account's contacts (the contacts of this local address book) are syncable.
+                put(ContactsContract.Settings.SHOULD_SYNC, 1)
 
-            // UNGROUPED_VISIBLE is required for making contacts work over Bluetooth (especially with some car systems).
-            put(ContactsContract.Settings.UNGROUPED_VISIBLE, 1)
-        }
+                // UNGROUPED_VISIBLE is required for making contacts work over Bluetooth (especially with some car systems).
+                put(ContactsContract.Settings.UNGROUPED_VISIBLE, 1)
+            }
 
         /**
          * Determines whether the address book should be set to read-only.

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.resource
+
+import android.accounts.Account
+import android.accounts.AccountManager
+import android.content.ContentProviderClient
+import android.content.ContentValues
+import android.content.Context
+import android.provider.ContactsContract
+import android.provider.ContactsContract.Groups
+import android.provider.ContactsContract.RawContacts
+import androidx.annotation.VisibleForTesting
+import at.bitfire.davdroid.R
+import at.bitfire.davdroid.db.Collection
+import at.bitfire.davdroid.resource.LocalAddressBook.Companion.USER_DATA_COLLECTION_ID
+import at.bitfire.davdroid.resource.LocalAddressBook.Companion.USER_DATA_URL
+import at.bitfire.davdroid.resource.LocalAddressBook.Companion.accountName
+import at.bitfire.davdroid.settings.Settings
+import at.bitfire.davdroid.settings.SettingsManager
+import at.bitfire.davdroid.sync.account.SystemAccountUtils
+import at.bitfire.davdroid.util.setAndVerifyUserData
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.logging.Level
+import java.util.logging.Logger
+import javax.inject.Inject
+
+class LocalAddressBookStore @Inject constructor(
+    val addressBookFactory: LocalAddressBook.Factory,
+    @ApplicationContext val context: Context,
+    val logger: Logger,
+    val settings: SettingsManager
+): LocalDataStore<LocalAddressBook> {
+
+    /** whether a (usually managed) setting wants all address-books to be read-only **/
+    val forceAllReadOnly: Boolean
+        get() = settings.getBoolean(Settings.FORCE_READ_ONLY_ADDRESSBOOKS)
+
+
+    override fun create(provider: ContentProviderClient, fromCollection: Collection): LocalAddressBook? {
+        val name = LocalAddressBook.accountName(context, fromCollection)
+        val account = createAccount(
+            name = name,
+            id = fromCollection.id,
+            url = fromCollection.url.toString()
+        ) ?: return null
+
+        val addressBook = addressBookFactory.create(account, provider)
+
+        // update settings
+        addressBook.updateSyncFrameworkSettings()
+        addressBook.settings = contactsProviderSettings
+        addressBook.readOnly = forceAllReadOnly || fromCollection.readOnly()
+
+        return addressBook
+    }
+
+    fun createAccount(name: String, id: Long, url: String): Account? {
+        // create account
+        val account = Account(name, context.getString(R.string.account_type_address_book))
+        val userData = LocalAddressBook.initialUserData(
+            url = url,
+            collectionId = id.toString()
+        )
+        if (!SystemAccountUtils.createAccount(context, account, userData)) {
+            logger.warning("Couldn't create address book account: $account")
+            return null
+        }
+
+        return account
+    }
+
+    override fun update(provider: ContentProviderClient, localCollection: LocalAddressBook, fromCollection: Collection) {
+        var currentAccount = localCollection.addressBookAccount
+        logger.log(Level.INFO, "Updating local address book $currentAccount from collection $fromCollection")
+
+        // Update the account name
+        val newAccountName = accountName(context, fromCollection)
+        if (currentAccount.name != newAccountName) {
+            // rename, move contacts/groups and update [AndroidAddressBook.]account
+            localCollection.renameAccount(newAccountName)
+            currentAccount.name = newAccountName
+        }
+
+        // Update the account user data
+        val accountManager = AccountManager.get(context)
+        accountManager.setAndVerifyUserData(currentAccount, USER_DATA_COLLECTION_ID, fromCollection.id.toString())
+        accountManager.setAndVerifyUserData(currentAccount, USER_DATA_URL, fromCollection.url.toString())
+
+        // Set contacts provider settings
+        localCollection.settings = contactsProviderSettings
+
+        // Update force read only
+        val nowReadOnly = shouldBeReadOnly(fromCollection, forceAllReadOnly)
+        if (nowReadOnly != localCollection.readOnly) {
+            logger.info("Address book now read-only = $nowReadOnly, updating contacts")
+
+            // update address book itself
+            localCollection.readOnly = nowReadOnly
+
+            // update raw contacts
+            val rawContactValues = ContentValues(1)
+            rawContactValues.put(RawContacts.RAW_CONTACT_IS_READ_ONLY, if (nowReadOnly) 1 else 0)
+            provider.update(localCollection.rawContactsSyncUri(), rawContactValues, null, null)
+
+            // update data rows
+            val dataValues = ContentValues(1)
+            dataValues.put(ContactsContract.Data.IS_READ_ONLY, if (nowReadOnly) 1 else 0)
+            provider.update(localCollection.syncAdapterURI(ContactsContract.Data.CONTENT_URI), dataValues, null, null)
+
+            // update group rows
+            val groupValues = ContentValues(1)
+            groupValues.put(Groups.GROUP_IS_READ_ONLY, if (nowReadOnly) 1 else 0)
+            provider.update(localCollection.groupsSyncUri(), groupValues, null, null)
+        }
+
+
+        // make sure it will still be synchronized when contacts are updated
+        localCollection.updateSyncFrameworkSettings()
+    }
+
+
+    override fun delete(localCollection: LocalAddressBook) {
+        val accountManager = AccountManager.get(context)
+        accountManager.removeAccountExplicitly(localCollection.addressBookAccount)
+    }
+
+
+    companion object {
+
+        /**
+         * Contacts Provider Settings (equal for every address book)
+         */
+        val contactsProviderSettings = ContentValues(2).apply {
+            // SHOULD_SYNC is just a hint that an account's contacts (the contacts of this local address book) are syncable.
+            put(ContactsContract.Settings.SHOULD_SYNC, 1)
+
+            // UNGROUPED_VISIBLE is required for making contacts work over Bluetooth (especially with some car systems).
+            put(ContactsContract.Settings.UNGROUPED_VISIBLE, 1)
+        }
+
+        /**
+         * Determines whether the address book should be set to read-only.
+         *
+         * @param forceAllReadOnly  Whether (usually managed, app-wide) setting should overwrite local read-only information
+         * @param info              Collection data to determine read-only status from (either user-set read-only flag or missing write privilege)
+         */
+        @VisibleForTesting
+        internal fun shouldBeReadOnly(info: Collection, forceAllReadOnly: Boolean): Boolean =
+            info.readOnly() || forceAllReadOnly
+
+    }
+
+}

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
@@ -11,8 +11,6 @@ import android.content.ContentValues
 import android.content.Context
 import android.os.Bundle
 import android.provider.ContactsContract
-import android.provider.ContactsContract.Groups
-import android.provider.ContactsContract.RawContacts
 import androidx.annotation.VisibleForTesting
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.Collection
@@ -161,28 +159,8 @@ class LocalAddressBookStore @Inject constructor(
         // Update force read only
         val nowReadOnly = shouldBeReadOnly(fromCollection, forceAllReadOnly)
         if (nowReadOnly != localCollection.readOnly) {
-            logger.info("Address book now read-only = $nowReadOnly, updating contacts")
-
-            // update address book itself
+            logger.info("Address book has changed to read-only = $nowReadOnly")
             localCollection.readOnly = nowReadOnly
-
-            // update raw contacts
-            val rawContactValues = ContentValues(1).apply {
-                put(RawContacts.RAW_CONTACT_IS_READ_ONLY, if (nowReadOnly) 1 else 0)
-            }
-            provider.update(localCollection.rawContactsSyncUri(), rawContactValues, null, null)
-
-            // update data rows
-            val dataValues = ContentValues(1).apply {
-                put(ContactsContract.Data.IS_READ_ONLY, if (nowReadOnly) 1 else 0)
-            }
-            provider.update(localCollection.syncAdapterURI(ContactsContract.Data.CONTENT_URI), dataValues, null, null)
-
-            // update group rows
-            val groupValues = ContentValues(1).apply {
-                put(Groups.GROUP_IS_READ_ONLY, if (nowReadOnly) 1 else 0)
-            }
-            provider.update(localCollection.groupsSyncUri(), groupValues, null, null)
         }
 
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
@@ -9,6 +9,7 @@ import android.accounts.AccountManager
 import android.content.ContentProviderClient
 import android.content.ContentValues
 import android.content.Context
+import android.os.Bundle
 import android.provider.ContactsContract
 import android.provider.ContactsContract.Groups
 import android.provider.ContactsContract.RawContacts
@@ -94,12 +95,12 @@ class LocalAddressBookStore @Inject constructor(
     }
 
     fun createAccount(name: String, id: Long, url: String): Account? {
-        // create account
+        // create account with collection ID and URL
         val account = Account(name, context.getString(R.string.account_type_address_book))
-        val userData = LocalAddressBook.initialUserData(
-            url = url,
-            collectionId = id.toString()
-        )
+        val userData = Bundle(2).apply {
+            putString(USER_DATA_COLLECTION_ID, id.toString())
+            putString(USER_DATA_URL, url)
+        }
         if (!SystemAccountUtils.createAccount(context, account, userData)) {
             logger.warning("Couldn't create address book account: $account")
             return null

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
@@ -42,28 +42,7 @@ class LocalCalendar private constructor(
         private val logger: Logger
             get() = Logger.getGlobal()
 
-        fun create(account: Account, provider: ContentProviderClient, info: Collection): Uri {
-            // If the collection doesn't have a color, use a default color.
-            if (info.color != null)
-                info.color = Constants.DAVDROID_GREEN_RGBA
-
-            val values = valuesFromCollectionInfo(info, withColor = true)
-
-            // ACCOUNT_NAME and ACCOUNT_TYPE are required (see docs)! If it's missing, other apps will crash.
-            values.put(Calendars.ACCOUNT_NAME, account.name)
-            values.put(Calendars.ACCOUNT_TYPE, account.type)
-
-            // Email address for scheduling. Used by the calendar provider to determine whether the
-            // user is ORGANIZER/ATTENDEE for a certain event.
-            values.put(Calendars.OWNER_ACCOUNT, account.name)
-
-            // flag as visible & synchronizable at creation, might be changed by user at any time
-            values.put(Calendars.VISIBLE, 1)
-            values.put(Calendars.SYNC_EVENTS, 1)
-            return create(account, provider, values)
-        }
-
-        private fun valuesFromCollectionInfo(info: Collection, withColor: Boolean): ContentValues {
+        fun valuesFromCollectionInfo(info: Collection, withColor: Boolean): ContentValues {
             val values = ContentValues()
             values.put(Calendars.NAME, info.url.toString())
             values.put(Calendars.CALENDAR_DISPLAY_NAME,
@@ -110,8 +89,6 @@ class LocalCalendar private constructor(
     private var accessLevel: Int = Calendars.CAL_ACCESS_OWNER   // assume full access if not specified
     override val readOnly
         get() = accessLevel <= Calendars.CAL_ACCESS_READ
-
-    override fun deleteCollection(): Boolean = delete()
 
     override var lastSyncState: SyncState?
         get() = provider.query(calendarSyncURI(), arrayOf(COLUMN_SYNC_STATE), null, null, null)?.use { cursor ->

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendarStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendarStore.kt
@@ -58,6 +58,9 @@ class LocalCalendarStore @Inject constructor(
         return AndroidCalendar.findByID(account, provider, LocalCalendar.Factory, ContentUris.parseId(uri))
     }
 
+    override fun getAll(account: Account, provider: ContentProviderClient) =
+        AndroidCalendar.find(account, provider, LocalCalendar.Factory, "${Calendars.SYNC_EVENTS}!=0", null)
+
     override fun update(provider: ContentProviderClient, localCollection: LocalCalendar, fromCollection: Collection) {
         logger.log(Level.FINE, "Updating local calendar ${fromCollection.url}", fromCollection)
         val accountSettings = accountSettingsFactory.create(localCollection.account)

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendarStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendarStore.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.resource
+
+import android.accounts.Account
+import android.content.ContentProviderClient
+import android.content.ContentUris
+import android.content.Context
+import android.provider.CalendarContract.Calendars
+import at.bitfire.davdroid.Constants
+import at.bitfire.davdroid.R
+import at.bitfire.davdroid.db.AppDatabase
+import at.bitfire.davdroid.db.Collection
+import at.bitfire.davdroid.resource.LocalCalendar.Companion.valuesFromCollectionInfo
+import at.bitfire.davdroid.settings.AccountSettings
+import at.bitfire.ical4android.AndroidCalendar
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.logging.Level
+import java.util.logging.Logger
+import javax.inject.Inject
+
+class LocalCalendarStore @Inject constructor(
+    @ApplicationContext val context: Context,
+    val accountSettingsFactory: AccountSettings.Factory,
+    db: AppDatabase,
+    val logger: Logger
+): LocalDataStore<LocalCalendar> {
+
+    private val serviceDao = db.serviceDao()
+
+
+    override fun create(provider: ContentProviderClient, fromCollection: Collection): LocalCalendar? {
+        val service = serviceDao.get(fromCollection.serviceId) ?: throw IllegalArgumentException("Couldn't fetch DB service from collection")
+        val account = Account(service.accountName, context.getString(R.string.account_type))
+
+        // If the collection doesn't have a color, use a default color.
+        if (fromCollection.color != null)
+            fromCollection.color = Constants.DAVDROID_GREEN_RGBA
+
+        val values = valuesFromCollectionInfo(fromCollection, withColor = true)
+
+        // ACCOUNT_NAME and ACCOUNT_TYPE are required (see docs)! If it's missing, other apps will crash.
+        values.put(Calendars.ACCOUNT_NAME, account.name)
+        values.put(Calendars.ACCOUNT_TYPE, account.type)
+
+        // Email address for scheduling. Used by the calendar provider to determine whether the
+        // user is ORGANIZER/ATTENDEE for a certain event.
+        values.put(Calendars.OWNER_ACCOUNT, account.name)
+
+        // flag as visible & syncable at creation, might be changed by user at any time
+        values.put(Calendars.VISIBLE, 1)
+        values.put(Calendars.SYNC_EVENTS, 1)
+
+        logger.log(Level.INFO, "Adding local calendar", values)
+        val uri = AndroidCalendar.create(account, provider, values)
+        return AndroidCalendar.findByID(account, provider, LocalCalendar.Factory, ContentUris.parseId(uri))
+    }
+
+    override fun update(provider: ContentProviderClient, localCollection: LocalCalendar, fromCollection: Collection) {
+        logger.log(Level.FINE, "Updating local calendar ${fromCollection.url}", fromCollection)
+        val accountSettings = accountSettingsFactory.create(localCollection.account)
+        localCollection.update(fromCollection, accountSettings.getManageCalendarColors())
+    }
+
+    override fun delete(localCollection: LocalCalendar) {
+        logger.log(Level.INFO, "Deleting local calendar", localCollection)
+        localCollection.delete()
+    }
+
+}

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalCollection.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalCollection.kt
@@ -4,7 +4,6 @@
 
 package at.bitfire.davdroid.resource
 
-import android.provider.CalendarContract.Events
 import at.bitfire.davdroid.db.SyncState
 
 interface LocalCollection<out T: LocalResource<*>> {
@@ -26,13 +25,6 @@ interface LocalCollection<out T: LocalResource<*>> {
      * Stops uploading dirty events (Server side changes are still downloaded).
      */
     val readOnly: Boolean
-
-    /**
-     * Deletes the local collection.
-     *
-     * @return true if the collection was deleted, false otherwise
-     */
-    fun deleteCollection(): Boolean
 
     /**
      * Finds local resources of this collection which have been marked as *deleted* by the user

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalDataStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalDataStore.kt
@@ -4,6 +4,7 @@
 
 package at.bitfire.davdroid.resource
 
+import android.accounts.Account
 import android.content.ContentProviderClient
 import at.bitfire.davdroid.db.Collection
 
@@ -22,6 +23,8 @@ interface LocalDataStore<T: LocalCollection<*>> {
      * @return the new local collection, or `null` if creation failed
      */
     fun create(provider: ContentProviderClient, fromCollection: Collection): T?
+
+    fun getAll(account: Account, provider: ContentProviderClient): List<T>
 
     /**
      * Updates the local collection with the data from the given (remote) collection info.

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalDataStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalDataStore.kt
@@ -24,6 +24,14 @@ interface LocalDataStore<T: LocalCollection<*>> {
      */
     fun create(provider: ContentProviderClient, fromCollection: Collection): T?
 
+    /**
+     * Returns all local collections of the data store.
+     *
+     * @param account  the account that the data store is associated with
+     * @param provider the content provider client
+     *
+     * @return a list of all local collections
+     */
     fun getAll(account: Account, provider: ContentProviderClient): List<T>
 
     /**

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalDataStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalDataStore.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.resource
+
+import android.content.ContentProviderClient
+import at.bitfire.davdroid.db.Collection
+
+/**
+ * Represents a local data store for a specific collection type.
+ * Manages creation, update, and deletion of collections of the given type.
+ */
+interface LocalDataStore<T: LocalCollection<*>> {
+
+    /**
+     * Creates a new local collection from the given (remote) collection info.
+     *
+     * @param provider       the content provider client
+     * @param fromCollection collection info
+     *
+     * @return the new local collection, or `null` if creation failed
+     */
+    fun create(provider: ContentProviderClient, fromCollection: Collection): T?
+
+    /**
+     * Updates the local collection with the data from the given (remote) collection info.
+     *
+     * @param provider        the content provider client
+     * @param localCollection the local collection to update
+     * @param fromCollection  collection info
+     */
+    fun update(provider: ContentProviderClient, localCollection: T, fromCollection: Collection)
+
+    /**
+     * Deletes the local collection.
+     *
+     * @param localCollection the local collection to delete
+     */
+    fun delete(localCollection: T)
+
+}

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollection.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollection.kt
@@ -62,7 +62,7 @@ class LocalJtxCollection(account: Account, client: ContentProviderClient, id: Lo
     override val readOnly: Boolean
         get() = throw NotImplementedError()
 
-    override fun deleteCollection(): Boolean = delete()
+    //override fun deleteCollection(): Boolean = delete()
 
     override val tag: String
         get() =  "jtx-${account.name}-$id"

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollection.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollection.kt
@@ -6,63 +6,19 @@ package at.bitfire.davdroid.resource
 
 import android.accounts.Account
 import android.content.ContentProviderClient
-import android.content.ContentValues
-import android.net.Uri
-import at.bitfire.davdroid.Constants
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Principal
 import at.bitfire.davdroid.db.SyncState
-import at.bitfire.davdroid.util.DavUtils.lastSegment
 import at.bitfire.ical4android.JtxCollection
 import at.bitfire.ical4android.JtxCollectionFactory
 import at.bitfire.ical4android.JtxICalObject
-import at.techbee.jtx.JtxContract
-import java.util.logging.Logger
 
 class LocalJtxCollection(account: Account, client: ContentProviderClient, id: Long):
     JtxCollection<JtxICalObject>(account, client, LocalJtxICalObject.Factory, id),
     LocalCollection<LocalJtxICalObject>{
 
-    companion object {
-
-        fun create(account: Account, client: ContentProviderClient, info: Collection, owner: Principal?): Uri {
-            // If the collection doesn't have a color, use a default color.
-            if (info.color != null)
-                info.color = Constants.DAVDROID_GREEN_RGBA
-
-            val values = valuesFromCollection(info, account, owner, withColor = true)
-
-            return create(account, client, values)
-        }
-
-        fun valuesFromCollection(info: Collection, account: Account, owner: Principal?, withColor: Boolean) =
-            ContentValues().apply {
-                put(JtxContract.JtxCollection.URL, info.url.toString())
-                put(
-                    JtxContract.JtxCollection.DISPLAYNAME,
-                    info.displayName ?: info.url.lastSegment
-                )
-                put(JtxContract.JtxCollection.DESCRIPTION, info.description)
-                if (owner != null)
-                    put(JtxContract.JtxCollection.OWNER, owner.url.toString())
-                else
-                    Logger.getGlobal().warning("No collection owner given. Will create jtx collection without owner")
-                put(JtxContract.JtxCollection.OWNER_DISPLAYNAME, owner?.displayName)
-                if (withColor && info.color != null)
-                    put(JtxContract.JtxCollection.COLOR, info.color)
-                put(JtxContract.JtxCollection.SUPPORTSVEVENT, info.supportsVEVENT)
-                put(JtxContract.JtxCollection.SUPPORTSVJOURNAL, info.supportsVJOURNAL)
-                put(JtxContract.JtxCollection.SUPPORTSVTODO, info.supportsVTODO)
-                put(JtxContract.JtxCollection.ACCOUNT_NAME, account.name)
-                put(JtxContract.JtxCollection.ACCOUNT_TYPE, account.type)
-                put(JtxContract.JtxCollection.READONLY, info.forceReadOnly || !info.privWriteContent)
-            }
-    }
-
     override val readOnly: Boolean
         get() = throw NotImplementedError()
-
-    //override fun deleteCollection(): Boolean = delete()
 
     override val tag: String
         get() =  "jtx-${account.name}-$id"
@@ -74,10 +30,6 @@ class LocalJtxCollection(account: Account, client: ContentProviderClient, id: Lo
         get() = SyncState.fromString(syncstate)
         set(value) { syncstate = value.toString() }
 
-    fun updateCollection(info: Collection, owner: Principal?, updateColor: Boolean) {
-        val values = valuesFromCollection(info, account, owner, updateColor)
-        update(values)
-    }
 
     override fun findDeleted(): List<LocalJtxICalObject> {
         val values = queryDeletedICalObjects()

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollectionStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollectionStore.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.resource
+
+import android.content.ContentProviderClient
+import at.bitfire.davdroid.db.Collection
+
+class LocalJtxCollectionStore: LocalDataStore<LocalJtxCollection> {
+
+    override fun create(provider: ContentProviderClient, fromCollection: Collection): LocalJtxCollection? {
+        TODO("Not yet implemented")
+    }
+
+    override fun update(provider: ContentProviderClient, localCollection: LocalJtxCollection, fromCollection: Collection) {
+        TODO("Not yet implemented")
+    }
+
+    override fun delete(localCollection: LocalJtxCollection) {
+        TODO("Not yet implemented")
+    }
+
+}

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollectionStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollectionStore.kt
@@ -6,24 +6,84 @@ package at.bitfire.davdroid.resource
 
 import android.accounts.Account
 import android.content.ContentProviderClient
+import android.content.ContentUris
+import android.content.ContentValues
+import android.content.Context
+import at.bitfire.davdroid.Constants
+import at.bitfire.davdroid.R
+import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.Collection
+import at.bitfire.davdroid.repository.PrincipalRepository
+import at.bitfire.davdroid.settings.AccountSettings
+import at.bitfire.davdroid.util.DavUtils.lastSegment
+import at.bitfire.ical4android.JtxCollection
+import at.techbee.jtx.JtxContract
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.logging.Logger
+import javax.inject.Inject
 
-class LocalJtxCollectionStore: LocalDataStore<LocalJtxCollection> {
+class LocalJtxCollectionStore @Inject constructor(
+    @ApplicationContext val context: Context,
+    val accountSettingsFactory: AccountSettings.Factory,
+    db: AppDatabase,
+    val principalRepository: PrincipalRepository
+): LocalDataStore<LocalJtxCollection> {
+
+    private val serviceDao = db.serviceDao()
 
     override fun create(provider: ContentProviderClient, fromCollection: Collection): LocalJtxCollection? {
-        TODO("Not yet implemented")
+        // If the collection doesn't have a color, use a default color.
+        if (fromCollection.color != null)
+            fromCollection.color = Constants.DAVDROID_GREEN_RGBA
+
+        val service = serviceDao.get(fromCollection.serviceId) ?: throw IllegalArgumentException("Couldn't fetch DB service from collection")
+        val account = Account(service.accountName, context.getString(R.string.account_type))
+        val values = valuesFromCollection(fromCollection, account = account, withColor = true)
+
+        val uri = JtxCollection.create(account, provider, values)
+        return LocalJtxCollection(account, provider, ContentUris.parseId(uri))
     }
 
-    override fun getAll(account: Account, provider: ContentProviderClient): List<LocalJtxCollection> {
-        TODO("Not yet implemented")
+    private fun valuesFromCollection(info: Collection, account: Account, withColor: Boolean): ContentValues {
+        val owner = info.ownerId?.let { principalRepository.get(it) }
+
+        return ContentValues().apply {
+            put(JtxContract.JtxCollection.URL, info.url.toString())
+            put(
+                JtxContract.JtxCollection.DISPLAYNAME,
+                info.displayName ?: info.url.lastSegment
+            )
+            put(JtxContract.JtxCollection.DESCRIPTION, info.description)
+            if (owner != null)
+                put(JtxContract.JtxCollection.OWNER, owner.url.toString())
+            else
+                Logger.getGlobal().warning("No collection owner given. Will create jtx collection without owner")
+            put(JtxContract.JtxCollection.OWNER_DISPLAYNAME, owner?.displayName)
+            if (withColor && info.color != null)
+                put(JtxContract.JtxCollection.COLOR, info.color)
+            put(JtxContract.JtxCollection.SUPPORTSVEVENT, info.supportsVEVENT)
+            put(JtxContract.JtxCollection.SUPPORTSVJOURNAL, info.supportsVJOURNAL)
+            put(JtxContract.JtxCollection.SUPPORTSVTODO, info.supportsVTODO)
+            put(JtxContract.JtxCollection.ACCOUNT_NAME, account.name)
+            put(JtxContract.JtxCollection.ACCOUNT_TYPE, account.type)
+            put(JtxContract.JtxCollection.READONLY, info.forceReadOnly || !info.privWriteContent)
+        }
     }
+
+
+    override fun getAll(account: Account, provider: ContentProviderClient): List<LocalJtxCollection> =
+        JtxCollection.find(account, provider, context, LocalJtxCollection.Factory, null, null)
+
 
     override fun update(provider: ContentProviderClient, localCollection: LocalJtxCollection, fromCollection: Collection) {
-        TODO("Not yet implemented")
+        val accountSettings = accountSettingsFactory.create(localCollection.account)
+        val values = valuesFromCollection(fromCollection, account = localCollection.account, withColor = accountSettings.getManageCalendarColors())
+        localCollection.update(values)
     }
 
+
     override fun delete(localCollection: LocalJtxCollection) {
-        TODO("Not yet implemented")
+        localCollection.delete()
     }
 
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollectionStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollectionStore.kt
@@ -4,12 +4,17 @@
 
 package at.bitfire.davdroid.resource
 
+import android.accounts.Account
 import android.content.ContentProviderClient
 import at.bitfire.davdroid.db.Collection
 
 class LocalJtxCollectionStore: LocalDataStore<LocalJtxCollection> {
 
     override fun create(provider: ContentProviderClient, fromCollection: Collection): LocalJtxCollection? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getAll(account: Account, provider: ContentProviderClient): List<LocalJtxCollection> {
         TODO("Not yet implemented")
     }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskList.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskList.kt
@@ -9,11 +9,7 @@ import android.annotation.SuppressLint
 import android.content.ContentProviderClient
 import android.content.ContentValues
 import android.content.Context
-import android.net.Uri
-import at.bitfire.davdroid.Constants
-import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.SyncState
-import at.bitfire.davdroid.util.DavUtils.lastSegment
 import at.bitfire.ical4android.DmfsTaskList
 import at.bitfire.ical4android.DmfsTaskListFactory
 import at.bitfire.ical4android.TaskProvider
@@ -35,18 +31,6 @@ class LocalTaskList private constructor(
 
     companion object {
 
-        fun create(account: Account, provider: ContentProviderClient, providerName: TaskProvider.ProviderName, info: Collection): Uri {
-            // If the collection doesn't have a color, use a default color.
-            if (info.color != null)
-                info.color = Constants.DAVDROID_GREEN_RGBA
-
-            val values = valuesFromCollectionInfo(info, withColor = true)
-            values.put(TaskLists.OWNER, account.name)
-            values.put(TaskLists.SYNC_ENABLED, 1)
-            values.put(TaskLists.VISIBLE, 1)
-            return create(account, provider, providerName, values)
-        }
-
         @SuppressLint("Recycle")
         @Throws(Exception::class)
         fun onRenameAccount(context: Context, oldName: String, newName: String) {
@@ -59,23 +43,6 @@ class LocalTaskList private constructor(
                         "${Tasks.ACCOUNT_NAME}=?", arrayOf(oldName)
                 )
             }
-        }
-
-        private fun valuesFromCollectionInfo(info: Collection, withColor: Boolean): ContentValues {
-            val values = ContentValues(3)
-            values.put(TaskLists._SYNC_ID, info.url.toString())
-            values.put(TaskLists.LIST_NAME,
-                if (info.displayName.isNullOrBlank()) info.url.lastSegment else info.displayName)
-
-            if (withColor && info.color != null)
-                values.put(TaskLists.LIST_COLOR, info.color)
-
-            if (info.privWriteContent && !info.forceReadOnly)
-                values.put(TaskListColumns.ACCESS_LEVEL, TaskListColumns.ACCESS_LEVEL_OWNER)
-            else
-                values.put(TaskListColumns.ACCESS_LEVEL, TaskListColumns.ACCESS_LEVEL_READ)
-
-            return values
         }
 
     }
@@ -123,9 +90,6 @@ class LocalTaskList private constructor(
         super.populate(values)
         accessLevel = values.getAsInteger(TaskListColumns.ACCESS_LEVEL)
     }
-
-    fun update(info: Collection, updateColor: Boolean) =
-        update(valuesFromCollectionInfo(info, updateColor))
 
 
     override fun findDeleted() = queryTasks(Tasks._DELETED, null)

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskList.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskList.kt
@@ -88,8 +88,6 @@ class LocalTaskList private constructor(
             accessLevel != TaskListColumns.ACCESS_LEVEL_UNDEFINED &&
             accessLevel <= TaskListColumns.ACCESS_LEVEL_READ
 
-    override fun deleteCollection(): Boolean = delete()
-
     override val collectionUrl: String?
         get() = syncId
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskListStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskListStore.kt
@@ -6,24 +6,97 @@ package at.bitfire.davdroid.resource
 
 import android.accounts.Account
 import android.content.ContentProviderClient
+import android.content.ContentUris
+import android.content.ContentValues
+import android.content.Context
+import android.net.Uri
+import at.bitfire.davdroid.Constants
+import at.bitfire.davdroid.R
+import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.Collection
+import at.bitfire.davdroid.settings.AccountSettings
+import at.bitfire.davdroid.util.DavUtils.lastSegment
+import at.bitfire.ical4android.DmfsTaskList
+import at.bitfire.ical4android.TaskProvider
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.qualifiers.ApplicationContext
+import org.dmfs.tasks.contract.TaskContract.TaskListColumns
+import org.dmfs.tasks.contract.TaskContract.TaskLists
+import java.util.logging.Level
+import java.util.logging.Logger
 
-class LocalTaskListStore: LocalDataStore<LocalTaskList> {
+class LocalTaskListStore @AssistedInject constructor(
+    @Assisted authority: String,
+    val accountSettingsFactory: AccountSettings.Factory,
+    @ApplicationContext val context: Context,
+    val db: AppDatabase,
+    val logger: Logger
+): LocalDataStore<LocalTaskList> {
+
+    @AssistedFactory
+    interface Factory {
+        fun create(authority: String): LocalTaskListStore
+    }
+
+    private val serviceDao = db.serviceDao()
+
+    private val providerName = TaskProvider.ProviderName.fromAuthority(authority)
+
 
     override fun create(provider: ContentProviderClient, fromCollection: Collection): LocalTaskList? {
-        TODO("Not yet implemented")
+        val service = serviceDao.get(fromCollection.serviceId) ?: throw IllegalArgumentException("Couldn't fetch DB service from collection")
+        val account = Account(service.accountName, context.getString(R.string.account_type))
+
+        logger.log(Level.INFO, "Adding local task list", fromCollection)
+        val uri = create(account, provider, providerName, fromCollection)
+        return DmfsTaskList.findByID(account, provider, providerName, LocalTaskList.Factory, ContentUris.parseId(uri))
     }
 
-    override fun getAll(account: Account, provider: ContentProviderClient): List<LocalTaskList> {
-        TODO("Not yet implemented")
+    private fun create(account: Account, provider: ContentProviderClient, providerName: TaskProvider.ProviderName, info: Collection): Uri {
+        // If the collection doesn't have a color, use a default color.
+        if (info.color != null)
+            info.color = Constants.DAVDROID_GREEN_RGBA
+
+        val values = valuesFromCollectionInfo(info, withColor = true)
+        values.put(TaskLists.OWNER, account.name)
+        values.put(TaskLists.SYNC_ENABLED, 1)
+        values.put(TaskLists.VISIBLE, 1)
+        return DmfsTaskList.Companion.create(account, provider, providerName, values)
     }
+
+    private fun valuesFromCollectionInfo(info: Collection, withColor: Boolean): ContentValues {
+        val values = ContentValues(3)
+        values.put(TaskLists._SYNC_ID, info.url.toString())
+        values.put(TaskLists.LIST_NAME,
+            if (info.displayName.isNullOrBlank()) info.url.lastSegment else info.displayName)
+
+        if (withColor && info.color != null)
+            values.put(TaskLists.LIST_COLOR, info.color)
+
+        if (info.privWriteContent && !info.forceReadOnly)
+            values.put(TaskListColumns.ACCESS_LEVEL, TaskListColumns.ACCESS_LEVEL_OWNER)
+        else
+            values.put(TaskListColumns.ACCESS_LEVEL, TaskListColumns.ACCESS_LEVEL_READ)
+
+        return values
+    }
+
+
+    override fun getAll(account: Account, provider: ContentProviderClient) =
+        DmfsTaskList.find(account, LocalTaskList.Factory, provider, providerName, null, null)
+
 
     override fun update(provider: ContentProviderClient, localCollection: LocalTaskList, fromCollection: Collection) {
-        TODO("Not yet implemented")
+        logger.log(Level.FINE, "Updating local task list ${fromCollection.url}", fromCollection)
+        val accountSettings = accountSettingsFactory.create(localCollection.account)
+        localCollection.update(valuesFromCollectionInfo(fromCollection, withColor = accountSettings.getManageCalendarColors()))
     }
 
+
     override fun delete(localCollection: LocalTaskList) {
-        TODO("Not yet implemented")
+        localCollection.delete()
     }
 
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskListStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskListStore.kt
@@ -4,12 +4,17 @@
 
 package at.bitfire.davdroid.resource
 
+import android.accounts.Account
 import android.content.ContentProviderClient
 import at.bitfire.davdroid.db.Collection
 
 class LocalTaskListStore: LocalDataStore<LocalTaskList> {
 
     override fun create(provider: ContentProviderClient, fromCollection: Collection): LocalTaskList? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getAll(account: Account, provider: ContentProviderClient): List<LocalTaskList> {
         TODO("Not yet implemented")
     }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskListStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskListStore.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.resource
+
+import android.content.ContentProviderClient
+import at.bitfire.davdroid.db.Collection
+
+class LocalTaskListStore: LocalDataStore<LocalTaskList> {
+
+    override fun create(provider: ContentProviderClient, fromCollection: Collection): LocalTaskList? {
+        TODO("Not yet implemented")
+    }
+
+    override fun update(provider: ContentProviderClient, localCollection: LocalTaskList, fromCollection: Collection) {
+        TODO("Not yet implemented")
+    }
+
+    override fun delete(localCollection: LocalTaskList) {
+        TODO("Not yet implemented")
+    }
+
+}

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
@@ -42,14 +42,6 @@ class AddressBookSyncer @AssistedInject constructor(
         get() = ContactsContract.AUTHORITY // Address books use the contacts authority for sync
 
 
-    override fun getLocalCollections(provider: ContentProviderClient): List<LocalAddressBook> =
-        serviceRepository.getByAccountAndType(account.name, serviceType)?.let { service ->
-            // Get _all_ address books; Otherwise address book accounts of unchecked address books will not be removed
-            collectionRepository.getByService(service.id).mapNotNull { collection ->
-                LocalAddressBook.findByCollection(context, provider, collection.id)
-            }
-        }.orEmpty()
-
     override fun getDbSyncCollections(serviceId: Long): List<Collection> =
         collectionRepository.getByServiceAndSync(serviceId)
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncer.kt
@@ -40,9 +40,6 @@ class CalendarSyncer @AssistedInject constructor(
         get() = CalendarContract.AUTHORITY
 
 
-    override fun getLocalCollections(provider: ContentProviderClient): List<LocalCalendar>
-        = AndroidCalendar.find(account, provider, LocalCalendar.Factory, "${CalendarContract.Calendars.SYNC_EVENTS}!=0", null)
-
     override fun prepare(provider: ContentProviderClient): Boolean {
         // Update colors
         if (accountSettings.getEventColors())

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncer.kt
@@ -10,15 +10,12 @@ import android.content.ContentProviderClient
 import android.os.Build
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service
-import at.bitfire.davdroid.repository.PrincipalRepository
 import at.bitfire.davdroid.resource.LocalJtxCollection
 import at.bitfire.davdroid.resource.LocalJtxCollectionStore
-import at.bitfire.ical4android.JtxCollection
 import at.bitfire.ical4android.TaskProvider
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import java.util.logging.Level
 
 /**
  * Sync logic for jtx board
@@ -27,8 +24,8 @@ class JtxSyncer @AssistedInject constructor(
     @Assisted account: Account,
     @Assisted extras: Array<String>,
     @Assisted syncResult: SyncResult,
+    localJtxCollectionStore: LocalJtxCollectionStore,
     private val jtxSyncManagerFactory: JtxSyncManager.Factory,
-    private val principalRepository: PrincipalRepository,
     private val tasksAppManager: dagger.Lazy<TasksAppManager>
 ): Syncer<LocalJtxCollectionStore, LocalJtxCollection>(account, extras, syncResult) {
 
@@ -37,17 +34,13 @@ class JtxSyncer @AssistedInject constructor(
         fun create(account: Account, extras: Array<String>, syncResult: SyncResult): JtxSyncer
     }
 
-    override val dataStore: LocalJtxCollectionStore
-        get() = TODO("Not yet implemented")
+    override val dataStore = localJtxCollectionStore
 
     override val serviceType: String
         get() = Service.TYPE_CALDAV
     override val authority: String
         get() = TaskProvider.ProviderName.JtxBoard.authority
 
-
-    /*override fun getLocalCollections(provider: ContentProviderClient): List<LocalJtxCollection>
-        = JtxCollection.find(account, provider, context, LocalJtxCollection.Factory, null, null)*/
 
     override fun prepare(provider: ContentProviderClient): Boolean {
         // check whether jtx Board is new enough
@@ -73,26 +66,6 @@ class JtxSyncer @AssistedInject constructor(
 
     override fun getDbSyncCollections(serviceId: Long): List<Collection> =
         collectionRepository.getSyncJtxCollections(serviceId)
-
-    /*override fun update(localCollection: LocalJtxCollection, remoteCollection: Collection) {
-        logger.log(Level.FINE, "Updating local jtx collection ${remoteCollection.url}", remoteCollection)
-        val owner = remoteCollection.ownerId?.let { principalRepository.get(it) }
-        localCollection.updateCollection(remoteCollection, owner, accountSettings.getManageCalendarColors())
-    }*/
-
-    /*override fun create(provider: ContentProviderClient, remoteCollection: Collection): LocalJtxCollection {
-        logger.log(Level.INFO, "Adding local jtx collection", remoteCollection)
-        val owner = remoteCollection.ownerId?.let { principalRepository.get(it) }
-        val uri = LocalJtxCollection.create(account, provider, remoteCollection, owner)
-        return JtxCollection.find(
-            account,
-            provider,
-            context,
-            LocalJtxCollection.Factory,
-            "${JtxContract.JtxCollection.ID} = ?",
-            arrayOf("${ContentUris.parseId(uri)}")
-        ).first()
-    }*/
 
     override fun syncCollection(provider: ContentProviderClient, localCollection: LocalJtxCollection, remoteCollection: Collection) {
         logger.info("Synchronizing jtx collection $localCollection")

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncer.kt
@@ -7,15 +7,14 @@ package at.bitfire.davdroid.sync
 import android.accounts.Account
 import android.accounts.AccountManager
 import android.content.ContentProviderClient
-import android.content.ContentUris
 import android.os.Build
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service
 import at.bitfire.davdroid.repository.PrincipalRepository
 import at.bitfire.davdroid.resource.LocalJtxCollection
+import at.bitfire.davdroid.resource.LocalJtxCollectionStore
 import at.bitfire.ical4android.JtxCollection
 import at.bitfire.ical4android.TaskProvider
-import at.techbee.jtx.JtxContract
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -31,12 +30,15 @@ class JtxSyncer @AssistedInject constructor(
     private val jtxSyncManagerFactory: JtxSyncManager.Factory,
     private val principalRepository: PrincipalRepository,
     private val tasksAppManager: dagger.Lazy<TasksAppManager>
-): Syncer<LocalJtxCollection>(account, extras, syncResult) {
+): Syncer<LocalJtxCollectionStore, LocalJtxCollection>(account, extras, syncResult) {
 
     @AssistedFactory
     interface Factory {
         fun create(account: Account, extras: Array<String>, syncResult: SyncResult): JtxSyncer
     }
+
+    override val dataStore: LocalJtxCollectionStore
+        get() = TODO("Not yet implemented")
 
     override val serviceType: String
         get() = Service.TYPE_CALDAV
@@ -72,13 +74,13 @@ class JtxSyncer @AssistedInject constructor(
     override fun getDbSyncCollections(serviceId: Long): List<Collection> =
         collectionRepository.getSyncJtxCollections(serviceId)
 
-    override fun update(localCollection: LocalJtxCollection, remoteCollection: Collection) {
+    /*override fun update(localCollection: LocalJtxCollection, remoteCollection: Collection) {
         logger.log(Level.FINE, "Updating local jtx collection ${remoteCollection.url}", remoteCollection)
         val owner = remoteCollection.ownerId?.let { principalRepository.get(it) }
         localCollection.updateCollection(remoteCollection, owner, accountSettings.getManageCalendarColors())
-    }
+    }*/
 
-    override fun create(provider: ContentProviderClient, remoteCollection: Collection): LocalJtxCollection {
+    /*override fun create(provider: ContentProviderClient, remoteCollection: Collection): LocalJtxCollection {
         logger.log(Level.INFO, "Adding local jtx collection", remoteCollection)
         val owner = remoteCollection.ownerId?.let { principalRepository.get(it) }
         val uri = LocalJtxCollection.create(account, provider, remoteCollection, owner)
@@ -90,7 +92,7 @@ class JtxSyncer @AssistedInject constructor(
             "${JtxContract.JtxCollection.ID} = ?",
             arrayOf("${ContentUris.parseId(uri)}")
         ).first()
-    }
+    }*/
 
     override fun syncCollection(provider: ContentProviderClient, localCollection: LocalJtxCollection, remoteCollection: Collection) {
         logger.info("Synchronizing jtx collection $localCollection")

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncer.kt
@@ -46,8 +46,8 @@ class JtxSyncer @AssistedInject constructor(
         get() = TaskProvider.ProviderName.JtxBoard.authority
 
 
-    override fun getLocalCollections(provider: ContentProviderClient): List<LocalJtxCollection>
-        = JtxCollection.find(account, provider, context, LocalJtxCollection.Factory, null, null)
+    /*override fun getLocalCollections(provider: ContentProviderClient): List<LocalJtxCollection>
+        = JtxCollection.find(account, provider, context, LocalJtxCollection.Factory, null, null)*/
 
     override fun prepare(provider: ContentProviderClient): Boolean {
         // check whether jtx Board is new enough

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
@@ -98,7 +98,7 @@ abstract class Syncer<StoreType: LocalDataStore<CollectionType>, CollectionType:
 
         // Find collections in database and provider which should be synced (are sync-enabled)
         val dbCollections = getSyncEnabledCollections()
-        val localCollections = getLocalCollections(provider)
+        val localCollections = dataStore.getAll(account, provider)
 
         // Create/update/delete local collections according to DB
         val updatedLocalCollections = updateCollections(provider, localCollections, dbCollections)
@@ -216,17 +216,6 @@ abstract class Syncer<StoreType: LocalDataStore<CollectionType>, CollectionType:
      * @return *true* to run the sync; *false* to abort
      */
     open fun prepare(provider: ContentProviderClient): Boolean = true
-
-    /**
-     * Gets all local collections (not from the database, but from the content provider).
-     *
-     * [Syncer] will remove collections which are returned by this method, but not by
-     * [getDbSyncCollections], and add collections which are returned by [getDbSyncCollections], but not by this method.
-     *
-     * @param provider Content provider to access local collections
-     * @return Local collections to be updated
-     */
-    abstract fun getLocalCollections(provider: ContentProviderClient): List<CollectionType>
 
     /**
      * Get the local database collections which are sync-enabled (should by synchronized).

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/TaskSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/TaskSyncer.kt
@@ -7,18 +7,17 @@ package at.bitfire.davdroid.sync
 import android.accounts.Account
 import android.accounts.AccountManager
 import android.content.ContentProviderClient
-import android.content.ContentUris
 import android.os.Build
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service
 import at.bitfire.davdroid.resource.LocalTaskList
+import at.bitfire.davdroid.resource.LocalTaskListStore
 import at.bitfire.ical4android.DmfsTaskList
 import at.bitfire.ical4android.TaskProvider
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import org.dmfs.tasks.contract.TaskContract.TaskLists
-import java.util.logging.Level
 
 /**
  * Sync logic for tasks in CalDAV collections ({@code VTODO}).
@@ -30,7 +29,7 @@ class TaskSyncer @AssistedInject constructor(
     @Assisted syncResult: SyncResult,
     private val tasksAppManager: dagger.Lazy<TasksAppManager>,
     private val tasksSyncManagerFactory: TasksSyncManager.Factory,
-): Syncer<LocalTaskList>(account, extras, syncResult) {
+): Syncer<LocalTaskListStore, LocalTaskList>(account, extras, syncResult) {
 
     @AssistedFactory
     interface Factory {
@@ -38,6 +37,9 @@ class TaskSyncer @AssistedInject constructor(
     }
 
     private val providerName = TaskProvider.ProviderName.fromAuthority(authority)
+
+    override val dataStore: LocalTaskListStore
+        get() = TODO("Not yet implemented")
 
     override val serviceType: String
         get() = Service.TYPE_CALDAV
@@ -70,16 +72,16 @@ class TaskSyncer @AssistedInject constructor(
     override fun getDbSyncCollections(serviceId: Long): List<Collection> =
         collectionRepository.getSyncTaskLists(serviceId)
 
-    override fun update(localCollection: LocalTaskList, remoteCollection: Collection) {
+    /*override fun update(localCollection: LocalTaskList, remoteCollection: Collection) {
         logger.log(Level.FINE, "Updating local task list ${remoteCollection.url}", remoteCollection)
         localCollection.update(remoteCollection, accountSettings.getManageCalendarColors())
-    }
+    }*/
 
-    override fun create(provider: ContentProviderClient, remoteCollection: Collection): LocalTaskList {
+    /*override fun create(provider: ContentProviderClient, remoteCollection: Collection): LocalTaskList {
         logger.log(Level.INFO, "Adding local task list", remoteCollection)
         val uri = LocalTaskList.create(account, provider, providerName, remoteCollection)
         return DmfsTaskList.findByID(account, provider, providerName, LocalTaskList.Factory, ContentUris.parseId(uri))
-    }
+    }*/
 
     override fun syncCollection(provider: ContentProviderClient, localCollection: LocalTaskList, remoteCollection: Collection) {
         logger.info("Synchronizing task list #${localCollection.id} [${localCollection.syncId}]")

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/TaskSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/TaskSyncer.kt
@@ -12,12 +12,10 @@ import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service
 import at.bitfire.davdroid.resource.LocalTaskList
 import at.bitfire.davdroid.resource.LocalTaskListStore
-import at.bitfire.ical4android.DmfsTaskList
 import at.bitfire.ical4android.TaskProvider
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import org.dmfs.tasks.contract.TaskContract.TaskLists
 
 /**
  * Sync logic for tasks in CalDAV collections ({@code VTODO}).
@@ -44,8 +42,8 @@ class TaskSyncer @AssistedInject constructor(
     override val serviceType: String
         get() = Service.TYPE_CALDAV
 
-    override fun getLocalCollections(provider: ContentProviderClient): List<LocalTaskList>
-        = DmfsTaskList.find(account, LocalTaskList.Factory, provider, providerName, "${TaskLists.SYNC_ENABLED}!=0", null)
+    /*override fun getLocalCollections(provider: ContentProviderClient): List<LocalTaskList>
+        = DmfsTaskList.find(account, LocalTaskList.Factory, provider, providerName, "${TaskLists.SYNC_ENABLED}!=0", null)*/
 
     override fun prepare(provider: ContentProviderClient): Boolean {
         // Don't sync if task provider is too old

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/TaskSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/TaskSyncer.kt
@@ -25,6 +25,7 @@ class TaskSyncer @AssistedInject constructor(
     @Assisted override val authority: String,
     @Assisted extras: Array<String>,
     @Assisted syncResult: SyncResult,
+    private val localTaskListStoreFactory: LocalTaskListStore.Factory,
     private val tasksAppManager: dagger.Lazy<TasksAppManager>,
     private val tasksSyncManagerFactory: TasksSyncManager.Factory,
 ): Syncer<LocalTaskListStore, LocalTaskList>(account, extras, syncResult) {
@@ -36,14 +37,11 @@ class TaskSyncer @AssistedInject constructor(
 
     private val providerName = TaskProvider.ProviderName.fromAuthority(authority)
 
-    override val dataStore: LocalTaskListStore
-        get() = TODO("Not yet implemented")
+    override val dataStore = localTaskListStoreFactory.create(authority)
 
     override val serviceType: String
         get() = Service.TYPE_CALDAV
 
-    /*override fun getLocalCollections(provider: ContentProviderClient): List<LocalTaskList>
-        = DmfsTaskList.find(account, LocalTaskList.Factory, provider, providerName, "${TaskLists.SYNC_ENABLED}!=0", null)*/
 
     override fun prepare(provider: ContentProviderClient): Boolean {
         // Don't sync if task provider is too old
@@ -69,17 +67,6 @@ class TaskSyncer @AssistedInject constructor(
 
     override fun getDbSyncCollections(serviceId: Long): List<Collection> =
         collectionRepository.getSyncTaskLists(serviceId)
-
-    /*override fun update(localCollection: LocalTaskList, remoteCollection: Collection) {
-        logger.log(Level.FINE, "Updating local task list ${remoteCollection.url}", remoteCollection)
-        localCollection.update(remoteCollection, accountSettings.getManageCalendarColors())
-    }*/
-
-    /*override fun create(provider: ContentProviderClient, remoteCollection: Collection): LocalTaskList {
-        logger.log(Level.INFO, "Adding local task list", remoteCollection)
-        val uri = LocalTaskList.create(account, provider, providerName, remoteCollection)
-        return DmfsTaskList.findByID(account, provider, providerName, LocalTaskList.Factory, ContentUris.parseId(uri))
-    }*/
 
     override fun syncCollection(provider: ContentProviderClient, localCollection: LocalTaskList, remoteCollection: Collection) {
         logger.info("Synchronizing task list #${localCollection.id} [${localCollection.syncId}]")

--- a/app/src/main/kotlin/at/bitfire/davdroid/util/CompatUtils.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/util/CompatUtils.kt
@@ -17,9 +17,13 @@ import java.util.logging.Logger
  */
 fun AccountManager.setAndVerifyUserData(account: Account, key: String, value: String?) {
     for (i in 1..10) {
-        if (getUserData(account, key) != value)
-            setUserData(account, key, value)
+        if (getUserData(account, key) == value)
+            /* already set / success */
+            return
 
+        setUserData(account, key, value)
+
+        // wait a bit because AccountManager access sometimes seems a bit asynchronous
         Thread.sleep(100)
     }
     Logger.getGlobal().warning("AccountManager failed to set $account user data $key := $value")

--- a/app/src/main/kotlin/at/bitfire/davdroid/util/CompatUtils.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/util/CompatUtils.kt
@@ -17,9 +17,8 @@ import java.util.logging.Logger
  */
 fun AccountManager.setAndVerifyUserData(account: Account, key: String, value: String?) {
     for (i in 1..10) {
-        setUserData(account, key, value)
-        if (getUserData(account, key) == value)
-            return /* success */
+        if (getUserData(account, key) != value)
+            setUserData(account, key, value)
 
         Thread.sleep(100)
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,6 @@ android.enableR8.fullMode=false
 
 # https://docs.gradle.org/current/userguide/build_cache.html
 # org.gradle.caching=true
+
+# temporary fix for https://github.com/google/ksp/issues/2072
+ksp.incremental=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,7 @@ hilt = "2.52"
 kotlin = "2.0.21"
 kotlinx-coroutines = "1.9.0"
 # see https://github.com/google/ksp/releases for version numbers
-ksp = "2.0.21-1.0.25"
+ksp = "2.0.21-1.0.26"
 mikepenz-aboutLibraries = "11.2.3"
 nsk90-kstatemachine = "0.31.1"
 mockk = "1.13.13"


### PR DESCRIPTION
### Purpose

Refactors the code by relocating the management of local collections from companion objects to a dedicated LocalDataStore interface + implementations.

Goal is to explicitly define who is responsible for managing (CRUD) local collections (address books, calendars etc). Usage of DI allows to fetch settings in the specific implementations, which makes calling classes like the `Syncer` sub-classes much shorter.

TODO:

- simplify repeated Collection → Service → Account query
- tests


### Short description

- Define a new `LocalDataStore` interface, which is responsible for managing local collections (= the ones accessed over a content provider).
- Implementations for address books, calendars, jtx Board collections, tasks.org task lists.
- Move as much unstructured code from companion objects to a location where it belongs to.


### Checklist

- [ ] The PR has a proper title, description and label.
- [ ] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [ ] I have added documentation to complex functions and functions that can be used by other modules.
- [ ] I have added reasonable tests or consciously decided to not add tests.

