### PR TITLE
`DnsRecordResolverTest`: Use seeded random number generator for deterministic test result

### DIFF
--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/network/DnsRecordResolverTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/network/DnsRecordResolverTest.kt
@@ -18,6 +18,7 @@ import org.xbill.DNS.Name
 import org.xbill.DNS.SRVRecord
 import org.xbill.DNS.TXTRecord
 import javax.inject.Inject
+import kotlin.random.Random
 
 @HiltAndroidTest
 class DnsRecordResolverTest {
@@ -69,8 +70,9 @@ class DnsRecordResolverTest {
         // entries are selected randomly (for load balancing)
         // run 1000 times to get a good distribution
         val counts = IntArray(2)
+        val seededRandom = Random(0) // Seed of 0 ensures 100% deterministic non-failing results
         for (i in 0 until 1000) {
-            val result = dnsRecordResolver.bestSRVRecord(arrayOf(dns1010, dns1020))
+            val result = dnsRecordResolver.bestSRVRecord(arrayOf(dns1010, dns1020), seededRandom)
 
             when (result) {
                 dns1010 -> counts[0]++

--- a/app/src/main/kotlin/at/bitfire/davdroid/network/DnsRecordResolver.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/network/DnsRecordResolver.kt
@@ -107,10 +107,10 @@ class DnsRecordResolver @Inject constructor(
      * Selects the best SRV record from a list of records, based on algorithm from RFC 2782.
      *
      * @param records the records to choose from
-     * @param random a random number generator to use for random selection
+     * @param randomGenerator a random number generator to use for random selection
      * @return the best SRV record, or `null` if no SRV record is available
      */
-    fun bestSRVRecord(records: Array<out Record>, random: Random = Random.Default): SRVRecord? {
+    fun bestSRVRecord(records: Array<out Record>, randomGenerator: Random = Random.Default): SRVRecord? {
         val srvRecords = records.filterIsInstance<SRVRecord>()
         if (srvRecords.size <= 1)
             return srvRecords.firstOrNull()
@@ -149,7 +149,7 @@ class DnsRecordResolver @Inject constructor(
             map[runningWeight] = record
         }
 
-        val selector = (0..runningWeight).random(random)
+        val selector = (0..runningWeight).random(randomGenerator)
         return map.ceilingEntry(selector)!!.value
     }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/network/DnsRecordResolver.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/network/DnsRecordResolver.kt
@@ -104,7 +104,7 @@ class DnsRecordResolver @Inject constructor(
     // record selection
 
     /**
-     * Selects the best SRV record from a list of records algorithm from RFC 2782.
+     * Selects the best SRV record from a list of records, based on algorithm from RFC 2782.
      *
      * @param records the records to choose from
      * @param random a random number generator to use for random selection

--- a/app/src/main/kotlin/at/bitfire/davdroid/network/DnsRecordResolver.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/network/DnsRecordResolver.kt
@@ -22,6 +22,7 @@ import java.util.LinkedList
 import java.util.TreeMap
 import java.util.logging.Logger
 import javax.inject.Inject
+import kotlin.random.Random
 
 /**
  * Allows to resolve SRV/TXT records. Chooses the correct resolver, DNS servers etc.
@@ -102,7 +103,14 @@ class DnsRecordResolver @Inject constructor(
 
     // record selection
 
-    fun bestSRVRecord(records: Array<out Record>): SRVRecord? {
+    /**
+     * Selects the best SRV record from a list of records algorithm from RFC 2782.
+     *
+     * @param records the records to choose from
+     * @param random a random number generator to use for random selection
+     * @return the best SRV record, or `null` if no SRV record is available
+     */
+    fun bestSRVRecord(records: Array<out Record>, random: Random = Random.Default): SRVRecord? {
         val srvRecords = records.filterIsInstance<SRVRecord>()
         if (srvRecords.size <= 1)
             return srvRecords.firstOrNull()
@@ -141,7 +149,7 @@ class DnsRecordResolver @Inject constructor(
             map[runningWeight] = record
         }
 
-        val selector = (0..runningWeight).random()
+        val selector = (0..runningWeight).random(random)
         return map.ceilingEntry(selector)!!.value
     }
 


### PR DESCRIPTION
### Purpose

The test `testBestSRVRecord_MultipleRecords_Priority_Same` fails in rare occasions.

### Short description

Use a seeded random number generator for 100% deterministic results.

### Checklist

- [x] The PR has a proper title, description and label.
- [ ] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [ ] I have added documentation to complex functions and functions that can be used by other modules.
- [ ] I have added reasonable tests or consciously decided to not add tests.

