### PR TITLE
Use `TaskStackBuilder` instead of `PendingIntent.getActivity`

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/db/AppDatabase.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/db/AppDatabase.kt
@@ -10,6 +10,7 @@ import android.content.Context
 import android.content.Intent
 import android.database.sqlite.SQLiteQueryBuilder
 import androidx.core.app.NotificationCompat
+import androidx.core.app.TaskStackBuilder
 import androidx.core.database.getStringOrNull
 import androidx.room.AutoMigration
 import androidx.room.Database
@@ -21,7 +22,8 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.TextTable
-import at.bitfire.davdroid.db.migration.*
+import at.bitfire.davdroid.db.migration.AutoMigration12
+import at.bitfire.davdroid.db.migration.AutoMigration16
 import at.bitfire.davdroid.ui.AccountsActivity
 import at.bitfire.davdroid.ui.NotificationRegistry
 import dagger.Module
@@ -80,7 +82,11 @@ abstract class AppDatabase: RoomDatabase() {
                             .setContentTitle(context.getString(R.string.database_destructive_migration_title))
                             .setContentText(context.getString(R.string.database_destructive_migration_text))
                             .setCategory(NotificationCompat.CATEGORY_ERROR)
-                            .setContentIntent(PendingIntent.getActivity(context, 0, launcherIntent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE))
+                            .setContentIntent(
+                                TaskStackBuilder.create(context)
+                                    .addNextIntent(launcherIntent)
+                                    .getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+                            )
                             .setAutoCancel(true)
                             .build()
                     }

