### PR TITLE
Use R8 full mode

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -181,6 +181,7 @@ dependencies {
     implementation(libs.bitfire.cert4android)
     implementation(libs.bitfire.dav4jvm) {
         exclude(group="junit")
+        exclude(group="org.ogce", module="xpp3")    // Android has its own XmlPullParser implementation
     }
     implementation(libs.bitfire.ical4android)
     implementation(libs.bitfire.vcard4android)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,6 @@
-/***************************************************************************************************
+/*
  * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
- **************************************************************************************************/
+ */
 
 plugins {
     alias(libs.plugins.mikepenz.aboutLibraries)
@@ -215,6 +215,7 @@ dependencies {
     androidTestImplementation(libs.okhttp.mockwebserver)
     androidTestImplementation(libs.room.testing)
 
+    testImplementation(libs.bitfire.dav4jvm)
     testImplementation(libs.junit)
     testImplementation(libs.mockk)
     testImplementation(libs.okhttp.mockwebserver)

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,6 @@ org.gradle.parallel=true
 
 # Android
 android.useAndroidX=true
-android.enableR8.fullMode=false
 
 # It's recommended to add these settings to your $GRADLE_USER_HOME/gradle.properties:
 


### PR DESCRIPTION

### Purpose

Since AGP 8, Android uses [R8 full mode by default](https://developer.android.com/build/shrink-code#full-mode). R8 full mode optimizes the APK and removes more unnecessary code.

However, there were build problems (release builds) when R8 full mode was active.


### Short description

This PR

- activates [R8 full mode](https://r8.googlesource.com/r8/+/refs/heads/master/compatibility-faq.md#r8-full-mode),
- removes the xpp3 dependency of dav4jvm. [XPP3 is a `XmlPullParser` implementation.](https://www.xmlpull.org/) However Android has [it's own implementation](https://developer.android.com/reference/org/xmlpull/v1/XmlPullParser?hl=en) which is always used. If xpp3 is not excluded, R8 can see multiple implementations of the same class and prints an error in full mode.


### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

