### PR TITLE
Fix show only personal setting not updating the view immediately

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettings.kt
@@ -286,15 +286,25 @@ class AccountSettings @AssistedInject constructor(
 
     // UI settings
 
-    fun getShowOnlyPersonal(): Boolean {
-        @Suppress("DEPRECATION")
-        val pair = getShowOnlyPersonalPair()
-        return pair.first
+    /**
+     * Whether to show only personal collections in the UI
+     *
+     * @return *true* if only personal collections shall be shown; *false* otherwise
+     */
+    fun getShowOnlyPersonal(): Boolean = when (settingsManager.getIntOrNull(KEY_SHOW_ONLY_PERSONAL)) {
+        0 -> false
+        1 -> true
+        else /* including -1 */ -> accountManager.getUserData(account, KEY_SHOW_ONLY_PERSONAL) != null
     }
-    fun getShowOnlyPersonalLocked(): Boolean {
-        @Suppress("DEPRECATION")
-        val pair = getShowOnlyPersonalPair()
-        return !pair.second
+
+    /**
+     * Whether the user shall be able to change the setting (= setting not locked)
+     *
+     * @return *true* if the setting is locked; *false* otherwise
+     */
+    fun getShowOnlyPersonalLocked(): Boolean = when (settingsManager.getIntOrNull(KEY_SHOW_ONLY_PERSONAL)) {
+        0, 1 -> true
+        else /* including -1 */ -> false
     }
 
     /**

--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettings.kt
@@ -286,15 +286,15 @@ class AccountSettings @AssistedInject constructor(
 
     // UI settings
 
-    data class ShowOnlyPersonal(
-        val onlyPersonal: Boolean,
-        val locked: Boolean
-    )
-
-    fun getShowOnlyPersonal(): ShowOnlyPersonal {
+    fun getShowOnlyPersonal(): Boolean {
         @Suppress("DEPRECATION")
         val pair = getShowOnlyPersonalPair()
-        return ShowOnlyPersonal(onlyPersonal = pair.first, locked = !pair.second)
+        return pair.first
+    }
+    fun getShowOnlyPersonalLocked(): Boolean {
+        @Suppress("DEPRECATION")
+        val pair = getShowOnlyPersonalPair()
+        return !pair.second
     }
 
     /**

--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettings.kt
@@ -307,11 +307,11 @@ class AccountSettings @AssistedInject constructor(
      */
     @Deprecated("Use getShowOnlyPersonal() instead", replaceWith = ReplaceWith("getShowOnlyPersonal()"))
     fun getShowOnlyPersonalPair(): Pair<Boolean, Boolean> =
-            when (settingsManager.getIntOrNull(KEY_SHOW_ONLY_PERSONAL)) {
-                0 -> Pair(false, false)
-                1 -> Pair(true, false)
-                else /* including -1 */ -> Pair(accountManager.getUserData(account, KEY_SHOW_ONLY_PERSONAL) != null, true)
-            }
+        when (settingsManager.getIntOrNull(KEY_SHOW_ONLY_PERSONAL)) {
+            0 -> Pair(false, false)
+            1 -> Pair(true, false)
+            else /* including -1 */ -> Pair(accountManager.getUserData(account, KEY_SHOW_ONLY_PERSONAL) != null, true)
+        }
 
     fun setShowOnlyPersonal(showOnlyPersonal: Boolean) {
         accountManager.setAndVerifyUserData(account, KEY_SHOW_ONLY_PERSONAL, if (showOnlyPersonal) "1" else null)

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreen.kt
@@ -69,7 +69,6 @@ import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.Collection
-import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.ui.AppTheme
 import at.bitfire.davdroid.ui.PermissionsActivity
 import at.bitfire.davdroid.ui.account.AccountProgress
@@ -114,9 +113,8 @@ fun AccountScreen(
         error = model.error,
         onResetError = model::resetError,
         invalidAccount = model.invalidAccount.collectAsStateWithLifecycle(false).value,
-        showOnlyPersonal = model.showOnlyPersonal.collectAsStateWithLifecycle(
-            initialValue = AccountSettings.ShowOnlyPersonal(onlyPersonal = false, locked = false)
-        ).value,
+        showOnlyPersonal = model.showOnlyPersonal.collectAsStateWithLifecycle().value,
+        showOnlyPersonalLocked = model.showOnlyPersonalLocked.collectAsStateWithLifecycle().value,
         onSetShowOnlyPersonal = model::setShowOnlyPersonal,
         hasCardDav = cardDavService != null,
         canCreateAddressBook = model.canCreateAddressBook.collectAsStateWithLifecycle(false).value,
@@ -169,7 +167,8 @@ fun AccountScreen(
     error: String? = null,
     onResetError: () -> Unit = {},
     invalidAccount: Boolean = false,
-    showOnlyPersonal: AccountSettings.ShowOnlyPersonal,
+    showOnlyPersonal: Boolean = false,
+    showOnlyPersonalLocked: Boolean = false,
     onSetShowOnlyPersonal: (showOnlyPersonal: Boolean) -> Unit = {},
     hasCardDav: Boolean,
     canCreateAddressBook: Boolean,
@@ -257,6 +256,7 @@ fun AccountScreen(
                             canCreateCalendar = canCreateCalendar,
                             onCreateCalendar = onCreateCalendar,
                             showOnlyPersonal = showOnlyPersonal,
+                            showOnlyPersonalLocked = showOnlyPersonalLocked,
                             onSetShowOnlyPersonal = onSetShowOnlyPersonal,
                             currentPage = pagerState.currentPage,
                             idxCardDav = idxCardDav,
@@ -440,7 +440,8 @@ fun AccountScreen_Actions(
     onCreateAddressBook: () -> Unit,
     canCreateCalendar: Boolean,
     onCreateCalendar: () -> Unit,
-    showOnlyPersonal: AccountSettings.ShowOnlyPersonal,
+    showOnlyPersonal: Boolean,
+    showOnlyPersonalLocked: Boolean,
     onSetShowOnlyPersonal: (showOnlyPersonal: Boolean) -> Unit,
     currentPage: Int,
     idxCardDav: Int?,
@@ -513,8 +514,8 @@ fun AccountScreen_Actions(
                     LocalMinimumInteractiveComponentSize provides Dp.Unspecified
                 ) {
                     Checkbox(
-                        checked = showOnlyPersonal.onlyPersonal,
-                        enabled = !showOnlyPersonal.locked,
+                        checked = showOnlyPersonal,
+                        enabled = !showOnlyPersonalLocked,
                         onCheckedChange = {
                             onSetShowOnlyPersonal(it)
                             overflowOpen = false
@@ -527,10 +528,10 @@ fun AccountScreen_Actions(
                 Text(stringResource(R.string.account_only_personal))
             },
             onClick = {
-                onSetShowOnlyPersonal(!showOnlyPersonal.onlyPersonal)
+                onSetShowOnlyPersonal(!showOnlyPersonal)
                 overflowOpen = false
             },
-            enabled = !showOnlyPersonal.locked
+            enabled = !showOnlyPersonalLocked
         )
 
         // rename account
@@ -651,7 +652,8 @@ fun AccountScreen_ServiceTab(
 fun AccountScreen_Preview() {
     AccountScreen(
         accountName = "test@example.com",
-        showOnlyPersonal = AccountSettings.ShowOnlyPersonal(onlyPersonal = false, locked = true),
+        showOnlyPersonal = false,
+        showOnlyPersonalLocked = true,
         hasCardDav = true,
         canCreateAddressBook = false,
         cardDavProgress = AccountProgress.Active,

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreenModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreenModel.kt
@@ -60,7 +60,14 @@ class AccountScreenModel @AssistedInject constructor(
     interface Factory {
         fun create(account: Account): AccountScreenModel
     }
-    
+
+    init {
+        viewModelScope.launch {
+            reloadShowOnlyPersonal()
+            reloadShowOnlyPersonalLocked()
+        }
+    }
+
     /**
      * Only acquire account settings on a worker thread!
      */

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreenModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreenModel.kt
@@ -60,33 +60,34 @@ class AccountScreenModel @AssistedInject constructor(
     interface Factory {
         fun create(account: Account): AccountScreenModel
     }
-
-    private val _showOnlyPersonal = MutableStateFlow(false)
-    val showOnlyPersonal = _showOnlyPersonal.asStateFlow()
-
-    private var _showOnlyPersonalLocked = MutableStateFlow(false)
-    val showOnlyPersonalLocked = _showOnlyPersonalLocked.asStateFlow()
-
+    
     /**
      * Only acquire account settings on a worker thread!
      */
     private val accountSettings by lazy { accountSettingsFactory.create(account) }
-
-    private suspend fun reload() = withContext(Dispatchers.Default) {
-        _showOnlyPersonal.value = accountSettings.getShowOnlyPersonal()
-        _showOnlyPersonalLocked.value = accountSettings.getShowOnlyPersonalLocked()
-    }
 
     /** whether the account is invalid and the screen shall be closed */
     val invalidAccount = accountRepository.getAllFlow().map { accounts ->
         !accounts.contains(account)
     }
 
+
+    private val _showOnlyPersonal = MutableStateFlow(false)
+    val showOnlyPersonal = _showOnlyPersonal.asStateFlow()
+    private suspend fun reloadShowOnlyPersonal() = withContext(Dispatchers.Default) {
+        _showOnlyPersonal.value = accountSettings.getShowOnlyPersonal()
+    }
     fun setShowOnlyPersonal(showOnlyPersonal: Boolean) {
         CoroutineScope(Dispatchers.Default).launch {
             accountSettings.setShowOnlyPersonal(showOnlyPersonal)
-            reload()
+            reloadShowOnlyPersonal()
         }
+    }
+
+    private var _showOnlyPersonalLocked = MutableStateFlow(false)
+    val showOnlyPersonalLocked = _showOnlyPersonalLocked.asStateFlow()
+    private suspend fun reloadShowOnlyPersonalLocked() = withContext(Dispatchers.Default) {
+        _showOnlyPersonalLocked.value = accountSettings.getShowOnlyPersonalLocked()
     }
 
     val cardDavSvc = serviceRepository

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreenModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreenModel.kt
@@ -69,7 +69,9 @@ class AccountScreenModel @AssistedInject constructor(
         !accounts.contains(account)
     }
 
-
+    /**
+     * Whether to show only personal collections.
+     */
     private val _showOnlyPersonal = MutableStateFlow(false)
     val showOnlyPersonal = _showOnlyPersonal.asStateFlow()
     private suspend fun reloadShowOnlyPersonal() = withContext(Dispatchers.Default) {
@@ -82,6 +84,9 @@ class AccountScreenModel @AssistedInject constructor(
         }
     }
 
+    /**
+     * Whether the user setting to show only personal collections is locked.
+     */
     private var _showOnlyPersonalLocked = MutableStateFlow(false)
     val showOnlyPersonalLocked = _showOnlyPersonalLocked.asStateFlow()
     private suspend fun reloadShowOnlyPersonalLocked() = withContext(Dispatchers.Default) {

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreenModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreenModel.kt
@@ -59,13 +59,6 @@ class AccountScreenModel @AssistedInject constructor(
         fun create(account: Account): AccountScreenModel
     }
 
-    init {
-        viewModelScope.launch {
-            reloadShowOnlyPersonal()
-            reloadShowOnlyPersonalLocked()
-        }
-    }
-
     /**
      * Only acquire account settings on a worker thread!
      */
@@ -93,6 +86,13 @@ class AccountScreenModel @AssistedInject constructor(
     val showOnlyPersonalLocked = _showOnlyPersonalLocked.asStateFlow()
     private suspend fun reloadShowOnlyPersonalLocked() = withContext(Dispatchers.Default) {
         _showOnlyPersonalLocked.value = accountSettings.getShowOnlyPersonalLocked()
+    }
+
+    init {
+        viewModelScope.launch {
+            reloadShowOnlyPersonal()
+            reloadShowOnlyPersonalLocked()
+        }
     }
 
     val cardDavSvc = serviceRepository

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreenModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreenModel.kt
@@ -26,9 +26,7 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -85,7 +83,7 @@ class AccountScreenModel @AssistedInject constructor(
         _showOnlyPersonal.value = accountSettings.getShowOnlyPersonal()
     }
     fun setShowOnlyPersonal(showOnlyPersonal: Boolean) {
-        CoroutineScope(Dispatchers.Default).launch {
+        viewModelScope.launch {
             accountSettings.setShowOnlyPersonal(showOnlyPersonal)
             reloadShowOnlyPersonal()
         }
@@ -143,11 +141,9 @@ class AccountScreenModel @AssistedInject constructor(
 
     // actions
 
-    private val notInterruptibleScope = CoroutineScope(SupervisorJob())
-
     /** Deletes the account from the system (won't touch collections on the server). */
     fun deleteAccount() {
-        notInterruptibleScope.launch {
+        viewModelScope.launch {
             accountRepository.delete(account.name)
         }
     }
@@ -167,7 +163,7 @@ class AccountScreenModel @AssistedInject constructor(
      * @param newName new account name
      */
     fun renameAccount(newName: String) {
-        notInterruptibleScope.launch {
+        viewModelScope.launch {
             try {
                 accountRepository.rename(account.name, newName)
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/GetServiceCollectionPagerUseCase.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/GetServiceCollectionPagerUseCase.kt
@@ -11,7 +11,6 @@ import androidx.paging.map
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service
 import at.bitfire.davdroid.repository.DavCollectionRepository
-import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.settings.Settings
 import at.bitfire.davdroid.settings.SettingsManager
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -43,7 +42,7 @@ class GetServiceCollectionPagerUseCase @Inject constructor(
     operator fun invoke(
         serviceFlow: Flow<Service?>,
         collectionType: String,
-        showOnlyPersonalFlow: Flow<AccountSettings.ShowOnlyPersonal?>
+        showOnlyPersonalFlow: Flow<Boolean>
     ): Flow<PagingData<Collection>> =
         combine(serviceFlow, showOnlyPersonalFlow, forceReadOnlyAddressBooksFlow) { service, onlyPersonal, forceReadOnlyAddressBooks ->
             if (service == null)
@@ -52,7 +51,7 @@ class GetServiceCollectionPagerUseCase @Inject constructor(
                 val dataFlow = Pager(
                     config = PagingConfig(PAGER_SIZE),
                     pagingSourceFactory = {
-                        if (onlyPersonal?.onlyPersonal == true)
+                        if (onlyPersonal == true)
                             collectionRepository.pagePersonalByServiceAndType(service.id, collectionType)
                         else
                             collectionRepository.pageByServiceAndType(service.id, collectionType)

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/GetServiceCollectionPagerUseCase.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/GetServiceCollectionPagerUseCase.kt
@@ -16,7 +16,7 @@ import at.bitfire.davdroid.settings.SettingsManager
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flattenConcat
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -71,6 +71,6 @@ class GetServiceCollectionPagerUseCase @Inject constructor(
                 else
                     dataFlow
             }
-        }.flattenConcat()
+        }.flatMapLatest { it }
 
 }


### PR DESCRIPTION
### Purpose

Fix show only personal setting not updating the view.

### Short description

- AccountSettings: Split pair of show only personal settings (grouped in a single data class before)
- Remove/Replace deprecated `getShowOnlyPersonalPair` method
- AccountScreen, AccountScreenModel and GetServiceCollectionPagerUseCase: Create and consume showOnlyPersonal settings separately
- use `viewModelScope` instead of `CoroutineScope(Dispatchers.Default)`
- GetServiceCollectionPagerUseCase: Fix showOnlyPersonal flow state change not triggering re-emission
  - Note: The problem was that we used `flatMapConcat` which waits for the inner flow to finish before emitting new values even if `showOnlyPersonalFlow` emitted new values. Now we are using `flatMapLatest` which will cancel the inner flow instead of waiting. Note also that using `flattenMerge` would also work, but probably creates unnecessary overhead as it continuously merges emits from both the inner and outer flow, which we don't need.


### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [ ] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

