### PR TITLE
Use DI for HttpClient.Builder

### DIFF
--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/OkhttpClientTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/OkhttpClientTest.kt
@@ -4,10 +4,7 @@
 
 package at.bitfire.davdroid
 
-import android.content.Context
 import at.bitfire.davdroid.network.HttpClient
-import at.bitfire.davdroid.settings.SettingsManager
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import okhttp3.Request
@@ -19,15 +16,11 @@ import javax.inject.Inject
 @HiltAndroidTest
 class OkhttpClientTest {
 
+    @Inject
+    lateinit var httpClientBuilder: HttpClient.Builder
+
     @get:Rule
     val hiltRule = HiltAndroidRule(this)
-
-    @Inject
-    @ApplicationContext
-    lateinit var context: Context
-
-    @Inject
-    lateinit var settingsManager: SettingsManager
 
     @Before
     fun inject() {
@@ -37,12 +30,14 @@ class OkhttpClientTest {
 
     @Test
     fun testIcloudWithSettings() {
-        val client = HttpClient.Builder(qgit qcontext).build()
-        client.okHttpClient.newCall(Request.Builder()
+        httpClientBuilder.build().use { client ->
+            client.okHttpClient
+                .newCall(Request.Builder()
                 .get()
                 .url("https://icloud.com")
                 .build())
                 .execute()
+        }
     }
 
 }

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/OkhttpClientTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/OkhttpClientTest.kt
@@ -37,7 +37,7 @@ class OkhttpClientTest {
 
     @Test
     fun testIcloudWithSettings() {
-        val client = HttpClient.Builder(context).build()
+        val client = HttpClient.Builder(qgit qcontext).build()
         client.okHttpClient.newCall(Request.Builder()
                 .get()
                 .url("https://icloud.com")

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/db/CollectionTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/db/CollectionTest.kt
@@ -4,14 +4,11 @@
 
 package at.bitfire.davdroid.db
 
-import android.content.Context
 import android.security.NetworkSecurityPolicy
 import androidx.test.filters.SmallTest
 import at.bitfire.dav4jvm.DavResource
 import at.bitfire.dav4jvm.property.webdav.ResourceType
 import at.bitfire.davdroid.network.HttpClient
-import at.bitfire.davdroid.settings.SettingsManager
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -31,15 +28,11 @@ import javax.inject.Inject
 @HiltAndroidTest
 class CollectionTest {
 
+    @Inject
+    lateinit var httpClientBuilder: HttpClient.Builder
+
     @get:Rule
     val hiltRule = HiltAndroidRule(this)
-
-    @Inject
-    @ApplicationContext
-    lateinit var context: Context
-
-    @Inject
-    lateinit var settingsManager: SettingsManager
 
     private lateinit var httpClient: HttpClient
     private val server = MockWebServer()
@@ -48,7 +41,7 @@ class CollectionTest {
     fun setup() {
         hiltRule.inject()
 
-        httpClient = HttpClient.Builder(context).build()
+        httpClient = httpClientBuilder.build()
         Assume.assumeTrue(NetworkSecurityPolicy.getInstance().isCleartextTrafficPermitted)
     }
 

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientTest.kt
@@ -4,9 +4,7 @@
 
 package at.bitfire.davdroid.network
 
-import android.content.Context
 import android.security.NetworkSecurityPolicy
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import okhttp3.Request
@@ -25,21 +23,20 @@ import javax.inject.Inject
 @HiltAndroidTest
 class HttpClientTest {
 
-    lateinit var server: MockWebServer
-    lateinit var httpClient: HttpClient
-
     @get:Rule
     var hiltRule = HiltAndroidRule(this)
 
     @Inject
-    @ApplicationContext
-    lateinit var context: Context
+    lateinit var httpClientBuilder: HttpClient.Builder
+
+    lateinit var httpClient: HttpClient
+    lateinit var server: MockWebServer
 
     @Before
     fun setUp() {
         hiltRule.inject()
 
-        httpClient = HttpClient.Builder(context).build()
+        httpClient = httpClientBuilder.build()
 
         server = MockWebServer()
         server.start(30000)

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/repository/DavHomeSetRepositoryTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/repository/DavHomeSetRepositoryTest.kt
@@ -18,26 +18,30 @@ import javax.inject.Inject
 @HiltAndroidTest
 class DavHomeSetRepositoryTest {
 
-    @get:Rule
-    var hiltRule = HiltAndroidRule(this)
-
     @Inject
     lateinit var repository: DavHomeSetRepository
 
     @Inject
     lateinit var serviceRepository: DavServiceRepository
 
+    @get:Rule
+    var hiltRule = HiltAndroidRule(this)
+
+    var serviceId: Long = 0
+
     @Before
     fun setUp() {
         hiltRule.inject()
+
+        serviceId = serviceRepository.insertOrReplace(
+            Service(id=0, accountName="test", type= Service.TYPE_CALDAV, principal = null)
+        )
     }
 
 
     @Test
     fun testInsertOrUpdate() {
         // should insert new row or update (upsert) existing row - without changing its key!
-        val serviceId = createTestService()
-
         val entry1 = HomeSet(id=0, serviceId=serviceId, personal=true, url="https://example.com/1".toHttpUrl())
         val insertId1 = repository.insertOrUpdateByUrl(entry1)
         assertEquals(1L, insertId1)
@@ -57,8 +61,6 @@ class DavHomeSetRepositoryTest {
     @Test
     fun testDelete() {
         // should delete row with given primary key (id)
-        val serviceId = createTestService()
-
         val entry1 = HomeSet(id=1, serviceId=serviceId, personal=true, url= "https://example.com/1".toHttpUrl())
 
         val insertId1 = repository.insertOrUpdateByUrl(entry1)
@@ -67,12 +69,6 @@ class DavHomeSetRepositoryTest {
 
         repository.delete(entry1)
         assertEquals(null, repository.getById(1L))
-    }
-
-
-    private fun createTestService() : Long {
-        val service = Service(id=0, accountName="test", type= Service.TYPE_CALDAV, principal = null)
-        return serviceRepository.insertOrReplace(service)
     }
 
 }

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/TestSyncManager.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/TestSyncManager.kt
@@ -25,7 +25,6 @@ import org.junit.Assert.assertEquals
 
 class TestSyncManager @AssistedInject constructor(
     @Assisted account: Account,
-    @Assisted accountSettings: AccountSettings,
     @Assisted extras: Array<String>,
     @Assisted authority: String,
     @Assisted httpClient: HttpClient,
@@ -34,7 +33,6 @@ class TestSyncManager @AssistedInject constructor(
     @Assisted collection: Collection
 ): SyncManager<LocalTestResource, LocalTestCollection, DavCollection>(
     account,
-    accountSettings,
     httpClient,
     extras,
     authority,
@@ -47,7 +45,6 @@ class TestSyncManager @AssistedInject constructor(
     interface Factory {
         fun create(
             account: Account,
-            accountSettings: AccountSettings,
             extras: Array<String>,
             authority: String,
             httpClient: HttpClient,

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/webdav/DavDocumentsProviderTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/webdav/DavDocumentsProviderTest.kt
@@ -6,7 +6,6 @@ package at.bitfire.davdroid.webdav
 
 import android.content.Context
 import android.security.NetworkSecurityPolicy
-import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.WebDavDocument
 import at.bitfire.davdroid.db.WebDavMount
@@ -64,7 +63,7 @@ class DavDocumentsProviderTest {
         mockServer.dispatcher = TestDispatcher(logger)
         mockServer.start()
 
-        client = HttpClient.Builder(context).build()
+        client = TODO()     //HttpClient.Builder(context).build()
 
         // mock server delivers HTTP without encryption
         assertTrue(NetworkSecurityPolicy.getInstance().isCleartextTrafficPermitted)
@@ -86,8 +85,9 @@ class DavDocumentsProviderTest {
         val cookieStore = mutableMapOf<Long, CookieJar>()
 
         // Query
-        DavDocumentsProvider.DavDocumentsActor(context, db, logger, cookieStore, CredentialsStore(context), context.getString(R.string.webdav_authority))
-            .queryChildren(parent)
+        TODO()
+        /*DavDocumentsProvider.DavDocumentsActor(context, db, logger, cookieStore, CredentialsStore(context), context.getString(R.string.webdav_authority))
+            .queryChildren(parent)*/
 
         // Assert new children were inserted into db
         assertEquals(3, db.webDavDocumentDao().getChildren(parent.id).size)
@@ -120,8 +120,9 @@ class DavDocumentsProviderTest {
         assertEquals("My Books", db.webDavDocumentDao().get(folderId)!!.displayName)
 
         // Query - should update the parent displayname and folder name
-        DavDocumentsProvider.DavDocumentsActor(context, db, logger, cookieStore, CredentialsStore(context), context.getString(R.string.webdav_authority))
-            .queryChildren(parent)
+        TODO()
+        /*DavDocumentsProvider.DavDocumentsActor(context, db, logger, cookieStore, CredentialsStore(context), context.getString(R.string.webdav_authority))
+            .queryChildren(parent)*/
 
         // Assert parent and children were updated in database
         assertEquals("Cats WebDAV", db.webDavDocumentDao().get(parent.id)!!.displayName)
@@ -145,8 +146,9 @@ class DavDocumentsProviderTest {
         assertEquals("deleteme", db.webDavDocumentDao().get(folderId)!!.name)
 
         // Query - discovers serverside deletion
-        DavDocumentsProvider.DavDocumentsActor(context, db, logger, cookieStore, CredentialsStore(context), context.getString(R.string.webdav_authority))
-            .queryChildren(parent)
+        TODO()
+        /*DavDocumentsProvider.DavDocumentsActor(context, db, logger, cookieStore, CredentialsStore(context), context.getString(R.string.webdav_authority))
+            .queryChildren(parent)*/
 
         // Assert folder got deleted
         assertEquals(null, db.webDavDocumentDao().get(folderId))
@@ -169,10 +171,11 @@ class DavDocumentsProviderTest {
         assertEquals("parent2", parent2.name)
 
         // Query - find children of two nodes simultaneously
-        DavDocumentsProvider.DavDocumentsActor(context, db, logger, cookieStore, CredentialsStore(context), context.getString(R.string.webdav_authority))
+        TODO()
+        /*DavDocumentsProvider.DavDocumentsActor(context, db, logger, cookieStore, CredentialsStore(context), context.getString(R.string.webdav_authority))
             .queryChildren(parent1)
         DavDocumentsProvider.DavDocumentsActor(context, db, logger, cookieStore, CredentialsStore(context), context.getString(R.string.webdav_authority))
-            .queryChildren(parent2)
+            .queryChildren(parent2)*/
 
         // Assert the two folders names have changed
         assertEquals("childOne.txt", db.webDavDocumentDao().getChildren(parent1Id)[0].name)

--- a/app/src/main/kotlin/at/bitfire/davdroid/network/ClientCertKeyManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/network/ClientCertKeyManager.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.network
+
+import android.content.Context
+import android.security.KeyChain
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.net.Socket
+import java.security.Principal
+import javax.net.ssl.X509ExtendedKeyManager
+
+/**
+ * KeyManager that provides a client certificate and private key from the Android KeyChain.
+ *
+ * @throws IllegalArgumentException if the alias doesn't exist or is not accessible
+ */
+class ClientCertKeyManager @AssistedInject constructor(
+    @Assisted private val alias: String,
+    @ApplicationContext private val context: Context
+): X509ExtendedKeyManager() {
+
+    @AssistedFactory
+    interface Factory {
+        fun create(alias: String): ClientCertKeyManager
+    }
+
+    val certs = KeyChain.getCertificateChain(context, alias) ?: throw IllegalArgumentException("Alias doesn't exist or not accessible: $alias")
+    val key = KeyChain.getPrivateKey(context, alias) ?: throw IllegalArgumentException("Alias doesn't exist or not accessible: $alias")
+
+    override fun getServerAliases(p0: String?, p1: Array<out Principal>?): Array<String>? = null
+    override fun chooseServerAlias(p0: String?, p1: Array<out Principal>?, p2: Socket?) = null
+
+    override fun getClientAliases(p0: String?, p1: Array<out Principal>?) = arrayOf(alias)
+    override fun chooseClientAlias(p0: Array<out String>?, p1: Array<out Principal>?, p2: Socket?) = alias
+
+    override fun getCertificateChain(forAlias: String?) =
+        certs.takeIf { forAlias == alias }
+
+    override fun getPrivateKey(forAlias: String?) =
+        key.takeIf { forAlias == alias }
+
+}

--- a/app/src/main/kotlin/at/bitfire/davdroid/network/HttpClient.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/network/HttpClient.kt
@@ -47,6 +47,11 @@ class HttpClient(
 
     // builder
 
+    /**
+     * Builder for the [HttpClient]. Note that if you inject the builder, it's only suitable for single use.
+     * Don't inject a builder and use it from multiple locations. For use in different locations, inject
+     * `Provider<HttpClient.Builder>` instead.
+     */
     class Builder @Inject constructor(
         private val accountSettingsFactory: AccountSettings.Factory,
         private val authorizationServiceProvider: Provider<AuthorizationService>,

--- a/app/src/main/kotlin/at/bitfire/davdroid/network/HttpClient.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/network/HttpClient.kt
@@ -50,9 +50,12 @@ class HttpClient(
     // builder
 
     /**
-     * Builder for the [HttpClient]. Note that if you inject the builder, it's only suitable for single use.
-     * Don't inject a builder and use it from multiple locations. For use in different locations, inject
-     * `Provider<HttpClient.Builder>` instead.
+     * Builder for the [HttpClient].
+     *
+     * **Attention:** If the builder is injected, it shouldn't be used from multiple locations to generate different clients because then
+     * there's only one [Builder] object and setting properties from one location would influence the others.
+     *
+     * To generate multiple clients, inject and use `Provider<HttpClient.Builder>` instead.
      */
     class Builder @Inject constructor(
         private val accountSettingsFactory: AccountSettings.Factory,
@@ -180,7 +183,7 @@ class HttpClient(
                 // allow cleartext and TLS 1.2+
                 .connectionSpecs(listOf(
                     ConnectionSpec.CLEARTEXT,
-                    ConnectionSpec.MODERN_TLS
+                    ConnectionSpec.COMPATIBLE_TLS
                 ))
 
                 // offer Brotli and gzip compression (can be disabled per request with `Accept-Encoding: identity`)

--- a/app/src/main/kotlin/at/bitfire/davdroid/network/HttpClient.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/network/HttpClient.kt
@@ -186,7 +186,7 @@ class HttpClient(
                 // allow cleartext and TLS 1.2+
                 .connectionSpecs(listOf(
                     ConnectionSpec.CLEARTEXT,
-                    ConnectionSpec.COMPATIBLE_TLS
+                    ConnectionSpec.MODERN_TLS
                 ))
 
                 // offer Brotli and gzip compression (can be disabled per request with `Accept-Encoding: identity`)

--- a/app/src/main/kotlin/at/bitfire/davdroid/network/HttpClient.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/network/HttpClient.kt
@@ -4,150 +4,82 @@
 
 package at.bitfire.davdroid.network
 
+import android.accounts.Account
 import android.content.Context
-import android.os.Build
-import android.security.KeyChain
 import at.bitfire.cert4android.CustomCertManager
 import at.bitfire.dav4jvm.BasicDigestAuthHandler
 import at.bitfire.dav4jvm.UrlUtils
-import at.bitfire.davdroid.BuildConfig
 import at.bitfire.davdroid.db.Credentials
 import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.settings.Settings
 import at.bitfire.davdroid.settings.SettingsManager
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
-import dagger.hilt.EntryPoint
-import dagger.hilt.InstallIn
-import dagger.hilt.android.EntryPointAccessors
-import dagger.hilt.components.SingletonComponent
-import java.io.File
-import java.net.InetSocketAddress
-import java.net.Proxy
-import java.net.Socket
-import java.security.KeyStore
-import java.security.Principal
-import java.util.Locale
-import java.util.concurrent.TimeUnit
-import java.util.logging.Level
-import java.util.logging.Logger
-import javax.net.ssl.KeyManager
-import javax.net.ssl.SSLContext
-import javax.net.ssl.TrustManagerFactory
-import javax.net.ssl.X509ExtendedKeyManager
-import javax.net.ssl.X509TrustManager
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import net.openid.appauth.AuthState
 import net.openid.appauth.AuthorizationService
-import okhttp3.Cache
+import okhttp3.Authenticator
 import okhttp3.ConnectionSpec
 import okhttp3.CookieJar
 import okhttp3.Interceptor
-import okhttp3.OkHttp
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
-import okhttp3.Response
 import okhttp3.brotli.BrotliInterceptor
 import okhttp3.internal.tls.OkHostnameVerifier
 import okhttp3.logging.HttpLoggingInterceptor
+import java.util.concurrent.TimeUnit
+import java.util.logging.Level
+import java.util.logging.Logger
+import javax.inject.Inject
+import javax.inject.Provider
+import javax.net.ssl.KeyManager
+import javax.net.ssl.SSLContext
 
-class HttpClient @AssistedInject constructor(
-    @Assisted val okHttpClient: OkHttpClient,
-    @Assisted private var authService: AuthorizationService? = null,
-    val settingsManager: SettingsManager
+class HttpClient(
+    val okHttpClient: OkHttpClient,
+    val authorizationService: AuthorizationService? = null
 ): AutoCloseable {
 
-    companion object {
-        /** max. size of disk cache (10 MB) */
-        const val DISK_CACHE_MAX_SIZE: Long = 10*1024*1024
-
-        /** Base Builder to build all clients from. Use rarely; [OkHttpClient]s should
-         * be reused as much as possible. */
-        fun baseBuilder() =
-            OkHttpClient.Builder()
-                // Set timeouts. According to [AbstractThreadedSyncAdapter], when there is no network
-                // traffic within a minute, a sync will be cancelled.
-                .connectTimeout(15, TimeUnit.SECONDS)
-                .writeTimeout(30, TimeUnit.SECONDS)
-                .readTimeout(120, TimeUnit.SECONDS)
-                .pingInterval(
-                    45,
-                    TimeUnit.SECONDS
-                )     // avoid cancellation because of missing traffic; only works for HTTP/2
-
-                // keep TLS 1.0 and 1.1 for now; remove when major browsers have dropped it (probably 2020)
-                .connectionSpecs(
-                    listOf(
-                        ConnectionSpec.CLEARTEXT,
-                        ConnectionSpec.COMPATIBLE_TLS
-                    )
-                )
-
-                // don't allow redirects by default, because it would break PROPFIND handling
-                .followRedirects(false)
-
-                // add User-Agent to every request
-                .addInterceptor(UserAgentInterceptor)
-    }
-
-    @AssistedFactory
-    interface Factory {
-        fun create(okHttpClient: OkHttpClient, authService: AuthorizationService?): HttpClient
-    }
-
-
     override fun close() {
-        authService?.dispose()
+        authorizationService?.dispose()
         okHttpClient.cache?.close()
     }
 
 
-    class Builder(
-        val context: Context,
-        accountSettings: AccountSettings? = null,
-        val logger: Logger = Logger.getGlobal(),
-        val loggerLevel: HttpLoggingInterceptor.Level = HttpLoggingInterceptor.Level.BODY
+    // builder
+
+    class Builder @Inject constructor(
+        private val accountSettingsFactory: AccountSettings.Factory,
+        private val authorizationServiceProvider: Provider<AuthorizationService>,
+        @ApplicationContext private val context: Context,
+        defaultLogger: Logger,
+        private val keyManagerFactory: ClientCertKeyManager.Factory,
+        private val settingsManager: SettingsManager
     ) {
 
-        @EntryPoint
-        @InstallIn(SingletonComponent::class)
-        interface HttpClientBuilderEntryPoint {
-            fun authorizationService(): AuthorizationService
-            fun httpClientFactory(): Factory
-            fun settingsManager(): SettingsManager
+        // property setters/getters
+
+        private var logger: Logger = defaultLogger
+        fun setLogger(logger: Logger): Builder {
+            this.logger = logger
+            return this
         }
 
-        private val entryPoint = EntryPointAccessors.fromApplication<HttpClientBuilderEntryPoint>(context)
-
-        fun interface CertManagerProducer {
-            fun certManager(): CustomCertManager
+        private var loggerLevel: HttpLoggingInterceptor.Level = HttpLoggingInterceptor.Level.BODY
+        fun setLoggerLevel(level: HttpLoggingInterceptor.Level): Builder {
+            loggerLevel = level
+            return this
         }
-
-        private var appInForeground: MutableStateFlow<Boolean>? =
-                MutableStateFlow(false)
-        private var authService: AuthorizationService? = null
-        private var certManagerProducer: CertManagerProducer? = null
-        private var certificateAlias: String? = null
-        private var offerCompression: Boolean = false
 
         // default cookie store for non-persistent cookies (some services like Horde use cookies for session tracking)
-        private var cookieStore: CookieJar? = MemoryCookieStore()
-
-        private val orig = baseBuilder()
+        private var cookieStore: CookieJar = MemoryCookieStore()
+        fun setCookieStore(cookieStore: CookieJar): Builder {
+            this.cookieStore = cookieStore
+            return this
+        }
 
         init {
-            // add network logging, if requested
-            if (logger.isLoggable(Level.FINEST)) {
-                val loggingInterceptor = HttpLoggingInterceptor { message -> logger.finest(message) }
-                loggingInterceptor.level = loggerLevel
-                orig.addNetworkInterceptor(loggingInterceptor)
-            }
-
-            val settings = entryPoint.settingsManager()
-
             // custom proxy support
-            try {
+            /*try {
                 val proxyTypeValue = settings.getInt(Settings.PROXY_TYPE)
                 if (proxyTypeValue != Settings.PROXY_TYPE_SYSTEM) {
                     // we set our own proxy
@@ -169,71 +101,55 @@ class HttpClient @AssistedInject constructor(
                 }
             } catch (e: Exception) {
                 logger.log(Level.SEVERE, "Can't set proxy, ignoring", e)
-            }
-
-            customCertManager {
-                // by default, use a CustomCertManager that respects the "distrust system certificates" setting
-                val trustSystemCerts = !settings.getBoolean(Settings.DISTRUST_SYSTEM_CERTIFICATES)
-                CustomCertManager(context, trustSystemCerts, appInForeground)
-            }
+            }*/
 
             // use account settings for authentication and cookies
-            if (accountSettings != null)
+            /*if (accountSettings != null)
                 addAuthentication(null, accountSettings.credentials(), authStateCallback = { authState: AuthState ->
                     accountSettings.credentials(Credentials(authState = authState))
-                })
+                })*/
         }
 
-        constructor(context: Context, host: String?, credentials: Credentials?) : this(context) {
-            if (credentials != null)
-                addAuthentication(host, credentials)
-        }
-
-        fun addAuthentication(host: String?, credentials: Credentials, insecurePreemptive: Boolean = false, authStateCallback: BearerAuthInterceptor.AuthStateUpdateCallback? = null): Builder {
+        private var authenticationInterceptor: Interceptor? = null
+        private var authenticator: Authenticator? = null
+        private var authorizationService: AuthorizationService? = null
+        private var certificateAlias: String? = null
+        fun authenticate(host: String?, credentials: Credentials, authStateCallback: BearerAuthInterceptor.AuthStateUpdateCallback? = null): Builder {
             if (credentials.username != null && credentials.password != null) {
-                val authHandler = BasicDigestAuthHandler(UrlUtils.hostToDomain(host), credentials.username, credentials.password, insecurePreemptive)
-                orig.addNetworkInterceptor(authHandler)
-                    .authenticator(authHandler)
+                // basic/digest auth
+                val authHandler = BasicDigestAuthHandler(UrlUtils.hostToDomain(host), credentials.username, credentials.password, insecurePreemptive = true)
+                authenticationInterceptor = authHandler
+                authenticator = authHandler
+
+            } else if (credentials.authState != null) {
+                // OAuth
+                val authService = authorizationServiceProvider.get()
+                authenticationInterceptor = BearerAuthInterceptor.fromAuthState(authService, credentials.authState, authStateCallback)
+                authorizationService = authService
             }
 
+            // client certificate
             if (credentials.certificateAlias != null)
                 certificateAlias = credentials.certificateAlias
 
-            credentials.authState?.let { authState ->
-                val newAuthService = entryPoint.authorizationService()
-                authService = newAuthService
-                BearerAuthInterceptor.fromAuthState(newAuthService, authState, authStateCallback)?.let { bearerAuthInterceptor ->
-                    orig.addNetworkInterceptor(bearerAuthInterceptor)
-                }
-            }
             return this
         }
 
-        fun allowCompression(allow: Boolean): Builder {
-            offerCompression = allow
-            return this
-        }
-
-        fun cookieStore(store: CookieJar?): Builder {
-            cookieStore = store
-            return this
-        }
-
+        private var followRedirects = false
         fun followRedirects(follow: Boolean): Builder {
-            orig.followRedirects(follow)
+            followRedirects = follow
             return this
         }
 
-        fun customCertManager(producer: CertManagerProducer) {
-            certManagerProducer = producer
-        }
-        fun setForeground(foreground: Boolean): Builder {
+        private var appInForeground: MutableStateFlow<Boolean>? = MutableStateFlow(false)
+        fun inForeground(foreground: Boolean): Builder {
             appInForeground?.value = foreground
             return this
         }
 
+        @Suppress("unused")
         fun withDiskCache(): Builder {
-            for (dir in arrayOf(context.externalCacheDir, context.cacheDir).filterNotNull()) {
+            /*for (dir in arrayOf(context.externalCacheDir, context.cacheDir).filterNotNull()) {
                 if (dir.exists() && dir.canWrite()) {
                     val cacheDir = File(dir, "HttpClient")
                     cacheDir.mkdir()
@@ -241,96 +157,116 @@ class HttpClient @AssistedInject constructor(
                     orig.cache(Cache(cacheDir, DISK_CACHE_MAX_SIZE))
                     break
                 }
-            }
+            }*/
             return this
         }
 
-        fun build(): HttpClient {
-            cookieStore?.let {
-                orig.cookieJar(it)
-            }
 
-            if (offerCompression)
-                // offer Brotli and gzip compression
-                orig.addInterceptor(BrotliInterceptor)
+        // convenience builders from other classes
 
-            var keyManager: KeyManager? = null
-            certificateAlias?.let { alias ->
-                // get provider certificate and private key
-                val certs = KeyChain.getCertificateChain(context, alias) ?: return@let
-                val key = KeyChain.getPrivateKey(context, alias) ?: return@let
-                logger?.fine("Using provider certificate $alias for authentication (chain length: ${certs.size})")
-
-                // create KeyManager
-                keyManager = object : X509ExtendedKeyManager() {
-                    override fun getServerAliases(p0: String?, p1: Array<out Principal>?): Array<String>? = null
-                    override fun chooseServerAlias(p0: String?, p1: Array<out Principal>?, p2: Socket?) = null
-
-                    override fun getClientAliases(p0: String?, p1: Array<out Principal>?) =
-                            arrayOf(alias)
-
-                    override fun chooseClientAlias(p0: Array<out String>?, p1: Array<out Principal>?, p2: Socket?) =
-                            alias
-
-                    override fun getCertificateChain(forAlias: String?) =
-                            certs.takeIf { forAlias == alias }
-
-                    override fun getPrivateKey(forAlias: String?) =
-                            key.takeIf { forAlias == alias }
+        fun fromAccount(account: Account): Builder {
+            val accountSettings = accountSettingsFactory.create(account)
+            authenticate(
+                host = null,
+                credentials = accountSettings.credentials(),
+                authStateCallback = { authState: AuthState ->
+                    accountSettings.credentials(Credentials(authState = authState))
                 }
-
-                // HTTP/2 doesn't support client certificates (yet)
-                // see https://tools.ietf.org/html/draft-ietf-httpbis-http2-secondary-certs-04
-                orig.protocols(listOf(Protocol.HTTP_1_1))
-            }
-
-            if (certManagerProducer != null || keyManager != null) {
-                val manager = certManagerProducer?.certManager()
-
-                val trustManager = manager ?: /* fall back to system default trust manager */
-                    TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
-                    .let { factory ->
-                        factory.init(null as KeyStore?)
-                        factory.trustManagers.first() as X509TrustManager
-                    }
-
-                val hostnameVerifier =
-                    if (manager != null)
-                        manager.HostnameVerifier(OkHostnameVerifier)
-                    else
-                        OkHostnameVerifier
-
-                val sslContext = SSLContext.getInstance("TLS")
-                sslContext.init(
-                    if (keyManager != null) arrayOf(keyManager) else null,
-                    arrayOf(trustManager),
-                    null)
-                orig.sslSocketFactory(sslContext.socketFactory, trustManager)
-                orig.hostnameVerifier(hostnameVerifier)
-            }
-
-            return entryPoint.httpClientFactory().create(orig.build(), authService = authService)
+            )
+            return this
         }
 
-    }
 
+        // actual builder
 
-    object UserAgentInterceptor: Interceptor {
+        fun build(): HttpClient {
+            val okBuilder = OkHttpClient.Builder()
+                // Set timeouts. According to [AbstractThreadedSyncAdapter], when there is no network
+                // traffic within a minute, a sync will be cancelled.
+                .connectTimeout(15, TimeUnit.SECONDS)
+                .writeTimeout(30, TimeUnit.SECONDS)
+                .readTimeout(120, TimeUnit.SECONDS)
+                .pingInterval(45, TimeUnit.SECONDS)     // avoid cancellation because of missing traffic; only works for HTTP/2
 
-        val userAgent = "DAVx5/${BuildConfig.VERSION_NAME} (dav4jvm; " +
-                "okhttp/${OkHttp.VERSION}) Android/${Build.VERSION.RELEASE}"
+                // don't allow redirects by default, because it would break PROPFIND handling
+                .followRedirects(false)
 
-        init {
-            Logger.getGlobal().info("Will set User-Agent: $userAgent")
+                // add User-Agent to every request
+                .addInterceptor(UserAgentInterceptor)
+
+                // connection-private cookie store
+                .cookieJar(cookieStore)
+
+                // allow cleartext and TLS 1.2+
+                .connectionSpecs(listOf(
+                    ConnectionSpec.CLEARTEXT,
+                    ConnectionSpec.MODERN_TLS
+                ))
+
+                // offer Brotli and gzip compression (can be disabled per request with `Accept-Encoding: identity`)
+                .addInterceptor(BrotliInterceptor)
+
+            // add authentication
+            buildAuthentication(okBuilder)
+
+            // add network logging, if requested
+            if (logger.isLoggable(Level.FINEST)) {
+                val loggingInterceptor = HttpLoggingInterceptor { message -> logger.finest(message) }
+                loggingInterceptor.level = loggerLevel
+                okBuilder.addNetworkInterceptor(loggingInterceptor)
+            }
+
+            return HttpClient(
+                okHttpClient = okBuilder.build(),
+                authorizationService = authorizationService
+            )
         }
 
-        override fun intercept(chain: Interceptor.Chain): Response {
-            val locale = Locale.getDefault()
-            val request = chain.request().newBuilder()
-                    .header("User-Agent", userAgent)
-                    .header("Accept-Language", "${locale.language}-${locale.country}, ${locale.language};q=0.7, *;q=0.5")
-                    .build()
-            return chain.proceed(request)
+        private fun buildAuthentication(okBuilder: OkHttpClient.Builder) {
+            // basic/digest auth and OAuth
+            authenticationInterceptor?.let { okBuilder.addInterceptor(it) }
+            authenticator?.let { okBuilder.authenticator(it) }
+
+            // client certificate
+            val keyManager: KeyManager? = certificateAlias?.let { alias ->
+                try {
+                    val manager = keyManagerFactory.create(alias)
+                    logger.fine("Using certificate $alias for authentication")
+
+                    // HTTP/2 doesn't support client certificates (yet)
+                    // see https://tools.ietf.org/html/draft-ietf-httpbis-http2-secondary-certs-04
+                    okBuilder.protocols(listOf(Protocol.HTTP_1_1))
+
+                    manager
+                } catch (e: IllegalArgumentException) {
+                    logger.log(Level.SEVERE, "Couldn't create KeyManager for certificate $alias", e)
+                    null
+                }
+            }
+
+            // cert4android integration
+            val certManager = CustomCertManager(
+                context = context,
+                trustSystemCerts = !settingsManager.getBoolean(Settings.DISTRUST_SYSTEM_CERTIFICATES),
+                appInForeground = appInForeground
+            )
+            val hostnameVerifier = certManager.HostnameVerifier(OkHostnameVerifier)
+
+            val sslContext = SSLContext.getInstance("TLS")
+            sslContext.init(
+                if (keyManager != null) arrayOf(keyManager) else null,
+                arrayOf(certManager),
+                null)
+
+            okBuilder.sslSocketFactory(sslContext.socketFactory, certManager)
+            okBuilder.hostnameVerifier(hostnameVerifier)
+        }
+
+        companion object {
+
+            /** max. size of disk cache (10 MB) */
+            const val DISK_CACHE_MAX_SIZE: Long = 10*1024*1024
+
         }
 
     }

--- a/app/src/main/kotlin/at/bitfire/davdroid/network/NextcloudLoginFlow.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/network/NextcloudLoginFlow.kt
@@ -4,7 +4,6 @@
 
 package at.bitfire.davdroid.network
 
-import android.content.Context
 import at.bitfire.dav4jvm.exception.DavException
 import at.bitfire.dav4jvm.exception.HttpException
 import at.bitfire.davdroid.db.Credentials
@@ -24,14 +23,15 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import org.json.JSONObject
 import java.net.HttpURLConnection
 import java.net.URI
+import javax.inject.Inject
 
 /**
  * Implements Nextcloud Login Flow v2.
  *
  * See https://docs.nextcloud.com/server/latest/developer_manual/client_apis/LoginFlow/index.html#login-flow-v2
  */
-class NextcloudLoginFlow(
-    context: Context
+class NextcloudLoginFlow @Inject constructor(
+    httpClientBuilder: HttpClient.Builder
 ): AutoCloseable {
 
     companion object {
@@ -42,8 +42,8 @@ class NextcloudLoginFlow(
         const val DAV_PATH = "remote.php/dav"
     }
 
-    val httpClient = HttpClient.Builder(context)
-        .setForeground(true)
+    val httpClient = httpClientBuilder
+        .inForeground(true)
         .build()
 
     override fun close() {

--- a/app/src/main/kotlin/at/bitfire/davdroid/network/OAuthModule.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/network/OAuthModule.kt
@@ -26,8 +26,9 @@ object OAuthModule {
                 .setConnectionBuilder { uri ->
                     val url = URL(uri.toString())
                     (url.openConnection() as HttpURLConnection).apply {
-                        setRequestProperty("User-Agent", HttpClient.UserAgentInterceptor.userAgent)
+                        setRequestProperty("User-Agent", UserAgentInterceptor.userAgent)
                     }
                 }.build()
         )
+
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/network/UserAgentInterceptor.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/network/UserAgentInterceptor.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.network
+
+import android.os.Build
+import at.bitfire.davdroid.BuildConfig
+import okhttp3.Interceptor
+import okhttp3.OkHttp
+import okhttp3.Response
+import java.util.Locale
+import java.util.logging.Logger
+
+object UserAgentInterceptor: Interceptor {
+
+    val userAgent = "DAVx5/${BuildConfig.VERSION_NAME} (dav4jvm; " +
+            "okhttp/${OkHttp.VERSION}) Android/${Build.VERSION.RELEASE}"
+
+    init {
+        Logger.getGlobal().info("Will set User-Agent: $userAgent")
+    }
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val locale = Locale.getDefault()
+        val request = chain.request().newBuilder()
+            .header("User-Agent", userAgent)
+            .header("Accept-Language", "${locale.language}-${locale.country}, ${locale.language};q=0.7, *;q=0.5")
+            .build()
+        return chain.proceed(request)
+    }
+
+}

--- a/app/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationWorker.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationWorker.kt
@@ -35,6 +35,7 @@ import java.time.Duration
 import java.time.Instant
 import java.util.logging.Level
 import java.util.logging.Logger
+import javax.inject.Provider
 
 /**
  * Worker that registers push for all collections that support it.
@@ -47,7 +48,7 @@ class PushRegistrationWorker @AssistedInject constructor(
     @Assisted context: Context,
     @Assisted workerParameters: WorkerParameters,
     private val collectionRepository: DavCollectionRepository,
-    private val httpClientBuilder: HttpClient.Builder,
+    private val httpClientBuilder: Provider<HttpClient.Builder>,
     private val logger: Logger,
     private val preferenceRepository: PreferenceRepository,
     private val serviceRepository: DavServiceRepository
@@ -67,7 +68,7 @@ class PushRegistrationWorker @AssistedInject constructor(
     }
 
     private suspend fun registerPushSubscription(collection: Collection, account: Account, endpoint: String) {
-        val httpClient = httpClientBuilder
+        val httpClient = httpClientBuilder.get()
             .fromAccount(account)
             .inForeground(true)
             .build()
@@ -148,7 +149,7 @@ class PushRegistrationWorker @AssistedInject constructor(
     }
 
     private suspend fun unregisterPushSubscription(collection: Collection, account: Account, url: HttpUrl) {
-        val httpClient = httpClientBuilder
+        val httpClient = httpClientBuilder.get()
             .fromAccount(account)
             .inForeground(true)
             .build()

--- a/app/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
@@ -27,7 +27,6 @@ import at.bitfire.davdroid.db.CollectionType
 import at.bitfire.davdroid.db.HomeSet
 import at.bitfire.davdroid.network.HttpClient
 import at.bitfire.davdroid.servicedetection.RefreshCollectionsWorker
-import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.util.DavUtils
 import at.bitfire.ical4android.util.DateUtils
 import dagger.Lazy
@@ -55,10 +54,10 @@ import javax.inject.Inject
  * Implements an observer pattern that can be used to listen for changes of collections.
  */
 class DavCollectionRepository @Inject constructor(
-    private val accountSettingsFactory: AccountSettings.Factory,
     @ApplicationContext private val context: Context,
     private val db: AppDatabase,
     defaultListeners: Lazy<Set<@JvmSuppressWildcards OnChangeListener>>,
+    private val httpClientBuilder: HttpClient.Builder,
     private val serviceRepository: DavServiceRepository
 ) {
 
@@ -177,12 +176,14 @@ class DavCollectionRepository @Inject constructor(
         val service = serviceRepository.get(collection.serviceId) ?: throw IllegalArgumentException("Service not found")
         val account = Account(service.accountName, context.getString(R.string.account_type))
 
-        HttpClient.Builder(context, accountSettingsFactory.create(account))
-            .setForeground(true)
-            .build().use { httpClient ->
+        httpClientBuilder
+            .fromAccount(account)
+            .inForeground(true)
+            .build()
+            .use { httpClient ->
                 withContext(Dispatchers.IO) {
                     runInterruptible {
-                        DavResource(httpClient.okHttpClient, collection.url).delete() {
+                        DavResource(httpClient.okHttpClient, collection.url).delete {
                             // success, otherwise an exception would have been thrown → delete locally, too
                             delete(collection)
                         }
@@ -291,9 +292,11 @@ class DavCollectionRepository @Inject constructor(
     // helpers
 
     private suspend fun createOnServer(account: Account, url: HttpUrl, method: String, xmlBody: String) {
-        HttpClient.Builder(context, accountSettingsFactory.create(account))
-            .setForeground(true)
-            .build().use { httpClient ->
+        httpClientBuilder
+            .fromAccount(account)
+            .inForeground(true)
+            .build()
+            .use { httpClient ->
                 withContext(Dispatchers.IO) {
                     runInterruptible {
                         DavResource(httpClient.okHttpClient, url).mkCol(

--- a/app/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
@@ -47,6 +47,7 @@ import java.io.StringWriter
 import java.util.Collections
 import java.util.UUID
 import javax.inject.Inject
+import javax.inject.Provider
 
 /**
  * Repository for managing collections.
@@ -57,7 +58,7 @@ class DavCollectionRepository @Inject constructor(
     @ApplicationContext private val context: Context,
     private val db: AppDatabase,
     defaultListeners: Lazy<Set<@JvmSuppressWildcards OnChangeListener>>,
-    private val httpClientBuilder: HttpClient.Builder,
+    private val httpClientBuilder: Provider<HttpClient.Builder>,
     private val serviceRepository: DavServiceRepository
 ) {
 
@@ -176,7 +177,7 @@ class DavCollectionRepository @Inject constructor(
         val service = serviceRepository.get(collection.serviceId) ?: throw IllegalArgumentException("Service not found")
         val account = Account(service.accountName, context.getString(R.string.account_type))
 
-        httpClientBuilder
+        httpClientBuilder.get()
             .fromAccount(account)
             .inForeground(true)
             .build()
@@ -292,7 +293,7 @@ class DavCollectionRepository @Inject constructor(
     // helpers
 
     private suspend fun createOnServer(account: Account, url: HttpUrl, method: String, xmlBody: String) {
-        httpClientBuilder
+        httpClientBuilder.get()
             .fromAccount(account)
             .inForeground(true)
             .build()

--- a/app/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
@@ -37,7 +37,6 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.Multibinds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runInterruptible
-import kotlinx.coroutines.withContext
 import net.fortuna.ical4j.model.Calendar
 import net.fortuna.ical4j.model.Component
 import net.fortuna.ical4j.model.ComponentList
@@ -182,12 +181,10 @@ class DavCollectionRepository @Inject constructor(
             .inForeground(true)
             .build()
             .use { httpClient ->
-                withContext(Dispatchers.IO) {
-                    runInterruptible {
-                        DavResource(httpClient.okHttpClient, collection.url).delete {
-                            // success, otherwise an exception would have been thrown → delete locally, too
-                            delete(collection)
-                        }
+                runInterruptible(Dispatchers.IO) {
+                    DavResource(httpClient.okHttpClient, collection.url).delete {
+                        // success, otherwise an exception would have been thrown → delete locally, too
+                        delete(collection)
                     }
                 }
             }
@@ -298,14 +295,12 @@ class DavCollectionRepository @Inject constructor(
             .inForeground(true)
             .build()
             .use { httpClient ->
-                withContext(Dispatchers.IO) {
-                    runInterruptible {
-                        DavResource(httpClient.okHttpClient, url).mkCol(
-                            xmlBody = xmlBody,
-                            method = method
-                        ) {
-                            // success, otherwise an exception would have been thrown
-                        }
+                runInterruptible(Dispatchers.IO) {
+                    DavResource(httpClient.okHttpClient, url).mkCol(
+                        xmlBody = xmlBody,
+                        method = method
+                    ) {
+                        // success, otherwise an exception would have been thrown
                     }
                 }
             }

--- a/app/src/main/kotlin/at/bitfire/davdroid/servicedetection/CollectionListRefresher.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/servicedetection/CollectionListRefresher.kt
@@ -386,8 +386,8 @@ class CollectionListRefresher @AssistedInject constructor(
      * Before a collection is pre-selected, we check whether its URL matches the regexp in
      * [Settings.PRESELECT_COLLECTIONS_EXCLUDED], in which case *false* is returned.
      *
-     * @param collection the collection to check
-     * @param homeSets list of home-sets (to check whether collection is in a personal home-set)
+     * @param collection    the collection to check
+     * @param homeSets      list of personal home-sets
      * @return *true* if the collection should be preselected for synchronization; *false* otherwise
      */
     internal fun shouldPreselect(collection: Collection, homeSets: Iterable<HomeSet>): Boolean {

--- a/app/src/main/kotlin/at/bitfire/davdroid/servicedetection/DavResourceFinder.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/servicedetection/DavResourceFinder.kt
@@ -48,9 +48,8 @@ import java.util.logging.Level
 import java.util.logging.Logger
 
 /**
- * Does initial resource detection (straight after app install). Called after user has supplied url in
- * app setup process [at.bitfire.davdroid.ui.setup.DetectConfigurationFragment].
- * It uses the (user given) base URL to find
+ * Does initial resource detection when an account is added. It uses the (user given) base URL to find
+ *
  * - services (CalDAV and/or CardDAV),
  * - principal,
  * - homeset/collections (multistatus responses are handled through dav4jvm).
@@ -63,7 +62,8 @@ class DavResourceFinder @AssistedInject constructor(
     @Assisted private val baseURI: URI,
     @Assisted private val credentials: Credentials? = null,
     @ApplicationContext val context: Context,
-    private val dnsRecordResolver: DnsRecordResolver
+    private val dnsRecordResolver: DnsRecordResolver,
+    httpClientBuilder: HttpClient.Builder
 ): AutoCloseable {
 
     @AssistedFactory
@@ -83,13 +83,17 @@ class DavResourceFinder @AssistedInject constructor(
 
     private var encountered401 = false
 
-    private val httpClient: HttpClient = HttpClient.Builder(context, logger = log).let {
-        credentials?.let { credentials ->
-            it.addAuthentication(null, credentials)
-        }
-        it.setForeground(true)
-        it.build()
-    }
+    private val httpClient = httpClientBuilder
+        .inForeground(true)
+        .setLogger(log)
+        .apply {
+            if (credentials != null)
+                authenticate(
+                    host = null,
+                    credentials = credentials
+                )
+            }
+        .build()
 
     override fun close() {
         httpClient.close()
@@ -136,7 +140,7 @@ class DavResourceFinder @AssistedInject constructor(
                 log.log(Level.INFO, "CalDAV service detection failed", e)
                 processException(e)
             }
-        } catch(e: Exception) {
+        } catch(_: Exception) {
             // we have been interrupted; reset results so that an error message will be shown
             cardDavConfig = null
             calDavConfig = null

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
@@ -12,6 +12,7 @@ import at.bitfire.davdroid.db.Service
 import at.bitfire.davdroid.network.HttpClient
 import at.bitfire.davdroid.resource.LocalAddressBook
 import at.bitfire.davdroid.resource.LocalAddressBookStore
+import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.sync.account.setAndVerifyUserData
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -26,6 +27,7 @@ class AddressBookSyncer @AssistedInject constructor(
     @Assisted extras: Array<String>,
     @Assisted syncResult: SyncResult,
     addressBookStore: LocalAddressBookStore,
+    private val accountSettingsFactory: AccountSettings.Factory,
     private val contactsSyncManagerFactory: ContactsSyncManager.Factory
 ): Syncer<LocalAddressBookStore, LocalAddressBook>(account, extras, syncResult) {
 
@@ -96,7 +98,7 @@ class AddressBookSyncer @AssistedInject constructor(
             }
             accountSettings.accountManager.setAndVerifyUserData(addressBook.addressBookAccount, PREVIOUS_GROUP_METHOD, groupMethod)
 
-            val syncManager = contactsSyncManagerFactory.contactsSyncManager(account, accountSettings, httpClient.value, extras, authority, syncResult, provider, addressBook, collection)
+            val syncManager = contactsSyncManagerFactory.contactsSyncManager(account, httpClient.value, extras, authority, syncResult, provider, addressBook, collection)
             syncManager.performSync()
 
         } catch(e: Exception) {

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
@@ -5,6 +5,7 @@
 package at.bitfire.davdroid.sync
 
 import android.accounts.Account
+import android.accounts.AccountManager
 import android.content.ContentProviderClient
 import android.provider.ContactsContract
 import at.bitfire.davdroid.db.Collection
@@ -80,11 +81,12 @@ class AddressBookSyncer @AssistedInject constructor(
         collection: Collection
     ) {
         try {
-            val accountSettings = accountSettingsFactory.create(account)
-
             // handle group method change
+            val accountSettings = accountSettingsFactory.create(account)
             val groupMethod = accountSettings.getGroupMethod().name
-            accountSettings.accountManager.getUserData(addressBook.addressBookAccount, PREVIOUS_GROUP_METHOD)?.let { previousGroupMethod ->
+
+            val accountManager = AccountManager.get(context)
+            accountManager.getUserData(addressBook.addressBookAccount, PREVIOUS_GROUP_METHOD)?.let { previousGroupMethod ->
                 if (previousGroupMethod != groupMethod) {
                     logger.info("Group method changed, deleting all local contacts/groups")
 
@@ -96,7 +98,7 @@ class AddressBookSyncer @AssistedInject constructor(
                     addressBook.syncState = null
                 }
             }
-            accountSettings.accountManager.setAndVerifyUserData(addressBook.addressBookAccount, PREVIOUS_GROUP_METHOD, groupMethod)
+            accountManager.setAndVerifyUserData(addressBook.addressBookAccount, PREVIOUS_GROUP_METHOD, groupMethod)
 
             val syncManager = contactsSyncManagerFactory.contactsSyncManager(account, httpClient.value, extras, authority, syncResult, provider, addressBook, collection)
             syncManager.performSync()

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
@@ -50,16 +50,15 @@ import java.util.logging.Level
  */
 class CalendarSyncManager @AssistedInject constructor(
     @Assisted account: Account,
-    @Assisted accountSettings: AccountSettings,
     @Assisted extras: Array<String>,
     @Assisted httpClient: HttpClient,
     @Assisted authority: String,
     @Assisted syncResult: SyncResult,
     @Assisted localCalendar: LocalCalendar,
-    @Assisted collection: Collection
+    @Assisted collection: Collection,
+    private val accountSettingsFactory: AccountSettings.Factory
 ): SyncManager<LocalEvent, LocalCalendar, DavCalendar>(
     account,
-    accountSettings,
     httpClient,
     extras,
     authority,
@@ -72,7 +71,6 @@ class CalendarSyncManager @AssistedInject constructor(
     interface Factory {
         fun calendarSyncManager(
             account: Account,
-            accountSettings: AccountSettings,
             extras: Array<String>,
             httpClient: HttpClient,
             authority: String,
@@ -81,6 +79,9 @@ class CalendarSyncManager @AssistedInject constructor(
             collection: Collection
         ): CalendarSyncManager
     }
+
+    private val accountSettings = accountSettingsFactory.create(account)
+
 
     override fun prepare(): Boolean {
         davCollection = DavCalendar(httpClient.okHttpClient, collection.url)

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncer.kt
@@ -11,6 +11,7 @@ import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service
 import at.bitfire.davdroid.resource.LocalCalendar
 import at.bitfire.davdroid.resource.LocalCalendarStore
+import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.ical4android.AndroidCalendar
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -24,6 +25,7 @@ class CalendarSyncer @AssistedInject constructor(
     @Assisted extras: Array<String>,
     @Assisted syncResult: SyncResult,
     calendarStore: LocalCalendarStore,
+    private val accountSettingsFactory: AccountSettings.Factory,
     private val calendarSyncManagerFactory: CalendarSyncManager.Factory
 ): Syncer<LocalCalendarStore, LocalCalendar>(account, extras, syncResult) {
 
@@ -42,6 +44,7 @@ class CalendarSyncer @AssistedInject constructor(
 
     override fun prepare(provider: ContentProviderClient): Boolean {
         // Update colors
+        val accountSettings = accountSettingsFactory.create(account)
         if (accountSettings.getEventColors())
             AndroidCalendar.insertColors(provider, account)
         else
@@ -57,7 +60,6 @@ class CalendarSyncer @AssistedInject constructor(
 
         val syncManager = calendarSyncManagerFactory.calendarSyncManager(
             account,
-            accountSettings,
             extras,
             httpClient.value,
             authority,

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
@@ -95,7 +95,6 @@ import kotlin.jvm.optionals.getOrNull
  */
 class ContactsSyncManager @AssistedInject constructor(
     @Assisted account: Account,
-    @Assisted accountSettings: AccountSettings,
     @Assisted httpClient: HttpClient,
     @Assisted extras: Array<String>,
     @Assisted authority: String,
@@ -103,10 +102,11 @@ class ContactsSyncManager @AssistedInject constructor(
     @Assisted val provider: ContentProviderClient,
     @Assisted localAddressBook: LocalAddressBook,
     @Assisted collection: Collection,
-    val dirtyVerifier: Optional<ContactDirtyVerifier>
+    val dirtyVerifier: Optional<ContactDirtyVerifier>,
+    accountSettingsFactory: AccountSettings.Factory,
+    private val httpClientBuilder: HttpClient.Builder
 ): SyncManager<LocalAddress, LocalAddressBook, DavAddressBook>(
     account,
-    accountSettings,
     httpClient,
     extras,
     authority,
@@ -119,7 +119,6 @@ class ContactsSyncManager @AssistedInject constructor(
     interface Factory {
         fun contactsSyncManager(
             account: Account,
-            accountSettings: AccountSettings,
             httpClient: HttpClient,
             extras: Array<String>,
             authority: String,
@@ -133,6 +132,8 @@ class ContactsSyncManager @AssistedInject constructor(
     companion object {
         infix fun <T> Set<T>.disjunct(other: Set<T>) = (this - other) union (other - this)
     }
+
+    private val accountSettings = accountSettingsFactory.create(account)
 
     private var hasVCard4 = false
     private var hasJCard = false
@@ -434,7 +435,7 @@ class ContactsSyncManager @AssistedInject constructor(
     // downloader helper class
 
     private inner class ResourceDownloader(
-            val baseUrl: HttpUrl
+        val baseUrl: HttpUrl
     ): Contact.Downloader {
 
         override fun download(url: String, accepts: String): ByteArray? {
@@ -445,25 +446,29 @@ class ContactsSyncManager @AssistedInject constructor(
             }
 
             // authenticate only against a certain host, and only upon request
-            val client = HttpClient.Builder(context, baseUrl.host, accountSettings.credentials())
+            httpClientBuilder
+                .authenticate(
+                    host = baseUrl.host,
+                    credentials = accountSettings.credentials()
+                )
                 .followRedirects(true)      // allow redirects
                 .build()
+                .use { httpClient ->
+                    try {
+                        val response = httpClient.okHttpClient.newCall(Request.Builder()
+                            .get()
+                            .url(httpUrl)
+                            .build()).execute()
 
-            try {
-                val response = client.okHttpClient.newCall(Request.Builder()
-                        .get()
-                        .url(httpUrl)
-                        .build()).execute()
+                        if (response.isSuccessful)
+                            return response.body?.bytes()
+                        else
+                            logger.warning("Couldn't download external resource")
+                    } catch(e: IOException) {
+                        logger.log(Level.SEVERE, "Couldn't download external resource", e)
+                    }
+                }
 
-                if (response.isSuccessful)
-                    return response.body?.bytes()
-                else
-                    logger.warning("Couldn't download external resource")
-            } catch(e: IOException) {
-                logger.log(Level.SEVERE, "Couldn't download external resource", e)
-            } finally {
-                client.close()
-            }
             return null
         }
     }

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
@@ -447,10 +447,7 @@ class ContactsSyncManager @AssistedInject constructor(
 
             // authenticate only against a certain host, and only upon request
             httpClientBuilder
-                .authenticate(
-                    host = baseUrl.host,
-                    credentials = accountSettings.credentials()
-                )
+                .fromAccount(account, onlyHost = baseUrl.host)
                 .followRedirects(true)      // allow redirects
                 .build()
                 .use { httpClient ->

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
@@ -22,7 +22,6 @@ import at.bitfire.davdroid.network.HttpClient
 import at.bitfire.davdroid.resource.LocalJtxCollection
 import at.bitfire.davdroid.resource.LocalJtxICalObject
 import at.bitfire.davdroid.resource.LocalResource
-import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.util.DavUtils.lastSegment
 import at.bitfire.ical4android.InvalidCalendarException
 import at.bitfire.ical4android.JtxICalObject
@@ -39,7 +38,6 @@ import java.util.logging.Level
 
 class JtxSyncManager @AssistedInject constructor(
     @Assisted account: Account,
-    @Assisted accountSettings: AccountSettings,
     @Assisted extras: Array<String>,
     @Assisted httpClient: HttpClient,
     @Assisted authority: String,
@@ -48,7 +46,6 @@ class JtxSyncManager @AssistedInject constructor(
     @Assisted collection: Collection
 ): SyncManager<LocalJtxICalObject, LocalJtxCollection, DavCalendar>(
     account,
-    accountSettings,
     httpClient,
     extras,
     authority,
@@ -61,7 +58,6 @@ class JtxSyncManager @AssistedInject constructor(
     interface Factory {
         fun jtxSyncManager(
             account: Account,
-            accountSettings: AccountSettings,
             extras: Array<String>,
             httpClient: HttpClient,
             authority: String,

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncer.kt
@@ -72,7 +72,6 @@ class JtxSyncer @AssistedInject constructor(
 
         val syncManager = jtxSyncManagerFactory.jtxSyncManager(
             account,
-            accountSettings,
             extras,
             httpClient.value,
             authority,

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/TaskSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/TaskSyncer.kt
@@ -73,7 +73,6 @@ class TaskSyncer @AssistedInject constructor(
 
         val syncManager = tasksSyncManagerFactory.tasksSyncManager(
             account,
-            accountSettings,
             httpClient.value,
             extras,
             authority,

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
@@ -22,7 +22,6 @@ import at.bitfire.davdroid.network.HttpClient
 import at.bitfire.davdroid.resource.LocalResource
 import at.bitfire.davdroid.resource.LocalTask
 import at.bitfire.davdroid.resource.LocalTaskList
-import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.util.DavUtils.lastSegment
 import at.bitfire.ical4android.InvalidCalendarException
 import at.bitfire.ical4android.Task
@@ -42,7 +41,6 @@ import java.util.logging.Level
  */
 class TasksSyncManager @AssistedInject constructor(
     @Assisted account: Account,
-    @Assisted accountSettings: AccountSettings,
     @Assisted httpClient: HttpClient,
     @Assisted extras: Array<String>,
     @Assisted authority: String,
@@ -51,7 +49,6 @@ class TasksSyncManager @AssistedInject constructor(
     @Assisted collection: Collection
 ): SyncManager<LocalTask, LocalTaskList, DavCalendar>(
     account,
-    accountSettings,
     httpClient,
     extras,
     authority,
@@ -64,7 +61,6 @@ class TasksSyncManager @AssistedInject constructor(
     interface Factory {
         fun tasksSyncManager(
             account: Account,
-            accountSettings: AccountSettings,
             httpClient: HttpClient,
             extras: Array<String>,
             authority: String,

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/NextcloudLoginModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/NextcloudLoginModel.kt
@@ -26,8 +26,8 @@ import java.util.logging.Logger
 class NextcloudLoginModel @AssistedInject constructor(
     @Assisted val initialLoginInfo: LoginInfo,
     @ApplicationContext val context: Context,
-    private val logger: Logger
-    //val state: SavedStateHandle
+    private val logger: Logger,
+    private val loginFlow: NextcloudLoginFlow
 ): ViewModel() {
 
     @AssistedFactory
@@ -89,8 +89,6 @@ class NextcloudLoginModel @AssistedInject constructor(
     fun updateBaseUrl(baseUrl: String) {
         uiState = uiState.copy(baseUrl = baseUrl)
     }
-
-    val loginFlow = NextcloudLoginFlow(context)
 
     // Login flow state
     /*private var pollUrl: HttpUrl?

--- a/app/src/main/kotlin/at/bitfire/davdroid/webdav/DavDocumentsProvider.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/webdav/DavDocumentsProvider.kt
@@ -725,7 +725,7 @@ class DavDocumentsProvider: DocumentsProvider() {
          */
         internal fun httpClient(mountId: Long, logBody: Boolean = true): HttpClient {
             val builder = httpClientBuilder.get()
-                .setLoggerLevel(if (logBody) HttpLoggingInterceptor.Level.BODY else HttpLoggingInterceptor.Level.HEADERS)
+                .loggerInterceptorLevel(if (logBody) HttpLoggingInterceptor.Level.BODY else HttpLoggingInterceptor.Level.HEADERS)
                 .setCookieStore(
                     cookieStores.getOrPut(mountId) { MemoryCookieStore() }
                 )

--- a/app/src/main/kotlin/at/bitfire/davdroid/webdav/DavDocumentsProvider.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/webdav/DavDocumentsProvider.kt
@@ -77,6 +77,7 @@ import java.net.HttpURLConnection
 import java.util.concurrent.ConcurrentHashMap
 import java.util.logging.Level
 import java.util.logging.Logger
+import javax.inject.Provider
 
 /**
  * Provides functionality on WebDav documents.
@@ -633,7 +634,7 @@ class DavDocumentsProvider: DocumentsProvider() {
         @Assisted private val credentialsStore: CredentialsStore,
         @ApplicationContext private val context: Context,
         private val db: AppDatabase,
-        private val httpClientBuilder: HttpClient.Builder,
+        private val httpClientBuilder: Provider<HttpClient.Builder>,
         private val logger: Logger
     ) {
 
@@ -723,7 +724,7 @@ class DavDocumentsProvider: DocumentsProvider() {
          * @param logBody    whether to log the body of HTTP requests (disable for potentially large files)
          */
         internal fun httpClient(mountId: Long, logBody: Boolean = true): HttpClient {
-            val builder = httpClientBuilder
+            val builder = httpClientBuilder.get()
                 .setLoggerLevel(if (logBody) HttpLoggingInterceptor.Level.BODY else HttpLoggingInterceptor.Level.HEADERS)
                 .setCookieStore(
                     cookieStores.getOrPut(mountId) { MemoryCookieStore() }

--- a/app/src/main/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallbackWrapper.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallbackWrapper.kt
@@ -12,7 +12,6 @@ import android.os.HandlerThread
 import android.os.ProxyFileDescriptorCallback
 import androidx.annotation.RequiresApi
 import at.bitfire.davdroid.network.HttpClient
-import at.bitfire.davdroid.webdav.RandomAccessCallbackWrapper.Companion.TIMEOUT_INTERVAL
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject


### PR DESCRIPTION
`HttpClient.Builder` was a bit unclean and didn't use DI.

This PR attempts to bring `HttpClient.Builder` to the current architecture pattern.

Also it removes support for the deprecated TLS 1.0 and 1.1 (#1249).