### PR TITLE
Added confirmation dialog for "Distrust System Certificates"

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsScreen.kt
@@ -70,7 +70,6 @@ import at.bitfire.davdroid.ui.composable.Setting
 import at.bitfire.davdroid.ui.composable.SettingsHeader
 import at.bitfire.davdroid.ui.composable.SwitchSetting
 import kotlinx.coroutines.launch
-import kotlin.collections.orEmpty
 
 @Composable
 fun AppSettingsScreen(
@@ -424,13 +423,37 @@ fun AppSettings_Security(
         Text(stringResource(R.string.app_settings_security))
     }
 
+    var showingDistrustWarning by remember { mutableStateOf(false) }
+    if (showingDistrustWarning) {
+        AlertDialog(
+            onDismissRequest = { showingDistrustWarning = false },
+            title = { Text(stringResource(R.string.app_settings_distrust_system_certs)) },
+            text = { Text(stringResource(R.string.app_settings_distrust_system_certs_warning)) },
+            confirmButton = {
+                TextButton(
+                    onClick = { onDistrustSystemCertsUpdated(true) }
+                ) { Text(stringResource(R.string.dialog_confirm)) }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = { showingDistrustWarning = false }
+                ) { Text(stringResource(R.string.dialog_deny)) }
+            },
+        )
+    }
+
     SwitchSetting(
         checked = distrustSystemCerts,
         name = stringResource(R.string.app_settings_distrust_system_certs),
         summaryOn = stringResource(R.string.app_settings_distrust_system_certs_on),
         summaryOff = stringResource(R.string.app_settings_distrust_system_certs_off)
-    ) {
-        onDistrustSystemCertsUpdated(it)
+    ) { checked ->
+        if (checked) {
+            // Show warning before enabling.
+            showingDistrustWarning = true
+        } else {
+            onDistrustSystemCertsUpdated(false)
+        }
     }
 
     Setting(

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsScreen.kt
@@ -425,23 +425,9 @@ fun AppSettings_Security(
 
     var showingDistrustWarning by remember { mutableStateOf(false) }
     if (showingDistrustWarning) {
-        AlertDialog(
-            onDismissRequest = { showingDistrustWarning = false },
-            title = { Text(stringResource(R.string.app_settings_distrust_system_certs)) },
-            text = { Text(stringResource(R.string.app_settings_distrust_system_certs_warning)) },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        onDistrustSystemCertsUpdated(true)
-                        showingDistrustWarning = false
-                    }
-                ) { Text(stringResource(R.string.dialog_confirm)) }
-            },
-            dismissButton = {
-                TextButton(
-                    onClick = { showingDistrustWarning = false }
-                ) { Text(stringResource(R.string.dialog_deny)) }
-            },
+        DistrustSystemCertificatesAlertDialog(
+            onDistrustSystemCertsRequested = { onDistrustSystemCertsUpdated(true) },
+            onDismissRequested = { showingDistrustWarning = false }
         )
     }
 
@@ -470,6 +456,39 @@ fun AppSettings_Security(
         summary = stringResource(R.string.app_settings_security_app_permissions_summary),
         onClick = onNavPermissionsScreen
     )
