### PR TITLE
LocalAddressBookStore: return all address books, including orphaned ones

### DIFF
--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/TestModules.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/TestModules.kt
@@ -9,30 +9,26 @@ import dagger.hilt.components.SingletonComponent
 import dagger.hilt.testing.TestInstallIn
 import dagger.multibindings.Multibinds
 
-interface TestModules {
+// remove PushRegistrationWorkerModule from Android tests
+@Module
+@TestInstallIn(
+    components = [SingletonComponent::class],
+    replaces = [PushRegistrationWorkerManager.PushRegistrationWorkerModule::class]
+)
+abstract class TestPushRegistrationWorkerModule {
+    // provides empty set of listeners
+    @Multibinds
+    abstract fun empty(): Set<DavCollectionRepository.OnChangeListener>
+}
 
-    // remove PushRegistrationWorkerModule from Android tests
-    @Module
-    @TestInstallIn(
-        components = [SingletonComponent::class],
-        replaces = [PushRegistrationWorkerManager.PushRegistrationWorkerModule::class]
-    )
-    abstract class TestPushRegistrationWorkerModule {
-        // provides empty set of listeners
-        @Multibinds
-        abstract fun empty(): Set<DavCollectionRepository.OnChangeListener>
-    }
-
-    // remove TasksAppWatcherModule from Android tests
-    @Module
-    @TestInstallIn(
-        components = [SingletonComponent::class],
-        replaces = [TasksAppWatcher.TasksAppWatcherModule::class]
-    )
-    abstract class TestTasksAppWatcherModuleModule {
-        // provides empty set of plugins
-        @Multibinds
-        abstract fun empty(): Set<StartupPlugin>
-    }
-
+// remove TasksAppWatcherModule from Android tests
+@Module
+@TestInstallIn(
+    components = [SingletonComponent::class],
+    replaces = [TasksAppWatcher.TasksAppWatcherModule::class]
+)
+abstract class TestTasksAppWatcherModuleModule {
+    // provides empty set of plugins
+    @Multibinds
+    abstract fun empty(): Set<StartupPlugin>
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
@@ -11,6 +11,7 @@ import android.content.ContentValues
 import android.content.Context
 import android.os.Bundle
 import android.provider.ContactsContract
+import androidx.annotation.OpenForTesting
 import androidx.annotation.VisibleForTesting
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.Collection
@@ -89,7 +90,8 @@ class LocalAddressBookStore @Inject constructor(
         return addressBook
     }
 
-    fun createAccount(name: String, id: Long, url: String): Account? {
+    @OpenForTesting
+    internal fun createAccount(name: String, id: Long, url: String): Account? {
         // create account with collection ID and URL
         val account = Account(name, context.getString(R.string.account_type_address_book))
         val userData = Bundle(2).apply {

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalDataStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalDataStore.kt
@@ -25,7 +25,8 @@ interface LocalDataStore<T: LocalCollection<*>> {
     fun create(provider: ContentProviderClient, fromCollection: Collection): T?
 
     /**
-     * Returns all local collections of the data store.
+     * Returns all local collections of the data store, including those which don't have a corresponding remote
+     * [Collection] entry.
      *
      * @param account  the account that the data store is associated with
      * @param provider the content provider client

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
@@ -150,7 +150,7 @@ abstract class Syncer<StoreType: LocalDataStore<CollectionType>, CollectionType:
             val dbCollection = dbCollections[localCollection.collectionUrl?.toHttpUrlOrNull()]
             if (dbCollection == null) {
                 // Collection not available in db = on server (anymore), delete and remove from the updated list
-                logger.fine("Deleting local collection ${localCollection.title}")
+                logger.info("Deleting local collection ${localCollection.title} without matching remote collection")
                 dataStore.delete(localCollection)
                 updatedLocalCollections -= localCollection
             } else {
@@ -164,7 +164,7 @@ abstract class Syncer<StoreType: LocalDataStore<CollectionType>, CollectionType:
         // Create local collections which are in DB, but don't exist locally yet
         if (newDbCollections.isNotEmpty()) {
             val toBeCreated = newDbCollections.values.toList()
-            logger.log(Level.FINE, "Creating new local collections", toBeCreated.toTypedArray())
+            logger.log(Level.INFO, "Creating new local collections", toBeCreated.toTypedArray())
             val newLocalCollections = createLocalCollections(provider, toBeCreated)
             // Add the newly created collections to the updated list
             updatedLocalCollections.addAll(newLocalCollections)


### PR DESCRIPTION
### Purpose

`LocalAddressBookStore.getAll()` previously didn't return _all_ address books, but only those that are mapped to a known ID from the database.

However `Syncer` needs a list of _all_ local collections. It then deletes the ones that don't have a corresponding remote collection = database entry in `Collections`.


### Short description

- `LocalAddressBookStore.getAll()` now returns als address books
- `LocalDataStore.getAll()`: updated KDoc to make it clear that all entries must be returned


### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

