### PR TITLE
Support UnifiedPush Connector 3.x

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -195,7 +195,12 @@ dependencies {
     implementation(libs.okhttp.brotli)
     implementation(libs.okhttp.logging)
     implementation(libs.openid.appauth)
-    implementation(libs.unifiedpush)
+    implementation(libs.unifiedpush) {
+        // UnifiedPush connector seems to be using a workaround by importing this library.
+        // Will be removed after https://github.com/tink-crypto/tink-java-apps/pull/5 is merged.
+        // See: https://codeberg.org/UnifiedPush/android-connector/src/commit/28cb0d622ed0a972996041ab9cc85b701abc48c6/connector/build.gradle#L56-L59
+        exclude(group = "com.google.crypto.tink", module = "tink")
+    }
 
     // for tests
     androidTestImplementation(libs.androidx.arch.core.testing)

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsModel.kt
@@ -160,12 +160,12 @@ class AppSettingsModel @Inject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             if (pushDistributor == null) {
                 // Disable UnifiedPush if the distributor given is null
-                UnifiedPush.safeRemoveDistributor(context)
-                UnifiedPush.unregisterApp(context)
+                UnifiedPush.removeDistributor(context)
+                UnifiedPush.unregister(context)
             } else {
                 // If a distributor was passed, store it and register the app
                 UnifiedPush.saveDistributor(context, pushDistributor)
-                UnifiedPush.registerApp(context)
+                UnifiedPush.register(context)
             }
             _pushDistributor.value = pushDistributor
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,7 @@ mockk = "1.13.16"
 okhttp = "4.12.0"
 openid-appauth = "0.11.1"
 room = "2.6.1"
-unifiedpush = "2.4.0"
+unifiedpush = "3.0.4"
 
 [libraries]
 android-desugaring = { module = "com.android.tools:desugar_jdk_libs_nio", version.ref = "android-desugaring" }


### PR DESCRIPTION
### Purpose

Upgrade the UnifiedPush connector version to the latest one (3.0.4). This one includes built-in support for message encryption.

Also gives support to DAVPush encryption with [VAPID](https://bitfireat.github.io/webdav-push/draft-bitfire-webdav-push-00.html#name-vapid) and [message encryption](https://bitfireat.github.io/webdav-push/draft-bitfire-webdav-push-00.html#name-message-encryption).

### Short description

- Upgrade UnifiedPush Connector.
    Note that there seems to be a bug in a dependency they use, so they import it locally:

    https://github.com/UnifiedPush/android-connector/blob/28cb0d622ed0a972996041ab9cc85b701abc48c6/connector/build.gradle#L56-L59

    It breaks the build because of duplicated libraries, so I've had to exclude it from UnifiedPush. I guess that when https://github.com/tink-crypto/tink-java-apps/pull/5 is merged they will release a new version.

For some reason push is broken right now, I don't know if it's our fault, UnifiedPush's fault, or the Nextcloud server's fault.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

