### PR TITLE
SyncAdapter: Hilt error handling

### DIFF
--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/HiltTestRunner.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/HiltTestRunner.kt
@@ -6,12 +6,22 @@ package at.bitfire.davdroid
 
 import android.app.Application
 import android.content.Context
+import android.os.Build
+import android.os.Bundle
 import androidx.test.runner.AndroidJUnitRunner
 import dagger.hilt.android.testing.HiltTestApplication
 
+@Suppress("unused")
 class HiltTestRunner : AndroidJUnitRunner() {
 
     override fun newApplication(cl: ClassLoader, name: String, context: Context): Application =
         super.newApplication(cl, HiltTestApplication::class.java.name, context)
+
+    override fun onCreate(arguments: Bundle?) {
+        super.onCreate(arguments)
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P)
+            throw AssertionError("MockK requires Android P [https://mockk.io/ANDROID.html]")
+    }
 
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncAdapterServices.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncAdapterServices.kt
@@ -17,6 +17,7 @@ import android.os.Bundle
 import android.os.IBinder
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
+import at.bitfire.davdroid.BuildConfig
 import at.bitfire.davdroid.InvalidAccountException
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.repository.DavCollectionRepository
@@ -25,8 +26,10 @@ import at.bitfire.davdroid.resource.LocalAddressBook.Companion.USER_DATA_COLLECT
 import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.sync.worker.BaseSyncWorker
 import at.bitfire.davdroid.sync.worker.SyncWorkerManager
-import dagger.hilt.android.AndroidEntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -37,15 +40,46 @@ import kotlinx.coroutines.withTimeout
 import java.util.logging.Level
 import java.util.logging.Logger
 import javax.inject.Inject
