### PR TITLE
OpenSourceDonation: Set default time value on page load in case user skips the page

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/intro/OpenSourcePage.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/intro/OpenSourcePage.kt
@@ -73,11 +73,17 @@ class OpenSourcePage @Inject constructor(
          */
         val donationPopupIntervalOptions = listOf(1, 3, 9)
 
+        init {
+            // Set default value on page load, in case user skips the page
+            setDontShowFor()
+        }
+
         /**
          * Set the next time the donation popup should be shown.
          * @param dontShowFor Number of months (30 days) to hide the donation popup for.
          */
-        fun setDontShowFor(dontShowFor: Int) {
+        fun setDontShowFor(dontShowFor: Int? = null) {
+            val dontShowFor = dontShowFor ?: donationPopupIntervalOptions.first()
             logger.info("Setting next donation popup to $dontShowFor months")
             val month = 30*86400000L            // 30 days (~ 1 month)
             val nextReminder = month * dontShowFor + System.currentTimeMillis()
@@ -91,7 +97,7 @@ class OpenSourcePage @Inject constructor(
 @Composable
 fun OpenSourcePage(
     donationPopupIntervalOptions: List<Int>,
-    onChangeDontShowFor: (Int) -> Unit = {}
+    onChangeDontShowFor: (Int?) -> Unit = {}
 ) {
     val uriHandler = LocalUriHandler.current
 
@@ -142,8 +148,7 @@ fun OpenSourcePage(
             RadioButtons(
                 radioOptions = radioOptions.keys.toList(),
                 onOptionSelected = { option ->
-                    val months = radioOptions[option] ?: radioOptions.values.first()
-                    onChangeDontShowFor(months)
+                    onChangeDontShowFor(radioOptions[option])
                 },
                 modifier = Modifier.padding(bottom = 12.dp)
             )


### PR DESCRIPTION
### Purpose

We are not setting any default time even though it shows the first option as selected. Now when the user skips the page, it shows up repeatedly until a time is actually tapped/selected.

### Short description

- Set default time value on page load in case user skips the page

### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.

