### PR TITLE
MockK: use MockkRule if possible

### DIFF
--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration18Test.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration18Test.kt
@@ -15,11 +15,8 @@ import at.bitfire.davdroid.resource.LocalAddressBook
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
-import io.mockk.MockKAnnotations
 import io.mockk.every
-import io.mockk.impl.annotations.InjectMockKs
-import io.mockk.impl.annotations.MockK
-import io.mockk.mockk
+import io.mockk.junit4.MockKRule
 import io.mockk.mockkObject
 import io.mockk.verify
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -34,29 +31,27 @@ class AccountSettingsMigration18Test {
     @Inject @ApplicationContext
     lateinit var context: Context
 
-    @MockK
+    @Inject
     lateinit var db: AppDatabase
 
-    @InjectMockKs
+    @Inject
     lateinit var migration: AccountSettingsMigration18
 
     @get:Rule
     val hiltRule = HiltAndroidRule(this)
 
+    @get:Rule
+    val mockkRule = MockKRule(this)
+
 
     @Before
     fun setUp() {
         hiltRule.inject()
-        MockKAnnotations.init(this)
     }
 
 
     @Test
     fun testMigrate_AddressBook_InvalidCollection() {
-        every { db.serviceDao() } returns mockk {
-            every { getByAccountAndType(any(), any()) } returns null
-        }
-
         val addressBookAccountType = context.getString(R.string.account_type_address_book)
         var addressBookAccount = Account("Address Book", addressBookAccountType)
 
@@ -75,10 +70,6 @@ class AccountSettingsMigration18Test {
 
     @Test
     fun testMigrate_AddressBook_NoCollection() {
-        every { db.serviceDao() } returns mockk {
-            every { getByAccountAndType(any(), any()) } returns null
-        }
-
         val addressBookAccountType = context.getString(R.string.account_type_address_book)
         var addressBookAccount = Account("Address Book", addressBookAccountType)
 
@@ -99,22 +90,18 @@ class AccountSettingsMigration18Test {
     fun testMigrate_AddressBook_ValidCollection() {
         val account = Account("test", "test")
 
-        every { db.serviceDao() } returns mockk {
-            every { getByAccountAndType(any(), any()) } returns Service(
-                id = 10,
-                accountName = account.name,
-                type = Service.TYPE_CARDDAV,
-                principal = null
-            )
-        }
-        every { db.collectionDao() } returns mockk {
-            every { getByService(10) } returns listOf(Collection(
-                id = 100,
-                serviceId = 10,
-                url = "http://example.com".toHttpUrl(),
-                type = Collection.TYPE_ADDRESSBOOK
-            ))
-        }
+        db.serviceDao().insertOrReplace(Service(
+            id = 10,
+            accountName = account.name,
+            type = Service.TYPE_CARDDAV,
+            principal = null
+        ))
+        db.collectionDao().insertOrUpdateByUrl(Collection(
+            id = 100,
+            serviceId = 10,
+            url = "http://example.com".toHttpUrl(),
+            type = Collection.TYPE_ADDRESSBOOK
+        ))
 
         val addressBookAccountType = context.getString(R.string.account_type_address_book)
         var addressBookAccount = Account("Address Book", addressBookAccountType)

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration19Test.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration19Test.kt
@@ -13,16 +13,13 @@ import androidx.work.WorkManager
 import androidx.work.testing.WorkManagerTestInitHelper
 import at.bitfire.davdroid.sync.AutomaticSyncManager
 import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
-import io.mockk.MockKAnnotations
-import io.mockk.impl.annotations.InjectMockKs
-import io.mockk.impl.annotations.MockK
-import io.mockk.impl.annotations.SpyK
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.junit4.MockKRule
 import io.mockk.mockkObject
-import io.mockk.unmockkAll
 import io.mockk.verify
-import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -32,13 +29,13 @@ import javax.inject.Inject
 class AccountSettingsMigration19Test {
 
     @Inject @ApplicationContext
-    @SpyK
     lateinit var context: Context
 
-    @MockK(relaxed = true)
+    @BindValue
+    @RelaxedMockK
     lateinit var automaticSyncManager: AutomaticSyncManager
 
-    @InjectMockKs
+    @Inject
     lateinit var migration: AccountSettingsMigration19
 
     @Inject
@@ -46,6 +43,9 @@ class AccountSettingsMigration19Test {
 
     @get:Rule
     val hiltRule = HiltAndroidRule(this)
+
+    @get:Rule
+    val mockkRule = MockKRule(this)
 
 
     @Before
@@ -58,13 +58,6 @@ class AccountSettingsMigration19Test {
             .setWorkerFactory(workerFactory)
             .build()
         WorkManagerTestInitHelper.initializeTestWorkManager(context, config)
-
-        MockKAnnotations.init(this)
-    }
-
-    @After
-    fun tearDown() {
-        unmockkAll()
     }
 
 


### PR DESCRIPTION
To make sure everything is unmockked.

Unfortunately, `LocalAddressBookStoreTest` still uses `MockKAnnotations.init(this)` and isn't easy to rewrite, but it at least uses `unmockkAll()`.