### PR TITLE
Added timestamp to debug info

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoActivity.kt
@@ -12,12 +12,14 @@ import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ShareCompat
 import androidx.core.content.FileProvider
+import androidx.core.content.IntentCompat
 import at.bitfire.davdroid.BuildConfig
 import at.bitfire.davdroid.R
 import com.google.common.base.Ascii
 import dagger.hilt.android.AndroidEntryPoint
 import okhttp3.HttpUrl
 import java.io.File
+import java.time.Instant
 
 /**
  * Debug info activity. Provides verbose information for debugging and support. Should enable users
@@ -50,6 +52,9 @@ class DebugInfoActivity : AppCompatActivity() {
 
         /** URL of remote resource related to the problem (plain-text [String]) */
         private const val EXTRA_REMOTE_RESOURCE = "remoteResource"
+
+        /** A timestamp of the moment at which the error took place. */
+        private const val EXTRA_TIMESTAMP = "timestamp"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -58,12 +63,13 @@ class DebugInfoActivity : AppCompatActivity() {
 
         setContent { 
             DebugInfoScreen(
-                account = extras?.getParcelable(EXTRA_ACCOUNT),
+                account = IntentCompat.getParcelableExtra(intent, EXTRA_ACCOUNT, Account::class.java),
                 authority = extras?.getString(EXTRA_AUTHORITY),
-                cause = extras?.getSerializable(EXTRA_CAUSE) as? Throwable,
+                cause = IntentCompat.getParcelableExtra(intent, EXTRA_ACCOUNT, Throwable::class.java),
                 localResource = extras?.getString(EXTRA_LOCAL_RESOURCE),
                 remoteResource = extras?.getString(EXTRA_REMOTE_RESOURCE),
                 logs = extras?.getString(EXTRA_LOGS),
+                timestamp = extras?.getLong(EXTRA_TIMESTAMP),
                 onShareZipFile = ::shareZipFile,
                 onViewFile = ::viewFile,
                 onNavUp = ::onSupportNavigateUp
@@ -132,6 +138,7 @@ class DebugInfoActivity : AppCompatActivity() {
         }
 
         val intent = Intent(context, DebugInfoActivity::class.java)
+            .putExtra(EXTRA_TIMESTAMP, Instant.now().epochSecond)
 
         fun newTask(): IntentBuilder {
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoGenerator.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoGenerator.kt
@@ -52,6 +52,8 @@ import java.io.PrintWriter
 import java.io.Writer
 import java.time.Instant
 import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 import java.util.TimeZone
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -86,8 +88,11 @@ class DebugInfoGenerator @Inject constructor(
 
         // begin with a timestamp to know when the error occurred
         if (timestamp != null) {
-            val instant = Instant.ofEpochSecond(timestamp).atZone(ZoneId.systemDefault())
-            writer.println("TIMESTAMP: $instant")
+            val instant = Instant.ofEpochSecond(timestamp)
+            writer.println("NOTIFICATION TIME")
+            val iso = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+            writer.println("Local time: ${instant.atZone(ZoneId.systemDefault()).format(iso)}")
+            writer.println("UTC: ${instant.atZone(ZoneOffset.UTC).format(iso)}")
             writer.println()
         }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoGenerator.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoGenerator.kt
@@ -50,7 +50,8 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import org.dmfs.tasks.contract.TaskContract
 import java.io.PrintWriter
 import java.io.Writer
-import java.time.ZonedDateTime
+import java.time.Instant
+import java.time.ZoneId
 import java.util.TimeZone
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -77,15 +78,18 @@ class DebugInfoGenerator @Inject constructor(
         cause: Throwable?,
         localResource: String?,
         remoteResource: String?,
+        timestamp: Long?,
         writer: PrintWriter
     ) {
         writer.println("--- BEGIN DEBUG INFO ---")
         writer.println()
 
-        // begin with a timestamp to know when this was generated
-        val now = ZonedDateTime.now()
-        writer.println("TIMESTAMP: $now")
-        writer.println()
+        // begin with a timestamp to know when the error occurred
+        if (timestamp != null) {
+            val instant = Instant.ofEpochSecond(timestamp).atZone(ZoneId.systemDefault())
+            writer.println("TIMESTAMP: $instant")
+            writer.println()
+        }
 
         // continue with most specific information
         if (syncAccount != null || syncAuthority != null) {

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoGenerator.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoGenerator.kt
@@ -50,13 +50,11 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import org.dmfs.tasks.contract.TaskContract
 import java.io.PrintWriter
 import java.io.Writer
+import java.time.ZonedDateTime
 import java.util.TimeZone
 import java.util.logging.Level
 import java.util.logging.Logger
 import javax.inject.Inject
-import kotlin.collections.filter
-import kotlin.collections.orEmpty
-import kotlin.text.removePrefix
 import kotlin.use
 import at.bitfire.ical4android.util.MiscUtils.asSyncAdapter as asCalendarSyncAdapter
 import at.bitfire.vcard4android.Utils.asSyncAdapter as asContactsSyncAdapter
@@ -84,7 +82,12 @@ class DebugInfoGenerator @Inject constructor(
         writer.println("--- BEGIN DEBUG INFO ---")
         writer.println()
 
-        // begin with most specific information
+        // begin with a timestamp to know when this was generated
+        val now = ZonedDateTime.now()
+        writer.println("TIMESTAMP: $now")
+        writer.println()
+
+        // continue with most specific information
         if (syncAccount != null || syncAuthority != null) {
             writer.append("SYNCHRONIZATION INFO\n")
             if (syncAccount != null)

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoModel.kt
@@ -42,7 +42,8 @@ class DebugInfoModel @AssistedInject constructor(
         val cause: Throwable?,
         val localResource: String?,
         val remoteResource: String?,
-        val logs: String?
+        val logs: String?,
+        val timestamp: Long?
     )
 
     @AssistedFactory
@@ -102,7 +103,8 @@ class DebugInfoModel @AssistedInject constructor(
                 syncAuthority = details.authority,
                 cause = details.cause,
                 localResource = details.localResource,
-                remoteResource = details.remoteResource
+                remoteResource = details.remoteResource,
+                timestamp = details.timestamp
             )
         }
     }
@@ -112,7 +114,14 @@ class DebugInfoModel @AssistedInject constructor(
      *
      * Note: Part of this method and all of it's helpers (listed below) should probably be extracted in the future
      */
-    private fun generateDebugInfo(syncAccount: Account?, syncAuthority: String?, cause: Throwable?, localResource: String?, remoteResource: String?) {
+    private fun generateDebugInfo(
+        syncAccount: Account?,
+        syncAuthority: String?,
+        cause: Throwable?,
+        localResource: String?,
+        remoteResource: String?,
+        timestamp: Long?
+    ) {
         val debugInfoFile = File(LogFileHandler.debugDir(context), FILE_DEBUG_INFO)
         debugInfoFile.printWriter().use { writer ->
             debugInfoGenerator(
@@ -121,6 +130,7 @@ class DebugInfoModel @AssistedInject constructor(
                 cause = cause,
                 localResource = localResource,
                 remoteResource = remoteResource,
+                timestamp = timestamp,
                 writer = writer
             )
         }

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoScreen.kt
@@ -58,6 +58,7 @@ fun DebugInfoScreen(
     localResource: String?,
     remoteResource: String?,
     logs: String?,
+    timestamp: Long?,
     onShareZipFile: (File) -> Unit,
     onViewFile: (File) -> Unit,
     onNavUp: () -> Unit
@@ -70,7 +71,8 @@ fun DebugInfoScreen(
                 cause = cause,
                 localResource = localResource,
                 remoteResource = remoteResource,
-                logs = logs
+                logs = logs,
+                timestamp = timestamp
             ))
         }
     )


### PR DESCRIPTION
### Purpose

See #1312

### Short description

Added a new line to the top of the debug info file to show the moment when the error occurred:
```
TIMESTAMP: 2025-02-24T16:54:14.330+01:00[Europe/Madrid]
```
This is obtained using a new extra called `timestamp`, and passed to `DebugInfoActivity` as the action of the notification shown by the error.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

