### PR TITLE
Remove special chars in address book account names

### DIFF
--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStoreTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStoreTest.kt
@@ -86,6 +86,17 @@ class LocalAddressBookStoreTest {
 
 
     @Test
+    fun test_accountName_removesSpecialChars() {
+        val collection = mockk<Collection> {
+            every { id } returns 1
+            every { url } returns "https://example.com/addressbook/funnyfriends".toHttpUrl()
+            every { displayName } returns "Mate's _ \"Fri-ends\" \\(´д`)/  øåæä äöü #42"
+            every { serviceId } returns service.id
+        }
+        assertEquals("Mates _ Fri-ends     42 (Test Account) #1", localAddressBookStore.accountName(collection))
+    }
+
+    @Test
     fun test_accountName_missingService() {
         val collection = mockk<Collection> {
             every { id } returns 42

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStoreTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStoreTest.kt
@@ -87,13 +87,14 @@ class LocalAddressBookStoreTest {
 
     @Test
     fun test_accountName_removesSpecialChars() {
+        // Should remove iso control characters and `, ", ',
         val collection = mockk<Collection> {
             every { id } returns 1
             every { url } returns "https://example.com/addressbook/funnyfriends".toHttpUrl()
-            every { displayName } returns "Mate's _ \"Fri-ends\" \\(´д`)/  øåæä äöü #42"
+            every { displayName } returns "手 M's_\"F-e\"\\(´д`)/;æøå% äöü #42"
             every { serviceId } returns service.id
         }
-        assertEquals("Mates _ Fri-ends     42 (Test Account) #1", localAddressBookStore.accountName(collection))
+        assertEquals("手 Ms_F-e\\(´д)/;æøå% äöü #42 (Test Account) #1", localAddressBookStore.accountName(collection))
     }
 
     @Test

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
@@ -47,7 +47,7 @@ class LocalAddressBookStore @Inject constructor(
      *
      * The address book account name contains
      *
-     * - the collection display name or last URL path segment
+     * - the collection display name or last URL path segment (filtered for special characters)
      * - the actual account name
      * - the collection ID, to make it unique.
      *

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
@@ -54,14 +54,14 @@ class LocalAddressBookStore @Inject constructor(
      * @param info  Collection to take info from
      */
     fun accountName(info: Collection): String {
-        // Name the address book after given collection display name, otherwise use last URL path segment
-        val sb = StringBuilder(info.displayName.let {
-            if (it.isNullOrEmpty())
-                info.url.lastSegment
-            else
-                it
-        })
+        // Name of address book is given collection display name, otherwise the last URL path segment
+        var name = info.displayName.takeIf { !it.isNullOrEmpty() } ?: info.url.lastSegment
+
+        // Remove every character that is not alphanumeric or "-", "_", " "
+        name = name.replace(Regex("[^a-zA-Z0-9-_ ]"), "")
+
         // Add the actual account name to the address book account name
+        val sb = StringBuilder(name)
         serviceRepository.get(info.serviceId)?.let { service ->
             sb.append(" (${service.accountName})")
         }


### PR DESCRIPTION
### Purpose

DAVx5 shouldn't use special characters (and especially apostrophes) in auto-generated account names because this can cause problems on some devices. [Details](https://github.com/bitfireAT/davx5-ose/issues/1318)

### Short description

- filter special chars from address book account name
- document in kdoc
- add a test for the new behaviour 

### Checklist

- [X] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.

