### PR TITLE
Sync after sync flag or forceReadOnly flag of a collection are changed

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/DelayedSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/DelayedSyncManager.kt
@@ -25,8 +25,8 @@ class DelayedSyncManager @Inject constructor(
     private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     /**
-     * Enqueues a one-time sync for given account, after a delay of 10 seconds. Resets delay when called
-     * again before delay finishes.
+     * Enqueues a one-time sync for given account, after a delay of [DELAY] ms. Resets delay when
+     * called again before delay finishes.
      * @param account   account to sync
      */
     fun enqueueAfterDelay(account: Account) {
@@ -37,10 +37,19 @@ class DelayedSyncManager @Inject constructor(
 
             // Start delay and enqueue sync on finish
             applicationScope.launch {
-                delay(10000L)
+                delay(DELAY)
                 syncWorkerManager.enqueueOneTimeAllAuthorities(account)
             }
         }
+    }
+
+    companion object {
+
+        /**
+         * Length of delay in milliseconds
+         */
+        const val DELAY = 10000L // 10 seconds
+
     }
 
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/DelayedSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/DelayedSyncManager.kt
@@ -36,7 +36,7 @@ class DelayedSyncManager @Inject constructor(
             previousJob?.cancel()
 
             // Start delay and enqueue sync on finish
-            /* return */ applicationScope.launch {
+            applicationScope.launch {
                 delay(10000L)
                 syncWorkerManager.enqueueOneTimeAllAuthorities(account)
             }

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreenModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreenModel.kt
@@ -202,7 +202,7 @@ class AccountScreenModel @AssistedInject constructor(
     private suspend fun syncAfterDelay(collectionId: Long) = withContext(Dispatchers.IO) {
         val serviceId = collectionRepository.get(collectionId)?.serviceId ?: return@withContext
         val accountName = serviceRepository.get(serviceId)?.accountName ?: return@withContext
-        val account = Account(accountName, context.getString(R.string.account_type))
+        val account = accountRepository.fromName(accountName)
 
         delayedSyncManager.enqueueAfterDelay(account)
     }

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreenModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreenModel.kt
@@ -185,7 +185,7 @@ class AccountScreenModel @AssistedInject constructor(
     }
 
     fun setCollectionSync(id: Long, sync: Boolean) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch {
             collectionRepository.setSync(id, sync)
             syncAfterDelay(id)
         }
@@ -199,9 +199,9 @@ class AccountScreenModel @AssistedInject constructor(
      * Enqueues a one-time account wide sync after a short delay or scope cancellation.
      * @param collectionId collection ID of collection in the account to be synchronized
      */
-    private fun syncAfterDelay(collectionId: Long) {
-        val serviceId = collectionRepository.get(collectionId)?.serviceId ?: return
-        val accountName = serviceRepository.get(serviceId)?.accountName ?: return
+    private suspend fun syncAfterDelay(collectionId: Long) = withContext(Dispatchers.IO) {
+        val serviceId = collectionRepository.get(collectionId)?.serviceId ?: return@withContext
+        val accountName = serviceRepository.get(serviceId)?.accountName ?: return@withContext
         val account = Account(accountName, context.getString(R.string.account_type))
 
         delayedSyncManager.enqueueAfterDelay(account)

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionScreenModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionScreenModel.kt
@@ -4,16 +4,14 @@
 
 package at.bitfire.davdroid.ui.account
 
-import android.accounts.Account
-import android.content.Context
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.Collection
+import at.bitfire.davdroid.repository.AccountRepository
 import at.bitfire.davdroid.repository.DavCollectionRepository
 import at.bitfire.davdroid.repository.DavServiceRepository
 import at.bitfire.davdroid.repository.DavSyncStatsRepository
@@ -25,7 +23,6 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -39,7 +36,7 @@ import kotlinx.coroutines.withContext
 
 @HiltViewModel(assistedFactory = CollectionScreenModel.Factory::class)
 class CollectionScreenModel @AssistedInject constructor(
-    @ApplicationContext private val context: Context,
+    private val accountRepository: AccountRepository,
     @Assisted val collectionId: Long,
     db: AppDatabase,
     private val collectionRepository: DavCollectionRepository,
@@ -155,7 +152,7 @@ class CollectionScreenModel @AssistedInject constructor(
     private suspend fun syncAfterDelay(collectionId: Long) = withContext(Dispatchers.IO) {
         val serviceId = collectionRepository.get(collectionId)?.serviceId ?: return@withContext
         val accountName = serviceRepository.get(serviceId)?.accountName ?: return@withContext
-        val account = Account(accountName, context.getString(R.string.account_type))
+        val account = accountRepository.fromName(accountName)
 
         delayedSyncManager.enqueueAfterDelay(account)
     }

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionScreenModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionScreenModel.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @HiltViewModel(assistedFactory = CollectionScreenModel.Factory::class)
 class CollectionScreenModel @AssistedInject constructor(
@@ -134,14 +135,14 @@ class CollectionScreenModel @AssistedInject constructor(
     }
 
     fun setForceReadOnly(forceReadOnly: Boolean) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch {
             collectionRepository.setForceReadOnly(collectionId, forceReadOnly)
             syncAfterDelay(collectionId)
         }
     }
 
     fun setSync(sync: Boolean) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch {
             collectionRepository.setSync(collectionId, sync)
             syncAfterDelay(collectionId)
         }
@@ -151,9 +152,9 @@ class CollectionScreenModel @AssistedInject constructor(
      * Enqueues a one-time account wide sync after a short delay or scope cancellation.
      * @param collectionId collection ID of collection in the account to be synchronized
      */
-    private fun syncAfterDelay(collectionId: Long) {
-        val serviceId = collectionRepository.get(collectionId)?.serviceId ?: return
-        val accountName = serviceRepository.get(serviceId)?.accountName ?: return
+    private suspend fun syncAfterDelay(collectionId: Long) = withContext(Dispatchers.IO) {
+        val serviceId = collectionRepository.get(collectionId)?.serviceId ?: return@withContext
+        val accountName = serviceRepository.get(serviceId)?.accountName ?: return@withContext
         val account = Account(accountName, context.getString(R.string.account_type))
 
         delayedSyncManager.enqueueAfterDelay(account)


### PR DESCRIPTION
### Purpose
Sync account (all authorities/sync data types) when:
- a collection is enabled/disabled for synchronization in UI
- Force Read-Only of a collection is being enabled/disabled in UI

### Short description

- Create `DelayedSyncManager` with `enqueueAfterDelay` which can enqueue a one time account wide sync after a short delay of 10 seconds, where the delay resets if the method is called again before the delay ends (within 10 seconds).
- In `CollectionScreenModel` and `AccountScreenModel`: Inject `DelayedSyncManager` and use `enqueueAfterDelay` on sync or force-read-only state changes. 

### Note
Idea: create a hilt module and inject application scope to handle it globally in the app instead of having multiple 
`private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)`. Would also make it more modular and probably increase testability.

Relevant todo (not in this PR):
- sync after collection refresh (no issue yet)
- https://github.com/orgs/bitfireAT/projects/5?pane=issue&itemId=107228912&issue=bitfireAT%7Cdavx5-ose%7C1398

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

