### PR TITLE
NPE when trying to log in without specifying an email

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/EmailLogin.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/EmailLogin.kt
@@ -141,7 +141,7 @@ fun EmailLoginScreen(
                     imeAction = ImeAction.Done
                 ),
                 keyboardActions = KeyboardActions(
-                    onDone = { onLogin() }
+                    onDone = { if (canContinue) onLogin() }
                 ),
                 modifier = Modifier.fillMaxWidth()
             )

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
@@ -188,11 +188,14 @@ class LoginScreenModel @AssistedInject constructor(
     private var detectResourcesJob: Job? = null
 
     private fun detectResources() {
+        // Make sure baseUri has been initialized
+        val baseUri = loginInfo.baseUri ?: return
+
         detectResourcesUiState = detectResourcesUiState.copy(loading = true)
         detectResourcesJob = viewModelScope.launch {
             val result = withContext(Dispatchers.IO) {
                  runInterruptible {
-                     resourceFinderFactory.create(loginInfo.baseUri!!, loginInfo.credentials).use { finder ->
+                     resourceFinderFactory.create(baseUri, loginInfo.credentials).use { finder ->
                          finder.findInitialConfiguration()
                      }
                  }

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
@@ -188,14 +188,11 @@ class LoginScreenModel @AssistedInject constructor(
     private var detectResourcesJob: Job? = null
 
     private fun detectResources() {
-        // Make sure baseUri has been initialized
-        val baseUri = loginInfo.baseUri ?: return
-
         detectResourcesUiState = detectResourcesUiState.copy(loading = true)
         detectResourcesJob = viewModelScope.launch {
             val result = withContext(Dispatchers.IO) {
                  runInterruptible {
-                     resourceFinderFactory.create(baseUri, loginInfo.credentials).use { finder ->
+                     resourceFinderFactory.create(loginInfo.baseUri!!, loginInfo.credentials).use { finder ->
                          finder.findInitialConfiguration()
                      }
                  }


### PR DESCRIPTION
### Purpose

To reproduce:
1. Add a new account to DAVx⁵
2. Choose "Login with email address"
3. Type a password without introducing any emails
4. Tap the "done" button in the virtual keyboard
5. The app crashes because `loginInfo.baseUri` is null
    https://github.com/bitfireAT/davx5-ose/blob/04fe8e1aca85094721b3fd39c14ba3fb34f342df/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt#L195

### Short description

Added check to the IME action as well as disabling the "next" button.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

