### PR TITLE
Drop address books authority

### DIFF
--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration19Test.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration19Test.kt
@@ -11,7 +11,6 @@ import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
 import androidx.work.WorkManager
 import androidx.work.testing.WorkManagerTestInitHelper
-import at.bitfire.davdroid.R
 import at.bitfire.davdroid.sync.AutomaticSyncManager
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
@@ -77,9 +76,8 @@ class AccountSettingsMigration19Test {
         val account = Account("Some", "Test")
         migration.migrate(account)
 
-        val addressBookAuthority = context.getString(R.string.address_books_authority)
         verify {
-            workManager.cancelUniqueWork("periodic-sync $addressBookAuthority Test/Some")
+            workManager.cancelUniqueWork("periodic-sync at.bitfire.davdroid.addressbooks Test/Some")
             workManager.cancelUniqueWork("periodic-sync com.android.calendar Test/Some")
             workManager.cancelUniqueWork("periodic-sync at.techbee.jtx.provider Test/Some")
             workManager.cancelUniqueWork("periodic-sync org.dmfs.tasks Test/Some")

--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration14.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration14.kt
@@ -6,16 +6,13 @@ package at.bitfire.davdroid.settings.migration
 
 import android.accounts.Account
 import android.content.ContentResolver
-import android.content.Context
 import android.provider.CalendarContract
-import at.bitfire.davdroid.R
 import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.sync.SyncDataType
 import at.bitfire.ical4android.TaskProvider
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntKey
 import dagger.multibindings.IntoMap
@@ -27,7 +24,6 @@ import javax.inject.Inject
  */
 class AccountSettingsMigration14 @Inject constructor(
     private val accountSettingsFactory: AccountSettings.Factory,
-    @ApplicationContext private val context: Context,
     private val logger: Logger
 ): AccountSettingsMigration {
 
@@ -36,7 +32,7 @@ class AccountSettingsMigration14 @Inject constructor(
         ContentResolver.cancelSync(account, null)
 
         val authorities = listOf(
-            context.getString(R.string.address_books_authority),
+            "at.bitfire.davdroid.addressbooks",
             CalendarContract.AUTHORITY,
             TaskProvider.ProviderName.JtxBoard.authority,
             TaskProvider.ProviderName.OpenTasks.authority,

--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration19.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration19.kt
@@ -8,7 +8,6 @@ import android.accounts.Account
 import android.content.Context
 import android.provider.CalendarContract
 import androidx.work.WorkManager
-import at.bitfire.davdroid.R
 import at.bitfire.davdroid.sync.AutomaticSyncManager
 import at.bitfire.ical4android.TaskProvider
 import dagger.Binds
@@ -35,7 +34,7 @@ class AccountSettingsMigration19 @Inject constructor(
         // cancel old workers
         val workManager = WorkManager.getInstance(context)
         val authorities = listOf(
-            context.getString(R.string.address_books_authority),
+            "at.bitfire.davdroid.addressbooks",
             CalendarContract.AUTHORITY,
             *TaskProvider.TASK_PROVIDERS.map { it.authority }.toTypedArray()
         )

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/AutomaticSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/AutomaticSyncManager.kt
@@ -5,14 +5,12 @@
 package at.bitfire.davdroid.sync
 
 import android.accounts.Account
-import android.content.Context
 import android.provider.CalendarContract
-import at.bitfire.davdroid.R
+import android.provider.ContactsContract
 import at.bitfire.davdroid.db.Service
 import at.bitfire.davdroid.repository.DavServiceRepository
 import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.sync.worker.SyncWorkerManager
-import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -29,7 +27,6 @@ import javax.inject.Provider
  */
 class AutomaticSyncManager @Inject constructor(
     private val accountSettingsFactory: AccountSettings.Factory,
-    @ApplicationContext private val context: Context,
     private val serviceRepository: DavServiceRepository,
     private val syncFramework: SyncFrameworkIntegration,
     private val tasksAppManager: Provider<TasksAppManager>,
@@ -42,7 +39,7 @@ class AutomaticSyncManager @Inject constructor(
     private fun disableAutomaticSync(account: Account, dataType: SyncDataType) {
         workerManager.disablePeriodic(account, dataType)
 
-        for (authority in dataType.possibleAuthorities(context))
+        for (authority in dataType.possibleAuthorities())
             syncFramework.disableSyncAbility(account, authority)
     }
 
@@ -69,9 +66,9 @@ class AutomaticSyncManager @Inject constructor(
             workerManager.disablePeriodic(account, dataType)
 
         // also enable/disable content-triggered syncs
-        val possibleAuthorities = dataType.possibleAuthorities(context)
+        val possibleAuthorities = dataType.possibleAuthorities()
         val authority: String? = when (dataType) {
-            SyncDataType.CONTACTS -> context.getString(R.string.address_books_authority)
+            SyncDataType.CONTACTS -> ContactsContract.AUTHORITY
             SyncDataType.EVENTS -> CalendarContract.AUTHORITY
             SyncDataType.TASKS -> tasksAppManager.get().currentProvider()?.authority
         }

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/AutomaticSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/AutomaticSyncManager.kt
@@ -6,7 +6,6 @@ package at.bitfire.davdroid.sync
 
 import android.accounts.Account
 import android.provider.CalendarContract
-import android.provider.ContactsContract
 import at.bitfire.davdroid.db.Service
 import at.bitfire.davdroid.repository.DavServiceRepository
 import at.bitfire.davdroid.settings.AccountSettings
@@ -68,12 +67,15 @@ class AutomaticSyncManager @Inject constructor(
         // also enable/disable content-triggered syncs
         val possibleAuthorities = dataType.possibleAuthorities()
         val authority: String? = when (dataType) {
-            SyncDataType.CONTACTS -> ContactsContract.AUTHORITY
+            // Content triggered sync of contacts is handled per address book account in
+            // [LocalAddressBook.updateSyncFrameworkSettings()]
+            SyncDataType.CONTACTS -> null
             SyncDataType.EVENTS -> CalendarContract.AUTHORITY
             SyncDataType.TASKS -> tasksAppManager.get().currentProvider()?.authority
         }
         if (authority != null && syncInterval != null) {
-            // enable authority, but completely disable all other possible authorities (for instance, tasks apps which are not the current task app)
+            // enable given authority, but completely disable all other possible authorities
+            // (for instance, tasks apps which are not the current task app)
             syncFramework.enableSyncOnContentChange(account, authority)
             for (disableAuthority in possibleAuthorities - authority)
                 syncFramework.disableSyncAbility(account, disableAuthority)

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncAdapterServices.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncAdapterServices.kt
@@ -15,7 +15,6 @@ import android.content.Intent
 import android.content.SyncResult
 import android.os.Bundle
 import android.os.IBinder
-import android.provider.ContactsContract
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import at.bitfire.davdroid.InvalidAccountException
@@ -119,17 +118,8 @@ abstract class SyncAdapterService: Service() {
                 return
             }
 
-            /* Special case for contacts: because address books are separate accounts, changed contacts cause
-            this method to be called with authority = ContactsContract.AUTHORITY. However the sync worker shall be run for the
-            address book authority instead. */
-            val workerAuthority =
-                if (authority == ContactsContract.AUTHORITY)
-                    context.getString(R.string.address_books_authority)
-                else
-                    authority
-
-            logger.fine("Starting OneTimeSyncWorker for $account $workerAuthority and waiting for it")
-            val workerName = syncWorkerManager.enqueueOneTime(account, dataType = SyncDataType.fromAuthority(context, workerAuthority), upload = upload)
+            logger.fine("Starting OneTimeSyncWorker for $account $authority and waiting for it")
+            val workerName = syncWorkerManager.enqueueOneTime(account, dataType = SyncDataType.fromAuthority(authority), upload = upload)
 
             /* Because we are not allowed to observe worker state on a background thread, we can not
             use it to block the sync adapter. Instead we use a Flow to get notified when the sync

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncDataType.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncDataType.kt
@@ -4,10 +4,8 @@
 
 package at.bitfire.davdroid.sync
 
-import android.content.Context
 import android.provider.CalendarContract
 import android.provider.ContactsContract
-import at.bitfire.davdroid.R
 import at.bitfire.ical4android.TaskProvider
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
@@ -26,11 +24,10 @@ enum class SyncDataType {
     }
 
 
-    fun possibleAuthorities(context: Context): List<String> =
+    fun possibleAuthorities(): List<String> =
         when (this) {
             CONTACTS -> listOf(
-                ContactsContract.AUTHORITY,
-                context.getString(R.string.address_books_authority)
+                ContactsContract.AUTHORITY
             )
             EVENTS -> listOf(
                 CalendarContract.AUTHORITY
@@ -41,9 +38,8 @@ enum class SyncDataType {
 
     companion object {
 
-        fun fromAuthority(context: Context, authority: String): SyncDataType {
+        fun fromAuthority(authority: String): SyncDataType {
             return when (authority) {
-                context.getString(R.string.address_books_authority),
                 ContactsContract.AUTHORITY ->
                     CONTACTS
                 CalendarContract.AUTHORITY ->

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncDataType.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncDataType.kt
@@ -11,7 +11,6 @@ import at.bitfire.davdroid.R
 import at.bitfire.ical4android.TaskProvider
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
-import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
 
 enum class SyncDataType {
@@ -39,25 +38,6 @@ enum class SyncDataType {
             TASKS ->
                 TaskProvider.ProviderName.entries.map { it.authority }
         }
-
-
-    /**
-     * Gets the authority that should be used for managing sync adapters for this account and data type.
-     *
-     * In case of contacts, it will return the address books authority (and not the contacts authority).
-     */
-    fun toSyncAuthority(context: Context): String? = when(this) {
-        CONTACTS ->
-            context.getString(R.string.address_books_authority)
-        EVENTS ->
-            CalendarContract.AUTHORITY
-        TASKS -> {
-            val entryPoint = EntryPointAccessors.fromApplication<SyncDataTypeEntryPoint>(context)
-            val tasksAppManager = entryPoint.tasksAppManager()
-            tasksAppManager.currentProvider()?.authority
-        }
-    }
-
 
     companion object {
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoModel.kt
@@ -468,7 +468,7 @@ class DebugInfoModel @AssistedInject constructor(
         writer.append("\n\n - Account: ${account.name}\n")
         val accountSettings = accountSettingsFactory.create(account)
 
-        writer.append(dumpAccount(account, accountSettings, AccountDumpInfo.caldavAccount(context, account)))
+        writer.append(dumpAccount(account, accountSettings, AccountDumpInfo.caldavAccount(account)))
         try {
             val credentials = accountSettings.credentials()
             val authStr = mutableListOf<String>()
@@ -596,8 +596,7 @@ data class AccountDumpInfo(
 
     companion object {
 
-        fun caldavAccount(context: Context, account: Account) = listOf(
-            AccountDumpInfo(account, context.getString(R.string.address_books_authority), null, null),
+        fun caldavAccount(account: Account) = listOf(
             AccountDumpInfo(account, CalendarContract.AUTHORITY, CalendarContract.Events.CONTENT_URI.asCalendarSyncAdapter(account), "event(s)"),
             AccountDumpInfo(account, TaskProvider.ProviderName.JtxBoard.authority, JtxContract.JtxICalObject.CONTENT_URI.asJtxSyncAdapter(account), "jtx Board ICalObject(s)"),
             AccountDumpInfo(account, TaskProvider.ProviderName.OpenTasks.authority, TaskContract.Tasks.getContentUri(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,8 +8,6 @@
     <string name="account_type_address_book" translatable="false">at.bitfire.davdroid.address_book</string>
     <string name="account_title_address_book">DAVx⁵ Address book</string>
     <string name="account_prefs_use_app">Don\'t change the account here! Directly use the app to manage accounts instead.</string>
-    <string name="address_books_authority" translatable="false">at.bitfire.davdroid.addressbooks</string>
-    <string name="address_books_authority_title">Address books</string>
     <string name="dialog_delete">Delete</string>
     <string name="dialog_remove">Remove</string>
     <string name="dialog_deny">Cancel</string>


### PR DESCRIPTION
### Purpose

Since https://github.com/bitfireAT/davx5-ose/pull/1177 the `address_books_authority` is not required anymore and this PR removes it and any remaining usages.

### Short description

- drop unused method `toSyncAuthority`
- AutomaticSyncManager falsely translated the CONTACTS constant to  `context.getString(R.string.address_books_authority)` and passed it to the content providers to set sync settings. Replaced it with `ContactsContract.AUTHORITY`.
- replace `context.getString(R.string.address_books_authority)` calls in migrations with constant value
- remove remaining `context.getString(R.string.address_books_authority)` calls
- also removed `address_books_authority_title` since there are no usages.

### Checklist

- [X] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [ ] I have added documentation to complex functions and functions that can be used by other modules.
- [ ] I have added reasonable tests or consciously decided to not add tests.

