### PR TITLE
Replaced `LocalContext` casting with `LocalActivity`

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/composable/SelectClientCertificateCard.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/composable/SelectClientCertificateCard.kt
@@ -4,9 +4,9 @@
 
 package at.bitfire.davdroid.ui.composable
 
-import android.app.Activity
 import android.os.Build
 import android.security.KeyChain
+import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Card
@@ -19,7 +19,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -46,7 +45,7 @@ fun SelectClientCertificateCard(
                 modifier = Modifier.padding(8.dp)
             )
 
-            val activity = LocalContext.current as? Activity
+            val activity = LocalActivity.current
             val scope = rememberCoroutineScope()
             OutlinedButton(
                 enabled = enabled,


### PR DESCRIPTION
### Purpose

In activity-compose 1.10.0 Google has introduced `LocalActivity` and discourages the use of `LocalContext.current as? Activity`.

### Short description

Replaced the usage we have of
```kotlin
LocalContext.current as? Activity
```
with
```kotlin
LocalActivity.current
```

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

