### PR TITLE
Change warning when Internet is not available

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -122,7 +122,7 @@
   <string name="navigation_drawer_contribute">Einen Beitrag leisten</string>
   <string name="navigation_drawer_privacy_policy">Datenschutzerklärung</string>
   <string name="account_list_no_notification_permission">Benachrichtigungen deaktiviert. Sie werden nicht über Fehler bei der Synchronisierung informiert.</string>
-  <string name="account_list_no_internet">Keine überprüfte Internetverbindung. Synchronisierung funktioniert eventuell nicht.</string>
+  <string name="account_list_no_internet">Automatische Synchronisierung nicht aktiv (keine überprüfte Internetverbindung).</string>
   <string name="account_list_manage_connections">Verbindungen steuern</string>
   <string name="account_list_datasaver_enabled">Datensparen aktiviert. Hintergrundsynchronisierung ist eingeschränkt.</string>
   <string name="account_list_manage_datasaver">Datensparen verwalten</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -133,7 +133,7 @@
     <string name="navigation_drawer_contribute">How to contribute</string>
     <string name="navigation_drawer_privacy_policy">Privacy policy</string>
     <string name="account_list_no_notification_permission">Notifications disabled. You won\'t be notified about sync errors.</string>
-    <string name="account_list_no_internet">No validated Internet connectivity. Synchronization may not run.</string>
+    <string name="account_list_no_internet">Automatic synchronization not active (no verified Internet connection).</string>
     <string name="account_list_manage_connections">Manage connections</string>
     <string name="account_list_datasaver_enabled">Data saver enabled. Background synchronization is restricted.</string>
     <string name="account_list_manage_datasaver">Manage data saver</string>


### PR DESCRIPTION
Please delete this paragraph and other repeating text (like the examples) after reading and before submitting the PR.

### Purpose

Currently the warning says "No validated Internet connectivity. Synchronization may not run.", however it's not "maybe", but it will **certainly** not work. So we should use a better warning text.

### Short description

Add new warning text in english and german
- Automatic synchronization not active (no verified Internet connection)
- Automatische Synchronisierung nicht aktiv (keine überprüfte Internetverbindung)

### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [ ] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.

