### PR TITLE
Ignore push messages when sync pending/running already

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/push/PushMessageHandler.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/push/PushMessageHandler.kt
@@ -7,14 +7,6 @@ package at.bitfire.davdroid.push
 import androidx.annotation.VisibleForTesting
 import at.bitfire.dav4jvm.XmlReader
 import at.bitfire.dav4jvm.XmlUtils
-import at.bitfire.davdroid.db.Collection.Companion.TYPE_ADDRESSBOOK
-import at.bitfire.davdroid.repository.AccountRepository
-import at.bitfire.davdroid.repository.DavCollectionRepository
-import at.bitfire.davdroid.repository.DavServiceRepository
-import at.bitfire.davdroid.sync.SyncDataType
-import at.bitfire.davdroid.sync.TasksAppManager
-import at.bitfire.davdroid.sync.worker.SyncWorkerManager
-import dagger.Lazy
 import org.unifiedpush.android.connector.data.PushMessage
 import org.xmlpull.v1.XmlPullParserException
 import java.io.StringReader
@@ -27,14 +19,15 @@ import at.bitfire.dav4jvm.property.push.PushMessage as DavPushMessage
  * Handles incoming WebDAV-Push messages.
  */
 class PushMessageHandler @Inject constructor(
-    private val accountRepository: AccountRepository,
-    private val collectionRepository: DavCollectionRepository,
     private val logger: Logger,
-    private val serviceRepository: DavServiceRepository,
-    private val syncWorkerManager: SyncWorkerManager,
-    private val tasksAppManager: Lazy<TasksAppManager>
+    private val pushSyncManager: PushSyncManager
 ) {
 
+    /**
+     * Processes a WebDAV-Push message and requests synchronization of the affected collection.
+     * @param message  the push message to process
+     * @param instance UnifiedPush Registration Instance. We use [at.bitfire.davdroid.db.Service.id]
+     */
     suspend fun processMessage(message: PushMessage, instance: String) {
         if (!message.decrypted) {
             logger.severe("Received a push message that could not be decrypted.")
@@ -45,56 +38,15 @@ class PushMessageHandler @Inject constructor(
 
         // parse push notification
         val topic = parse(messageXml)
+        val serviceId = instance.toLongOrNull()
 
-        // sync affected collection
-        if (topic != null) {
-            logger.info("Got push notification for topic $topic")
-
-            // Sync all authorities of account that the collection belongs to
-            // Later: only sync affected collection and authorities
-            collectionRepository.getSyncableByTopic(topic)?.let { collection ->
-                serviceRepository.get(collection.serviceId)?.let { service ->
-                    val syncDataTypes = mutableSetOf<SyncDataType>()
-                    // If the type is an address book, add the contacts type
-                    if (collection.type == TYPE_ADDRESSBOOK)
-                        syncDataTypes += SyncDataType.CONTACTS
-
-                    // If the collection supports events, add the events type
-                    if (collection.supportsVEVENT != false)
-                        syncDataTypes += SyncDataType.EVENTS
-
-                    // If the collection supports tasks, make sure there's a provider installed,
-                    // and add the tasks type
-                    if (collection.supportsVJOURNAL != false || collection.supportsVTODO != false)
-                        if (tasksAppManager.get().currentProvider() != null)
-                            syncDataTypes += SyncDataType.TASKS
-
-                    // Schedule sync for all the types identified
-                    val account = accountRepository.fromName(service.accountName)
-                    for (syncDataType in syncDataTypes)
-                        syncWorkerManager.enqueueOneTime(account, syncDataType, fromPush = true)
-                }
-            }
-
-        } else {
-            // fallback when no known topic is present (shouldn't happen)
-            val service = instance.toLongOrNull()?.let { serviceRepository.getBlocking(it) }
-            if (service != null) {
-                logger.warning("Got push message without topic and service, syncing all accounts")
-                val account = accountRepository.fromName(service.accountName)
-                syncWorkerManager.enqueueOneTimeAllAuthorities(account, fromPush = true)
-
-            } else {
-                logger.warning("Got push message without topic, syncing all accounts")
-                for (account in accountRepository.getAll())
-                    syncWorkerManager.enqueueOneTimeAllAuthorities(account, fromPush = true)
-            }
-        }
+        // Request synchronization
+        pushSyncManager.requestSync(topic, serviceId)
     }
 
     /**
      * Parses a WebDAV-Push message and returns the `topic` that the message is about.
-     *
+     * @param message  the push message to parse
      * @return topic of the modified collection, or `null` if the topic couldn't be determined
      */
     @VisibleForTesting

--- a/app/src/main/kotlin/at/bitfire/davdroid/push/PushSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/push/PushSyncManager.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.push
+
+import android.accounts.Account
+import at.bitfire.davdroid.db.Collection
+import at.bitfire.davdroid.db.Collection.Companion.TYPE_ADDRESSBOOK
+import at.bitfire.davdroid.repository.AccountRepository
+import at.bitfire.davdroid.repository.DavCollectionRepository
+import at.bitfire.davdroid.repository.DavServiceRepository
+import at.bitfire.davdroid.sync.SyncDataType
+import at.bitfire.davdroid.sync.TasksAppManager
+import at.bitfire.davdroid.sync.worker.SyncWorkerManager
+import com.google.common.annotations.VisibleForTesting
+import dagger.Lazy
+import java.util.logging.Logger
+import javax.inject.Inject
+
+class PushSyncManager @Inject constructor(
+    private val accountRepository: AccountRepository,
+    private val collectionRepository: DavCollectionRepository,
+    private val logger: Logger,
+    private val serviceRepository: DavServiceRepository,
+    private val syncWorkerManager: SyncWorkerManager,
+    private val tasksAppManager: Lazy<TasksAppManager>
+) {
+
+    private var _ignorePushSyncs: Boolean = false
+
+    fun ignorePushSyncs(ignore: Boolean) {
+        _ignorePushSyncs = ignore
+    }
+
+    /**
+     * Requests a sync for the given collection topic and service ID.
+     * @param topic the topic belonging to the collection to sync
+     * @param serviceId the ID of the service which the collection belongs to
+     */
+    suspend fun requestSync(topic: String?, serviceId: Long?) {
+        // If sync is uploading, ignore push message - don't trigger sync
+        if (_ignorePushSyncs) {
+            logger.severe("Ignoring push sync.")
+            return
+        }
+
+        // Sync datatypes of account which the collection supports
+        // Future: only sync affected collection
+        if (topic != null) {
+            logger.info("Got push message with topic $topic")
+            collectionRepository.getSyncableByTopic(topic)?.let { collection ->
+
+                // Identify sync data types of collection
+                val syncDataTypes = syncDataTypes(collection)
+
+                // Schedule sync for all the types identified
+                serviceRepository.get(collection.serviceId)?.let { service ->
+                    val account = accountRepository.fromName(service.accountName)
+                    requestSync(account, syncDataTypes)
+                }
+            }
+        } else {
+            // Fallback when no known topic is present (shouldn't happen)
+            val service = serviceId?.let { serviceRepository.getBlocking(it) }
+            if (service != null) {
+                // Sync account from service with all datatypes
+                logger.warning("Got push message without topic and service, syncing all accounts")
+                val account = accountRepository.fromName(service.accountName)
+                requestSync(account)
+            } else {
+                // Sync all accounts
+                logger.warning("Got push message without topic, syncing all accounts")
+                for (account in accountRepository.getAll())
+                    requestSync(account)
+            }
+        }
+    }
+
+    /**
+     * Request sync for the given account and sync data types.
+     * @param account the account to sync
+     * @param syncDataTypes the sync data types to sync, or an empty set to sync all data types
+     */
+    private fun requestSync(account: Account, syncDataTypes: Set<SyncDataType> = emptySet()) {
+        if (syncDataTypes.isNotEmpty()) {
+            // Only sync given datatypes
+            for (syncDataType in syncDataTypes) {
+                syncWorkerManager.enqueueOneTime(account, syncDataType, fromPush = true)
+            }
+        } else {
+            // Sync all datatypes
+            syncWorkerManager.enqueueOneTimeAllAuthorities(account, fromPush = true)
+        }
+    }
+
+
+    // helpers
+
+    /**
+     * Returns the sync data types for the given collection.
+     * @param collection the collection to get the sync data types for
+     * @return the sync data types for the given collection
+     */
+    @VisibleForTesting
+    internal fun syncDataTypes(collection: Collection) = buildSet {
+        // If the type is an address book, add the contacts type
+        if (collection.type == TYPE_ADDRESSBOOK)
+            add(SyncDataType.CONTACTS)
+
+        // If the collection supports events, add the events type
+        if (collection.supportsVEVENT != false)
+            add(SyncDataType.EVENTS)
+
+        // If the collection supports tasks, make sure there's a provider installed,
+        // and add the tasks type
+        if (collection.supportsVJOURNAL != false || collection.supportsVTODO != false)
+            if (tasksAppManager.get().currentProvider() != null)
+                add(SyncDataType.TASKS)
+    }
+
+}

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -30,6 +30,7 @@ import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.SyncState
 import at.bitfire.davdroid.network.HttpClient
+import at.bitfire.davdroid.push.PushSyncManager
 import at.bitfire.davdroid.repository.AccountRepository
 import at.bitfire.davdroid.repository.DavCollectionRepository
 import at.bitfire.davdroid.repository.DavServiceRepository
@@ -134,22 +135,25 @@ abstract class SyncManager<ResourceType: LocalResource<*>, out CollectionType: L
     lateinit var context: Context
 
     @Inject
-    lateinit var logger: Logger
-
-    @Inject
     lateinit var accountRepository: AccountRepository
-
-    @Inject
-    lateinit var syncStatsRepository: DavSyncStatsRepository
-
-    @Inject
-    lateinit var serviceRepository: DavServiceRepository
 
     @Inject
     lateinit var collectionRepository: DavCollectionRepository
 
     @Inject
+    lateinit var logger: Logger
+
+    @Inject
+    lateinit var pushSyncManager: PushSyncManager 
+            
+    @Inject
+    lateinit var serviceRepository: DavServiceRepository
+
+    @Inject
     lateinit var syncNotificationManagerFactory: SyncNotificationManager.Factory
+
+    @Inject
+    lateinit var syncStatsRepository: DavSyncStatsRepository
 
 
     init {
@@ -171,29 +175,36 @@ abstract class SyncManager<ResourceType: LocalResource<*>, out CollectionType: L
 
 
         try {
-            logger.info("Preparing synchronization")
-            if (!prepare()) {
-                logger.info("No reason to synchronize, aborting")
-                return
-            }
-            syncStatsRepository.logSyncTimeBlocking(collection.id, authority)
+            var remoteSyncState: SyncState? = null
+            var modificationsPresent = false
+            try {
+                logger.info("Preparing synchronization")
+                if (!prepare()) {
+                    logger.info("No reason to synchronize, aborting")
+                    return
+                }
+                syncStatsRepository.logSyncTimeBlocking(collection.id, authority)
 
-            logger.info("Querying server capabilities")
-            var remoteSyncState = queryCapabilities()
+                logger.info("Querying server capabilities")
+                remoteSyncState = queryCapabilities()
 
-            logger.info("Processing local deletes/updates")
-            val modificationsPresent =
-                processLocallyDeleted() or uploadDirty()     // bitwise OR guarantees that both expressions are evaluated
+                logger.info("Processing local deletes/updates")
+                // bitwise OR guarantees that both expressions are evaluated
+                modificationsPresent = processLocallyDeleted() or uploadDirty()
 
-            if (extras.contains(Syncer.SYNC_EXTRAS_FULL_RESYNC)) {
-                logger.info("Forcing re-synchronization of all entries")
+                if (extras.contains(Syncer.SYNC_EXTRAS_FULL_RESYNC)) {
+                    logger.info("Forcing re-synchronization of all entries")
 
-                // forget sync state of collection (→ initial sync in case of SyncAlgorithm.COLLECTION_SYNC)
-                localCollection.lastSyncState = null
-                remoteSyncState = null
+                    // forget sync state of collection (→ initial sync in case of SyncAlgorithm.COLLECTION_SYNC)
+                    localCollection.lastSyncState = null
+                    remoteSyncState = null
 
-                // forget sync state of members (→ download all members again and update them locally)
-                localCollection.forgetETags()
+                    // forget sync state of members (→ download all members again and update them locally)
+                    localCollection.forgetETags()
+                }
+            } finally {
+                logger.info("Stopping to ignore push syncs")
+                pushSyncManager.ignorePushSyncs(false)
             }
 
             if (modificationsPresent || syncRequired(remoteSyncState))

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/SyncWorkerManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/SyncWorkerManager.kt
@@ -25,7 +25,6 @@ import androidx.work.WorkManager
 import androidx.work.WorkQuery
 import androidx.work.WorkRequest
 import at.bitfire.davdroid.push.PushNotificationManager
-import at.bitfire.davdroid.push.PushSyncManager
 import at.bitfire.davdroid.sync.SyncDataType
 import at.bitfire.davdroid.sync.TasksAppManager
 import at.bitfire.davdroid.sync.worker.BaseSyncWorker.Companion.INPUT_ACCOUNT_NAME
@@ -54,7 +53,6 @@ class SyncWorkerManager @Inject constructor(
     @ApplicationContext val context: Context,
     val logger: Logger,
     val pushNotificationManager: PushNotificationManager,
-    val pushSyncManager: Lazy<PushSyncManager>,
     val tasksAppManager: Lazy<TasksAppManager>
 ) {
 
@@ -129,9 +127,6 @@ class SyncWorkerManager @Inject constructor(
         fromPush: Boolean = false
     ): String {
         logger.info("Enqueueing unique worker for account=$account, dataType=$dataType, manual=$manual, resync=$resync, upload=$upload, fromPush=$fromPush")
-
-        pushSyncManager.get().ignorePushSyncs(true)
-        logger.info("Starting to ignore push syncs")
 
         // enqueue and start syncing
         val name = OneTimeSyncWorker.workerName(account, dataType)
@@ -261,11 +256,11 @@ class SyncWorkerManager @Inject constructor(
 
     /**
      * Observes whether >0 sync workers (both [PeriodicSyncWorker] and [OneTimeSyncWorker])
-     * exist, belonging to given account and authorities (sync data type), and which are/is in the given worker state.
+     * exist, belonging to given account and authorities, and which are/is in the given worker state.
      *
      * @param workStates   list of states of workers to match
      * @param account      the account which the workers belong to
-     * @param dataTypes  type of sync work, ie [CalendarContract.AUTHORITY]
+     * @param authorities  type of sync work, ie [CalendarContract.AUTHORITY]
      * @param whichTag     function to generate tag that should be observed for given account and authority
      *
      * @return flow that emits `true` if at least one worker with matching query was found; `false` otherwise

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/SyncWorkerManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/SyncWorkerManager.kt
@@ -25,6 +25,7 @@ import androidx.work.WorkManager
 import androidx.work.WorkQuery
 import androidx.work.WorkRequest
 import at.bitfire.davdroid.push.PushNotificationManager
+import at.bitfire.davdroid.push.PushSyncManager
 import at.bitfire.davdroid.sync.SyncDataType
 import at.bitfire.davdroid.sync.TasksAppManager
 import at.bitfire.davdroid.sync.worker.BaseSyncWorker.Companion.INPUT_ACCOUNT_NAME
@@ -53,6 +54,7 @@ class SyncWorkerManager @Inject constructor(
     @ApplicationContext val context: Context,
     val logger: Logger,
     val pushNotificationManager: PushNotificationManager,
+    val pushSyncManager: Lazy<PushSyncManager>,
     val tasksAppManager: Lazy<TasksAppManager>
 ) {
 
@@ -127,6 +129,9 @@ class SyncWorkerManager @Inject constructor(
         fromPush: Boolean = false
     ): String {
         logger.info("Enqueueing unique worker for account=$account, dataType=$dataType, manual=$manual, resync=$resync, upload=$upload, fromPush=$fromPush")
+
+        pushSyncManager.get().ignorePushSyncs(true)
+        logger.info("Starting to ignore push syncs")
 
         // enqueue and start syncing
         val name = OneTimeSyncWorker.workerName(account, dataType)
@@ -256,11 +261,11 @@ class SyncWorkerManager @Inject constructor(
 
     /**
      * Observes whether >0 sync workers (both [PeriodicSyncWorker] and [OneTimeSyncWorker])
-     * exist, belonging to given account and authorities, and which are/is in the given worker state.
+     * exist, belonging to given account and authorities (sync data type), and which are/is in the given worker state.
      *
      * @param workStates   list of states of workers to match
      * @param account      the account which the workers belong to
-     * @param authorities  type of sync work, ie [CalendarContract.AUTHORITY]
+     * @param dataTypes  type of sync work, ie [CalendarContract.AUTHORITY]
      * @param whichTag     function to generate tag that should be observed for given account and authority
      *
      * @return flow that emits `true` if at least one worker with matching query was found; `false` otherwise


### PR DESCRIPTION
### Purpose

Ignore push messages for collection if a pending or running sync for the account containing the collection exists already.

### Short description

Ignore push message sync request if sync work for affected account is pending/running already. 

### Checklist

- [ ] The PR has a proper title, description and label.
- [ ] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [ ] I have added documentation to complex functions and functions that can be used by other modules.
- [ ] I have added reasonable tests or consciously decided to not add tests.