--- a/app/src/main/kotlin/at/bitfire/davdroid/log/LogFileHandler.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/log/LogFileHandler.kt
@@ -140,7 +140,7 @@ class LogFileHandler @Inject constructor(
                 .newTask()
                 .share()
             val pendingShare = TaskStackBuilder.create(context)
-                .addNextIntent(shareIntent)
+                .addNextIntentWithParentStack(shareIntent)
                 .getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
             builder.addAction(
                 NotificationCompat.Action.Builder(
@@ -154,7 +154,7 @@ class LogFileHandler @Inject constructor(
             val prefIntent = Intent(context, AppSettingsActivity::class.java)
             prefIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             val pendingPref = TaskStackBuilder.create(context)
-                .addNextIntent(prefIntent)
+                .addNextIntentWithParentStack(prefIntent)
                 .getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
             builder.addAction(
                 NotificationCompat.Action.Builder(

--- a/app/src/main/kotlin/at/bitfire/davdroid/log/LogFileHandler.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/log/LogFileHandler.kt
@@ -10,6 +10,7 @@ import android.content.Intent
 import android.os.Process
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.app.TaskStackBuilder
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.ui.AppSettingsActivity
 import at.bitfire.davdroid.ui.DebugInfoActivity
@@ -138,8 +139,9 @@ class LogFileHandler @Inject constructor(
             val shareIntent = DebugInfoActivity.IntentBuilder(context)
                 .newTask()
                 .share()
-            val pendingShare =
-                PendingIntent.getActivity(context, 0, shareIntent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+            val pendingShare = TaskStackBuilder.create(context)
+                .addNextIntent(shareIntent)
+                .getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
             builder.addAction(
                 NotificationCompat.Action.Builder(
                     R.drawable.ic_share,
@@ -151,8 +153,9 @@ class LogFileHandler @Inject constructor(
             // add action to disable verbose logging
             val prefIntent = Intent(context, AppSettingsActivity::class.java)
             prefIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            val pendingPref =
-                PendingIntent.getActivity(context, 0, prefIntent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+            val pendingPref = TaskStackBuilder.create(context)
+                .addNextIntent(prefIntent)
+                .getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
             builder.addAction(
                 NotificationCompat.Action.Builder(
                     R.drawable.ic_settings,

--- a/app/src/main/kotlin/at/bitfire/davdroid/push/PushNotificationManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/push/PushNotificationManager.kt
@@ -47,7 +47,7 @@ class PushNotificationManager @Inject constructor(
                 .setOnlyAlertOnce(true)
                 .setContentIntent(
                     TaskStackBuilder.create(context)
-                        .addNextIntent(
+                        .addNextIntentWithParentStack(
                             Intent(context, AccountActivity::class.java).apply {
                                 putExtra(AccountActivity.EXTRA_ACCOUNT, account)
                             }

--- a/app/src/main/kotlin/at/bitfire/davdroid/push/PushNotificationManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/push/PushNotificationManager.kt
@@ -10,6 +10,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.app.TaskStackBuilder
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.sync.SyncDataType
 import at.bitfire.davdroid.ui.NotificationRegistry
@@ -45,14 +46,13 @@ class PushNotificationManager @Inject constructor(
                 .setAutoCancel(true)
                 .setOnlyAlertOnce(true)
                 .setContentIntent(
-                    PendingIntent.getActivity(
-                        context,
-                        0,
-                        Intent(context, AccountActivity::class.java).apply {
-                            putExtra(AccountActivity.EXTRA_ACCOUNT, account)
-                        },
-                        PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-                    )
+                    TaskStackBuilder.create(context)
+                        .addNextIntent(
+                            Intent(context, AccountActivity::class.java).apply {
+                                putExtra(AccountActivity.EXTRA_ACCOUNT, account)
+                            }
+                        )
+                        .getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
                 )
                 .build()
         }

--- a/app/src/main/kotlin/at/bitfire/davdroid/servicedetection/RefreshCollectionsWorker.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/servicedetection/RefreshCollectionsWorker.kt
@@ -10,6 +10,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.app.TaskStackBuilder
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.Data
@@ -26,6 +27,7 @@ import at.bitfire.davdroid.InvalidAccountException
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.network.HttpClient
 import at.bitfire.davdroid.repository.DavServiceRepository
+import at.bitfire.davdroid.servicedetection.RefreshCollectionsWorker.Companion.ARG_SERVICE_ID
 import at.bitfire.davdroid.ui.DebugInfoActivity
 import at.bitfire.davdroid.ui.NotificationRegistry
 import at.bitfire.davdroid.ui.account.AccountSettingsActivity
@@ -226,12 +228,9 @@ class RefreshCollectionsWorker @AssistedInject constructor(
                 .setContentTitle(applicationContext.getString(R.string.refresh_collections_worker_refresh_failed))
                 .setContentText(contentText)
                 .setContentIntent(
-                    PendingIntent.getActivity(
-                        applicationContext,
-                        0,
-                        contentIntent,
-                        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-                    )
+                    TaskStackBuilder.create(applicationContext)
+                        .addNextIntent(contentIntent)
+                        .getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
                 )
                 .setSubText(account?.name)
                 .setCategory(NotificationCompat.CATEGORY_ERROR)

--- a/app/src/main/kotlin/at/bitfire/davdroid/servicedetection/RefreshCollectionsWorker.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/servicedetection/RefreshCollectionsWorker.kt
@@ -27,7 +27,6 @@ import at.bitfire.davdroid.InvalidAccountException
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.network.HttpClient
 import at.bitfire.davdroid.repository.DavServiceRepository
-import at.bitfire.davdroid.servicedetection.RefreshCollectionsWorker.Companion.ARG_SERVICE_ID
 import at.bitfire.davdroid.ui.DebugInfoActivity
 import at.bitfire.davdroid.ui.NotificationRegistry
 import at.bitfire.davdroid.ui.account.AccountSettingsActivity

--- a/app/src/main/kotlin/at/bitfire/davdroid/servicedetection/RefreshCollectionsWorker.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/servicedetection/RefreshCollectionsWorker.kt
@@ -229,7 +229,7 @@ class RefreshCollectionsWorker @AssistedInject constructor(
                 .setContentText(contentText)
                 .setContentIntent(
                     TaskStackBuilder.create(applicationContext)
-                        .addNextIntent(contentIntent)
+                        .addNextIntentWithParentStack(contentIntent)
                         .getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
                 )
                 .setSubText(account?.name)

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -816,7 +816,7 @@ abstract class SyncManager<ResourceType: LocalResource<*>, out CollectionType: L
                 .setOnlyAlertOnce(true)
                 .setContentIntent(
                     TaskStackBuilder.create(context)
-                        .addNextIntent(contentIntent)
+                        .addNextIntentWithParentStack(contentIntent)
                         .getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
                 )
                 .setPriority(priority)

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -16,6 +16,7 @@ import android.provider.CalendarContract
 import android.provider.ContactsContract
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.app.TaskStackBuilder
 import at.bitfire.dav4jvm.DavCollection
 import at.bitfire.dav4jvm.DavResource
 import at.bitfire.dav4jvm.Error
@@ -814,12 +815,9 @@ abstract class SyncManager<ResourceType: LocalResource<*>, out CollectionType: L
                 .setSubText(account.name)
                 .setOnlyAlertOnce(true)
                 .setContentIntent(
-                    PendingIntent.getActivity(
-                        context,
-                        0,
-                        contentIntent,
-                        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-                    )
+                    TaskStackBuilder.create(context)
+                        .addNextIntent(contentIntent)
+                        .getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
                 )
                 .setPriority(priority)
                 .setCategory(NotificationCompat.CATEGORY_ERROR)
@@ -864,8 +862,13 @@ abstract class SyncManager<ResourceType: LocalResource<*>, out CollectionType: L
             }
         }
         return if (intent != null && context.packageManager.resolveActivity(intent, 0) != null)
-            NotificationCompat.Action(android.R.drawable.ic_menu_view, context.getString(R.string.sync_error_view_item),
-                    PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE))
+            NotificationCompat.Action(
+                android.R.drawable.ic_menu_view,
+                context.getString(R.string.sync_error_view_item),
+                TaskStackBuilder.create(context)
+                    .addNextIntent(intent)
+                    .getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+            )
         else
             null
     }
@@ -880,12 +883,9 @@ abstract class SyncManager<ResourceType: LocalResource<*>, out CollectionType: L
                 .setContentText(context.getString(R.string.sync_invalid_resources_ignoring))
                 .setSubText(account.name)
                 .setContentIntent(
-                    PendingIntent.getActivity(
-                        context,
-                        0,
-                        intent,
-                        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-                    )
+                    TaskStackBuilder.create(context)
+                        .addNextIntent(intent)
+                        .getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
                 )
                 .setAutoCancel(true)
                 .setOnlyAlertOnce(true)

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/TasksAppManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/TasksAppManager.kt
@@ -11,6 +11,7 @@ import android.content.pm.PackageManager
 import android.graphics.drawable.BitmapDrawable
 import android.net.Uri
 import androidx.core.app.NotificationCompat
+import androidx.core.app.TaskStackBuilder
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.repository.AccountRepository
 import at.bitfire.davdroid.resource.LocalDataStore
@@ -125,7 +126,11 @@ class TasksAppManager @Inject constructor(
             val flags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
 
             if (intent.resolveActivity(pm) != null)
-                notify.setContentIntent(PendingIntent.getActivity(context, 0, intent, flags))
+                notify.setContentIntent(
+                    TaskStackBuilder.create(context)
+                        .addNextIntent(intent)
+                        .getPendingIntent(0, flags)
+                )
 
             notify.build()
         }

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/NotificationRegistry.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/NotificationRegistry.kt
@@ -168,7 +168,7 @@ class NotificationRegistry @Inject constructor(
                 .setContentText(context.getString(R.string.sync_error_permissions_text))
                 .setContentIntent(
                     TaskStackBuilder.create(context)
-                        .addNextIntent(contentIntent)
+                        .addNextIntentWithParentStack(contentIntent)
                         .getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
                 )
                 .setCategory(NotificationCompat.CATEGORY_ERROR)

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/NotificationRegistry.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/NotificationRegistry.kt
@@ -16,6 +16,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.app.TaskStackBuilder
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import at.bitfire.davdroid.R
@@ -166,12 +167,9 @@ class NotificationRegistry @Inject constructor(
                 .setContentTitle(context.getString(R.string.sync_error_permissions))
                 .setContentText(context.getString(R.string.sync_error_permissions_text))
                 .setContentIntent(
-                    PendingIntent.getActivity(
-                        context,
-                        0,
-                        contentIntent,
-                        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-                    )
+                    TaskStackBuilder.create(context)
+                        .addNextIntent(contentIntent)
+                        .getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
                 )
                 .setCategory(NotificationCompat.CATEGORY_ERROR)
                 .setAutoCancel(true)

--- a/app/src/main/kotlin/at/bitfire/davdroid/webdav/DavDocumentsProvider.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/webdav/DavDocumentsProvider.kt
@@ -760,7 +760,7 @@ class DavDocumentsProvider: DocumentsProvider() {
                     throw AuthenticationRequiredException(
                         this,
                         TaskStackBuilder.create(ourContext)
-                            .addNextIntent(intent)
+                            .addNextIntentWithParentStack(intent)
                             .getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
                     )
                 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/webdav/DavDocumentsProvider.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/webdav/DavDocumentsProvider.kt
@@ -27,6 +27,7 @@ import android.provider.DocumentsContract.buildRootsUri
 import android.provider.DocumentsProvider
 import android.webkit.MimeTypeMap
 import androidx.annotation.WorkerThread
+import androidx.core.app.TaskStackBuilder
 import androidx.core.content.getSystemService
 import at.bitfire.dav4jvm.DavCollection
 import at.bitfire.dav4jvm.DavResource
@@ -756,7 +757,12 @@ class DavDocumentsProvider: DocumentsProvider() {
                 if (Build.VERSION.SDK_INT >= 26) {
                     // TODO edit mount
                     val intent = Intent(ourContext, WebdavMountsActivity::class.java)
-                    throw AuthenticationRequiredException(this, PendingIntent.getActivity(ourContext, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE))
+                    throw AuthenticationRequiredException(
+                        this,
+                        TaskStackBuilder.create(ourContext)
+                            .addNextIntent(intent)
+                            .getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+                    )
                 }
             }
             HttpURLConnection.HTTP_NOT_FOUND ->


### PR DESCRIPTION
### Purpose

The [current state-of-the-art seems to be TaskStackBuilder](https://developer.android.com/develop/ui/views/notifications/navigation#PendingIntent-back-stack), also [for Compose deep links](https://developer.android.com/develop/ui/compose/navigation#deeplinks).

### Short description

Replaced all usages of `PendingIntent.getActivity` with the equivalent `TaskStackBuilder`.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

