### PR TITLE
Trimmed URLs for URI generation

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/UrlLoginModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/UrlLoginModel.kt
@@ -37,7 +37,7 @@ class UrlLoginModel @AssistedInject constructor(
                 url
             else
                 "https://$url"
-        val uri = urlWithPrefix.toURIorNull()
+        val uri = urlWithPrefix.trim().toURIorNull()
 
         val canContinue = uri != null && username.isNotEmpty() && password.isNotEmpty()
 


### PR DESCRIPTION
### Purpose

Allowing whitespaces in URLs is marked as unsafe by RFC (see #1201), and causes some issues like #1180. We should trim them before converting to URI.

In any case, if someone really needs to have a trailing whitespace in a URL they can just add it URL-encoded (`%20`).

### Short description

- Trimmed URL in `UrlLoginModel` before converting to URI.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

