### PR TITLE
Don't remove port from URI of nextcloud login intent

### DIFF
--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/ui/setup/LoginActivityTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/ui/setup/LoginActivityTest.kt
@@ -10,6 +10,19 @@ class LoginActivityTest {
     @Test
     fun loginInfoFromIntent() {
         val intent = Intent().apply {
+            data = Uri.parse("https://example.com/nextcloud")
+            putExtra(LoginActivity.EXTRA_USERNAME, "user")
+            putExtra(LoginActivity.EXTRA_PASSWORD, "password")
+        }
+        val loginInfo = LoginActivity.loginInfoFromIntent(intent)
+        assertEquals("https://example.com/nextcloud", loginInfo.baseUri.toString())
+        assertEquals("user", loginInfo.credentials!!.username)
+        assertEquals("password", loginInfo.credentials.password)
+    }
+
+    @Test
+    fun loginInfoFromIntent_withPort() {
+        val intent = Intent().apply {
             data = Uri.parse("https://example.com:444/nextcloud")
             putExtra(LoginActivity.EXTRA_USERNAME, "user")
             putExtra(LoginActivity.EXTRA_PASSWORD, "password")

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/ui/setup/LoginActivityTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/ui/setup/LoginActivityTest.kt
@@ -32,4 +32,22 @@ class LoginActivityTest {
         assertEquals("user", loginInfo.credentials!!.username)
         assertEquals("password", loginInfo.credentials.password)
     }
+
+    @Test
+    fun loginInfoFromIntent_implicit() {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("davx5://user:password@example.com/path"))
+        val loginInfo = LoginActivity.loginInfoFromIntent(intent)
+        assertEquals("https://example.com/path", loginInfo.baseUri.toString())
+        assertEquals("user", loginInfo.credentials!!.username)
+        assertEquals("password", loginInfo.credentials.password)
+    }
+
+    @Test
+    fun loginInfoFromIntent_implicit_withPort() {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("davx5://user:password@example.com:0/path"))
+        val loginInfo = LoginActivity.loginInfoFromIntent(intent)
+        assertEquals("https://example.com:0/path", loginInfo.baseUri.toString())
+        assertEquals("user", loginInfo.credentials!!.username)
+        assertEquals("password", loginInfo.credentials.password)
+    }
 }

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/ui/setup/LoginActivityTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/ui/setup/LoginActivityTest.kt
@@ -1,0 +1,22 @@
+package at.bitfire.davdroid.ui.setup
+
+import android.content.Intent
+import android.net.Uri
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LoginActivityTest {
+
+    @Test
+    fun loginInfoFromIntent() {
+        val intent = Intent().apply {
+            data = Uri.parse("https://example.com:444/nextcloud")
+            putExtra(LoginActivity.EXTRA_USERNAME, "user")
+            putExtra(LoginActivity.EXTRA_PASSWORD, "password")
+        }
+        val loginInfo = LoginActivity.loginInfoFromIntent(intent)
+        assertEquals("https://example.com:444/nextcloud", loginInfo.baseUri.toString())
+        assertEquals("user", loginInfo.credentials!!.username)
+        assertEquals("password", loginInfo.credentials.password)
+    }
+}

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginActivity.kt
@@ -71,7 +71,7 @@ class LoginActivity @Inject constructor(): AppCompatActivity() {
                 if (realScheme != null) {
                     val realUri = Uri.Builder()
                         .scheme(realScheme)
-                        .encodedAuthority(uri.host+":"+uri.port)
+                        .encodedAuthority(uri.authority)
                         .path(uri.path)
                         .query(uri.query)
                     givenUri = realUri.build().toString()

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginActivity.kt
@@ -71,7 +71,7 @@ class LoginActivity @Inject constructor(): AppCompatActivity() {
                 if (realScheme != null) {
                     val realUri = Uri.Builder()
                         .scheme(realScheme)
-                        .encodedAuthority(uri.authority)
+                        .encodedAuthority(uri.host + if (uri.port > -1) ":"+uri.port else "")
                         .path(uri.path)
                         .query(uri.query)
                     givenUri = realUri.build().toString()

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginActivity.kt
@@ -71,7 +71,7 @@ class LoginActivity @Inject constructor(): AppCompatActivity() {
                 if (realScheme != null) {
                     val realUri = Uri.Builder()
                         .scheme(realScheme)
-                        .authority(uri.host)
+                        .encodedAuthority(uri.host+":"+uri.port)
                         .path(uri.path)
                         .query(uri.query)
                     givenUri = realUri.build().toString()


### PR DESCRIPTION
### Purpose

We should not remove the port from the URI passed through nextcloud login intent.

### Short description

- create a test for loginInfoFromIntent
- fix the URI creation

### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.

