### PR TITLE
Skip login type selection when logging in via intent

### DIFF
--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/ui/setup/LoginActivityTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/ui/setup/LoginActivityTest.kt
@@ -55,7 +55,7 @@ class LoginActivityTest {
     fun loginInfoFromIntent_implicit_email() {
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse("mailto:user@example.com"))
         val loginInfo = LoginActivity.loginInfoFromIntent(intent)
-        assertEquals(null, loginInfo.baseUri.toString())
+        assertEquals(null, loginInfo.baseUri)
         assertEquals("user@example.com", loginInfo.credentials!!.username)
         assertEquals(null, loginInfo.credentials.password)
     }

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/ui/setup/LoginActivityTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/ui/setup/LoginActivityTest.kt
@@ -50,4 +50,14 @@ class LoginActivityTest {
         assertEquals("user", loginInfo.credentials!!.username)
         assertEquals("password", loginInfo.credentials.password)
     }
+
+    @Test
+    fun loginInfoFromIntent_implicit_email() {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("mailto:user@example.com"))
+        val loginInfo = LoginActivity.loginInfoFromIntent(intent)
+        assertEquals(null, loginInfo.baseUri.toString())
+        assertEquals("user@example.com", loginInfo.credentials!!.username)
+        assertEquals(null, loginInfo.credentials.password)
+    }
+    
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginActivity.kt
@@ -85,9 +85,16 @@ class LoginActivity @Inject constructor(): AppCompatActivity() {
             var givenUsername: String? = null
             var givenPassword: String? = null
 
-            // extract URI and optionally username/password from Intent data
+            // extract URI or Email and optionally username/password from Intent data
             val logger = Logger.getGlobal()
             intent.data?.normalizeScheme()?.let { uri ->
+                // Handle mailto scheme: extract user info
+                if (uri.scheme == "mailto") {
+                    givenUsername = uri.schemeSpecificPart
+                    return@let
+                }
+
+                // Handle URLs
                 try {
                     // replace caldav[s]:// and carddav[s]:// with http[s]://
                     val realScheme = when (uri.scheme) {

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginActivity.kt
@@ -28,7 +28,8 @@ class LoginActivity @Inject constructor(): AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val (initialLoginType, skipLoginTypePage) = loginTypesProvider.intentToInitialLoginType(intent)
+        val initialLoginType = loginTypesProvider.intentToInitialLoginType(intent)
+        val skipLoginTypePage = initialLoginType != loginTypesProvider.defaultLoginType
 
         setContent {
             LoginScreen(
@@ -88,7 +89,7 @@ class LoginActivity @Inject constructor(): AppCompatActivity() {
             // extract URI or Email and optionally username/password from Intent data
             val logger = Logger.getGlobal()
             intent.data?.normalizeScheme()?.let { uri ->
-                // Handle mailto scheme: extract user info
+                // Handle mailto scheme
                 if (uri.scheme == "mailto") {
                     givenUsername = uri.schemeSpecificPart
                     return@let

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginActivity.kt
@@ -28,8 +28,7 @@ class LoginActivity @Inject constructor(): AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val initialLoginType = loginTypesProvider.intentToInitialLoginType(intent)
-        val skipLoginTypePage = initialLoginType != loginTypesProvider.defaultLoginType
+        val (initialLoginType, skipLoginTypePage) = loginTypesProvider.intentToInitialLoginType(intent)
 
         setContent {
             LoginScreen(

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginActivity.kt
@@ -23,6 +23,32 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class LoginActivity @Inject constructor(): AppCompatActivity() {
 
+    @Inject lateinit var loginTypesProvider: LoginTypesProvider
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val (initialLoginType, skipLoginTypePage) = loginTypesProvider.intentToInitialLoginType(intent)
+
+        setContent {
+            LoginScreen(
+                initialLoginType = initialLoginType,
+                skipLoginTypePage = skipLoginTypePage,
+                initialLoginInfo = loginInfoFromIntent(intent),
+                onNavUp = { onSupportNavigateUp() },
+                onFinish = { newAccount ->
+                    finish()
+
+                    if (newAccount != null) {
+                        val intent = Intent(this, AccountActivity::class.java)
+                        intent.putExtra(AccountActivity.EXTRA_ACCOUNT, newAccount)
+                        startActivity(intent)
+                    }
+                }
+            )
+        }
+    }
+
     companion object {
 
         /**
@@ -112,32 +138,6 @@ class LoginActivity @Inject constructor(): AppCompatActivity() {
             )
         }
 
-    }
-
-    @Inject lateinit var loginTypesProvider: LoginTypesProvider
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-        val (initialLoginType, skipLoginTypePage) = loginTypesProvider.intentToInitialLoginType(intent)
-
-        setContent {
-            LoginScreen(
-                initialLoginType = initialLoginType,
-                skipLoginTypePage = skipLoginTypePage,
-                initialLoginInfo = loginInfoFromIntent(intent),
-                onNavUp = { onSupportNavigateUp() },
-                onFinish = { newAccount ->
-                    finish()
-
-                    if (newAccount != null) {
-                        val intent = Intent(this, AccountActivity::class.java)
-                        intent.putExtra(AccountActivity.EXTRA_ACCOUNT, newAccount)
-                        startActivity(intent)
-                    }
-                }
-            )
-        }
     }
 
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginTypesProvider.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginTypesProvider.kt
@@ -16,7 +16,7 @@ interface LoginTypesProvider {
      * Which login type to use and whether to skip the login type selection page. Used for Nextcloud
      * login flow. May be used by other login flows.
      */
-    fun intentToInitialLoginType(intent: Intent): Pair<LoginType, Boolean> = Pair(defaultLoginType, false)
+    fun intentToInitialLoginType(intent: Intent): LoginType = defaultLoginType
 
     /** Whether the [LoginTypePage] may be non-interactive. This causes it to be skipped in back navigation. */
     val maybeNonInteractive: Boolean

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginTypesProvider.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginTypesProvider.kt
@@ -13,8 +13,7 @@ interface LoginTypesProvider {
     val defaultLoginType: LoginType
 
     /**
-     * Which login type to use and whether to skip the login type selection page. Used for Nextcloud
-     * login flow. May be used by other login flows.
+     * Which login type to use. Used for Nextcloud login flow and may be used for other intent started flows.
      */
     fun intentToInitialLoginType(intent: Intent): LoginType = defaultLoginType
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginTypesProvider.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginTypesProvider.kt
@@ -10,13 +10,18 @@ import androidx.compose.runtime.Composable
 
 interface LoginTypesProvider {
 
+    data class LoginAction(
+        val loginType: LoginType,
+        val skipLoginTypePage: Boolean
+    )
+
     val defaultLoginType: LoginType
 
     /**
      * Which login type to use and whether to skip the login type page. Used for Nextcloud login
      * flow and may be used for other intent started flows.
      */
-    fun intentToInitialLoginType(intent: Intent): Pair<LoginType, Boolean> = Pair(defaultLoginType, false)
+    fun intentToInitialLoginType(intent: Intent): LoginAction = LoginAction(defaultLoginType, false)
 
     /** Whether the [LoginTypePage] may be non-interactive. This causes it to be skipped in back navigation. */
     val maybeNonInteractive: Boolean

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginTypesProvider.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginTypesProvider.kt
@@ -13,9 +13,10 @@ interface LoginTypesProvider {
     val defaultLoginType: LoginType
 
     /**
-     * Which login type to use. Used for Nextcloud login flow and may be used for other intent started flows.
+     * Which login type to use and whether to skip the login type page. Used for Nextcloud login
+     * flow and may be used for other intent started flows.
      */
-    fun intentToInitialLoginType(intent: Intent): LoginType = defaultLoginType
+    fun intentToInitialLoginType(intent: Intent): Pair<LoginType, Boolean> = Pair(defaultLoginType, false)
 
     /** Whether the [LoginTypePage] may be non-interactive. This causes it to be skipped in back navigation. */
     val maybeNonInteractive: Boolean

--- a/app/src/ose/kotlin/at/bitfire/davdroid/ui/setup/StandardLoginTypesProvider.kt
+++ b/app/src/ose/kotlin/at/bitfire/davdroid/ui/setup/StandardLoginTypesProvider.kt
@@ -27,13 +27,13 @@ class StandardLoginTypesProvider @Inject constructor() : LoginTypesProvider {
     override val defaultLoginType = UrlLogin
 
     override fun intentToInitialLoginType(intent: Intent): LoginType =
-        intent.data?.normalizeScheme().toString().let { uri ->
+        intent.data?.normalizeScheme().let { uri ->
             when {
                 intent.hasExtra(LoginActivity.EXTRA_LOGIN_FLOW) ->
                     NextcloudLogin
-                uri.startsWith("mailto:") ->
+                uri?.scheme == "mailto" ->
                     EmailLogin
-                listOf("caldavs", "carddavs", "davx5", "http", "https").any { uri.startsWith(it) } ->
+                listOf("caldavs", "carddavs", "davx5", "http", "https").any { uri?.scheme == it } ->
                     UrlLogin
                 else ->
                     defaultLoginType

--- a/app/src/ose/kotlin/at/bitfire/davdroid/ui/setup/StandardLoginTypesProvider.kt
+++ b/app/src/ose/kotlin/at/bitfire/davdroid/ui/setup/StandardLoginTypesProvider.kt
@@ -26,17 +26,17 @@ class StandardLoginTypesProvider @Inject constructor() : LoginTypesProvider {
 
     override val defaultLoginType = UrlLogin
 
-    override fun intentToInitialLoginType(intent: Intent): LoginType =
+    override fun intentToInitialLoginType(intent: Intent): Pair<LoginType, Boolean> =
         intent.data?.normalizeScheme().let { uri ->
             when {
                 intent.hasExtra(LoginActivity.EXTRA_LOGIN_FLOW) ->
-                    NextcloudLogin
+                    Pair(NextcloudLogin, true)
                 uri?.scheme == "mailto" ->
-                    EmailLogin
+                    Pair(EmailLogin, true)
                 listOf("caldavs", "carddavs", "davx5", "http", "https").any { uri?.scheme == it } ->
-                    UrlLogin
+                    Pair(UrlLogin, true)
                 else ->
-                    defaultLoginType
+                    Pair(defaultLoginType, false) // Don't skip login type page if intent is unclear
             }
         }
 

--- a/app/src/ose/kotlin/at/bitfire/davdroid/ui/setup/StandardLoginTypesProvider.kt
+++ b/app/src/ose/kotlin/at/bitfire/davdroid/ui/setup/StandardLoginTypesProvider.kt
@@ -7,9 +7,12 @@ package at.bitfire.davdroid.ui.setup
 import android.content.Intent
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
+import java.util.logging.Logger
 import javax.inject.Inject
 
-class StandardLoginTypesProvider @Inject constructor() : LoginTypesProvider {
+class StandardLoginTypesProvider @Inject constructor(
+    private val logger: Logger
+) : LoginTypesProvider {
 
     companion object {
         val genericLoginTypes = listOf(
@@ -35,8 +38,10 @@ class StandardLoginTypesProvider @Inject constructor() : LoginTypesProvider {
                     Pair(EmailLogin, true)
                 listOf("caldavs", "carddavs", "davx5", "http", "https").any { uri?.scheme == it } ->
                     Pair(UrlLogin, true)
-                else ->
+                else -> {
+                    logger.warning("Did not understand login intent: $intent")
                     Pair(defaultLoginType, false) // Don't skip login type page if intent is unclear
+                }
             }
         }
 

--- a/app/src/ose/kotlin/at/bitfire/davdroid/ui/setup/StandardLoginTypesProvider.kt
+++ b/app/src/ose/kotlin/at/bitfire/davdroid/ui/setup/StandardLoginTypesProvider.kt
@@ -7,6 +7,7 @@ package at.bitfire.davdroid.ui.setup
 import android.content.Intent
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
+import at.bitfire.davdroid.ui.setup.LoginTypesProvider.LoginAction
 import java.util.logging.Logger
 import javax.inject.Inject
 
@@ -29,18 +30,18 @@ class StandardLoginTypesProvider @Inject constructor(
 
     override val defaultLoginType = UrlLogin
 
-    override fun intentToInitialLoginType(intent: Intent): Pair<LoginType, Boolean> =
+    override fun intentToInitialLoginType(intent: Intent): LoginAction =
         intent.data?.normalizeScheme().let { uri ->
             when {
                 intent.hasExtra(LoginActivity.EXTRA_LOGIN_FLOW) ->
-                    Pair(NextcloudLogin, true)
+                    LoginAction(NextcloudLogin, true)
                 uri?.scheme == "mailto" ->
-                    Pair(EmailLogin, true)
+                    LoginAction(EmailLogin, true)
                 listOf("caldavs", "carddavs", "davx5", "http", "https").any { uri?.scheme == it } ->
-                    Pair(UrlLogin, true)
+                    LoginAction(UrlLogin, true)
                 else -> {
                     logger.warning("Did not understand login intent: $intent")
-                    Pair(defaultLoginType, false) // Don't skip login type page if intent is unclear
+                    LoginAction(defaultLoginType, false) // Don't skip login type page if intent is unclear
                 }
             }
         }

--- a/app/src/ose/kotlin/at/bitfire/davdroid/ui/setup/StandardLoginTypesProvider.kt
+++ b/app/src/ose/kotlin/at/bitfire/davdroid/ui/setup/StandardLoginTypesProvider.kt
@@ -26,21 +26,17 @@ class StandardLoginTypesProvider @Inject constructor() : LoginTypesProvider {
 
     override val defaultLoginType = UrlLogin
 
-    override fun intentToInitialLoginType(intent: Intent): Pair<LoginType, Boolean> =
+    override fun intentToInitialLoginType(intent: Intent): LoginType =
         intent.data?.normalizeScheme().toString().let { uri ->
             when {
                 intent.hasExtra(LoginActivity.EXTRA_LOGIN_FLOW) ->
-                    Pair(NextcloudLogin, true)
+                    NextcloudLogin
                 uri.startsWith("mailto:") ->
-                    Pair(EmailLogin, true)
-                uri.startsWith("caldavs")
-                    || uri.startsWith("carddavs")
-                    || uri.startsWith("davx5")
-                    || uri.startsWith("http://")
-                    || uri.startsWith("https://") ->
-                    Pair(UrlLogin, true)
+                    EmailLogin
+                listOf("caldavs", "carddavs", "davx5", "http", "https").any { uri.startsWith(it) } ->
+                    UrlLogin
                 else ->
-                    Pair(defaultLoginType, false)
+                    defaultLoginType
             }
         }
 

--- a/app/src/ose/kotlin/at/bitfire/davdroid/ui/setup/StandardLoginTypesProvider.kt
+++ b/app/src/ose/kotlin/at/bitfire/davdroid/ui/setup/StandardLoginTypesProvider.kt
@@ -26,11 +26,23 @@ class StandardLoginTypesProvider @Inject constructor() : LoginTypesProvider {
 
     override val defaultLoginType = UrlLogin
 
-    override fun intentToInitialLoginType(intent: Intent) =
-        if (intent.hasExtra(LoginActivity.EXTRA_LOGIN_FLOW))
-            Pair(NextcloudLogin, true)
-        else
-            Pair(defaultLoginType, false)
+    override fun intentToInitialLoginType(intent: Intent): Pair<LoginType, Boolean> =
+        intent.data?.normalizeScheme().toString().let { uri ->
+            when {
+                intent.hasExtra(LoginActivity.EXTRA_LOGIN_FLOW) ->
+                    Pair(NextcloudLogin, true)
+                uri.startsWith("mailto:") ->
+                    Pair(EmailLogin, true)
+                uri.startsWith("caldavs")
+                    || uri.startsWith("carddavs")
+                    || uri.startsWith("davx5")
+                    || uri.startsWith("http://")
+                    || uri.startsWith("https://") ->
+                    Pair(UrlLogin, true)
+                else ->
+                    Pair(defaultLoginType, false)
+            }
+        }
 
     @Composable
     override fun LoginTypePage(


### PR DESCRIPTION
### Purpose

When DAVx5 is opened via intent containing a valid Email or URL (not nextcloud login flow), there is no need to show the login type page. We should open either the Email or URL login page directly. 

### Short description

- Add support for "mailto" scheme
- Always skip login type page if not default login type (Email, URL or Nextcloud)

Use for testing:
```
adb shell am start -d caldavs://user:password@example.com:444/path at.bitfire.davdroid/.ui.setup.LoginActivity

adb shell am start -d mailto:username@example.com at.bitfire.davdroid/.ui.setup.LoginActivity

adb shell am start -d mailto:username@example.com --es password 123 at.bitfire.davdroid/.ui.setup.LoginActivity
```


### Checklist

- [X] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

