### PR TITLE
Original string for webdav_add_mount_empty_more_info broken

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -476,7 +476,7 @@
     <string name="webdav_mounts_unmount">Unmount</string>
     <string name="webdav_add_mount_title">Add WebDAV mount</string>
     <string name="webdav_mounts_empty">Directly access your cloud files by adding a WebDAV mount!</string>
-    <string name="webdav_add_mount_empty_more_info"><![CDATA[See the manual for <a href="%1$s">how WebDAV mounts work</a>.</string>]]></string>
+    <string name="webdav_add_mount_empty_more_info"><![CDATA[See the manual for <a href="%1$s">how WebDAV mounts work</a>.]]></string>
     <string name="webdav_add_mount_display_name">Display name</string>
     <string name="webdav_add_mount_url">WebDAV URL</string>
     <string name="webdav_add_mount_url_invalid">Invalid URL</string>


### PR DESCRIPTION
### Purpose

The string has an extra tag inside of the CDATA.

### Short description

Got rid of extra `</string>` tag inside of CDATA.

I guess that the translations should be updated in transifex, or should we remove them manually here? @rfc2822 @sunkup @devvv4ever 

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

