### PR TITLE
MKCALENDAR does not send valid calendar-timezone

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
@@ -28,6 +28,7 @@ import at.bitfire.davdroid.network.HttpClient
 import at.bitfire.davdroid.servicedetection.RefreshCollectionsWorker
 import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.util.DavUtils
+import at.bitfire.ical4android.ICalendar
 import at.bitfire.ical4android.util.DateUtils
 import dagger.Lazy
 import dagger.Module
@@ -41,7 +42,10 @@ import kotlinx.coroutines.withContext
 import net.fortuna.ical4j.model.Calendar
 import net.fortuna.ical4j.model.Component
 import net.fortuna.ical4j.model.ComponentList
+import net.fortuna.ical4j.model.Property
+import net.fortuna.ical4j.model.PropertyList
 import net.fortuna.ical4j.model.component.VTimeZone
+import net.fortuna.ical4j.model.property.Version
 import okhttp3.HttpUrl
 import java.io.StringWriter
 import java.util.Collections
@@ -375,7 +379,15 @@ class DavCollectionRepository @Inject constructor(
                                 insertTag(CalendarTimezone.NAME) {
                                     text(
                                         // spec requires "an iCalendar object with exactly one VTIMEZONE component"
-                                        Calendar(ComponentList(listOf(vTimezone))).toString()
+                                        Calendar(
+                                            PropertyList<Property>().apply {
+                                                add(ICalendar.prodId)
+                                                add(Version.VERSION_2_0)
+                                            },
+                                            ComponentList(
+                                                listOf(vTimezone)
+                                            )
+                                        ).toString()
                                     )
                                 }
                             }


### PR DESCRIPTION
### Purpose

See #1246.

### Short description

Added `ProdId` and `Version` to the generated `VCALENDAR`.

