### PR TITLE
Track app foreground state via AppTheme using separate object

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/network/HttpClient.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/network/HttpClient.kt
@@ -13,8 +13,8 @@ import at.bitfire.davdroid.db.Credentials
 import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.settings.Settings
 import at.bitfire.davdroid.settings.SettingsManager
+import at.bitfire.davdroid.ui.ForegroundTracker
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.flow.MutableStateFlow
 import net.openid.appauth.AuthState
 import net.openid.appauth.AuthorizationService
 import okhttp3.Authenticator
@@ -117,12 +117,6 @@ class HttpClient(
         private var followRedirects = false
         fun followRedirects(follow: Boolean): Builder {
             followRedirects = follow
-            return this
-        }
-
-        private var appInForeground: MutableStateFlow<Boolean>? = MutableStateFlow(false)
-        fun inForeground(foreground: Boolean): Builder {
-            appInForeground?.value = foreground
             return this
         }
 
@@ -240,7 +234,7 @@ class HttpClient(
             val certManager = CustomCertManager(
                 context = context,
                 trustSystemCerts = !settingsManager.getBoolean(Settings.DISTRUST_SYSTEM_CERTIFICATES),
-                appInForeground = appInForeground
+                appInForeground = ForegroundTracker.inForeground
             )
 
             val sslContext = SSLContext.getInstance("TLS")

--- a/app/src/main/kotlin/at/bitfire/davdroid/network/NextcloudLoginFlow.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/network/NextcloudLoginFlow.kt
@@ -43,7 +43,6 @@ class NextcloudLoginFlow @Inject constructor(
     }
 
     val httpClient = httpClientBuilder
-        .inForeground(true)
         .build()
 
     override fun close() {

--- a/app/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationWorker.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationWorker.kt
@@ -70,7 +70,6 @@ class PushRegistrationWorker @AssistedInject constructor(
     private suspend fun registerPushSubscription(collection: Collection, account: Account, endpoint: String) {
         httpClientBuilder.get()
             .fromAccount(account)
-            .inForeground(true)
             .build()
             .use { client ->
                 runInterruptible {
@@ -151,7 +150,6 @@ class PushRegistrationWorker @AssistedInject constructor(
     private suspend fun unregisterPushSubscription(collection: Collection, account: Account, url: HttpUrl) {
         httpClientBuilder.get()
             .fromAccount(account)
-            .inForeground(true)
             .build()
             .use { httpClient ->
                 runInterruptible {

--- a/app/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
@@ -182,7 +182,6 @@ class DavCollectionRepository @Inject constructor(
 
         httpClientBuilder.get()
             .fromAccount(account)
-            .inForeground(true)
             .build()
             .use { httpClient ->
                 runInterruptible(Dispatchers.IO) {
@@ -296,7 +295,6 @@ class DavCollectionRepository @Inject constructor(
     private suspend fun createOnServer(account: Account, url: HttpUrl, method: String, xmlBody: String) {
         httpClientBuilder.get()
             .fromAccount(account)
-            .inForeground(true)
             .build()
             .use { httpClient ->
                 runInterruptible(Dispatchers.IO) {

--- a/app/src/main/kotlin/at/bitfire/davdroid/servicedetection/DavResourceFinder.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/servicedetection/DavResourceFinder.kt
@@ -84,7 +84,6 @@ class DavResourceFinder @AssistedInject constructor(
     private var encountered401 = false
 
     private val httpClient = httpClientBuilder
-        .inForeground(true)
         .setLogger(log)
         .apply {
             if (credentials != null)

--- a/app/src/main/kotlin/at/bitfire/davdroid/servicedetection/RefreshCollectionsWorker.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/servicedetection/RefreshCollectionsWorker.kt
@@ -149,7 +149,6 @@ class RefreshCollectionsWorker @AssistedInject constructor(
             // create authenticating OkHttpClient (credentials taken from account settings)
             httpClientBuilder
                 .fromAccount(account)
-                .inForeground(true)
                 .build()
                 .use { httpClient ->
                     runInterruptible {

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AppTheme.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AppTheme.kt
@@ -50,9 +50,9 @@ fun AppTheme(
     
     // Track if the app is in the foreground
     LifecycleResumeEffect(view) {
-        ForegroundTracker.inForeground.value = true
+        ForegroundTracker.onResume()
         onPauseOrDispose {
-            ForegroundTracker.inForeground.value = false
+            ForegroundTracker.onPaused()
         }
     }
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AppTheme.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AppTheme.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.LocalView
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import at.bitfire.davdroid.ui.composable.SafeAndroidUriHandler
 
 @Composable
@@ -45,5 +46,13 @@ fun AppTheme(
                 M3ColorScheme.darkScheme,
             content = content
         )
+    }
+    
+    // Track if the app is in the foreground
+    LifecycleResumeEffect(view) {
+        ForegroundTracker.inForeground.value = true
+        onPauseOrDispose {
+            ForegroundTracker.inForeground.value = false
+        }
     }
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/ForegroundTracker.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/ForegroundTracker.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.asStateFlow
  */
 object ForegroundTracker {
 
-    private val _inForeground: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    private val _inForeground = MutableStateFlow(false)
 
     /**
      * Whether the app is in foreground or not.

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/ForegroundTracker.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/ForegroundTracker.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.ui
+
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/**
+ * Used to track whether the app is in foreground (visible to user) or not.
+ */
+object ForegroundTracker {
+    val inForeground: MutableStateFlow<Boolean> = MutableStateFlow(false)
+}

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/ForegroundTracker.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/ForegroundTracker.kt
@@ -5,10 +5,31 @@
 package at.bitfire.davdroid.ui
 
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * Used to track whether the app is in foreground (visible to user) or not.
  */
 object ForegroundTracker {
-    val inForeground: MutableStateFlow<Boolean> = MutableStateFlow(false)
+
+    private val _inForeground: MutableStateFlow<Boolean> = MutableStateFlow(false)
+
+    /**
+     * Whether the app is in foreground or not.
+     */
+    val inForeground = _inForeground.asStateFlow()
+
+    /**
+     * Called when the app is resumed (at [androidx.lifecycle.Lifecycle.Event.ON_RESUME])
+     */
+    fun onResume() {
+        _inForeground.value = true
+    }
+
+    /**
+     * Called when the app is paused (at [androidx.lifecycle.Lifecycle.Event.ON_PAUSE])
+     */
+    fun onPaused() {
+        _inForeground.value = false
+    }
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/webdav/WebDavMountRepository.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/webdav/WebDavMountRepository.kt
@@ -116,7 +116,6 @@ class WebDavMountRepository @Inject constructor(
         val validVersions = arrayOf("1", "2", "3")
 
         val builder = httpClientBuilder.get()
-            .inForeground(true)
 
         if (credentials != null)
             builder.authenticate(


### PR DESCRIPTION
### Purpose

Currently `appInForeground` is not always updated when app goes into foreground/background. The effect is that the cert4android TrustCertificateActivity doesn't always appear automatically. Currently the HttpClient is "manually" being set to "in foreground". This is error prone. 

We can instead keep track of the app-in-foreground state using [LifecycleResumeEffect](https://developer.android.com/topic/libraries/architecture/compose#lifecycleresumeeffect) in `AppTheme`.

### Short description

- Create `ForegroundTracker` object to hold mutable state flow value of whether the app is in foreground
- change the value in `AppTheme` using `LifecycleResumeEffect` depending on whether the app is in foreground or not 
- remove `HttpClient.Builder.inForeground` method and usages

### Note
`ForegroundTracker.inForeground` will become a nullable var when this PR get's merged with the changes from https://github.com/bitfireAT/davx5/issues/650

### Further information
Each Composable has its own unique View. Therefore, using LocalView.current as the key in LifecycleResumeEffect ensures that the effect is correctly associated with the lifecycle of the Composable.

### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.

