### PR TITLE
Extract sync framework interaction to separate class

### DIFF
--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalTestAddressBook.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalTestAddressBook.kt
@@ -13,6 +13,7 @@ import android.provider.ContactsContract
 import at.bitfire.davdroid.repository.DavCollectionRepository
 import at.bitfire.davdroid.repository.DavServiceRepository
 import at.bitfire.davdroid.settings.AccountSettings
+import at.bitfire.davdroid.sync.SyncFrameworkIntegration
 import at.bitfire.vcard4android.GroupMethod
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -30,7 +31,8 @@ class LocalTestAddressBook @AssistedInject constructor(
     collectionRepository: DavCollectionRepository,
     @ApplicationContext context: Context,
     logger: Logger,
-    serviceRepository: DavServiceRepository
+    serviceRepository: DavServiceRepository,
+    syncFramework: SyncFrameworkIntegration
 ): LocalAddressBook(
     _addressBookAccount = ACCOUNT,
     provider = provider,
@@ -39,7 +41,8 @@ class LocalTestAddressBook @AssistedInject constructor(
     context = context,
     dirtyVerifier = Optional.empty(),
     logger = logger,
-    serviceRepository = serviceRepository
+    serviceRepository = serviceRepository,
+    syncFramework = syncFramework
 ) {
 
     @AssistedFactory

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncAdapterServices.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncAdapterServices.kt
@@ -48,13 +48,15 @@ abstract class SyncAdapterService: Service() {
     }
 
     /**
-     * Entry point for the sync adapter framework.
+     * Entry point for the Sync Adapter Framework.
      *
-     * Handles incoming sync requests from the sync adapter framework.
+     * Handles incoming sync requests from the Sync Adapter Framework.
      *
      * Although we do not use the sync adapter for syncing anymore, we keep this sole
      * adapter to provide exported services, which allow android system components and calendar,
      * contacts or task apps to sync via DAVx5.
+     *
+     * All Sync Adapter Framework related interaction should happen inside [SyncFrameworkIntegration].
      */
     class SyncAdapter @Inject constructor(
         private val accountSettingsFactory: AccountSettings.Factory,
@@ -66,8 +68,8 @@ abstract class SyncAdapterService: Service() {
         private val syncWorkerManager: SyncWorkerManager
     ): AbstractThreadedSyncAdapter(
         context,
-        true    // isSyncable shouldn't be -1 because DAVx5 sets it to 0 or 1.
-                           // However, if it is -1 by accident, set it to 1 to avoid endless sync loops.
+        true    // isSyncable shouldn't be -1 because DAVx5 (SyncFrameworkIntegration) sets it to 0 or 1.
+                // However, if it is -1 by accident, set it to 1 to avoid endless sync loops.
     ) {
 
         /**

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncFrameworkIntegration.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncFrameworkIntegration.kt
@@ -13,13 +13,17 @@ import javax.inject.Singleton
  * `ContentResolver.setIsSyncable()` or something similar themselves. Everything sync-framework
  * related must be handled by this class.
  *
- * Sync requests from the sync adapter framework are handled by [SyncAdapterService].
+ * Sync requests from the Sync Adapter Framework are handled by [SyncAdapterService].
  */
 @Singleton
 class SyncFrameworkIntegration @Inject constructor(
     private val logger: Logger
 ) {
 
+    /**
+     * Gets the global auto-sync setting that applies to all the providers and accounts. If this is
+     * false then the per-provider auto-sync setting is ignored.
+     */
     fun getMasterSyncAutomatically() =
         ContentResolver.getMasterSyncAutomatically()
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncFrameworkIntegration.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncFrameworkIntegration.kt
@@ -27,7 +27,7 @@ class SyncFrameworkIntegration @Inject constructor(
      * Check if this account/provider is syncable.
      */
     fun isSyncable(account: Account, authority: String): Boolean =
-        ContentResolver.getIsSyncable(account, authority) >= 0
+        ContentResolver.getIsSyncable(account, authority) > 0
 
     /**
      * Enable this account/provider to be syncable.

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncFrameworkIntegration.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncFrameworkIntegration.kt
@@ -15,7 +15,6 @@ import javax.inject.Singleton
  *
  * Sync requests from the Sync Adapter Framework are handled by [SyncAdapterService].
  */
-@Singleton
 class SyncFrameworkIntegration @Inject constructor(
     private val logger: Logger
 ) {

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncFrameworkIntegration.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncFrameworkIntegration.kt
@@ -1,0 +1,119 @@
+package at.bitfire.davdroid.sync
+
+import android.accounts.Account
+import android.content.ContentResolver
+import android.provider.CalendarContract
+import androidx.annotation.WorkerThread
+import java.util.logging.Logger
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Handles all Sync Adapter Framework related interaction. Other classes should never call
+ * `ContentResolver.setIsSyncable()` or something similar themselves. Everything sync-framework
+ * related must be handled by this class.
+ *
+ * Sync requests from the sync adapter framework are handled by [SyncAdapterService].
+ */
+@Singleton
+class SyncFrameworkIntegration @Inject constructor(
+    private val logger: Logger
+) {
+
+    fun getMasterSyncAutomatically() =
+        ContentResolver.getMasterSyncAutomatically()
+
+    /**
+     * Check if this account/provider is syncable.
+     */
+    fun isSyncable(account: Account, authority: String): Boolean =
+        ContentResolver.getIsSyncable(account, authority) >= 0
+
+    /**
+     * Enable this account/provider to be syncable.
+     */
+    fun enableSyncAbility(account: Account, authority: String) {
+        if (ContentResolver.getIsSyncable(account, authority) != 1)
+            ContentResolver.setIsSyncable(account, authority, 1)
+    }
+
+    /**
+     * Disable this account/provider to be syncable.
+     */
+    fun disableSyncAbility(account: Account, authority: String) {
+        if (ContentResolver.getIsSyncable(account, authority) != 0)
+            ContentResolver.setIsSyncable(account, authority, 0)
+    }
+
+    /**
+     * Check if the provider should be synced when content (contact, calendar event or task) changes.
+     */
+    fun syncsOnContentChange(account: Account, authority: String) =
+        ContentResolver.getSyncAutomatically(account, authority)
+
+    /**
+     * Enable syncing on content (contact, calendar event or task) changes.
+     */
+    fun enableSyncOnContentChange(account: Account, authority: String) {
+        if (!ContentResolver.getSyncAutomatically(account, authority))
+            setSyncOnContentChange(account, authority, true)
+    }
+
+    /**
+     * Disable syncing on content (contact, calendar event or task) changes.
+     */
+    fun disableSyncOnContentChange(account: Account, authority: String) {
+        if (ContentResolver.getSyncAutomatically(account, authority))
+            setSyncOnContentChange(account, authority, false)
+    }
+
+    /**
+     * Enables/disables sync adapter automatic sync (content triggered sync) for the given
+     * account and authority. Does *not* call [ContentResolver.setIsSyncable].
+     *
+     * We use the sync adapter framework only for the trigger, actual syncing is implemented
+     * with WorkManager. The trigger comes in through SyncAdapterService.
+     *
+     * This method blocks until the sync-on-content-change has been enabled or disabled, so it
+     * should not be called from the UI thread.
+     *
+     * @param enable    *true* enables automatic sync; *false* disables it
+     * @param authority sync authority (like [CalendarContract.AUTHORITY])
+     * @return whether the content triggered sync was enabled successfully
+     */
+    @WorkerThread
+    private fun setSyncOnContentChange(account: Account, authority: String, enable: Boolean): Boolean {
+        // Enable content change triggers (sync adapter framework)
+        val setContentTrigger: () -> Boolean =
+            /* Ugly hack: because there is no callback for when the sync status/interval has been
+            updated, we need to make this call blocking. */
+            if (enable) {{
+                logger.fine("Enabling content-triggered sync of $account/$authority")
+                ContentResolver.setSyncAutomatically(account, authority, true) // enables content triggers
+                /* return */ ContentResolver.getSyncAutomatically(account, authority)
+            }} else {{
+                logger.fine("Disabling content-triggered sync of $account/$authority")
+                ContentResolver.setSyncAutomatically(account, authority, false) // disables content triggers
+                /* return */ !ContentResolver.getSyncAutomatically(account, authority)
+            }}
+
+        // try up to 10 times with 100 ms pause
+        repeat(10) {
+            if (setContentTrigger()) {
+                // Successfully set
+                // Remove periodic syncs created by ContentResolver.setSyncAutomatically
+                ContentResolver.getPeriodicSyncs(account, authority).forEach { periodicSync ->
+                    ContentResolver.removePeriodicSync(
+                        periodicSync.account,
+                        periodicSync.authority,
+                        periodicSync.extras
+                    )
+                }
+                return true
+            }
+            Thread.sleep(100)
+        }
+        return false
+    }
+
+}


### PR DESCRIPTION
### Purpose

This is part of moving further away from the Sync Adapter Framework, which has been mostly replaced by Work Manager and is only used for sync requests coming from 3rd party apps and content changes.

While `SyncAdapterServices` is the entry point for said sync requests we are still en-/disabling general sync-ability and content triggered syncs for the sync framework via `ContentResolver` calls. These calls should be made from a single central place.

If we would ever like to change the notification of changed content provider entries to JobScheduler / WorkManager (https://github.com/bitfireAT/davx5/issues/247), it will be possible by adapting mainly this class and `SyncAdapterServices`.


### Short description

- Create `SyncFrameworkIntegration` class with all necessary methods.
- Use it everywhere `ContentResolver` calls are made, except in the migrations

Note that due to the Android 7 contacts upload work-around there are still several places where `ContentResolver.SYNC_EXTRAS_UPLOAD` is in use.

### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

