### PR TITLE
Use DB StringDefs also in DAOs and methods where they are used

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/db/CollectionDao.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/db/CollectionDao.kt
@@ -30,13 +30,13 @@ interface CollectionDao {
     fun getByServiceAndHomeset(serviceId: Long, homeSetId: Long?): List<Collection>
 
     @Query("SELECT * FROM collection WHERE serviceId=:serviceId AND type=:type ORDER BY displayName COLLATE NOCASE, url COLLATE NOCASE")
-    fun getByServiceAndType(serviceId: Long, type: String): List<Collection>
+    fun getByServiceAndType(serviceId: Long, @CollectionType type: String): List<Collection>
 
     @Query("SELECT * FROM collection WHERE pushTopic=:topic AND sync")
     fun getSyncableByPushTopic(topic: String): Collection?
 
     @Query("SELECT COUNT(*) FROM collection WHERE serviceId=:serviceId AND type=:type")
-    suspend fun anyOfType(serviceId: Long, type: String): Boolean
+    suspend fun anyOfType(serviceId: Long, @CollectionType type: String): Boolean
 
     @Query("SELECT COUNT(*) FROM collection WHERE supportsWebPush AND pushTopic IS NOT NULL")
     suspend fun anyPushCapable(): Boolean
@@ -48,13 +48,13 @@ interface CollectionDao {
      */
     @Query("SELECT * FROM collection WHERE serviceId=:serviceId AND type=:type " +
             "AND (supportsVTODO OR supportsVEVENT OR supportsVJOURNAL OR (supportsVEVENT IS NULL AND supportsVTODO IS NULL AND supportsVJOURNAL IS NULL)) ORDER BY displayName COLLATE NOCASE, URL COLLATE NOCASE")
-    fun pageByServiceAndType(serviceId: Long, type: String): PagingSource<Int, Collection>
+    fun pageByServiceAndType(serviceId: Long, @CollectionType type: String): PagingSource<Int, Collection>
 
     @Query("SELECT * FROM collection WHERE serviceId=:serviceId AND sync")
     fun getByServiceAndSync(serviceId: Long): List<Collection>
 
     @Query("SELECT collection.* FROM collection, homeset WHERE collection.serviceId=:serviceId AND type=:type AND homeSetId=homeset.id AND homeset.personal ORDER BY collection.displayName COLLATE NOCASE, collection.url COLLATE NOCASE")
-    fun pagePersonalByServiceAndType(serviceId: Long, type: String): PagingSource<Int, Collection>
+    fun pagePersonalByServiceAndType(serviceId: Long, @CollectionType type: String): PagingSource<Int, Collection>
 
     @Query("SELECT * FROM collection WHERE serviceId=:serviceId AND url=:url")
     fun getByServiceAndUrl(serviceId: Long, url: String): Collection?

--- a/app/src/main/kotlin/at/bitfire/davdroid/db/HomeSetDao.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/db/HomeSetDao.kt
@@ -24,7 +24,7 @@ interface HomeSetDao {
     fun getByService(serviceId: Long): List<HomeSet>
 
     @Query("SELECT * FROM homeset WHERE serviceId=(SELECT id FROM service WHERE accountName=:accountName AND type=:serviceType) AND privBind ORDER BY displayName, url COLLATE NOCASE")
-    fun getBindableByAccountAndServiceTypeFlow(accountName: String, serviceType: String): Flow<List<HomeSet>>
+    fun getBindableByAccountAndServiceTypeFlow(accountName: String, @ServiceType serviceType: String): Flow<List<HomeSet>>
 
     @Query("SELECT * FROM homeset WHERE serviceId=:serviceId AND privBind")
     fun getBindableByServiceFlow(serviceId: Long): Flow<List<HomeSet>>

--- a/app/src/main/kotlin/at/bitfire/davdroid/db/ServiceDao.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/db/ServiceDao.kt
@@ -14,10 +14,10 @@ import kotlinx.coroutines.flow.Flow
 interface ServiceDao {
 
     @Query("SELECT * FROM service WHERE accountName=:accountName AND type=:type")
-    fun getByAccountAndType(accountName: String, type: String): Service?
+    fun getByAccountAndType(accountName: String, @ServiceType type: String): Service?
 
     @Query("SELECT * FROM service WHERE accountName=:accountName AND type=:type")
-    fun getByAccountAndTypeFlow(accountName: String, type: String): Flow<Service?>
+    fun getByAccountAndTypeFlow(accountName: String, @ServiceType type: String): Flow<Service?>
 
     @Query("SELECT id FROM service WHERE accountName=:accountName")
     suspend fun getIdsByAccountAsync(accountName: String): List<Long>

--- a/app/src/main/kotlin/at/bitfire/davdroid/repository/AccountRepository.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/repository/AccountRepository.kt
@@ -13,6 +13,7 @@ import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.Credentials
 import at.bitfire.davdroid.db.HomeSet
 import at.bitfire.davdroid.db.Service
+import at.bitfire.davdroid.db.ServiceType
 import at.bitfire.davdroid.resource.LocalAddressBookStore
 import at.bitfire.davdroid.resource.LocalCalendarStore
 import at.bitfire.davdroid.servicedetection.DavResourceFinder
@@ -247,7 +248,7 @@ class AccountRepository @Inject constructor(
 
     // helpers
 
-    private fun insertService(accountName: String, type: String, info: DavResourceFinder.Configuration.ServiceInfo): Long {
+    private fun insertService(accountName: String, @ServiceType type: String, info: DavResourceFinder.Configuration.ServiceInfo): Long {
         // insert service
         val service = Service(0, accountName, type, info.principal)
         val serviceId = serviceRepository.insertOrReplace(service)

--- a/app/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
@@ -23,6 +23,7 @@ import at.bitfire.dav4jvm.property.webdav.ResourceType
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.Collection
+import at.bitfire.davdroid.db.CollectionType
 import at.bitfire.davdroid.db.HomeSet
 import at.bitfire.davdroid.network.HttpClient
 import at.bitfire.davdroid.servicedetection.RefreshCollectionsWorker
@@ -248,10 +249,10 @@ class DavCollectionRepository @Inject constructor(
         notifyOnChangeListeners()
     }
 
-    fun pageByServiceAndType(serviceId: Long, type: String) =
+    fun pageByServiceAndType(serviceId: Long, @CollectionType type: String) =
         dao.pageByServiceAndType(serviceId, type)
 
-    fun pagePersonalByServiceAndType(serviceId: Long, type: String) =
+    fun pagePersonalByServiceAndType(serviceId: Long, @CollectionType type: String) =
         dao.pagePersonalByServiceAndType(serviceId, type)
 
     /**

--- a/app/src/main/kotlin/at/bitfire/davdroid/repository/DavServiceRepository.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/repository/DavServiceRepository.kt
@@ -6,6 +6,7 @@ package at.bitfire.davdroid.repository
 
 import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.Service
+import at.bitfire.davdroid.db.ServiceType
 import javax.inject.Inject
 
 class DavServiceRepository @Inject constructor(
@@ -19,7 +20,7 @@ class DavServiceRepository @Inject constructor(
 
     fun get(id: Long): Service? = dao.get(id)
 
-    fun getByAccountAndType(name: String, serviceType: String): Service? =
+    fun getByAccountAndType(name: String, @ServiceType serviceType: String): Service? =
         dao.getByAccountAndType(name, serviceType)
 
     fun getCalDavServiceFlow(accountName: String) =

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
@@ -11,6 +11,7 @@ import android.os.DeadObjectException
 import androidx.annotation.VisibleForTesting
 import at.bitfire.davdroid.InvalidAccountException
 import at.bitfire.davdroid.db.Collection
+import at.bitfire.davdroid.db.ServiceType
 import at.bitfire.davdroid.network.HttpClient
 import at.bitfire.davdroid.repository.DavCollectionRepository
 import at.bitfire.davdroid.repository.DavServiceRepository
@@ -82,6 +83,7 @@ abstract class Syncer<StoreType: LocalDataStore<CollectionType>, CollectionType:
     lateinit var serviceRepository: DavServiceRepository
 
     abstract val authority: String
+    @ServiceType
     abstract val serviceType: String
 
     val accountSettings by lazy { accountSettingsFactory.create(account) }

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/GetServiceCollectionPagerUseCase.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/GetServiceCollectionPagerUseCase.kt
@@ -9,6 +9,7 @@ import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.map
 import at.bitfire.davdroid.db.Collection
+import at.bitfire.davdroid.db.CollectionType
 import at.bitfire.davdroid.db.Service
 import at.bitfire.davdroid.repository.DavCollectionRepository
 import at.bitfire.davdroid.settings.AccountSettings
@@ -42,12 +43,12 @@ class GetServiceCollectionPagerUseCase @Inject constructor(
     @OptIn(ExperimentalCoroutinesApi::class)
     operator fun invoke(
         serviceFlow: Flow<Service?>,
-        collectionType: String,
+        @CollectionType collectionType: String,
         showOnlyPersonalFlow: Flow<AccountSettings.ShowOnlyPersonal?>
     ): Flow<PagingData<Collection>> =
         combine(serviceFlow, showOnlyPersonalFlow, forceReadOnlyAddressBooksFlow) { service, onlyPersonal, forceReadOnlyAddressBooks ->
             if (service == null)
-                flowOf(PagingData.empty<Collection>())
+                flowOf(PagingData.empty())
             else {
                 val dataFlow = Pager(
                     config = PagingConfig(PAGER_SIZE),


### PR DESCRIPTION
### Purpose

In https://github.com/bitfireAT/davx5-ose/issues/1225 we have introduced @StringDefs for database fields. We should also use them in function calls.

### Short description

- Annotated arguments that use the annotations in the DAOs.
- Annotated all usages as well.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

