### PR TITLE
[WebDAV] Refactor coroutine usage

### DIFF
--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/webdav/DavDocumentsProviderTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/webdav/DavDocumentsProviderTest.kt
@@ -14,6 +14,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import io.mockk.junit4.MockKRule
+import kotlinx.coroutines.test.runTest
 import okhttp3.CookieJar
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
@@ -85,7 +86,7 @@ class DavDocumentsProviderTest {
 
 
     @Test
-    fun testDoQueryChildren_insert() {
+    fun testDoQueryChildren_insert() = runTest {
         // Create parent and root in database
         val id = db.webDavMountDao().insert(WebDavMount(0, "Cat food storage", server.url(PATH_WEBDAV_ROOT)))
         val webDavMount = db.webDavMountDao().getById(id)
@@ -106,7 +107,7 @@ class DavDocumentsProviderTest {
     }
 
     @Test
-    fun testDoQueryChildren_update() {
+    fun testDoQueryChildren_update() = runTest {
         // Create parent and root in database
         val mountId = db.webDavMountDao().insert(WebDavMount(0, "Cat food storage", server.url(PATH_WEBDAV_ROOT)))
         val webDavMount = db.webDavMountDao().getById(mountId)
@@ -142,7 +143,7 @@ class DavDocumentsProviderTest {
     }
 
     @Test
-    fun testDoQueryChildren_delete() {
+    fun testDoQueryChildren_delete() = runTest {
         // Create parent and root in database
         val mountId = db.webDavMountDao().insert(WebDavMount(0, "Cat food storage", server.url(PATH_WEBDAV_ROOT)))
         val webDavMount = db.webDavMountDao().getById(mountId)
@@ -166,7 +167,7 @@ class DavDocumentsProviderTest {
     }
 
     @Test
-    fun testDoQueryChildren_updateTwoDirectoriesSimultaneously() {
+    fun testDoQueryChildren_updateTwoDirectoriesSimultaneously() = runTest {
         // Create root in database
         val mountId = db.webDavMountDao().insert(WebDavMount(0, "Cat food storage", server.url(PATH_WEBDAV_ROOT)))
         val webDavMount = db.webDavMountDao().getById(mountId)

--- a/app/src/main/kotlin/at/bitfire/davdroid/db/WebDavDocument.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/db/WebDavDocument.kt
@@ -110,7 +110,7 @@ data class WebDavDocument(
         return bundle
     }
 
-    fun toHttpUrl(db: AppDatabase): HttpUrl {
+    suspend fun toHttpUrl(db: AppDatabase): HttpUrl {
         val mount = db.webDavMountDao().getById(mountId)
 
         val segments = mutableListOf(name)

--- a/app/src/main/kotlin/at/bitfire/davdroid/db/WebDavMountDao.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/db/WebDavMountDao.kt
@@ -17,16 +17,16 @@ interface WebDavMountDao {
     suspend fun deleteAsync(mount: WebDavMount)
 
     @Query("SELECT * FROM webdav_mount ORDER BY name, url")
-    fun getAll(): List<WebDavMount>
+    suspend fun getAll(): List<WebDavMount>
 
     @Query("SELECT * FROM webdav_mount ORDER BY name, url")
     fun getAllFlow(): Flow<List<WebDavMount>>
 
     @Query("SELECT * FROM webdav_mount WHERE id=:id")
-    fun getById(id: Long): WebDavMount
+    suspend fun getById(id: Long): WebDavMount
 
     @Insert
-    fun insert(mount: WebDavMount): Long
+    suspend fun insert(mount: WebDavMount): Long
 
 
     // complex queries

--- a/app/src/main/kotlin/at/bitfire/davdroid/util/CoroutineDispatcherModule.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/util/CoroutineDispatcherModule.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.util
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import javax.inject.Qualifier
+
+@Retention(AnnotationRetention.RUNTIME)
+@Qualifier
+annotation class DefaultDispatcher
+
+@Retention(AnnotationRetention.RUNTIME)
+@Qualifier
+annotation class IoDispatcher
+
+@Retention(AnnotationRetention.RUNTIME)
+@Qualifier
+annotation class MainDispatcher
+
+@Module
+@InstallIn(SingletonComponent::class)
+class CoroutineDispatcherModule {
+
+    @Provides
+    @DefaultDispatcher
+    fun defaultDispatcher(): CoroutineDispatcher = Dispatchers.Default
+
+    @Provides
+    @IoDispatcher
+    fun ioDispatcher(): CoroutineDispatcher = Dispatchers.IO
+
+    @Provides
+    @DefaultDispatcher
+    fun mainDispatcher(): CoroutineDispatcher = Dispatchers.Main
+
+}

--- a/app/src/main/kotlin/at/bitfire/davdroid/webdav/HeadResponse.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/webdav/HeadResponse.kt
@@ -4,6 +4,7 @@
 
 package at.bitfire.davdroid.webdav
 
+import androidx.annotation.WorkerThread
 import at.bitfire.dav4jvm.DavResource
 import at.bitfire.dav4jvm.HttpUtils
 import at.bitfire.dav4jvm.property.webdav.GetETag
@@ -25,6 +26,7 @@ data class HeadResponse(
 
     companion object {
 
+        @WorkerThread
         fun fromUrl(client: HttpClient, url: HttpUrl): HeadResponse {
             var size: Long? = null
             var eTag: String? = null

--- a/app/src/main/kotlin/at/bitfire/davdroid/webdav/PagingReader.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/webdav/PagingReader.kt
@@ -4,6 +4,7 @@
 
 package at.bitfire.davdroid.webdav
 
+import androidx.annotation.RequiresApi
 import com.google.common.cache.LoadingCache
 import java.io.IOException
 import java.util.logging.Logger
@@ -21,7 +22,7 @@ import kotlin.math.min
  * @param pageSize     page size (big enough to cache efficiently, small enough to avoid unnecessary traffic and spare memory)
  * @param pageCache    [LoadingCache] that loads page content from the actual data source
  */
-@Suppress("LocalVariableName")
+@RequiresApi(26)
 class PagingReader(
     private val fileSize: Long,
     private val pageSize: Int,
@@ -50,16 +51,16 @@ class PagingReader(
      * Will split the request into multiple page access operations, if necessary.
      *
      * @param offset    starting position
-     * @param _size     number of bytes to read
+     * @param size      number of bytes to read
      * @param dst       destination where data are read into
      *
-     * @return number of bytes read (may be smaller than [_size] if the file is not that big)
+     * @return number of bytes read (may be smaller than [size] if the file is not that big)
      */
-    fun read(offset: Long, _size: Int, dst: ByteArray): Int {
+    fun read(offset: Long, size: Int, dst: ByteArray): Int {
         // input validation
         if (offset > fileSize)
             throw IndexOutOfBoundsException()
-        var remaining = min(_size.toLong(), fileSize - offset).toInt()
+        var remaining = min(size.toLong(), fileSize - offset).toInt()
 
         var transferred = 0
         while (remaining > 0) {

--- a/app/src/main/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallback.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallback.kt
@@ -4,13 +4,13 @@
 
 package at.bitfire.davdroid.webdav
 
-import android.annotation.TargetApi
 import android.content.Context
 import android.os.CancellationSignal
 import android.os.ProxyFileDescriptorCallback
 import android.system.ErrnoException
 import android.system.OsConstants
 import android.text.format.Formatter
+import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import at.bitfire.dav4jvm.DavResource
@@ -28,10 +28,13 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.runInterruptible
 import okhttp3.Headers
@@ -42,7 +45,7 @@ import java.net.HttpURLConnection
 import java.util.logging.Level
 import java.util.logging.Logger
 
-@TargetApi(26)
+@RequiresApi(26)
 class RandomAccessCallback @AssistedInject constructor(
     @Assisted val httpClient: HttpClient,
     @Assisted val url: HttpUrl,
@@ -89,7 +92,8 @@ class RandomAccessCallback @AssistedInject constructor(
         .setOngoing(true)
     private val notificationTag = url.toString()
 
-    private val pageLoader = PageLoader()
+    private val scope = CoroutineScope(SupervisorJob())
+    private val pageLoader = PageLoader(scope)
     private val pageCache: LoadingCache<PageIdentifier, ByteArray> = CacheBuilder.newBuilder()
         .maximumSize(10)    // don't cache more than 10 entries (MAX_PAGE_SIZE each)
         .softValues()       // use SoftReference for the page contents so they will be garbage collected if memory is needed
@@ -98,27 +102,25 @@ class RandomAccessCallback @AssistedInject constructor(
     private val pagingReader = PagingReader(fileSize, MAX_PAGE_SIZE, pageCache)
 
     init {
-        cancellationSignal?.let {
+        cancellationSignal?.setOnCancelListener {
             logger.fine("Cancelling random access to $url")
-            pageLoader.cancelAll()
+            scope.cancel()
         }
     }
 
 
     override fun onFsync() { /* not used */ }
 
-    override fun onGetSize(): Long {
+    override fun onGetSize(): Long = runLocalScope("onGetFileSize") {
         logger.fine("onGetFileSize $url")
-        throwIfCancelled("onGetFileSize")
-        return fileSize
+        fileSize
     }
 
-    override fun onRead(offset: Long, size: Int, data: ByteArray): Int {
+    override fun onRead(offset: Long, size: Int, data: ByteArray) = runLocalScope("onRead") {
         logger.fine("onRead $url $offset $size")
-        throwIfCancelled("onRead")
 
         try {
-            return pagingReader.read(offset, size, data)
+            pagingReader.read(offset, size, data)
         } catch (e: Exception) {
             logger.log(Level.WARNING, "Couldn't read from WebDAV resource", e)
             throw e.toErrNoException("onRead")
@@ -136,12 +138,20 @@ class RandomAccessCallback @AssistedInject constructor(
         notificationManager.cancel(notificationTag, NotificationRegistry.NOTIFY_WEBDAV_ACCESS)
     }
 
-    private fun throwIfCancelled(functionName: String) {
-        if (cancellationSignal?.isCanceled == true) {
-            logger.warning("Random file access cancelled, throwing ErrnoException(EINTR)")
-            throw ErrnoException(functionName, OsConstants.EINTR)
+
+    // scope / cancellation
+
+    private fun<T> runLocalScope(functionName: String, block: () -> T): T =
+        runBlocking {
+            try {
+                scope.async {
+                    block()
+                }.await()
+            } catch (_: CancellationException) {
+                logger.warning("Random file access cancelled in $functionName, throwing ErrnoException(EINTR)")
+                throw ErrnoException(functionName, OsConstants.EINTR)
+            }
         }
-    }
 
     private fun Exception.toErrNoException(functionName: String) =
         ErrnoException(
@@ -164,17 +174,21 @@ class RandomAccessCallback @AssistedInject constructor(
 
     /**
      * Responsible for loading (= downloading) a single page from the WebDAV resource.
+     *
+     * @param scope     cancellable scope the loader runs in (loader cancels I/O) when this scope is cancelled
      */
-    inner class PageLoader: CacheLoader<PageIdentifier, ByteArray>() {
+    inner class PageLoader(
+        private val scope: CoroutineScope,
+        private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+    ): CacheLoader<PageIdentifier, ByteArray>() {
 
-        private val jobs = mutableSetOf<Deferred<ByteArray>>()
-
-        fun cancelAll() {
-            for (job in jobs)
-                job.cancel()
+        override fun load(key: PageIdentifier) = runBlocking {
+            scope.async {
+                loadAsync(key)
+            }.await()
         }
 
-        override fun load(key: PageIdentifier): ByteArray {
+        suspend fun loadAsync(key: PageIdentifier): ByteArray {
             val offset = key.offset
             val size = key.size
             logger.fine("Loading page $url $offset/$size")
@@ -196,39 +210,23 @@ class RandomAccessCallback @AssistedInject constructor(
                     Headers.headersOf("If-Unmodified-Since", HttpUtils.formatDate(lastModified))
                 } ?: throw DavException("ETag/Last-Modified required for random access")
 
-            // create async job that can be cancelled (and cancellation interrupts I/O)
-            val job = CoroutineScope(Dispatchers.IO).async {
-                runInterruptible {
-                    var result: ByteArray? = null
-                    dav.getRange(
-                        DavUtils.acceptAnything(preferred = mimeType),
-                        offset,
-                        size,
-                        ifMatch
-                    ) { response ->
-                        if (response.code == 200)       // server doesn't support ranged requests
-                            throw PartialContentNotSupportedException()
-                        else if (response.code != 206)
-                            throw HttpException(response)
+            return runInterruptible(ioDispatcher) {   // network I/O that should be cancelled by Thread interruption
+                var result: ByteArray? = null
+                dav.getRange(
+                    DavUtils.acceptAnything(preferred = mimeType),
+                    offset,
+                    size,
+                    ifMatch
+                ) { response ->
+                    if (response.code == 200)       // server doesn't support ranged requests
+                        throw PartialContentNotSupportedException()
+                    else if (response.code != 206)
+                        throw HttpException(response)
 
-                        result = response.body?.bytes()
-                    }
-                    return@runInterruptible result ?: throw DavException("No response body")
+                    result = response.body?.bytes()
                 }
+                result ?: throw DavException("No response body")
             }
-
-            try {
-                // register job in set so that it can be cancelled
-                jobs += job
-
-                // wait for result
-                return runBlocking {
-                    job.await()
-                }
-            } finally {
-                jobs -= job
-            }
-
         }
 
     }

--- a/app/src/main/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallback.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallback.kt
@@ -99,12 +99,12 @@ class RandomAccessCallback @AssistedInject constructor(
 
     override fun onFsync() { /* not used */ }
 
-    override fun onGetSize(): Long = runBlockingSaf("onGetFileSize") {
+    override fun onGetSize(): Long = runBlockingFd("onGetFileSize") {
         logger.fine("onGetFileSize $url")
         fileSize
     }
 
-    override fun onRead(offset: Long, size: Int, data: ByteArray) = runBlockingSaf("onRead") {
+    override fun onRead(offset: Long, size: Int, data: ByteArray) = runBlockingFd("onRead") {
         logger.fine("onRead $url $offset $size")
         pagingReader.read(offset, size, data)
     }
@@ -126,11 +126,12 @@ class RandomAccessCallback @AssistedInject constructor(
     /**
      * Runs blocking in [externalScope].
      *
-     * Exceptions (including [CancellationException]) are wrapped in an [ErrnoException] for Storage Access Framework.
+     * Exceptions (including [CancellationException]) are wrapped in an [ErrnoException], as expected by the file
+     * descriptor / Storage Access Framework.
      *
      * @param functionName  name of the operation, passed to [ErrnoException] in case of cancellation
      */
-    private fun<T> runBlockingSaf(functionName: String, block: () -> T): T =
+    private fun<T> runBlockingFd(functionName: String, block: () -> T): T =
         runBlocking {
             try {
                 externalScope.async {

--- a/app/src/main/kotlin/at/bitfire/davdroid/webdav/WebDavMountRepository.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/webdav/WebDavMountRepository.kt
@@ -13,8 +13,9 @@ import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.Credentials
 import at.bitfire.davdroid.db.WebDavMount
 import at.bitfire.davdroid.network.HttpClient
+import at.bitfire.davdroid.util.IoDispatcher
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withContext
@@ -23,8 +24,9 @@ import javax.inject.Inject
 import javax.inject.Provider
 
 class WebDavMountRepository @Inject constructor(
-    @ApplicationContext val context: Context,
-    val db: AppDatabase,
+    @ApplicationContext private val context: Context,
+    private val db: AppDatabase,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     private val httpClientBuilder: Provider<HttpClient.Builder>
 ) {
 
@@ -47,9 +49,9 @@ class WebDavMountRepository @Inject constructor(
         url: HttpUrl,
         displayName: String,
         credentials: Credentials?
-    ): Boolean = withContext(Dispatchers.IO) {
+    ): Boolean {
         if (!hasWebDav(url, credentials))
-            return@withContext false
+            return false
 
         // create in database
         val mount = WebDavMount(
@@ -65,7 +67,7 @@ class WebDavMountRepository @Inject constructor(
         // notify content URI listeners
         DavDocumentsProvider.notifyMountsChanged(context)
 
-        true
+        return true
     }
 
     suspend fun delete(mount: WebDavMount) {
@@ -86,7 +88,7 @@ class WebDavMountRepository @Inject constructor(
     suspend fun refreshAllQuota() {
         val resolver = context.contentResolver
 
-        withContext(Dispatchers.Default) {
+        withContext(ioDispatcher) {
             // query root document of each mount to refresh quota
             mountDao.getAll().forEach { mount ->
                 documentDao.getOrCreateRoot(mount).let { root ->
@@ -112,7 +114,7 @@ class WebDavMountRepository @Inject constructor(
     internal suspend fun hasWebDav(
         url: HttpUrl,
         credentials: Credentials?
-    ): Boolean = withContext(Dispatchers.IO) {
+    ): Boolean = withContext(ioDispatcher) {
         val validVersions = arrayOf("1", "2", "3")
 
         val builder = httpClientBuilder.get()


### PR DESCRIPTION
### Purpose

This PR is a first attempt to refactor code to use [best practices for coroutines on Android](https://developer.android.com/kotlin/coroutines/coroutines-best-practices).

It's not a complete rewrite because otherwise the PR would become too large. However it shall establish necessary infrastructure like the Hilt qualifies for dispatchers (`CoroutineDispatcherModule`) and be a first idea.

I started with WebDAV because it's a good usage of cancellation, and it's a bit separate from the rest of DAVx5.


### Short description

- Use `CoroutineScope` correctly and for cancellation (→ `CancellationSignal` in SAF is translated into coroutine cancellation).
- Repositories (in our case `WebDavMountRepository`) shall expose main-safe suspending methods for async work (means suspending DAO methods, too).
- Methods should switch context to a specific dispatcher, if they need it.
- Coroutines and dispatchers are provided in the constructor / injected, if possible and useful.
- `runInterruptible` on the I/O dispatcher is used for network I/O


### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

