### PR TITLE
Upgrade about libs to 12.1.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ kotlin = "2.1.20"
 kotlinx-coroutines = "1.10.2"
 # see https://github.com/google/ksp/releases for version numbers
 ksp = "2.1.20-2.0.0"
-mikepenz-aboutLibraries = "12.1.0-rc01"
+mikepenz-aboutLibraries = "12.1.0-rc02"
 nsk90-kstatemachine = "0.33.0"
 mockk = "1.14.0"
 okhttp = "4.12.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ kotlin = "2.1.20"
 kotlinx-coroutines = "1.10.2"
 # see https://github.com/google/ksp/releases for version numbers
 ksp = "2.1.20-2.0.0"
-mikepenz-aboutLibraries = "12.0.0"
+mikepenz-aboutLibraries = "12.1.0-rc01"
 nsk90-kstatemachine = "0.33.0"
 mockk = "1.14.0"
 okhttp = "4.12.0"


### PR DESCRIPTION
### Purpose

About libs 12.0.x is not compatible with Compose 1.8.0, which we have already upgraded to.

### Short description

- Upgrade about libs to `12.1.0-rc01` as a temporal fix until the stable version is released.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

