### PR TITLE
Hide "keep permissions" in API 29 and below

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/PermissionsModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/PermissionsModel.kt
@@ -23,7 +23,7 @@ class PermissionsModel @Inject constructor(
     @ApplicationContext val context: Context,
 ): ViewModel() {
 
-    var needKeepPermissions by mutableStateOf(false)
+    var needKeepPermissions by mutableStateOf<Boolean?>(null)
         private set
     var openTasksAvailable by mutableStateOf(false)
         private set

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/PermissionsScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/PermissionsScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -36,6 +35,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.viewmodel.compose.viewModel
 import at.bitfire.davdroid.BuildConfig
 import at.bitfire.davdroid.R


### PR DESCRIPTION
### Purpose

The "keep permissions" toggle was always shown, regardless of the current Android version. This should be hidden in Android 9 and below.

### Short description

Made the `needKeepPermissions` variable nullable on `PermissionsModel`. It will only be initialized in Android 30 and above. This is when [`isAutoRevokeWhitelisted`](https://developer.android.com/reference/android/content/pm/PackageManager.html#isAutoRevokeWhitelisted()) was introduced.

Also fixed an small deprecation on `PermissionsScreen`.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

