### PR TITLE
Migrate to `SecureTextField`

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/composable/InputDialogs.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/composable/InputDialogs.kt
@@ -10,8 +10,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -22,10 +22,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -34,7 +31,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -49,11 +45,10 @@ fun EditTextInputDialog(
     onValueEntered: (String) -> Unit = {},
     onDismiss: () -> Unit = {},
 ) {
-    var textValue by remember {
-        mutableStateOf(TextFieldValue(
-            initialValue ?: "", selection = TextRange(initialValue?.length ?: 0)
-        ))
-    }
+    val state = rememberTextFieldState(
+        initialText = initialValue ?: "",
+        initialSelection = TextRange(initialValue?.length ?: 0)
+    )
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -67,27 +62,22 @@ fun EditTextInputDialog(
             val focusRequester = remember { FocusRequester() }
             if (passwordField)
                 PasswordTextField(
-                    password = textValue.text,
+                    password = state,
                     labelText = inputLabel,
-                    onPasswordChange = { textValue = TextFieldValue(it) },
                     modifier = Modifier.focusRequester(focusRequester)
                 )
             else
                 TextField(
                     label = { inputLabel?.let { Text(it) } },
-                    value = textValue,
-                    onValueChange = { textValue = it },
-                    singleLine = true,
+                    state = state,
                     keyboardOptions = KeyboardOptions(
                         keyboardType = keyboardType,
                         imeAction = ImeAction.Done
                     ),
-                    keyboardActions = KeyboardActions(
-                        onDone = {
-                            onValueEntered(textValue.text)
-                            onDismiss()
-                        }
-                    ),
+                    onKeyboardAction = {
+                        onValueEntered(state.text.toString())
+                        onDismiss()
+                    },
                     modifier = Modifier.focusRequester(focusRequester)
                 )
             LaunchedEffect(Unit) {
@@ -97,10 +87,10 @@ fun EditTextInputDialog(
         confirmButton = {
             Button(
                 onClick = {
-                    onValueEntered(textValue.text)
+                    onValueEntered(state.text.toString())
                     onDismiss()
                 },
-                enabled = textValue.text != initialValue
+                enabled = state.text != initialValue
             ) {
                 Text(stringResource(android.R.string.ok))
             }

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/composable/PasswordTextField.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/composable/PasswordTextField.kt
@@ -5,14 +5,17 @@
 package at.bitfire.davdroid.ui.composable
 
 import androidx.compose.foundation.focusGroup
-import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.KeyboardActionHandler
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.TextObfuscationMode
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedSecureTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -22,39 +25,32 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import at.bitfire.davdroid.R
 
 @Composable
 fun PasswordTextField(
-    password: String,
+    password: TextFieldState,
     labelText: String?,
-    onPasswordChange: (String) -> Unit,
     modifier: Modifier = Modifier,
     leadingIcon: @Composable (() -> Unit)? = null,
     keyboardOptions: KeyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    onKeyboardAction: KeyboardActionHandler? = null,
     enabled: Boolean = true,
-    readOnly: Boolean = false,
     isError: Boolean = false
 ) {
     var passwordVisible by remember { mutableStateOf(false) }
 
-    OutlinedTextField(
-        value = password,
-        onValueChange = onPasswordChange,
+    OutlinedSecureTextField(
+        state = password,
         label = labelText?.let { { Text(it) } },
         leadingIcon = leadingIcon,
         isError = isError,
-        singleLine = true,
         enabled = enabled,
-        readOnly = readOnly,
         modifier = modifier.focusGroup(),
         keyboardOptions = keyboardOptions,
-        keyboardActions = keyboardActions,
-        visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
+        onKeyboardAction = onKeyboardAction,
+        textObfuscationMode = if (passwordVisible) TextObfuscationMode.Visible else TextObfuscationMode.RevealLastTyped,
         trailingIcon = {
             IconButton(
                 enabled = enabled,
@@ -73,11 +69,10 @@ fun PasswordTextField(
 @Preview
 fun PasswordTextField_Sample() {
     PasswordTextField(
-        password = "",
+        password = rememberTextFieldState(""),
         labelText = "labelText",
         enabled = true,
         isError = false,
-        onPasswordChange = {},
     )
 }
 
@@ -85,11 +80,10 @@ fun PasswordTextField_Sample() {
 @Preview
 fun PasswordTextField_Sample_Filled() {
     PasswordTextField(
-        password = "password",
+        password = rememberTextFieldState("password"),
         labelText = "labelText",
         enabled = true,
         isError = false,
-        onPasswordChange = {},
     )
 }
 
@@ -97,11 +91,10 @@ fun PasswordTextField_Sample_Filled() {
 @Preview
 fun PasswordTextField_Sample_Error() {
     PasswordTextField(
-        password = "password",
+        password = rememberTextFieldState("password"),
         labelText = "labelText",
         enabled = true,
         isError = true,
-        onPasswordChange = {},
     )
 }
 
@@ -109,10 +102,9 @@ fun PasswordTextField_Sample_Error() {
 @Preview
 fun PasswordTextField_Sample_Disabled() {
     PasswordTextField(
-        password = "password",
+        password = rememberTextFieldState("password"),
         labelText = "labelText",
         enabled = false,
         isError = false,
-        onPasswordChange = {},
     )
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/AdvancedLogin.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/AdvancedLogin.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Folder
@@ -69,7 +71,6 @@ object AdvancedLogin : LoginType {
             username = uiState.username,
             onSetUsername = model::setUsername,
             password = uiState.password,
-            onSetPassword = model::setPassword,
             certAlias = uiState.certAlias,
             onSetCertAlias = model::setCertAlias,
             canContinue = uiState.canContinue,
@@ -88,8 +89,7 @@ fun AdvancedLoginScreen(
     onSetUrl: (String) -> Unit = {},
     username: String,
     onSetUsername: (String) -> Unit = {},
-    password: String,
-    onSetPassword: (String) -> Unit = {},
+    password: TextFieldState,
     certAlias: String,
     onSetCertAlias: (String) -> Unit = {},
     canContinue: Boolean,
@@ -158,7 +158,6 @@ fun AdvancedLoginScreen(
 
             PasswordTextField(
                 password = password,
-                onPasswordChange = onSetPassword,
                 labelText = stringResource(R.string.login_password_optional),
                 leadingIcon = {
                     Icon(Icons.Default.Password, null)
@@ -199,7 +198,7 @@ fun AdvancedLoginScreen_Preview_Empty() {
         snackbarHostState = SnackbarHostState(),
         url = "",
         username = "",
-        password = "",
+        password = rememberTextFieldState(""),
         certAlias = "",
         canContinue = false
     )
@@ -212,7 +211,7 @@ fun AdvancedLoginScreen_Preview_AllFilled() {
         snackbarHostState = SnackbarHostState(),
         url = "dav.example.com",
         username = "someuser",
-        password = "password",
+        password = rememberTextFieldState("password"),
         certAlias = "someCert",
         canContinue = true
     )

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/AdvancedLoginModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/AdvancedLoginModel.kt
@@ -4,6 +4,7 @@
 
 package at.bitfire.davdroid.ui.setup
 
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -29,7 +30,7 @@ class AdvancedLoginModel @AssistedInject constructor(
     data class UiState(
         val url: String = "",
         val username: String = "",
-        val password: String = "",
+        val password: TextFieldState = TextFieldState(),
         val certAlias: String = ""
     ) {
 
@@ -46,7 +47,7 @@ class AdvancedLoginModel @AssistedInject constructor(
             baseUri = uri,
             credentials = Credentials(
                 username = username.trimToNull(),
-                password = password.trimToNull(),
+                password = password.text.toString().trimToNull(),
                 certificateAlias = certAlias.trimToNull()
             )
         )
@@ -60,7 +61,7 @@ class AdvancedLoginModel @AssistedInject constructor(
         uiState = uiState.copy(
             url = initialLoginInfo.baseUri?.toString()?.removePrefix("https://") ?: "",
             username = initialLoginInfo.credentials?.username ?: "",
-            password = initialLoginInfo.credentials?.password ?: "",
+            password = TextFieldState(initialLoginInfo.credentials?.password ?: ""),
             certAlias = initialLoginInfo.credentials?.certificateAlias ?: ""
         )
     }
@@ -71,10 +72,6 @@ class AdvancedLoginModel @AssistedInject constructor(
 
     fun setUsername(username: String) {
         uiState = uiState.copy(username = username)
-    }
-
-    fun setPassword(password: String) {
-        uiState = uiState.copy(password = password)
     }
 
     fun setCertAlias(certAlias: String) {

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/EmailLogin.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/EmailLogin.kt
@@ -8,8 +8,9 @@ import android.net.Uri
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.Password
@@ -63,7 +64,6 @@ object EmailLogin : LoginType {
             email = uiState.email,
             onSetEmail = model::setEmail,
             password = uiState.password,
-            onSetPassword = model::setPassword,
             canContinue = uiState.canContinue,
             onLogin = { onLogin(uiState.asLoginInfo()) }
         )
@@ -76,8 +76,7 @@ object EmailLogin : LoginType {
 fun EmailLoginScreen(
     email: String,
     onSetEmail: (String) -> Unit = {},
-    password: String,
-    onSetPassword: (String) -> Unit = {},
+    password: TextFieldState,
     canContinue: Boolean,
     onLogin: () -> Unit = {}
 ) {
@@ -131,7 +130,6 @@ fun EmailLoginScreen(
 
             PasswordTextField(
                 password = password,
-                onPasswordChange = onSetPassword,
                 labelText = stringResource(R.string.login_password),
                 leadingIcon = {
                     Icon(Icons.Default.Password, null)
@@ -140,9 +138,7 @@ fun EmailLoginScreen(
                     keyboardType = KeyboardType.Password,
                     imeAction = ImeAction.Done
                 ),
-                keyboardActions = KeyboardActions(
-                    onDone = { onLogin() }
-                ),
+                onKeyboardAction = { onLogin() },
                 modifier = Modifier.fillMaxWidth()
             )
         }
@@ -155,7 +151,7 @@ fun EmailLoginScreen(
 fun EmailLoginScreen_Preview() {
     EmailLoginScreen(
         email = "test@example.com",
-        password = "",
+        password = rememberTextFieldState(""),
         canContinue = false
     )
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/EmailLoginModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/EmailLoginModel.kt
@@ -4,6 +4,7 @@
 
 package at.bitfire.davdroid.ui.setup
 
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -27,18 +28,18 @@ class EmailLoginModel @AssistedInject constructor(
 
     data class UiState(
         val email: String = "",
-        val password: String = ""
+        val password: TextFieldState = TextFieldState()
     ) {
         val uri = "mailto:$email".toURIorNull()
 
-        val canContinue = uri != null && password.isNotEmpty()
+        val canContinue = uri != null && password.text.toString().isNotEmpty()
 
         fun asLoginInfo(): LoginInfo {
             return LoginInfo(
                 baseUri = uri,
                 credentials = Credentials(
                     username = email,
-                    password = password
+                    password = password.text.toString()
                 )
             )
         }
@@ -50,16 +51,12 @@ class EmailLoginModel @AssistedInject constructor(
     init {
         uiState = uiState.copy(
             email = initialLoginInfo.credentials?.username ?: "",
-            password = initialLoginInfo.credentials?.password ?: ""
+            password = TextFieldState(initialLoginInfo.credentials?.password ?: "")
         )
     }
 
     fun setEmail(email: String) {
         uiState = uiState.copy(email = email)
-    }
-
-    fun setPassword(password: String) {
-        uiState = uiState.copy(password = password)
     }
 
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/UrlLogin.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/UrlLogin.kt
@@ -8,8 +8,9 @@ import android.net.Uri
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Folder
@@ -65,7 +66,6 @@ object UrlLogin : LoginType {
             username = uiState.username,
             onSetUsername = model::setUsername,
             password = uiState.password,
-            onSetPassword = model::setPassword,
             canContinue = uiState.canContinue,
             onLogin = {
                 if (uiState.canContinue)
@@ -82,8 +82,7 @@ fun UrlLoginScreen(
     onSetUrl: (String) -> Unit = {},
     username: String,
     onSetUsername: (String) -> Unit = {},
-    password: String,
-    onSetPassword: (String) -> Unit = {},
+    password: TextFieldState,
     canContinue: Boolean,
     onLogin: () -> Unit = {}
 ) {
@@ -150,7 +149,6 @@ fun UrlLoginScreen(
 
             PasswordTextField(
                 password = password,
-                onPasswordChange = onSetPassword,
                 labelText = stringResource(R.string.login_password),
                 leadingIcon = {
                     Icon(Icons.Default.Password, null)
@@ -159,9 +157,7 @@ fun UrlLoginScreen(
                     keyboardType = KeyboardType.Password,
                     imeAction = ImeAction.Done
                 ),
-                keyboardActions = KeyboardActions(
-                    onDone = { onLogin() }
-                ),
+                onKeyboardAction = { onLogin() },
                 modifier = Modifier.fillMaxWidth()
             )
         }
@@ -178,7 +174,7 @@ fun UrlLoginScreen_Preview() {
     UrlLoginScreen(
         url = "https://example.com",
         username = "user",
-        password = "",
+        password = rememberTextFieldState(""),
         canContinue = false
     )
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/UrlLoginModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/UrlLoginModel.kt
@@ -4,6 +4,7 @@
 
 package at.bitfire.davdroid.ui.setup
 
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -29,7 +30,7 @@ class UrlLoginModel @AssistedInject constructor(
     data class UiState(
         val url: String = "",
         val username: String = "",
-        val password: String = ""
+        val password: TextFieldState = TextFieldState()
     ) {
 
         val urlWithPrefix =
@@ -39,14 +40,14 @@ class UrlLoginModel @AssistedInject constructor(
                 "https://$url"
         val uri = urlWithPrefix.toURIorNull()
 
-        val canContinue = uri != null && username.isNotEmpty() && password.isNotEmpty()
+        val canContinue = uri != null && username.isNotEmpty() && password.text.toString().isNotEmpty()
 
         fun asLoginInfo(): LoginInfo =
             LoginInfo(
                 baseUri = uri,
                 credentials = Credentials(
                     username = username.trimToNull(),
-                    password = password.trimToNull()
+                    password = password.text.toString().trimToNull()
                 )
             )
 
@@ -59,7 +60,7 @@ class UrlLoginModel @AssistedInject constructor(
         uiState = UiState(
             url = initialLoginInfo.baseUri?.toString()?.removePrefix("https://") ?: "",
             username = initialLoginInfo.credentials?.username ?: "",
-            password = initialLoginInfo.credentials?.password ?: ""
+            password = TextFieldState(initialLoginInfo.credentials?.password ?: "")
         )
     }
 
@@ -69,10 +70,6 @@ class UrlLoginModel @AssistedInject constructor(
 
     fun setUsername(username: String) {
         uiState = uiState.copy(username = username)
-    }
-
-    fun setPassword(password: String) {
-        uiState = uiState.copy(password = password)
     }
 
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/webdav/AddWebdavMountModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/webdav/AddWebdavMountModel.kt
@@ -5,6 +5,7 @@
 package at.bitfire.davdroid.ui.webdav
 
 import android.content.Context
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -34,7 +35,7 @@ class AddWebdavMountModel @Inject constructor(
         val displayName: String = "",
         val url: String = "",
         val username: String = "",
-        val password: String = "",
+        val password: TextFieldState = TextFieldState(),
         val certificateAlias: String? = null
     ) {
         val urlWithPrefix =
@@ -65,10 +66,6 @@ class AddWebdavMountModel @Inject constructor(
         uiState = uiState.copy(username = username)
     }
 
-    fun setPassword(password: String) {
-        uiState = uiState.copy(password = password)
-    }
-
     fun setCertificateAlias(certAlias: String) {
         uiState = uiState.copy(certificateAlias = certAlias)
     }
@@ -83,7 +80,7 @@ class AddWebdavMountModel @Inject constructor(
         val displayName = uiState.displayName
         val credentials = Credentials(
             username = uiState.username,
-            password = uiState.password,
+            password = uiState.password.text.toString(),
             certificateAlias = uiState.certificateAlias
         )
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/webdav/AddWebdavMountScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/webdav/AddWebdavMountScreen.kt
@@ -9,8 +9,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -71,7 +72,6 @@ fun AddWebdavMountScreen(
             username = uiState.username,
             onSetUsername = model::setUsername,
             password = uiState.password,
-            onSetPassword = model::setPassword,
             certificateAlias = uiState.certificateAlias,
             onSetCertificateAlias = model::setCertificateAlias,
             canContinue = uiState.canContinue,
@@ -93,8 +93,7 @@ fun AddWebDavMountScreen(
     onSetUrl: (String) -> Unit = {},
     username: String,
     onSetUsername: (String) -> Unit = {},
-    password: String,
-    onSetPassword: (String) -> Unit = {},
+    password: TextFieldState,
     certificateAlias: String?,
     onSetCertificateAlias: (String) -> Unit = {},
     canContinue: Boolean,
@@ -207,15 +206,12 @@ fun AddWebDavMountScreen(
                 )
                 PasswordTextField(
                     password = password,
-                    onPasswordChange = onSetPassword,
                     labelText = stringResource(R.string.login_password),
-                    readOnly = isLoading,
+                    enabled = isLoading,
                     keyboardOptions = KeyboardOptions(
                         imeAction = ImeAction.Done
                     ),
-                    keyboardActions = KeyboardActions(
-                        onDone = { onAddMount() }
-                    ),
+                    onKeyboardAction = { onAddMount() },
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(bottom = 8.dp)
@@ -253,7 +249,7 @@ fun AddWebDavMountScreen_Preview() {
             displayName = "Test",
             url = "https://example.com",
             username = "user",
-            password = "password",
+            password = rememberTextFieldState("password"),
             certificateAlias = null,
             canContinue = true
         )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ bitfire-ical4android = "c1ed0a0570"
 bitfire-vcard4android = "ae5d609f92"
 compose-accompanist = "0.36.0"
 compose-bom = "2024.12.01"
+compose-material3 = "1.4.0-alpha05"
 dnsjava = "3.6.0"
 glance = "1.1.1"
 guava = "33.3.1-android"
@@ -70,7 +71,7 @@ bitfire-ical4android = { module = "com.github.bitfireAT:ical4android", version.r
 bitfire-vcard4android = { module = "com.github.bitfireAT:vcard4android", version.ref = "bitfire-vcard4android" }
 compose-accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "compose-accompanist" }
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "compose-material3" }
 compose-materialIconsExtended = { module = "androidx.compose.material:material-icons-extended" }
 compose-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata" }
 compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }


### PR DESCRIPTION
### Purpose

Use `SecureTextField` for `PasswordTextField`

### Short description

- Upgraded Material 3 to `1.4.0-alpha05` (We should wait merging this until 1.4.0 stable is released).
- Using `OutlinedSecureTextField` in `PasswordTextField`.
- Migrated all usages of `String` password into `TextFieldState`. Followed the example [here](https://developer.android.com/reference/kotlin/androidx/compose/foundation/text/input/TextFieldState) for the viewmodel implementation.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

