### PR TITLE
[Push] Upon notification, only enqueue sync for the respective service type

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/push/UnifiedPushReceiver.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/push/UnifiedPushReceiver.kt
@@ -5,11 +5,18 @@
 package at.bitfire.davdroid.push
 
 import android.content.Context
+import android.provider.CalendarContract
+import at.bitfire.davdroid.R
+import at.bitfire.davdroid.db.Collection.Companion.TYPE_ADDRESSBOOK
+import at.bitfire.davdroid.db.Collection.Companion.TYPE_CALENDAR
+import at.bitfire.davdroid.db.Collection.Companion.TYPE_WEBCAL
 import at.bitfire.davdroid.repository.AccountRepository
 import at.bitfire.davdroid.repository.DavCollectionRepository
 import at.bitfire.davdroid.repository.DavServiceRepository
 import at.bitfire.davdroid.repository.PreferenceRepository
+import at.bitfire.davdroid.sync.TasksAppManager
 import at.bitfire.davdroid.sync.worker.SyncWorkerManager
+import dagger.Lazy
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -42,6 +49,9 @@ class UnifiedPushReceiver: MessagingReceiver() {
 
     @Inject
     lateinit var pushRegistrationWorkerManager: PushRegistrationWorkerManager
+
+    @Inject
+    lateinit var tasksAppManager: Lazy<TasksAppManager>
 
     @Inject
     lateinit var syncWorkerManager: SyncWorkerManager
@@ -77,7 +87,24 @@ class UnifiedPushReceiver: MessagingReceiver() {
                 collectionRepository.getSyncableByTopic(topic)?.let { collection ->
                     serviceRepository.get(collection.serviceId)?.let { service ->
                         val account = accountRepository.fromName(service.accountName)
-                        syncWorkerManager.enqueueOneTimeAllAuthorities(account, fromPush = true)
+                        val authority = when (collection.type) {
+                            TYPE_ADDRESSBOOK -> context.getString(R.string.address_books_authority)
+                            TYPE_CALENDAR -> CalendarContract.AUTHORITY
+                            TYPE_WEBCAL -> CalendarContract.AUTHORITY
+                            else -> null
+                        }
+                        if (authority == null) {
+                            logger.warning("Tried to sync collection ${collection.id} with an unknown type: ${collection.type}")
+                            return@let
+                        }
+                        syncWorkerManager.enqueueOneTime(account, authority, fromPush = true)
+
+                        // If the collection supports tasks, also schedule the tasks authority if any
+                        if (collection.supportsVJOURNAL != false || collection.supportsVTODO != false) {
+                            tasksAppManager.get().currentProvider()?.let { taskProvider ->
+                                syncWorkerManager.enqueueOneTime(account, taskProvider.authority, fromPush = true)
+                            }
+                        }
                     }
                 }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/push/UnifiedPushReceiver.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/push/UnifiedPushReceiver.kt
@@ -85,26 +85,23 @@ class UnifiedPushReceiver: MessagingReceiver() {
                     serviceRepository.get(collection.serviceId)?.let { service ->
                         val syncDataTypes = mutableSetOf<SyncDataType>()
                         // If the type is an address book, add the contacts type
-                        if (collection.type == TYPE_ADDRESSBOOK) {
-                            syncDataTypes.add(SyncDataType.CONTACTS)
-                        }
+                        if (collection.type == TYPE_ADDRESSBOOK)
+                            syncDataTypes += SyncDataType.CONTACTS
+
                         // If the collection supports events, add the events type
-                        if (collection.supportsVEVENT != false) {
-                            syncDataTypes.add(SyncDataType.EVENTS)
-                        }
-                        // If the collection supports tasks, add the tasks type
-                        if (collection.supportsVJOURNAL != false || collection.supportsVTODO != false) {
-                            // Make sure there's a tasks provider installed
-                            if (tasksAppManager.get().currentProvider() != null) {
-                                syncDataTypes.add(SyncDataType.TASKS)
-                            }
-                        }
+                        if (collection.supportsVEVENT != false)
+                            syncDataTypes += SyncDataType.EVENTS
+
+                        // If the collection supports tasks, make sure there's a provider installed,
+                        // and add the tasks type
+                        if (collection.supportsVJOURNAL != false || collection.supportsVTODO != false)
+                            if (tasksAppManager.get().currentProvider() != null)
+                                syncDataTypes += SyncDataType.TASKS
 
                         // Schedule sync for all the types identified
                         val account = accountRepository.fromName(service.accountName)
-                        for (syncDataType in syncDataTypes) {
+                        for (syncDataType in syncDataTypes)
                             syncWorkerManager.enqueueOneTime(account, syncDataType, fromPush = true)
-                        }
                     }
                 }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/push/UnifiedPushReceiver.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/push/UnifiedPushReceiver.kt
@@ -84,19 +84,19 @@ class UnifiedPushReceiver: MessagingReceiver() {
                 collectionRepository.getSyncableByTopic(topic)?.let { collection ->
                     serviceRepository.get(collection.serviceId)?.let { service ->
                         val syncDataTypes = mutableSetOf<SyncDataType>()
+                        // If the type is an address book, add the contacts type
                         if (collection.type == TYPE_ADDRESSBOOK) {
-                            // If the type is an address book, sync contacts
                             syncDataTypes.add(SyncDataType.CONTACTS)
-                        } else {
-                            // If not an address book, must be a calendar, add events
+                        }
+                        // If the collection supports events, add the events type
+                        if (collection.supportsVEVENT != false) {
                             syncDataTypes.add(SyncDataType.EVENTS)
-
-                            // If the collection supports tasks, also add the tasks type
-                            if (collection.supportsVJOURNAL != false || collection.supportsVTODO != false) {
-                                // Make sure there's a tasks provider installed
-                                if (tasksAppManager.get().currentProvider() != null) {
-                                    syncDataTypes.add(SyncDataType.TASKS)
-                                }
+                        }
+                        // If the collection supports tasks, add the tasks type
+                        if (collection.supportsVJOURNAL != false || collection.supportsVTODO != false) {
+                            // Make sure there's a tasks provider installed
+                            if (tasksAppManager.get().currentProvider() != null) {
+                                syncDataTypes.add(SyncDataType.TASKS)
                             }
                         }
 


### PR DESCRIPTION
### Purpose

When receiving a push notification, do not enqueue sync for all authorities, schedule only for the collection type's authority.

### Short description

After receiving a push notification, after the collection and service are loaded, the collection type is checked. Those authorities are scheduled depending on the type:

| Type | Authority |
|---|---|
|`TYPE_ADDRESSBOOK`|`at.bitfire.davdroid.addressbooks` (`R.string.address_books_authority`)|
|`TYPE_CALENDAR`|`CalendarContract.AUTHORITY`|
|`TYPE_WEBCAL`|`CalendarContract.AUTHORITY`|

Also, if the collection supports `VJOURNAL` or `VTODO`, a sync is enqueued for the current tasks provider, if any.

If the type received is unknown or invalid, no sync is scheduled. We could change this behavior to sync everything, whatever you think suits best.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

