### PR TITLE
Don't show app intro again after recomposition

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -96,9 +97,12 @@ fun AccountsScreen(
     val showAddAccount by model.showAddAccount.collectAsStateWithLifecycle(AccountsModel.FABStyle.Standard)
 
     val showAppIntro by model.showAppIntro.collectAsState(false)
+    var shown by rememberSaveable { mutableStateOf(false) }
     LaunchedEffect(showAppIntro) {
-        if (showAppIntro)
+        if (showAppIntro && !shown) {
+            shown = true
             onShowAppIntro()
+        }
     }
 
     AccountsScreen(

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
@@ -96,8 +96,9 @@ fun AccountsScreen(
     val showSyncAll by model.showSyncAll.collectAsStateWithLifecycle(true)
     val showAddAccount by model.showAddAccount.collectAsStateWithLifecycle(AccountsModel.FABStyle.Standard)
 
-    val showAppIntro by model.showAppIntro.collectAsState(false)
+    // Remember shown state, so the intro does not restart on rotation or theme-change
     var shown by rememberSaveable { mutableStateOf(false) }
+    val showAppIntro by model.showAppIntro.collectAsState(false)
     LaunchedEffect(showAppIntro) {
         if (showAppIntro && !shown) {
             shown = true


### PR DESCRIPTION
### Purpose

The app intro replays after finish, when changing between dark and light theme or rotating the screen. It should not do that.

### Short description

The problem is that we need to continuously consume the `showAppIntro` flow in order to start the app intro as soon as possible, but only want to do so once and not on every recomposition. There might be a cleaner way, but simply to 

- remember the launched state across recomposition
- use `rememberSaveable` instead of `remember` to survive configuration changes (like screen rotation)

works just fine.

### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.

