### PR TITLE
Use StringDef to annotate possible service and collection types

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/db/Collection.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/db/Collection.kt
@@ -4,6 +4,7 @@
 
 package at.bitfire.davdroid.db
 
+import androidx.annotation.StringDef
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.ForeignKey
@@ -28,6 +29,14 @@ import at.bitfire.davdroid.util.trimToNull
 import at.bitfire.ical4android.util.DateUtils
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+
+@Retention(AnnotationRetention.SOURCE)
+@StringDef(
+    Collection.TYPE_ADDRESSBOOK,
+    Collection.TYPE_CALENDAR,
+    Collection.TYPE_WEBCAL
+)
+annotation class CollectionType
 
 @Entity(tableName = "collection",
     foreignKeys = [
@@ -67,7 +76,8 @@ data class Collection(
     /**
      * Type of service. CalDAV or CardDAV
      */
-    var type: String,
+    @CollectionType
+    val type: String,
 
     /**
      * Address where this collection lives - with trailing slash

--- a/app/src/main/kotlin/at/bitfire/davdroid/db/Service.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/db/Service.kt
@@ -4,10 +4,15 @@
 
 package at.bitfire.davdroid.db
 
+import androidx.annotation.StringDef
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import okhttp3.HttpUrl
+
+@Retention(AnnotationRetention.SOURCE)
+@StringDef(Service.TYPE_CALDAV, Service.TYPE_CARDDAV)
+annotation class ServiceType
 
 /**
  * A service entity.
@@ -24,6 +29,8 @@ data class Service(
     var id: Long,
 
     var accountName: String,
+
+    @ServiceType
     var type: String,
 
     var principal: HttpUrl?


### PR DESCRIPTION
### Purpose

By adding the `@StringDef` annotation, we make the code more robust and easier to maintain.

- Type Safety: It prevents us from accidentally passing invalid string values to the type properties, which can help catch errors at compile time.
- Code Clarity: It makes the code more readable and self-documenting by clearly defining the allowed values for the respective type properties.
- Code Completion: When using the type properties, Android Studio will provide code completion suggestions for the allowed values, which can improve our development speed.

### Short description

- define annotation classes "CollectionType" and "ServiceType" with respective possible values in StringDef
- add the annotations to the two `type` params respectively

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [ ] I have added documentation to complex functions and functions that can be used by other modules.
- [ ] I have added reasonable tests or consciously decided to not add tests.

