### PR TITLE
[CI] Use if: !cancelled() instead of if: always()

### DIFF
--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -30,7 +30,7 @@ jobs:
 
   test:
     needs: compile
-    if: ${{ always() }}     # even if compile didn't run (because not on main branch)
+    if: ${{ !cancelled() }}     # even if compile didn't run (because not on main branch)
     name: Lint and unit tests
     runs-on: ubuntu-latest
     steps:
@@ -51,7 +51,7 @@ jobs:
 
   test_on_emulator:
     needs: compile
-    if: ${{ always() }}     # even if compile didn't run (because not on main branch)
+    if: ${{ !cancelled() }}     # even if compile didn't run (because not on main branch)
     name: Instrumented tests
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Currently tests (like instrumented tests) are not cancellable. This is especially annoying when there's a problem test causes tests to run indefinitely, like [here](https://github.com/bitfireAT/davx5-ose/actions/runs/12967568852). I think it will time out somewhen but until then it blocks one of our runners.

Seems to be caused by recent Github changes: https://github.com/orgs/community/discussions/26303

To make test jobs cancellable, see https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#always

I have cancelled the Instrumented tests job to test it, and it worked.

CC @euuurgh because it's CI