+}
+
+@Composable
+fun DistrustSystemCertificatesAlertDialog(
+    onDistrustSystemCertsRequested: () -> Unit,
+    onDismissRequested: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismissRequested,
+        title = { Text(stringResource(R.string.app_settings_distrust_system_certs_dialog_title)) },
+        text = { Text(stringResource(R.string.app_settings_distrust_system_certs_dialog_message)) },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    onDistrustSystemCertsRequested()
+                    onDismissRequested()
+                }
+            ) { Text(stringResource(R.string.dialog_enable)) }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismissRequested
+            ) { Text(stringResource(R.string.dialog_deny)) }
+        },
+    )
+}
+
+@Preview
+@Composable
+fun DistrustSystemCertificatesAlertDialog_Preview() {
+    AppTheme {
+        DistrustSystemCertificatesAlertDialog({}, {})
+    }
 }
 
 @Composable

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsScreen.kt
@@ -431,7 +431,10 @@ fun AppSettings_Security(
             text = { Text(stringResource(R.string.app_settings_distrust_system_certs_warning)) },
             confirmButton = {
                 TextButton(
-                    onClick = { onDistrustSystemCertsUpdated(true) }
+                    onClick = {
+                        onDistrustSystemCertsUpdated(true)
+                        showingDistrustWarning = false
+                    }
                 ) { Text(stringResource(R.string.dialog_confirm)) }
             },
             dismissButton = {

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.RadioButtonChecked
 import androidx.compose.material.icons.filled.RadioButtonUnchecked
 import androidx.compose.material.icons.filled.SyncProblem
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -465,7 +466,8 @@ fun DistrustSystemCertificatesAlertDialog(
 ) {
     AlertDialog(
         onDismissRequest = onDismissRequested,
-        title = { Text(stringResource(R.string.app_settings_distrust_system_certs_dialog_title)) },
+        icon = { Icon(Icons.Default.Warning, stringResource(R.string.app_settings_distrust_system_certs)) },
+        title = { Text(stringResource(R.string.app_settings_distrust_system_certs)) },
         text = { Text(stringResource(R.string.app_settings_distrust_system_certs_dialog_message)) },
         confirmButton = {
             TextButton(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,7 +11,7 @@
     <string name="dialog_delete">Delete</string>
     <string name="dialog_remove">Remove</string>
     <string name="dialog_deny">Cancel</string>
-    <string name="dialog_confirm">Confirm</string>
+    <string name="dialog_enable">Enable</string>
     <string name="field_required">This field is required</string>
     <string name="help">Help</string>
     <string name="navigate_up">Navigate up</string>
@@ -194,7 +194,8 @@
     <string name="app_settings_distrust_system_certs">Distrust system certificates</string>
     <string name="app_settings_distrust_system_certs_on">System and user-added CAs won\'t be trusted</string>
     <string name="app_settings_distrust_system_certs_off">System and user-added CAs will be trusted (recommended)</string>
-    <string name="app_settings_distrust_system_certs_warning">Are you sure that you want to enable distrusting system certificates? When enabled, you need to manually install the certificates required for your connections, or otherwise they won\'t be possible. This option is targeted to users with high knowledge of networking.</string>
+    <string name="app_settings_distrust_system_certs_dialog_title">Attention!</string>
+    <string name="app_settings_distrust_system_certs_dialog_message">Enabling this option will cause DAVx5 to distrust system certificates. You will need to manually install the required certificates. This option is intended for advanced users.</string>
     <string name="app_settings_reset_certificates">Reset (un)trusted certificates</string>
     <string name="app_settings_reset_certificates_summary">Resets trust of all custom certificates</string>
     <string name="app_settings_reset_certificates_success">All custom certificates have been cleared</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="dialog_delete">Delete</string>
     <string name="dialog_remove">Remove</string>
     <string name="dialog_deny">Cancel</string>
+    <string name="dialog_confirm">Confirm</string>
     <string name="field_required">This field is required</string>
     <string name="help">Help</string>
     <string name="navigate_up">Navigate up</string>
@@ -193,6 +194,7 @@
     <string name="app_settings_distrust_system_certs">Distrust system certificates</string>
     <string name="app_settings_distrust_system_certs_on">System and user-added CAs won\'t be trusted</string>
     <string name="app_settings_distrust_system_certs_off">System and user-added CAs will be trusted (recommended)</string>
+    <string name="app_settings_distrust_system_certs_warning">Are you sure that you want to enable distrusting system certificates? When enabled, you need to manually install the certificates required for your connections, or otherwise they won\'t be possible. This option is targeted to users with high knowledge of networking.</string>
     <string name="app_settings_reset_certificates">Reset (un)trusted certificates</string>
     <string name="app_settings_reset_certificates_summary">Resets trust of all custom certificates</string>
     <string name="app_settings_reset_certificates_success">All custom certificates have been cleared</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -194,8 +194,7 @@
     <string name="app_settings_distrust_system_certs">Distrust system certificates</string>
     <string name="app_settings_distrust_system_certs_on">System and user-added CAs won\'t be trusted</string>
     <string name="app_settings_distrust_system_certs_off">System and user-added CAs will be trusted (recommended)</string>
-    <string name="app_settings_distrust_system_certs_dialog_title">Attention!</string>
-    <string name="app_settings_distrust_system_certs_dialog_message">Enabling this option will cause DAVx5 to distrust system certificates. You will need to manually install the required certificates. This option is intended for advanced users.</string>
+    <string name="app_settings_distrust_system_certs_dialog_message">If this setting is active, system certificates are not considered as trustworthy. This means that you will have to manually accept every certificate (also when the server renews its certificate) or account setup and sync will not work.</string>
     <string name="app_settings_reset_certificates">Reset (un)trusted certificates</string>
     <string name="app_settings_reset_certificates_summary">Resets trust of all custom certificates</string>
     <string name="app_settings_reset_certificates_success">All custom certificates have been cleared</string>


### PR DESCRIPTION
### Purpose

See #1294

### Short description

- Added a confirmation dialog for enabling the "Distrust System Certificates" option.
- Disabling the option doesn't show any warning.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