Test request:
```xml
<?xml version='1.0' encoding='UTF-8' ?>
<CAL:mkcalendar
	xmlns="DAV:"
	xmlns:CAL="urn:ietf:params:xml:ns:caldav"
	xmlns:CARD="urn:ietf:params:xml:ns:carddav">
	<set>
		<prop>
			<resourcetype>
				<collection />
				<CAL:calendar />
			</resourcetype>
			<displayname>At Cairo</displayname>
			<CAL:calendar-description></CAL:calendar-description>
			<n0:calendar-color
				xmlns:n0="http://apple.com/ns/ical/">#0000CDFF
			</n0:calendar-color>
			<CAL:calendar-timezone-id>Africa/Cairo</CAL:calendar-timezone-id>
			<CAL:calendar-timezone>BEGIN:VCALENDAR
                 PRODID:+//IDN bitfire.at//ical4android
                 VERSION:2.0
                 BEGIN:VTIMEZONE
                 TZID:Africa/Cairo
                 LAST-MODIFIED:20240422T053450Z
                 TZURL:https://www.tzurl.org/zoneinfo/Africa/Cairo
                 X-LIC-LOCATION:Africa/Cairo
                 X-PROLEPTIC-TZNAME:LMT
                 BEGIN:STANDARD
                 TZNAME:EET
                 TZOFFSETFROM:+020509
                 TZOFFSETTO:+0200
                 DTSTART:19001001T011444
                 END:STANDARD
                 BEGIN:DAYLIGHT
                 TZNAME:EEST
                 TZOFFSETFROM:+0200
                 TZOFFSETTO:+0300
                 DTSTART:19400715T000000
                 RDATE:19410415T000000
                 RDATE:19450416T000000
                 RDATE:19570510T000000
                 RDATE:19580501T000000
                 RDATE:19820725T010000
                 RDATE:19830712T010000
                 RDATE:19890506T010000
                 RDATE:20100910T000000
                 RDATE:20140516T000000
                 RDATE:20140801T000000
                 END:DAYLIGHT
                 BEGIN:STANDARD
                 TZNAME:EET
                 TZOFFSETFROM:+0300
                 TZOFFSETTO:+0200
                 DTSTART:19401001T000000
                 RDATE:19410916T000000
                 RDATE:19421027T000000
                 RDATE:20060922T000000
                 RDATE:20070907T000000
                 RDATE:20080829T000000
                 RDATE:20090821T000000
                 RDATE:20100811T000000
                 RDATE:20101001T000000
                 RDATE:20140627T000000
                 RDATE:20140926T000000
                 END:STANDARD
                 BEGIN:DAYLIGHT
                 TZNAME:EEST
                 TZOFFSETFROM:+0200
                 TZOFFSETTO:+0300
                 DTSTART:19420401T000000
                 RRULE:FREQ=YEARLY;UNTIL=19440331T220000Z
                 END:DAYLIGHT
                 BEGIN:STANDARD
                 TZNAME:EET
                 TZOFFSETFROM:+0300
                 TZOFFSETTO:+0200
                 DTSTART:19431101T000000
                 RRULE:FREQ=YEARLY;UNTIL=19451031T210000Z
                 END:STANDARD
                 BEGIN:STANDARD
                 TZNAME:EET
                 TZOFFSETFROM:+0300
                 TZOFFSETTO:+0200
                 DTSTART:19571001T000000
                 RRULE:FREQ=YEARLY;UNTIL=19580930T210000Z
                 END:STANDARD
                 BEGIN:DAYLIGHT
                 TZNAME:EEST
                 TZOFFSETFROM:+0200
                 TZOFFSETTO:+0300
                 DTSTART:19590501T010000
                 RRULE:FREQ=YEARLY;UNTIL=19810430T230000Z
                 END:DAYLIGHT
                 BEGIN:STANDARD
                 TZNAME:EET
                 TZOFFSETFROM:+0300
                 TZOFFSETTO:+0200
                 DTSTART:19590930T030000
                 RRULE:FREQ=YEARLY;UNTIL=19650930T000000Z
                 END:STANDARD
                 BEGIN:STANDARD
                 TZNAME:EET
                 TZOFFSETFROM:+0300
                 TZOFFSETTO:+0200
                 DTSTART:19661001T030000
                 RRULE:FREQ=YEARLY;UNTIL=19941001T000000Z
                 END:STANDARD
                 BEGIN:DAYLIGHT
                 TZNAME:EEST
                 TZOFFSETFROM:+0200
                 TZOFFSETTO:+0300
                 DTSTART:19840501T010000
                 RRULE:FREQ=YEARLY;UNTIL=19880430T230000Z
                 END:DAYLIGHT
                 BEGIN:DAYLIGHT
                 TZNAME:EEST
                 TZOFFSETFROM:+0200
                 TZOFFSETTO:+0300
                 DTSTART:19900501T010000
                 RRULE:FREQ=YEARLY;UNTIL=19940430T230000Z
                 END:DAYLIGHT
                 BEGIN:DAYLIGHT
                 TZNAME:EEST
                 TZOFFSETFROM:+0200
                 TZOFFSETTO:+0300
                 DTSTART:19950428T000000
                 RRULE:FREQ=YEARLY;UNTIL=20100429T220000Z;BYMONTH=4;BYDAY=-1FR
                 END:DAYLIGHT
                 BEGIN:STANDARD
                 TZNAME:EET
                 TZOFFSETFROM:+0300
                 TZOFFSETTO:+0200
                 DTSTART:19950929T000000
                 RRULE:FREQ=YEARLY;UNTIL=20050929T210000Z;BYYEARDAY=-92,-93,-94,-95,-96,-97,-98;BYDAY=FR
                 END:STANDARD
                 BEGIN:DAYLIGHT
                 TZNAME:EEST
                 TZOFFSETFROM:+0200
                 TZOFFSETTO:+0300
                 DTSTART:20230428T000000
                 RRULE:FREQ=YEARLY;BYMONTH=4;BYDAY=-1FR
                 END:DAYLIGHT
                 BEGIN:STANDARD
                 TZNAME:EET
                 TZOFFSETFROM:+0300
                 TZOFFSETTO:+0200
                 DTSTART:20231027T000000
                 RRULE:FREQ=YEARLY;BYYEARDAY=-61,-62,-63,-64,-65,-66,-67;BYDAY=FR
                 END:STANDARD
                 END:VTIMEZONE
                 END:VCALENDAR
                 </CAL:calendar-timezone>
		</prop>
	</set>
</CAL:mkcalendar>
```

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

