### PR TITLE
[Push] Support sync-token

### DIFF
--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/push/PushMessageHandlerTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/push/PushMessageHandlerTest.kt
@@ -28,18 +28,18 @@ class PushMessageHandlerTest {
 
 
     @Test
-    fun testParse_InvalidXml() {
-        Assert.assertNull(handler.parse("Non-XML content"))
+    fun testParse_Topic_InvalidXml() {
+        Assert.assertNull(handler.parse("Non-XML content")?.topic?.topic)
     }
 
     @Test
-    fun testParse_WithXmlDeclAndTopic() {
+    fun testParse_Topic_WithXmlDeclAndTopic() {
         val topic = handler.parse(
             "<?xml version=\"1.0\" encoding=\"utf-8\" ?>" +
             "<P:push-message xmlns:D=\"DAV:\" xmlns:P=\"https://bitfire.at/webdav-push\">" +
             "  <P:topic>O7M1nQ7cKkKTKsoS_j6Z3w</P:topic>" +
             "</P:push-message>"
-        )
+        )?.topic?.topic
         Assert.assertEquals("O7M1nQ7cKkKTKsoS_j6Z3w", topic)
     }
 

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncerTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncerTest.kt
@@ -207,6 +207,14 @@ class SyncerTest {
             throw NotImplementedError()
         }
 
+        override fun getByDbCollectionId(
+            account: Account,
+            provider: ContentProviderClient,
+            id: Long
+        ): LocalTestCollection? {
+            throw NotImplementedError()
+        }
+
         override fun update(
             provider: ContentProviderClient,
             localCollection: LocalTestCollection,

--- a/app/src/main/kotlin/at/bitfire/davdroid/push/PushMessageHandler.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/push/PushMessageHandler.kt
@@ -4,16 +4,22 @@
 
 package at.bitfire.davdroid.push
 
+import android.accounts.Account
 import androidx.annotation.VisibleForTesting
 import at.bitfire.dav4jvm.XmlReader
 import at.bitfire.dav4jvm.XmlUtils
+import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Collection.Companion.TYPE_ADDRESSBOOK
+import at.bitfire.davdroid.db.SyncState
 import at.bitfire.davdroid.repository.AccountRepository
 import at.bitfire.davdroid.repository.DavCollectionRepository
 import at.bitfire.davdroid.repository.DavServiceRepository
+import at.bitfire.davdroid.resource.LocalAddressBookStore
+import at.bitfire.davdroid.resource.LocalCalendarStore
 import at.bitfire.davdroid.sync.SyncDataType
 import at.bitfire.davdroid.sync.TasksAppManager
 import at.bitfire.davdroid.sync.worker.SyncWorkerManager
+import at.bitfire.davdroid.util.trimToNull
 import dagger.Lazy
 import org.unifiedpush.android.connector.data.PushMessage
 import org.xmlpull.v1.XmlPullParserException
@@ -30,11 +36,21 @@ class PushMessageHandler @Inject constructor(
     private val accountRepository: AccountRepository,
     private val collectionRepository: DavCollectionRepository,
     private val logger: Logger,
+    private val localCalendarStore: Lazy<LocalCalendarStore>,
+    private val localAddressBookStore: Lazy<LocalAddressBookStore>,
     private val serviceRepository: DavServiceRepository,
     private val syncWorkerManager: SyncWorkerManager,
     private val tasksAppManager: Lazy<TasksAppManager>
 ) {
 
+    /**
+     * Compares incoming push message sync token with locally remembered sync token and
+     * enqueues an account wide sync if the sync token has changed. Will enqueue all accounts
+     * if no topic is found in the message.
+     *
+     * @param message The message to be processed
+     * @param instance The registration instance. We are using [at.bitfire.davdroid.db.Service.id]
+     */
     suspend fun processMessage(message: PushMessage, instance: String) {
         if (!message.decrypted) {
             logger.severe("Received a push message that could not be decrypted.")
@@ -43,77 +59,139 @@ class PushMessageHandler @Inject constructor(
         val messageXml = message.content.toString(Charsets.UTF_8)
         logger.log(Level.INFO, "Received push message", messageXml)
 
-        // parse push notification
-        val topic = parse(messageXml)
+        // Parse push notification
+        val pushMessage = parse(messageXml)
 
-        // sync affected collection
-        if (topic != null) {
-            logger.info("Got push notification for topic $topic")
-
-            // Sync all authorities of account that the collection belongs to
-            // Later: only sync affected collection and authorities
-            collectionRepository.getSyncableByTopic(topic)?.let { collection ->
-                serviceRepository.getAsync(collection.serviceId)?.let { service ->
-                    val syncDataTypes = mutableSetOf<SyncDataType>()
-                    // If the type is an address book, add the contacts type
-                    if (collection.type == TYPE_ADDRESSBOOK)
-                        syncDataTypes += SyncDataType.CONTACTS
-
-                    // If the collection supports events, add the events type
-                    if (collection.supportsVEVENT != false)
-                        syncDataTypes += SyncDataType.EVENTS
-
-                    // If the collection supports tasks, make sure there's a provider installed,
-                    // and add the tasks type
-                    if (collection.supportsVJOURNAL != false || collection.supportsVTODO != false)
-                        if (tasksAppManager.get().currentProvider() != null)
-                            syncDataTypes += SyncDataType.TASKS
-
-                    // Schedule sync for all the types identified
-                    val account = accountRepository.fromName(service.accountName)
-                    for (syncDataType in syncDataTypes)
-                        syncWorkerManager.enqueueOneTime(account, syncDataType, fromPush = true)
-                }
-            }
-
-        } else {
-            // fallback when no known topic is present (shouldn't happen)
+        // Sync all accounts when no known topic is present (shouldn't happen)
+        val topic = pushMessage?.topic?.topic
+        if (topic == null) {
             val service = instance.toLongOrNull()?.let { serviceRepository.get(it) }
             if (service != null) {
-                logger.warning("Got push message without topic and service, syncing all accounts")
+                logger.warning("Got push message without topic, syncing all accounts")
                 val account = accountRepository.fromName(service.accountName)
                 syncWorkerManager.enqueueOneTimeAllAuthorities(account, fromPush = true)
-
             } else {
-                logger.warning("Got push message without topic, syncing all accounts")
+                logger.warning("Got push message without topic and service, syncing all accounts")
                 for (account in accountRepository.getAll())
                     syncWorkerManager.enqueueOneTimeAllAuthorities(account, fromPush = true)
             }
+            return
+        }
+
+        // Find DB collection from topic
+        logger.info("Got push notification for topic $topic")
+        val dbCollection = collectionRepository.getSyncableByTopic(topic)
+        if (dbCollection == null) {
+            logger.info("Skipping sync: No sync-enabled collection with topic $topic")
+            return
+        }
+
+        // Find account from DB collection
+        val account = serviceRepository.getAsync(dbCollection.serviceId)?.let { service ->
+            accountRepository.fromName(service.accountName)
+        } ?: return
+
+        // Check sync token is present
+        val newSyncToken = pushMessage.contentUpdate?.syncToken?.token?.trimToNull()
+        if (newSyncToken == null) {
+            logger.info("No sync token in push message. Skipping sync")
+            return
+        }
+
+        // Sync all data types of account which the collection belongs to
+        // Future: only sync affected collection
+        for (syncDataType in syncDataTypes(dbCollection)) {
+
+            // Find old sync token
+            val oldSyncToken = getSavedSyncToken(account, syncDataType, dbCollection.id)?.trimToNull()
+            if (oldSyncToken == null) {
+                logger.info("No local sync token for collection #${dbCollection.id}. Skipping sync")
+                continue
+            }
+
+            // Check whether sync token has changed
+            if (oldSyncToken == newSyncToken) {
+                logger.info("Sync token has not changed. Skipping sync")
+                continue
+            }
+
+            // Enqueue sync
+            logger.info("Sync token changed! Enqueuing one-time sync")
+            syncWorkerManager.enqueueOneTime(account, syncDataType, fromPush = true)
         }
     }
 
+
+    // helpers
+
     /**
-     * Parses a WebDAV-Push message and returns the `topic` that the message is about.
+     * Parses a WebDAV-Push message and returns it as [DavPushMessage].
      *
-     * @return topic of the modified collection, or `null` if the topic couldn't be determined
+     * @param message WebDAV-Push message to be parsed
+     * @return [DavPushMessage]
      */
     @VisibleForTesting
-    internal fun parse(message: String): String? {
-        var topic: String? = null
+    internal fun parse(message: String): DavPushMessage? {
+        var pushMessage: DavPushMessage? = null
 
         val parser = XmlUtils.newPullParser()
         try {
             parser.setInput(StringReader(message))
 
             XmlReader(parser).processTag(DavPushMessage.NAME) {
-                val pushMessage = DavPushMessage.Factory.create(parser)
-                topic = pushMessage.topic?.topic
+                pushMessage = DavPushMessage.Factory.create(parser)
             }
         } catch (e: XmlPullParserException) {
             logger.log(Level.WARNING, "Couldn't parse push message", e)
         }
 
-        return topic
+        return pushMessage
+    }
+
+    /**
+     * Determines sync data types of given collection
+     *
+     * @param dbCollection Collection to find sync data types for
+     * @return sync data types for given collection
+     */
+    @VisibleForTesting
+    internal fun syncDataTypes(dbCollection: Collection): Set<SyncDataType> = buildSet {
+        // If the type is an address book, add the contacts type
+        if (dbCollection.type == TYPE_ADDRESSBOOK)
+            add(SyncDataType.CONTACTS)
+
+        // If the collection supports events, add the events type
+        if (dbCollection.supportsVEVENT != false)
+            add(SyncDataType.EVENTS)
+
+        // If the collection supports tasks, make sure there's a provider installed,
+        // and add the tasks type
+        if (dbCollection.supportsVJOURNAL != false || dbCollection.supportsVTODO != false)
+            if (tasksAppManager.get().currentProvider() != null)
+                add(SyncDataType.TASKS)
+    }
+
+    /**
+     * Retrieves the sync token stored in local collection corresponding to given remote/DB collection.
+     *
+     * @param account Account where the local collection is stored
+     * @param syncDataType To determine the content provider
+     * @param dbCollectionId ID of remote collection
+     * @return sync token
+     */
+    @VisibleForTesting
+    internal fun getSavedSyncToken(account: Account, syncDataType: SyncDataType, dbCollectionId: Long): String? {
+        val localDataStore = when (syncDataType) {
+            SyncDataType.CONTACTS -> localAddressBookStore.get()
+            SyncDataType.EVENTS -> localCalendarStore.get()
+            SyncDataType.TASKS -> tasksAppManager.get().getDataStore()
+        }
+        return localDataStore?.acquireContentProvider()?.use { provider ->
+            localDataStore.getByDbCollectionId(account, provider, dbCollectionId)
+                ?.lastSyncState
+                ?.takeIf { it.type == SyncState.Type.SYNC_TOKEN }
+                ?.value
+        }
     }
 
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendarStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendarStore.kt
@@ -76,6 +76,15 @@ class LocalCalendarStore @Inject constructor(
     override fun getAll(account: Account, provider: ContentProviderClient) =
         AndroidCalendar.find(account, provider, LocalCalendar.Factory, "${Calendars.SYNC_EVENTS}!=0", null)
 
+    override fun getByDbCollectionId(account: Account, provider: ContentProviderClient, id: Long): LocalCalendar? =
+        AndroidCalendar.find(
+            account,
+            provider,
+            LocalCalendar.Factory,
+            "${Calendars._SYNC_ID}=?",
+            arrayOf(id.toString())
+        ).firstOrNull()
+
     override fun update(provider: ContentProviderClient, localCollection: LocalCalendar, fromCollection: Collection) {
         val accountSettings = accountSettingsFactory.create(localCollection.account)
         val values = valuesFromCollectionInfo(fromCollection, withColor = accountSettings.getManageCalendarColors())

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalDataStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalDataStore.kt
@@ -12,7 +12,7 @@ import at.bitfire.davdroid.db.Collection
  * Represents a local data store for a specific collection type.
  * Manages creation, update, and deletion of collections of the given type.
  */
-interface LocalDataStore<T: LocalCollection<*>> {
+interface LocalDataStore<T : LocalCollection<*>> {
 
     /**
      * Content provider authority for the data store.
@@ -51,6 +51,15 @@ interface LocalDataStore<T: LocalCollection<*>> {
      * @return a list of all local collections
      */
     fun getAll(account: Account, provider: ContentProviderClient): List<T>
+
+    /**
+     * Returns the [LocalCollection] corresponding to given remote [Collection].
+     *
+     * @param account   the account in which to look
+     * @param id        ID of remote collection
+     * @return          the local collection, or `null` if not found
+     */
+    fun getByDbCollectionId(account: Account, provider: ContentProviderClient, id: Long): T?
 
     /**
      * Updates the local collection with the data from the given (remote) collection info.

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollectionStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollectionStore.kt
@@ -91,6 +91,16 @@ class LocalJtxCollectionStore @Inject constructor(
     override fun getAll(account: Account, provider: ContentProviderClient): List<LocalJtxCollection> =
         JtxCollection.find(account, provider, context, LocalJtxCollection.Factory, null, null)
 
+    override fun getByDbCollectionId(account: Account, provider: ContentProviderClient, id: Long): LocalJtxCollection? =
+        JtxCollection.find(
+            account,
+            provider,
+            context,
+            LocalJtxCollection.Factory,
+            "${JtxContract.JtxCollection.SYNC_ID}=?",
+            arrayOf(id.toString())
+        ).firstOrNull()
+
     override fun update(provider: ContentProviderClient, localCollection: LocalJtxCollection, fromCollection: Collection) {
         val accountSettings = accountSettingsFactory.create(localCollection.account)
         val values = valuesFromCollection(fromCollection, account = localCollection.account, withColor = accountSettings.getManageCalendarColors())

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskListStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskListStore.kt
@@ -35,7 +35,7 @@ class LocalTaskListStore @AssistedInject constructor(
     @ApplicationContext val context: Context,
     val db: AppDatabase,
     val logger: Logger
-): LocalDataStore<LocalTaskList> {
+) : LocalDataStore<LocalTaskList> {
 
     @AssistedFactory
     interface Factory {
@@ -80,8 +80,10 @@ class LocalTaskListStore @AssistedInject constructor(
     private fun valuesFromCollectionInfo(info: Collection, withColor: Boolean): ContentValues {
         val values = ContentValues(3)
         values.put(TaskLists._SYNC_ID, info.id.toString())
-        values.put(TaskLists.LIST_NAME,
-            if (info.displayName.isNullOrBlank()) info.url.lastSegment else info.displayName)
+        values.put(
+            TaskLists.LIST_NAME,
+            if (info.displayName.isNullOrBlank()) info.url.lastSegment else info.displayName
+        )
 
         if (withColor && info.color != null)
             values.put(TaskLists.LIST_COLOR, info.color)
@@ -96,6 +98,16 @@ class LocalTaskListStore @AssistedInject constructor(
 
     override fun getAll(account: Account, provider: ContentProviderClient) =
         DmfsTaskList.find(account, LocalTaskList.Factory, provider, providerName, null, null)
+
+    override fun getByDbCollectionId(account: Account, provider: ContentProviderClient, id: Long): LocalTaskList? =
+        DmfsTaskList.find(
+            account,
+            LocalTaskList.Factory,
+            provider,
+            providerName,
+            "${TaskLists._SYNC_ID}=?",
+            arrayOf(id.toString())
+        ).firstOrNull()
 
     override fun update(provider: ContentProviderClient, localCollection: LocalTaskList, fromCollection: Collection) {
         logger.log(Level.FINE, "Updating local task list ${fromCollection.url}", fromCollection)


### PR DESCRIPTION
### Purpose

Avoid (some) redundant sync jobs triggered by incoming push notifications which are caused by our own uploads. 

Details in the issue: https://github.com/bitfireAT/davx5-ose/issues/1147.

### Short description

- Allow finding `LocalCollection` based on remote / DB collection ID in the different local data stores
- Compare sync-token saved in local collection with sync-token from push message and only enqueue a sync if they differ

### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [ ] I have added reasonable tests or consciously decided to not add tests.

