### PR TITLE
Add syncActive flag to control SyncAdapter behavior during tests

### DIFF
--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/HiltTestRunner.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/HiltTestRunner.kt
@@ -9,6 +9,7 @@ import android.content.Context
 import android.os.Build
 import android.os.Bundle
 import androidx.test.runner.AndroidJUnitRunner
+import at.bitfire.davdroid.sync.SyncAdapterService
 import dagger.hilt.android.testing.HiltTestApplication
 
 @Suppress("unused")
@@ -20,8 +21,12 @@ class HiltTestRunner : AndroidJUnitRunner() {
     override fun onCreate(arguments: Bundle?) {
         super.onCreate(arguments)
 
+        // MockK requirements
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P)
             throw AssertionError("MockK requires Android P [https://mockk.io/ANDROID.html]")
+
+        // disable sync adapters
+        SyncAdapterService.syncActive.set(false)
     }
 
 }


### PR DESCRIPTION
# Purpose

The purpose of this pull request is to address and fix the `MockKException: can't find stub for android.accounts.AccountManager` issue that occurs during CI instrumented tests.

# Description

`SyncAdapterServices` now only does something when the newly introduced `syncActive` flag is set. It's `true` by default, but disabled by the instrumented tests runner.