### PR TITLE
Fixed deprecations with menu anchors

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateCalendarScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateCalendarScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -255,7 +256,7 @@ fun CreateCalendarScreen(
                             readOnly = true,
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .menuAnchor()
+                                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
                         )
 
                         ExposedDropdownMenu(

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/HomeSetSelection.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/HomeSetSelection.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -61,7 +62,7 @@ fun HomeSetSelection(
                 },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .menuAnchor()
+                    .menuAnchor(MenuAnchorType.PrimaryNotEditable)
             )
 
             ExposedDropdownMenu(

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/AccountDetailsPage.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/AccountDetailsPage.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.SnackbarHostState
@@ -122,7 +123,7 @@ fun AccountDetailsPageContent(
                         { ExposedDropdownMenuDefaults.TrailingIcon(expanded) }
                     } else null,
                     modifier = Modifier
-                        .menuAnchor()
+                        .menuAnchor(MenuAnchorType.PrimaryEditable)
                         .fillMaxWidth()
                 )
 


### PR DESCRIPTION
### Purpose

The modifier `menuAnchor` without any arguments was [deprecated in 1.3.0](https://developer.android.com/reference/kotlin/androidx/compose/material3/ExposedDropdownMenuBoxScope#(androidx.compose.ui.Modifier).menuAnchor()). Now it takes [an anchor type](https://developer.android.com/reference/kotlin/androidx/compose/material3/ExposedDropdownMenuBoxScope#(androidx.compose.ui.Modifier).menuAnchor(androidx.compose.material3.ExposedDropdownMenuAnchorType,kotlin.Boolean)).

### Short description

- Replaced usages with their respective anchor types.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

