### PR TITLE
Address book accounts: bind to accounts (again)

### DIFF
--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStoreTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStoreTest.kt
@@ -47,7 +47,7 @@ class LocalAddressBookStoreTest {
     @SpyK
     lateinit var context: Context
 
-    val account: Account = Account("MrRobert@example.com", "Mock Account Type")
+    val account: Account = Account("MrRobert@example.com", "Mock Address Book Type")
     val provider = mockk<ContentProviderClient>(relaxed = true)
     val addressBook: LocalAddressBook = mockk(relaxed = true) {
         every { updateSyncFrameworkSettings() } just runs
@@ -59,7 +59,7 @@ class LocalAddressBookStoreTest {
     lateinit var collectionRepository: DavCollectionRepository
 
     val localAddressBookFactory = mockk<LocalAddressBook.Factory> {
-        every { create(account, provider) } returns addressBook
+        every { create(any(), account, provider) } returns addressBook
     }
 
     @Inject
@@ -136,7 +136,7 @@ class LocalAddressBookStoreTest {
             every { id } returns 1
             every { url } returns "https://example.com/addressbook/funnyfriends".toHttpUrl()
         }
-        every { localAddressBookStore.createAccount(any(), any(), any()) } returns null
+        every { localAddressBookStore.createAddressBookAccount(any(), any(), any(), any()) } returns null
         assertEquals(null, localAddressBookStore.create(provider, collection))
     }
 
@@ -146,7 +146,7 @@ class LocalAddressBookStoreTest {
             every { id } returns 1
             every { url } returns "https://example.com/addressbook/funnyfriends".toHttpUrl()
         }
-        every { localAddressBookStore.createAccount(any(), any(), any()) } returns account
+        every { localAddressBookStore.createAddressBookAccount(any(), any(), any(), any()) } returns account
         every { addressBook.readOnly } returns true
         val addrBook = localAddressBookStore.create(provider, collection)!!
 
@@ -164,7 +164,7 @@ class LocalAddressBookStoreTest {
     fun test_createAccount_succeeds() {
         mockkObject(SystemAccountUtils)
         every { SystemAccountUtils.createAccount(any(), any(), any()) } returns true
-        val result: Account = localAddressBookStore.createAccount(
+        val result: Account = localAddressBookStore.createAddressBookAccount(
             "MrRobert@example.com", 42, "https://example.com/addressbook/funnyfriends"
         )!!
         verify(exactly = 1) { SystemAccountUtils.createAccount(any(), any(), any()) }

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookTest.kt
@@ -46,6 +46,7 @@ class LocalAddressBookTest {
     @ApplicationContext
     lateinit var context: Context
 
+    val account = Account("Test Account", "Test Account Type")
     lateinit var addressBook: LocalTestAddressBook
 
 
@@ -53,7 +54,7 @@ class LocalAddressBookTest {
     fun setUp() {
         hiltRule.inject()
 
-        addressBook = addressbookFactory.create(provider, GroupMethod.CATEGORIES)
+        addressBook = addressbookFactory.create(account, provider, GroupMethod.CATEGORIES)
         LocalTestAddressBook.createAccount(context)
     }
 

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalGroupTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalGroupTest.kt
@@ -5,6 +5,7 @@
 package at.bitfire.davdroid.resource
 
 import android.Manifest
+import android.accounts.Account
 import android.content.ContentProviderClient
 import android.content.ContentUris
 import android.content.ContentValues
@@ -69,7 +70,7 @@ class LocalGroupTest {
     @Inject
     lateinit var addressbookFactory: LocalTestAddressBook.Factory
 
-
+    val account = Account("Test Account", "Test Account Type")
     private lateinit var addressBookGroupsAsCategories: LocalTestAddressBook
     private lateinit var addressBookGroupsAsVCards: LocalTestAddressBook
 
@@ -77,8 +78,8 @@ class LocalGroupTest {
     fun setup() {
         hiltRule.inject()
 
-        addressBookGroupsAsCategories = addressbookFactory.create(provider, GroupMethod.CATEGORIES)
-        addressBookGroupsAsVCards = addressbookFactory.create(provider, GroupMethod.GROUP_VCARDS)
+        addressBookGroupsAsCategories = addressbookFactory.create(account, provider, GroupMethod.CATEGORIES)
+        addressBookGroupsAsVCards = addressbookFactory.create(account, provider, GroupMethod.GROUP_VCARDS)
 
         // clear contacts
         addressBookGroupsAsCategories.clear()

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalTestAddressBook.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalTestAddressBook.kt
@@ -25,6 +25,7 @@ import java.util.Optional
 import java.util.logging.Logger
 
 class LocalTestAddressBook @AssistedInject constructor(
+    @Assisted account: Account,
     @Assisted provider: ContentProviderClient,
     @Assisted override val groupMethod: GroupMethod,
     accountSettingsFactory: AccountSettings.Factory,
@@ -34,6 +35,7 @@ class LocalTestAddressBook @AssistedInject constructor(
     serviceRepository: DavServiceRepository,
     syncFramework: SyncFrameworkIntegration
 ): LocalAddressBook(
+    account = account,
     _addressBookAccount = ACCOUNT,
     provider = provider,
     accountSettingsFactory = accountSettingsFactory,
@@ -47,7 +49,7 @@ class LocalTestAddressBook @AssistedInject constructor(
 
     @AssistedFactory
     interface Factory {
-        fun create(provider: ContentProviderClient, groupMethod: GroupMethod): LocalTestAddressBook
+        fun create(account: Account, provider: ContentProviderClient, groupMethod: GroupMethod): LocalTestAddressBook
     }
 
     override var readOnly: Boolean

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/contactrow/CachedGroupMembershipHandlerTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/contactrow/CachedGroupMembershipHandlerTest.kt
@@ -5,6 +5,7 @@
 package at.bitfire.davdroid.resource.contactrow
 
 import android.Manifest
+import android.accounts.Account
 import android.content.ContentProviderClient
 import android.content.ContentValues
 import android.content.Context
@@ -65,6 +66,8 @@ class CachedGroupMembershipHandlerTest {
     @get:Rule
     val hiltRule = HiltAndroidRule(this)
 
+    val account = Account("Test Account", "Test Account Type")
+
     @Before
     fun inject() {
         hiltRule.inject()
@@ -73,7 +76,7 @@ class CachedGroupMembershipHandlerTest {
 
     @Test
     fun testMembership() {
-        val addressBook = addressbookFactory.create(provider, GroupMethod.GROUP_VCARDS)
+        val addressBook = addressbookFactory.create(account, provider, GroupMethod.GROUP_VCARDS)
 
         val contact = Contact()
         val localContact = LocalContact(addressBook, contact, null, null, 0)

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/contactrow/GroupMembershipBuilderTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/contactrow/GroupMembershipBuilderTest.kt
@@ -5,6 +5,7 @@
 package at.bitfire.davdroid.resource.contactrow
 
 import android.Manifest
+import android.accounts.Account
 import android.content.ContentProviderClient
 import android.content.Context
 import android.net.Uri
@@ -63,6 +64,8 @@ class GroupMembershipBuilderTest {
     @ApplicationContext
     lateinit var context: Context
 
+    val account = Account("Test Account", "Test Account Type")
+
     @Before
     fun inject() {
         hiltRule.inject()
@@ -74,7 +77,7 @@ class GroupMembershipBuilderTest {
         val contact = Contact().apply {
             categories += "TEST GROUP"
         }
-        val addressBookGroupsAsCategories = addressbookFactory.create(provider, GroupMethod.CATEGORIES)
+        val addressBookGroupsAsCategories = addressbookFactory.create(account, provider, GroupMethod.CATEGORIES)
         GroupMembershipBuilder(Uri.EMPTY, null, contact, addressBookGroupsAsCategories, false).build().also { result ->
             assertEquals(1, result.size)
             assertEquals(GroupMembership.CONTENT_ITEM_TYPE, result[0].values[GroupMembership.MIMETYPE])
@@ -87,7 +90,7 @@ class GroupMembershipBuilderTest {
         val contact = Contact().apply {
             categories += "TEST GROUP"
         }
-        val addressBookGroupsAsVCards = addressbookFactory.create(provider, GroupMethod.GROUP_VCARDS)
+        val addressBookGroupsAsVCards = addressbookFactory.create(account, provider, GroupMethod.GROUP_VCARDS)
         GroupMembershipBuilder(Uri.EMPTY, null, contact, addressBookGroupsAsVCards, false).build().also { result ->
             // group membership is constructed during post-processing
             assertEquals(0, result.size)

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/contactrow/GroupMembershipHandlerTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/contactrow/GroupMembershipHandlerTest.kt
@@ -5,6 +5,7 @@
 package at.bitfire.davdroid.resource.contactrow
 
 import android.Manifest
+import android.accounts.Account
 import android.content.ContentProviderClient
 import android.content.ContentValues
 import android.content.Context
@@ -66,6 +67,8 @@ class GroupMembershipHandlerTest {
     @get:Rule
     var hiltRule = HiltAndroidRule(this)
 
+    val account = Account("Test Account", "Test Account Type")
+
     @Before
     fun inject() {
         hiltRule.inject()
@@ -74,7 +77,7 @@ class GroupMembershipHandlerTest {
 
     @Test
     fun testMembership_GroupsAsCategories() {
-        val addressBookGroupsAsCategories = addressbookFactory.create(provider, GroupMethod.CATEGORIES)
+        val addressBookGroupsAsCategories = addressbookFactory.create(account, provider, GroupMethod.CATEGORIES)
         val addressBookGroupsAsCategoriesGroup = addressBookGroupsAsCategories.findOrCreateGroup("TEST GROUP")
 
         val contact = Contact()
@@ -90,7 +93,7 @@ class GroupMembershipHandlerTest {
 
     @Test
     fun testMembership_GroupsAsVCards() {
-        val addressBookGroupsAsVCards = addressbookFactory.create(provider, GroupMethod.GROUP_VCARDS)
+        val addressBookGroupsAsVCards = addressbookFactory.create(account, provider, GroupMethod.GROUP_VCARDS)
 
         val contact = Contact()
         val localContact = LocalContact(addressBookGroupsAsVCards, contact, null, null, 0)

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/settings/AccountSettingsTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/settings/AccountSettingsTest.kt
@@ -4,7 +4,6 @@
 
 package at.bitfire.davdroid.settings
 
-import android.accounts.Account
 import android.accounts.AccountManager
 import android.content.Context
 import at.bitfire.davdroid.sync.account.TestAccountAuthenticator
@@ -38,7 +37,7 @@ class AccountSettingsTest {
 
     @Test(expected = IllegalArgumentException::class)
     fun testUpdate_MissingMigrations() {
-        provideAccount(version = 1) { account ->
+        TestAccountAuthenticator.provide(version = 1) { account ->
             // will run AccountSettings.update
             accountSettingsFactory.create(account, abortOnMissingMigration = true)
         }
@@ -46,23 +45,13 @@ class AccountSettingsTest {
 
     @Test
     fun testUpdate_RunAllMigrations() {
-        provideAccount(version = 6) { account ->
+        TestAccountAuthenticator.provide(version = 6) { account ->
             // will run AccountSettings.update
             accountSettingsFactory.create(account, abortOnMissingMigration = true)
 
             val accountManager = AccountManager.get(context)
             val version = accountManager.getUserData(account, AccountSettings.KEY_SETTINGS_VERSION).toIntOrNull()
             assertEquals(AccountSettings.CURRENT_VERSION, version)
-        }
-    }
-
-
-    private fun provideAccount(version: Int, block: (Account) -> Unit) {
-        val account = TestAccountAuthenticator.create(version = version)
-        try {
-            block(account)
-        } finally {
-            TestAccountAuthenticator.remove(account)
         }
     }
 

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration17Test.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration17Test.kt
@@ -20,7 +20,6 @@ import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import io.mockk.mockk
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -40,9 +39,6 @@ class AccountSettingsMigration17Test {
     @Inject
     lateinit var migration: AccountSettingsMigration17
 
-    lateinit var account: Account
-    val accountManager by lazy { AccountManager.get(context) }
-
     @get:Rule
     val hiltRule = HiltAndroidRule(this)
 
@@ -53,48 +49,53 @@ class AccountSettingsMigration17Test {
     @Before
     fun setUp() {
         hiltRule.inject()
-
-        account = TestAccountAuthenticator.create(version = 16)
-    }
-
-    @After
-    fun tearDown() {
-        TestAccountAuthenticator.remove(account)
     }
 
 
     @Test
     fun testMigrate_OldAddressBook_CollectionInDB() {
-        val addressBookAccountType = context.getString(R.string.account_type_address_book)
-        var addressBookAccount = Account("Address Book", addressBookAccountType)
-        assertTrue(accountManager.addAccountExplicitly(addressBookAccount, null, null))
-        try {
-            // address book has account + URL
-            val url = "https://example.com/address-book"
-            accountManager.setAndVerifyUserData(addressBookAccount, "real_account_name", account.name)
-            accountManager.setAndVerifyUserData(addressBookAccount, LocalAddressBook.USER_DATA_URL, url)
+        TestAccountAuthenticator.provide(version = 16) { account ->
+            val accountManager = AccountManager.get(context)
+            val addressBookAccountType = context.getString(R.string.account_type_address_book)
+            var addressBookAccount = Account("Address Book", addressBookAccountType)
+            assertTrue(accountManager.addAccountExplicitly(addressBookAccount, null, null))
 
-            // and is known in database
-            db.serviceDao().insertOrReplace(Service(
-                id = 1, accountName = account.name, type = Service.TYPE_CARDDAV, principal = null
-            ))
-            db.collectionDao().insert(Collection(
-                id = 100, serviceId = 1, url = url.toHttpUrl(), type = Collection.TYPE_ADDRESSBOOK, displayName = "Some Address Book"
-            ))
+            try {
+                // address book has account + URL
+                val url = "https://example.com/address-book"
+                accountManager.setAndVerifyUserData(addressBookAccount, "real_account_name", account.name)
+                accountManager.setAndVerifyUserData(addressBookAccount, LocalAddressBook.USER_DATA_URL, url)
 
-            // run migration
-            migration.migrate(account, mockk())
+                // and is known in database
+                db.serviceDao().insertOrReplace(
+                    Service(
+                        id = 1, accountName = account.name, type = Service.TYPE_CARDDAV, principal = null
+                    )
+                )
+                db.collectionDao().insert(
+                    Collection(
+                        id = 100,
+                        serviceId = 1,
+                        url = url.toHttpUrl(),
+                        type = Collection.TYPE_ADDRESSBOOK,
+                        displayName = "Some Address Book"
+                    )
+                )
 
-            // migration renames address book, update account
-            addressBookAccount = accountManager.getAccountsByType(addressBookAccountType).filter {
-                accountManager.getUserData(it, LocalAddressBook.USER_DATA_URL) == url
-            }.first()
-            assertEquals("Some Address Book (${account.name}) #100", addressBookAccount.name)
+                // run migration
+                migration.migrate(account, mockk())
 
-            // ID is now assigned
-            assertEquals(100L, accountManager.getUserData(addressBookAccount, LocalAddressBook.USER_DATA_COLLECTION_ID)?.toLong())
-        } finally {
-            accountManager.removeAccountExplicitly(addressBookAccount)
+                // migration renames address book, update account
+                addressBookAccount = accountManager.getAccountsByType(addressBookAccountType).filter {
+                    accountManager.getUserData(it, LocalAddressBook.USER_DATA_URL) == url
+                }.first()
+                assertEquals("Some Address Book (${account.name}) #100", addressBookAccount.name)
+
+                // ID is now assigned
+                assertEquals(100L, accountManager.getUserData(addressBookAccount, LocalAddressBook.USER_DATA_COLLECTION_ID)?.toLong())
+            } finally {
+                accountManager.removeAccountExplicitly(addressBookAccount)
+            }
         }
     }
 

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration18Test.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration18Test.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.settings.migration
+
+import android.accounts.Account
+import android.accounts.AccountManager
+import android.content.Context
+import at.bitfire.davdroid.R
+import at.bitfire.davdroid.db.AppDatabase
+import at.bitfire.davdroid.db.Collection
+import at.bitfire.davdroid.db.Service
+import at.bitfire.davdroid.resource.LocalAddressBook
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.verify
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import javax.inject.Inject
+
+@HiltAndroidTest
+class AccountSettingsMigration18Test {
+
+    @Inject @ApplicationContext
+    lateinit var context: Context
+
+    @MockK
+    lateinit var db: AppDatabase
+
+    @InjectMockKs
+    lateinit var migration: AccountSettingsMigration18
+
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+
+
+    @Before
+    fun setUp() {
+        hiltRule.inject()
+        MockKAnnotations.init(this)
+    }
+
+
+    @Test
+    fun testMigrate_AddressBook_InvalidCollection() {
+        every { db.serviceDao() } returns mockk {
+            every { getByAccountAndType(any(), any()) } returns null
+        }
+
+        val addressBookAccountType = context.getString(R.string.account_type_address_book)
+        var addressBookAccount = Account("Address Book", addressBookAccountType)
+
+        val accountManager = AccountManager.get(context)
+        mockkObject(accountManager)
+        every { accountManager.getAccountsByType(addressBookAccountType) } returns arrayOf(addressBookAccount)
+        every { accountManager.getUserData(addressBookAccount, LocalAddressBook.USER_DATA_COLLECTION_ID) } returns "123"
+
+        val account = Account("test", "test")
+        migration.migrate(account, mockk())
+
+        verify(exactly = 0) {
+            accountManager.setUserData(addressBookAccount, any(), any())
+        }
+    }
+
+    @Test
+    fun testMigrate_AddressBook_NoCollection() {
+        every { db.serviceDao() } returns mockk {
+            every { getByAccountAndType(any(), any()) } returns null
+        }
+
+        val addressBookAccountType = context.getString(R.string.account_type_address_book)
+        var addressBookAccount = Account("Address Book", addressBookAccountType)
+
+        val accountManager = AccountManager.get(context)
+        mockkObject(accountManager)
+        every { accountManager.getAccountsByType(addressBookAccountType) } returns arrayOf(addressBookAccount)
+        every { accountManager.getUserData(addressBookAccount, LocalAddressBook.USER_DATA_COLLECTION_ID) } returns "123"
+
+        val account = Account("test", "test")
+        migration.migrate(account, mockk())
+
+        verify(exactly = 0) {
+            accountManager.setUserData(addressBookAccount, any(), any())
+        }
+    }
+
+    @Test
+    fun testMigrate_AddressBook_ValidCollection() {
+        val account = Account("test", "test")
+
+        every { db.serviceDao() } returns mockk {
+            every { getByAccountAndType(any(), any()) } returns Service(
+                id = 10,
+                accountName = account.name,
+                type = Service.TYPE_CARDDAV,
+                principal = null
+            )
+        }
+        every { db.collectionDao() } returns mockk {
+            every { getByService(10) } returns listOf(Collection(
+                id = 100,
+                serviceId = 10,
+                url = "http://example.com".toHttpUrl(),
+                type = Collection.TYPE_ADDRESSBOOK
+            ))
+        }
+
+        val addressBookAccountType = context.getString(R.string.account_type_address_book)
+        var addressBookAccount = Account("Address Book", addressBookAccountType)
+
+        val accountManager = AccountManager.get(context)
+        mockkObject(accountManager)
+        every { accountManager.getAccountsByType(addressBookAccountType) } returns arrayOf(addressBookAccount)
+        every { accountManager.getUserData(addressBookAccount, LocalAddressBook.USER_DATA_COLLECTION_ID) } returns "100"
+
+        migration.migrate(account, mockk())
+
+        verify {
+            accountManager.setUserData(addressBookAccount, LocalAddressBook.USER_DATA_ACCOUNT_NAME, account.name)
+            accountManager.setUserData(addressBookAccount, LocalAddressBook.USER_DATA_ACCOUNT_TYPE, account.type)
+        }
+    }
+
+}

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/account/AccountsCleanupWorkerTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/account/AccountsCleanupWorkerTest.kt
@@ -13,16 +13,18 @@ import androidx.work.testing.TestListenableWorkerBuilder
 import androidx.work.testing.WorkManagerTestInitHelper
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.AppDatabase
-import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service
-import at.bitfire.davdroid.resource.LocalAddressBook.Companion.USER_DATA_COLLECTION_ID
+import at.bitfire.davdroid.resource.LocalAddressBook
 import at.bitfire.davdroid.settings.SettingsManager
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
-import okhttp3.HttpUrl.Companion.toHttpUrl
+import io.mockk.every
+import io.mockk.mockkObject
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -86,8 +88,50 @@ class AccountsCleanupWorkerTest {
 
 
     @Test
-    fun testDeleteOrphanedAddressBookAccounts_deletesAddressBookAccountWithoutCollection() {
-        // Create address book account without corresponding collection
+    fun testCleanUpServices_noAccount() {
+        // Insert service that reference to invalid account
+        db.serviceDao().insertOrReplace(Service(id = 1, accountName = "test", type = Service.TYPE_CALDAV, principal = null))
+        assertNotNull(db.serviceDao().get(1))
+
+        // Create worker and run the method
+        val worker = TestListenableWorkerBuilder<AccountsCleanupWorker>(context)
+            .setWorkerFactory(workerFactory)
+            .build()
+        worker.cleanUpServices()
+
+        // Verify that service is deleted
+        assertNull(db.serviceDao().get(1))
+    }
+
+    @Test
+    fun testCleanUpServices_oneAccount() {
+        val account = Account("test", "test")
+        val accountManager = AccountManager.get(context)
+        mockkObject(accountManager)
+        every { accountManager.getAccountsByType(context.getString(R.string.account_type)) } returns arrayOf(account)
+
+        // Insert services, one that reference the existing account and one that references an invalid account
+        db.serviceDao().insertOrReplace(Service(id = 1, accountName = account.name, type = Service.TYPE_CALDAV, principal = null))
+        assertNotNull(db.serviceDao().get(1))
+
+        db.serviceDao().insertOrReplace(Service(id = 2, accountName = "not existing", type = Service.TYPE_CARDDAV, principal = null))
+        assertNotNull(db.serviceDao().get(2))
+
+        // Create worker and run the method
+        val worker = TestListenableWorkerBuilder<AccountsCleanupWorker>(context)
+            .setWorkerFactory(workerFactory)
+            .build()
+        worker.cleanUpServices()
+
+        // Verify that one service is deleted and the other one is kept
+        assertNotNull(db.serviceDao().get(1))
+        assertNull(db.serviceDao().get(2))
+    }
+
+
+    @Test
+    fun testCleanUpAddressBooks_deletesAddressBookWithoutAccount() {
+        // Create address book account without corresponding account
         assertTrue(accountManager.addAccountExplicitly(addressBookAccount, null, null))
 
         val addressBookAccounts = accountManager.getAccountsByType(addressBookAccountType)
@@ -95,49 +139,36 @@ class AccountsCleanupWorkerTest {
 
         // Create worker and run the method
         val worker = TestListenableWorkerBuilder<AccountsCleanupWorker>(context)
-            .setWorkerFactory(object: WorkerFactory() {
-                override fun createWorker(appContext: Context, workerClassName: String, workerParameters: WorkerParameters) =
-                    accountsCleanupWorkerFactory.create(appContext, workerParameters)
-            })
+            .setWorkerFactory(workerFactory)
             .build()
-        worker.deleteOrphanedAddressBookAccounts(addressBookAccounts)
+        worker.cleanUpAddressBooks()
 
         // Verify account was deleted
         assertTrue(accountManager.getAccountsByType(addressBookAccountType).isEmpty())
     }
 
     @Test
-    fun testDeleteOrphanedAddressBookAccounts_leavesAddressBookAccountWithCollection() {
-        // Create address book account _with_ corresponding collection and verify
-        val randomCollectionId = 12345L
-        val userData = Bundle(1).apply {
-            putString(USER_DATA_COLLECTION_ID, "$randomCollectionId")
+    fun testCleanUpAddressBooks_keepsAddressBookWithAccount() {
+        TestAccountAuthenticator.provide() { account ->
+            // Create address book account _with_ corresponding account and verify
+            val userData = Bundle(2).apply {
+                putString(LocalAddressBook.USER_DATA_ACCOUNT_NAME, account.name)
+                putString(LocalAddressBook.USER_DATA_ACCOUNT_TYPE, account.type)
+            }
+            assertTrue(accountManager.addAccountExplicitly(addressBookAccount, null, userData))
+
+            val addressBookAccounts = accountManager.getAccountsByType(addressBookAccountType)
+            assertEquals(addressBookAccount, addressBookAccounts.firstOrNull())
+
+            // Create worker and run the method
+            val worker = TestListenableWorkerBuilder<AccountsCleanupWorker>(context)
+                .setWorkerFactory(workerFactory)
+                .build()
+            worker.cleanUpAddressBooks()
+
+            // Verify account was _not_ deleted
+            assertEquals(addressBookAccount, addressBookAccounts.firstOrNull())
         }
-        assertTrue(accountManager.addAccountExplicitly(addressBookAccount, null, userData))
-
-        val addressBookAccounts = accountManager.getAccountsByType(addressBookAccountType)
-        assertEquals(randomCollectionId, accountManager.getUserData(addressBookAccount, USER_DATA_COLLECTION_ID).toLong())
-
-        // Create the collection
-        val collectionDao = db.collectionDao()
-        collectionDao.insert(Collection(
-            randomCollectionId,
-            serviceId = service.id,
-            type = Collection.TYPE_ADDRESSBOOK,
-            url = "http://www.example.com/yay.php".toHttpUrl()
-        ))
-
-        // Create worker and run the method
-        val worker = TestListenableWorkerBuilder<AccountsCleanupWorker>(context)
-            .setWorkerFactory(object: WorkerFactory() {
-                override fun createWorker(appContext: Context, workerClassName: String, workerParameters: WorkerParameters) =
-                    accountsCleanupWorkerFactory.create(appContext, workerParameters)
-            })
-            .build()
-        worker.deleteOrphanedAddressBookAccounts(addressBookAccounts)
-
-        // Verify account was _not_ deleted
-        assertEquals(addressBookAccount, addressBookAccounts.firstOrNull())
     }
 
 
@@ -147,6 +178,11 @@ class AccountsCleanupWorkerTest {
         val service = Service(id=0, accountName="test", type=serviceType, principal = null)
         val serviceId = db.serviceDao().insertOrReplace(service)
         return db.serviceDao().get(serviceId)!!
+    }
+
+    private fun workerFactory() = object : WorkerFactory() {
+        override fun createWorker(appContext: Context, workerClassName: String, workerParameters: WorkerParameters) =
+            accountsCleanupWorkerFactory.create(appContext, workerParameters)
     }
 
 }

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/account/SystemAccountUtilsTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/account/SystemAccountUtilsTest.kt
@@ -22,7 +22,7 @@ import org.junit.Test
 import javax.inject.Inject
 
 @HiltAndroidTest
-class AccountUtilsTest {
+class SystemAccountUtilsTest {
 
     @get:Rule
     val hiltRule = HiltAndroidRule(this)

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/account/TestAccountAuthenticator.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/account/TestAccountAuthenticator.kt
@@ -69,6 +69,18 @@ class TestAccountAuthenticator: Service() {
             assertTrue(am.removeAccountExplicitly(account))
         }
 
+        /**
+         * Convenience method to create a test account and remove it after executing the block.
+         */
+        fun provide(version: Int = AccountSettings.CURRENT_VERSION, block: (Account) -> Unit) {
+            val account = create(version)
+            try {
+                block(account)
+            } finally {
+                remove(account)
+            }
+        }
+
     }
 
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/repository/AccountRepository.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/repository/AccountRepository.kt
@@ -248,6 +248,9 @@ class AccountRepository @Inject constructor(
             // update account name references in database
             serviceRepository.renameAccount(oldName, newName)
 
+            // update address books
+            localAddressBookStore.get().updateAccount(oldAccount, newAccount)
+
             // calendar provider doesn't allow changing account_name of Events
             // (all events will have to be downloaded again at next sync)
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -44,20 +44,21 @@ import java.util.logging.Logger
  * account and there is no such thing as "address books". So, DAVx5 creates a "DAVx5
  * address book" account for every CardDAV address book.
  *
+ * @param account             TODO
  * @param _addressBookAccount Address book account (not: DAVx5 account) storing the actual Android
  * contacts. This is the initial value of [addressBookAccount]. However when the address book is renamed,
  * the new name will only be available in [addressBookAccount], so usually that one should be used.
- *
- * @param provider Content provider needed to access and modify the address book
+ * @param provider            Content provider needed to access and modify the address book
  */
 @OpenForTesting
 open class LocalAddressBook @AssistedInject constructor(
-    @Assisted _addressBookAccount: Account,
+    @Assisted("account") val account: Account,
+    @Assisted("addressBookAccount") _addressBookAccount: Account,
     @Assisted provider: ContentProviderClient,
     private val accountSettingsFactory: AccountSettings.Factory,
     private val collectionRepository: DavCollectionRepository,
-    @ApplicationContext val context: Context,
-    val dirtyVerifier: Optional<ContactDirtyVerifier>,
+    @ApplicationContext private val context: Context,
+    internal val dirtyVerifier: Optional<ContactDirtyVerifier>,
     private val logger: Logger,
     private val serviceRepository: DavServiceRepository,
     private val syncFramework: SyncFrameworkIntegration
@@ -65,7 +66,11 @@ open class LocalAddressBook @AssistedInject constructor(
 
     @AssistedFactory
     interface Factory {
-        fun create(addressBookAccount: Account, provider: ContentProviderClient): LocalAddressBook
+        fun create(
+            @Assisted("account") account: Account,
+            @Assisted("addressBookAccount") addressBookAccount: Account,
+            provider: ContentProviderClient
+        ): LocalAddressBook
     }
 
     override val tag: String
@@ -337,6 +342,9 @@ open class LocalAddressBook @AssistedInject constructor(
 
 
     companion object {
+
+        const val USER_DATA_ACCOUNT_NAME = "account_name"
+        const val USER_DATA_ACCOUNT_TYPE = "account_type"
 
         /**
          * URL of the corresponding CardDAV address book.

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
@@ -155,6 +155,25 @@ class LocalAddressBookStore @Inject constructor(
         localCollection.updateSyncFrameworkSettings()
     }
 
+    /**
+     * Updates address books which are assigned to [oldAccount] so that they're assigned to [newAccount] instead.
+     *
+     * @param oldAccount    The old account
+     * @param newAccount    The new account
+     */
+    fun updateAccount(oldAccount: Account, newAccount: Account) {
+        val accountManager = AccountManager.get(context)
+        accountManager.getAccountsByType(context.getString(R.string.account_type_address_book))
+            .filter { addressBookAccount ->
+                accountManager.getUserData(addressBookAccount, LocalAddressBook.USER_DATA_ACCOUNT_NAME) == oldAccount.name &&
+                accountManager.getUserData(addressBookAccount, LocalAddressBook.USER_DATA_ACCOUNT_TYPE) == oldAccount.type
+            }
+            .forEach { addressBookAccount ->
+                accountManager.setAndVerifyUserData(addressBookAccount, LocalAddressBook.USER_DATA_ACCOUNT_NAME, newAccount.name)
+                accountManager.setAndVerifyUserData(addressBookAccount, LocalAddressBook.USER_DATA_ACCOUNT_TYPE, newAccount.type)
+            }
+    }
+
 
     override fun delete(localCollection: LocalAddressBook) {
         val accountManager = AccountManager.get(context)

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
@@ -15,10 +15,7 @@ import androidx.annotation.OpenForTesting
 import androidx.annotation.VisibleForTesting
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.Collection
-import at.bitfire.davdroid.repository.DavCollectionRepository
 import at.bitfire.davdroid.repository.DavServiceRepository
-import at.bitfire.davdroid.resource.LocalAddressBook.Companion.USER_DATA_COLLECTION_ID
-import at.bitfire.davdroid.resource.LocalAddressBook.Companion.USER_DATA_URL
 import at.bitfire.davdroid.settings.Settings
 import at.bitfire.davdroid.settings.SettingsManager
 import at.bitfire.davdroid.sync.account.SystemAccountUtils
@@ -30,13 +27,12 @@ import java.util.logging.Logger
 import javax.inject.Inject
 
 class LocalAddressBookStore @Inject constructor(
-    val collectionRepository: DavCollectionRepository,
-    @ApplicationContext val context: Context,
-    val localAddressBookFactory: LocalAddressBook.Factory,
-    val logger: Logger,
-    val serviceRepository: DavServiceRepository,
-    val settings: SettingsManager
-    ): LocalDataStore<LocalAddressBook> {
+    @ApplicationContext private val context: Context,
+    private val localAddressBookFactory: LocalAddressBook.Factory,
+    private val logger: Logger,
+    private val serviceRepository: DavServiceRepository,
+    private val settings: SettingsManager
+): LocalDataStore<LocalAddressBook> {
 
     /** whether a (usually managed) setting wants all address-books to be read-only **/
     val forceAllReadOnly: Boolean
@@ -73,14 +69,18 @@ class LocalAddressBookStore @Inject constructor(
 
 
     override fun create(provider: ContentProviderClient, fromCollection: Collection): LocalAddressBook? {
+        val service = serviceRepository.get(fromCollection.serviceId) ?: throw IllegalArgumentException("Couldn't fetch DB service from collection")
+        val account = Account(service.accountName, context.getString(R.string.account_type))
+
         val name = accountName(fromCollection)
-        val account = createAccount(
+        val addressBookAccount = createAddressBookAccount(
+            account = account,
             name = name,
             id = fromCollection.id,
             url = fromCollection.url.toString()
         ) ?: return null
 
-        val addressBook = localAddressBookFactory.create(account, provider)
+        val addressBook = localAddressBookFactory.create(account, addressBookAccount, provider)
 
         // update settings
         addressBook.updateSyncFrameworkSettings()
@@ -91,26 +91,35 @@ class LocalAddressBookStore @Inject constructor(
     }
 
     @OpenForTesting
-    internal fun createAccount(name: String, id: Long, url: String): Account? {
-        // create account with collection ID and URL
-        val account = Account(name, context.getString(R.string.account_type_address_book))
-        val userData = Bundle(2).apply {
-            putString(USER_DATA_COLLECTION_ID, id.toString())
-            putString(USER_DATA_URL, url)
+    internal fun createAddressBookAccount(account: Account, name: String, id: Long, url: String): Account? {
+        // create address book account with reference to account, collection ID and URL
+        val addressBookAccount = Account(name, context.getString(R.string.account_type_address_book))
+        val userData = Bundle(4).apply {
+            putString(LocalAddressBook.USER_DATA_ACCOUNT_NAME, account.name)
+            putString(LocalAddressBook.USER_DATA_ACCOUNT_TYPE, account.type)
+            putString(LocalAddressBook.USER_DATA_COLLECTION_ID, id.toString())
+            putString(LocalAddressBook.USER_DATA_URL, url)
         }
-        if (!SystemAccountUtils.createAccount(context, account, userData)) {
-            logger.warning("Couldn't create address book account: $account")
+        if (!SystemAccountUtils.createAccount(context, addressBookAccount, userData)) {
+            logger.warning("Couldn't create address book account: $addressBookAccount")
             return null
         }
 
-        return account
+        return addressBookAccount
     }
 
 
-    override fun getAll(account: Account, provider: ContentProviderClient): List<LocalAddressBook> =
-        AccountManager.get(context)
-            .getAccountsByType(context.getString(R.string.account_type_address_book))
-            .map { account -> localAddressBookFactory.create(account, provider) }
+    override fun getAll(account: Account, provider: ContentProviderClient): List<LocalAddressBook> {
+        val accountManager = AccountManager.get(context)
+        return accountManager.getAccountsByType(context.getString(R.string.account_type_address_book))
+            .filter { addressBookAccount ->
+                accountManager.getUserData(addressBookAccount, LocalAddressBook.USER_DATA_ACCOUNT_NAME) == account.name &&
+                accountManager.getUserData(addressBookAccount, LocalAddressBook.USER_DATA_ACCOUNT_TYPE) == account.type
+            }
+            .map { addressBookAccount ->
+                localAddressBookFactory.create(account, addressBookAccount, provider)
+            }
+    }
 
 
     override fun update(provider: ContentProviderClient, localCollection: LocalAddressBook, fromCollection: Collection) {
@@ -127,8 +136,10 @@ class LocalAddressBookStore @Inject constructor(
 
         // Update the account user data
         val accountManager = AccountManager.get(context)
-        accountManager.setAndVerifyUserData(currentAccount, USER_DATA_COLLECTION_ID, fromCollection.id.toString())
-        accountManager.setAndVerifyUserData(currentAccount, USER_DATA_URL, fromCollection.url.toString())
+        accountManager.setAndVerifyUserData(currentAccount, LocalAddressBook.USER_DATA_ACCOUNT_NAME, localCollection.account.name)
+        accountManager.setAndVerifyUserData(currentAccount, LocalAddressBook.USER_DATA_ACCOUNT_TYPE, localCollection.account.type)
+        accountManager.setAndVerifyUserData(currentAccount, LocalAddressBook.USER_DATA_COLLECTION_ID, fromCollection.id.toString())
+        accountManager.setAndVerifyUserData(currentAccount, LocalAddressBook.USER_DATA_URL, fromCollection.url.toString())
 
         // Set contacts provider settings
         localCollection.settings = contactsProviderSettings
@@ -158,7 +169,7 @@ class LocalAddressBookStore @Inject constructor(
     fun deleteByCollectionId(id: Long) {
         val accountManager = AccountManager.get(context)
         val addressBookAccount = accountManager.getAccountsByType(context.getString(R.string.account_type_address_book)).firstOrNull { account ->
-            accountManager.getUserData(account, USER_DATA_COLLECTION_ID)?.toLongOrNull() == id
+            accountManager.getUserData(account, LocalAddressBook.USER_DATA_COLLECTION_ID)?.toLongOrNull() == id
         }
         if (addressBookAccount != null)
             accountManager.removeAccountExplicitly(addressBookAccount)

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendarStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendarStore.kt
@@ -12,8 +12,8 @@ import android.content.Context
 import android.provider.CalendarContract.Calendars
 import at.bitfire.davdroid.Constants
 import at.bitfire.davdroid.R
-import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.Collection
+import at.bitfire.davdroid.repository.DavServiceRepository
 import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.util.DavUtils.lastSegment
 import at.bitfire.ical4android.AndroidCalendar
@@ -25,17 +25,14 @@ import java.util.logging.Logger
 import javax.inject.Inject
 
 class LocalCalendarStore @Inject constructor(
-    @ApplicationContext val context: Context,
-    val accountSettingsFactory: AccountSettings.Factory,
-    db: AppDatabase,
-    val logger: Logger
+    @ApplicationContext private val context: Context,
+    private val accountSettingsFactory: AccountSettings.Factory,
+    private val logger: Logger,
+    private val serviceRepository: DavServiceRepository
 ): LocalDataStore<LocalCalendar> {
 
-    private val serviceDao = db.serviceDao()
-
-
     override fun create(provider: ContentProviderClient, fromCollection: Collection): LocalCalendar? {
-        val service = serviceDao.get(fromCollection.serviceId) ?: throw IllegalArgumentException("Couldn't fetch DB service from collection")
+        val service = serviceRepository.get(fromCollection.serviceId) ?: throw IllegalArgumentException("Couldn't fetch DB service from collection")
         val account = Account(service.accountName, context.getString(R.string.account_type))
 
         // If the collection doesn't have a color, use a default color.

--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettings.kt
@@ -76,7 +76,7 @@ class AccountSettings @AssistedInject constructor(
             "at.bitfire.davdroid.test"      // R.strings.account_type_test in androidTest
         )
         if (!allowedAccountTypes.contains(account.type))
-            throw IllegalArgumentException("Invalid account type: ${account.type}")
+            throw IllegalArgumentException("Invalid account type for AccountSettings(): ${account.type}")
 
         // synchronize because account migration must only be run one time
         synchronized(AccountSettings::class.java) {

--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettings.kt
@@ -375,7 +375,7 @@ class AccountSettings @AssistedInject constructor(
 
     companion object {
 
-        const val CURRENT_VERSION = 17
+        const val CURRENT_VERSION = 18
         const val KEY_SETTINGS_VERSION = "version"
 
         const val KEY_SYNC_INTERVAL_ADDRESSBOOKS = "sync_interval_addressbooks"

--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration17.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration17.kt
@@ -62,7 +62,7 @@ class AccountSettingsMigration17 @Inject constructor(
             for (oldAddressBookAccount in oldAddressBookAccounts) {
                 // Old address books only have a URL, so use it to determine the collection ID
                 logger.info("Migrating address book ${oldAddressBookAccount.name}")
-                val oldAddressBook = localAddressBookFactory.create(oldAddressBookAccount, provider)
+                val oldAddressBook = localAddressBookFactory.create(account, oldAddressBookAccount, provider)
                 val url = accountManager.getUserData(oldAddressBookAccount, LocalAddressBook.USER_DATA_URL)
                 collectionRepository.getByServiceAndUrl(service.id, url)?.let { collection ->
                     // Set collection ID and rename the account

--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration18.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration18.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.settings.migration
+
+import android.accounts.Account
+import android.accounts.AccountManager
+import android.content.Context
+import at.bitfire.davdroid.R
+import at.bitfire.davdroid.db.AppDatabase
+import at.bitfire.davdroid.db.Service
+import at.bitfire.davdroid.resource.LocalAddressBook
+import at.bitfire.davdroid.settings.AccountSettings
+import at.bitfire.davdroid.sync.account.setAndVerifyUserData
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntKey
+import dagger.multibindings.IntoMap
+import javax.inject.Inject
+
+/**
+ * v17 had removed the binding between address book accounts and accounts and introduced
+ * the binding to collection IDs instead.
+ *
+ * However, it turned out that the account binding is needed even with collection IDs for the case
+ * that the collection is not available in the database anymore (for instance, because it has been
+ * removed on the server). In that case, the [at.bitfire.davdroid.sync.Syncer] still needs to get
+ * a list of all address book accounts that belong to the account, and not _all_ address books.
+ *
+ * So this migration again assigns address book accounts to accounts.
+ */
+class AccountSettingsMigration18 @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val db: AppDatabase
+): AccountSettingsMigration {
+
+    override fun migrate(account: Account, accountSettings: AccountSettings) {
+        val accountManager = AccountManager.get(context)
+        db.serviceDao().getByAccountAndType(account.name, Service.TYPE_CARDDAV)?.let { service ->
+            db.collectionDao().getByService(service.id).forEach { collection ->
+                // Find associated address book account by collection ID (if it exists)
+                val addressBookAccount = accountManager
+                    .getAccountsByType(context.getString(R.string.account_type_address_book))
+                    .firstOrNull { accountManager.getUserData(it, LocalAddressBook.USER_DATA_COLLECTION_ID) == collection.id.toString() }
+
+                if (addressBookAccount != null) {
+                    // (Re-)assign address book to account
+                    accountManager.setAndVerifyUserData(addressBookAccount, LocalAddressBook.USER_DATA_ACCOUNT_NAME, account.name)
+                    accountManager.setAndVerifyUserData(addressBookAccount, LocalAddressBook.USER_DATA_ACCOUNT_TYPE, account.type)
+                }
+            }
+        }
+
+        // Address books without an assigned account will be removed by AccountsCleanupWorker
+    }
+
+
+    @Module
+    @InstallIn(SingletonComponent::class)
+    abstract class AccountSettingsMigrationModule {
+        @Binds @IntoMap
+        @IntKey(18)
+        abstract fun provide(impl: AccountSettingsMigration18): AccountSettingsMigration
+    }
+
+}

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
@@ -76,10 +76,10 @@ abstract class BaseSyncWorker(
     override suspend fun doWork(): Result {
         // ensure we got the required arguments
         val account = Account(
-            inputData.getString(INPUT_ACCOUNT_NAME) ?: throw IllegalArgumentException("$INPUT_ACCOUNT_NAME required"),
-            inputData.getString(INPUT_ACCOUNT_TYPE) ?: throw IllegalArgumentException("$INPUT_ACCOUNT_TYPE required")
+            inputData.getString(INPUT_ACCOUNT_NAME) ?: throw IllegalArgumentException("INPUT_ACCOUNT_NAME required"),
+            inputData.getString(INPUT_ACCOUNT_TYPE) ?: throw IllegalArgumentException("INPUT_ACCOUNT_TYPE required")
         )
-        val authority = inputData.getString(INPUT_AUTHORITY) ?: throw IllegalArgumentException("$INPUT_AUTHORITY required")
+        val authority = inputData.getString(INPUT_AUTHORITY) ?: throw IllegalArgumentException("INPUT_AUTHORITY required")
 
         val syncTag = commonTag(account, authority)
         logger.info("${javaClass.simpleName} called for $syncTag")

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreenModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreenModel.kt
@@ -163,7 +163,7 @@ class AccountScreenModel @AssistedInject constructor(
                 accountRepository.rename(account.name, newName)
 
                 // synchronize again
-                val newAccount = Account(context.getString(R.string.account_type), newName)
+                val newAccount = Account(newName, context.getString(R.string.account_type))
                 syncWorkerManager.enqueueOneTimeAllAuthorities(newAccount, manual = true)
             } catch (e: Exception) {
                 logger.log(Level.SEVERE, "Couldn't rename account", e)


### PR DESCRIPTION
This PR shall resolve these issues:

- orphaned address books are not removed in time,
- address books are removed randomly when multiple accounts are used.

In previous versions, the binding from address books to accounts has been removed. However this caused problems because `Syncer` then can't get a list of address books _of the current account_, and then mixes some operations (like deletion) with other accounts.

This PR binds address books to accounts again. However it still cleanly separates address books (address book accounts) from accounts. For instance, `AccountsSettings()` still can never be created for an address book (like in earlier DAVx5 versions).