### PR TITLE
Added warning about credentials in debug info

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.rounded.Adb
 import androidx.compose.material.icons.rounded.BugReport
 import androidx.compose.material.icons.rounded.Info
+import androidx.compose.material.icons.rounded.Password
 import androidx.compose.material.icons.rounded.Share
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
@@ -194,6 +195,13 @@ fun DebugInfoScreen(
             ) {
                 if (!showDebugInfo || zipProgress)
                     ProgressBar()
+
+                CardWithImage(
+                    title = stringResource(R.string.debug_info_credentials_warning_title),
+                    message = stringResource(R.string.debug_info_credentials_warning_description),
+                    icon = Icons.Rounded.Password,
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp)
+                )
 
                 if (showModelCause) {
                     CardWithImage(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?><resources xmlns:tools="http://schemas.android.com/tools">
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+  -->
+
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- common strings -->
     <string name="app_name" translatable="false">DAVx⁵</string>
@@ -463,6 +467,8 @@
     <string name="debug_info_logs_caption">Logs</string>
     <string name="debug_info_logs_subtitle">Verbose logs are available</string>
     <string name="debug_info_logs_view">View logs</string>
+    <string name="debug_info_credentials_warning_title">Privacy alert!</string>
+    <string name="debug_info_credentials_warning_description">Logs and debug info may contain masked or plain-text credentials. Please, be aware of this when sharing online.</string>
 
     <!-- ExceptionInfoFragment -->
     <string name="exception">An error has occurred.</string>


### PR DESCRIPTION
### Purpose

Logs may contain confidential information like passwords or Base64 encoded credentials, people may not know it.

### Short description

Added a warning message in the debug information screen to let the user know that log messages can contain credentials, and that they should be really careful while sharing.

<details>
<summary>Screenshot</summary>

![Screenshot_20250511_110633](https://github.com/user-attachments/assets/3ce723d9-edf2-45ad-9473-3dcadf549ad2)

</details>

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