-import javax.inject.Provider
 
 abstract class SyncAdapterService: Service() {
 
-    @Inject
-    lateinit var syncAdapter: Provider<SyncAdapter>
+    /**
+     * We don't use @AndroidEntryPoint / @Inject because it's unavoidable that instrumented tests sometimes accidentally / asynchronously
+     * create a [SyncAdapterService] instance before Hilt is initialized during the tests.
+     */
+    @dagger.hilt.EntryPoint
+    @InstallIn(SingletonComponent::class)
+    interface EntryPoint {
+        fun syncAdapter(): SyncAdapter
+    }
 
     override fun onBind(intent: Intent?): IBinder {
-        return syncAdapter.get().syncAdapterBinder
+        try {
+            // create sync adapter via Hilt
+            val entryPoint = EntryPointAccessors.fromApplication<EntryPoint>(this)
+            val syncAdapter = entryPoint.syncAdapter()
+            return syncAdapter.syncAdapterBinder
+
+        } catch (e: IllegalStateException) {
+            if (BuildConfig.DEBUG) {
+                // only for debug builds: handle "Hilt not initialized" exception
+                val logger = Logger.getLogger(this@SyncAdapterService::class.java.name)
+                logger.log(Level.WARNING, "SyncAdapterService.onBind() was called without Hilt initialization. Ignoring", e)
+
+                val fakeAdapter = object: AbstractThreadedSyncAdapter(this, false) {
+                    override fun onPerformSync(account: Account, extras: Bundle, authority: String, provider: ContentProviderClient, syncResult: SyncResult) {
+                        val message = StringBuilder()
+                        message.append("FakeSyncAdapter onPerformSync(account=$account, extras=$extras, authority=$authority, syncResult=$syncResult)")
+                        for (key in extras.keySet())
+                            message.append("\n\textras[$key] = ${extras[key]}")
+                        logger.warning(message.toString())
+                    }
+                }
+                return fakeAdapter.syncAdapterBinder
+            } else
+                // re-throw in production builds
+                throw e
+        }
     }
 
     /**
@@ -68,9 +102,9 @@ abstract class SyncAdapterService: Service() {
         private val syncConditionsFactory: SyncConditions.Factory,
         private val syncWorkerManager: SyncWorkerManager
     ): AbstractThreadedSyncAdapter(
-        context,
-        true    // isSyncable shouldn't be -1 because DAVx5 (SyncFrameworkIntegration) sets it to 0 or 1.
-                // However, if it is -1 by accident, set it to 1 to avoid endless sync loops.
+        /* context = */ context,
+        /* autoInitialize = */ true     // Sets isSyncable=1 when isSyncable=-1 and SYNC_EXTRAS_INITIALIZE is set.
+                                        // Doesn't matter for us because we have android:isAlwaysSyncable="true" for all sync adapters.
     ) {
 
         /**
@@ -174,18 +208,8 @@ abstract class SyncAdapterService: Service() {
 }
 
 // exported sync adapter services; we need a separate class for each authority
-
-@AndroidEntryPoint
 class CalendarsSyncAdapterService: SyncAdapterService()
-
-@AndroidEntryPoint
 class ContactsSyncAdapterService: SyncAdapterService()
-
-@AndroidEntryPoint
 class JtxSyncAdapterService: SyncAdapterService()
-
-@AndroidEntryPoint
 class OpenTasksSyncAdapterService: SyncAdapterService()
-
-@AndroidEntryPoint
 class TasksOrgSyncAdapterService: SyncAdapterService()

--- a/app/src/main/res/xml/sync_calendars.xml
+++ b/app/src/main/res/xml/sync_calendars.xml
@@ -3,4 +3,15 @@
     android:accountType="@string/account_type"
     android:userVisible="false"
     android:supportsUploading="true"
-    android:allowParallelSyncs="true" />
+    android:allowParallelSyncs="true"
+    android:isAlwaysSyncable="true" />
+
+<!-- Note:
+isAlwaysSyncable = false   sets isSyncable(contentAuthority) of newly created accountType accounts to -1
+                           → causes a sync with SYNC_EXTRAS_INITIALIZE to be scheduled
+                           → this sync is expected to finally set isSyncable to 0 or 1.
+isAlwaysSyncable = true    sets isSyncable(contentAuthority) of newly created accountType accounts to 1
+                           → causes a normal sync (without SYNC_EXTRAS_INITIALIZE) to be scheduled.
+
+There's no possibility to automatically set isSyncable to 0 at account creation.
+-->

--- a/app/src/main/res/xml/sync_calendars.xml
+++ b/app/src/main/res/xml/sync_calendars.xml
@@ -7,10 +7,10 @@
     android:isAlwaysSyncable="true" />
 
 <!-- Note:
-isAlwaysSyncable = false   sets isSyncable(contentAuthority) of newly created accountType accounts to -1
+isAlwaysSyncable = false   Sets isSyncable(contentAuthority) of new Account(type=accountType) to -1
                            → causes a sync with SYNC_EXTRAS_INITIALIZE to be scheduled
-                           → this sync is expected to finally set isSyncable to 0 or 1.
-isAlwaysSyncable = true    sets isSyncable(contentAuthority) of newly created accountType accounts to 1
+                           → that sync is expected to finally set isSyncable to 0 or 1.
+isAlwaysSyncable = true    Sets isSyncable(contentAuthority) of new Account(type=accountType) to 1
                            → causes a normal sync (without SYNC_EXTRAS_INITIALIZE) to be scheduled.
 
 There's no possibility to automatically set isSyncable to 0 at account creation.

--- a/app/src/main/res/xml/sync_contacts.xml
+++ b/app/src/main/res/xml/sync_contacts.xml
@@ -3,4 +3,7 @@
     android:accountType="@string/account_type_address_book"
     android:userVisible="false"
     android:supportsUploading="true"
-    android:allowParallelSyncs="true" />
+    android:allowParallelSyncs="true"
+    android:isAlwaysSyncable="true" />
+
+<!-- See sync_calendars.xml for an explanation of isAlwaysSyncable. -->

--- a/app/src/main/res/xml/sync_notes.xml
+++ b/app/src/main/res/xml/sync_notes.xml
@@ -3,4 +3,7 @@
     android:accountType="@string/account_type"
     android:userVisible="false"
     android:supportsUploading="true"
-    android:allowParallelSyncs="true" />
+    android:allowParallelSyncs="true"
+    android:isAlwaysSyncable="true" />
+
+<!-- See sync_calendars.xml for an explanation of isAlwaysSyncable. -->

--- a/app/src/main/res/xml/sync_opentasks.xml
+++ b/app/src/main/res/xml/sync_opentasks.xml
@@ -3,4 +3,7 @@
     android:accountType="@string/account_type"
     android:userVisible="false"
     android:supportsUploading="true"
-    android:allowParallelSyncs="true" />
+    android:allowParallelSyncs="true"
+    android:isAlwaysSyncable="true" />
+
+<!-- See sync_calendars.xml for an explanation of isAlwaysSyncable. -->

--- a/app/src/main/res/xml/sync_tasks_org.xml
+++ b/app/src/main/res/xml/sync_tasks_org.xml
@@ -3,4 +3,7 @@
     android:accountType="@string/account_type"
     android:userVisible="false"
     android:supportsUploading="true"
-    android:allowParallelSyncs="true" />
+    android:allowParallelSyncs="true"
+    android:isAlwaysSyncable="true" />
+
+<!-- See sync_calendars.xml for an explanation of isAlwaysSyncable. -->


### PR DESCRIPTION
After a lot of playing around and testing, I chose the simplest modification to work around the problem. I think it can't be completely avoided that syncs are called (except when we would use a "test account" account type for testing, but then we would test something else that we'd use in the real app).

### Short description

* This PR handles the "Hilt: component not initialized" exception in `SyncAdapterServices`, so that the tests don't fail when such an (unwanted) sync is started.
* Adds a comment to `sync_calendars.xml` to explain what `isAlwaysSyncable` really does.
* Adds a comment to the `SyncAdapter` constructor to explain what `autoInitialize` really does.
* Requires Android P for instrumented tests (throws error on <P) because the tests use MockK features which are not available for <P.

CC @sunkup