### PR TITLE
Reset subscription URLs on distributor change

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
@@ -111,6 +111,25 @@ class PushRegistrationManager @Inject constructor(
         // will then call processSubscription or removeSubscription.
     }
 
+    /**
+     * Sets or removes (disable push) the distributor and updates the subscriptions + worker.
+     */
+    suspend fun setPushDistributor(pushDistributor: String?) {
+        if (pushDistributor == null) {
+            // Disable UnifiedPush if the distributor given is null
+            UnifiedPush.removeDistributor(context)
+        } else {
+            // If a distributor was passed, store it
+            UnifiedPush.saveDistributor(context, pushDistributor)
+        }
+
+        // Update subscriptions
+        update()
+    }
+
+    fun getDistributor() = UnifiedPush.getSavedDistributor(context)
+
+    fun getDistributors() = UnifiedPush.getDistributors(context)
 
     /**
      * Called by [UnifiedPushService] when a subscription (endpoint) is available for the given service.

--- a/app/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
@@ -91,6 +91,10 @@ class PushRegistrationManager @Inject constructor(
         updatePeriodicWorker()
     }
 
+    /**
+     * Registers or unregisters depending on whether there is a distributor available. Also unsubscribes
+     * if no distributor is available.
+     */
     private suspend fun updateService(serviceId: Long) {
         val service = serviceRepository.get(serviceId) ?: return
 
@@ -123,7 +127,11 @@ class PushRegistrationManager @Inject constructor(
             UnifiedPush.saveDistributor(context, pushDistributor)
         }
 
-        // Update subscriptions
+        // Manually unsubscribe collections
+        for (service in serviceRepository.getAll())
+            unsubscribeAll(service)
+
+        // Update/Recreate subscriptions and worker
         update()
     }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
@@ -124,7 +124,7 @@ class PushRegistrationManager @Inject constructor(
     private suspend fun updateService(serviceId: Long) {
         val service = serviceRepository.get(serviceId) ?: return
 
-        val distributorAvailable = UnifiedPush.getSavedDistributor(context) != null
+        val distributorAvailable = getCurrentDistributor() != null
         if (distributorAvailable)
             try {
                 val vapid = collectionRepository.getVapidKey(serviceId)

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsModel.kt
@@ -135,8 +135,8 @@ class AppSettingsModel @Inject constructor(
      * - Makes sure the app is registered with UnifiedPush if there's already a distributor selected.
      */
     private fun loadPushDistributors() {
-        val savedPushDistributor = pushRegistrationManager.getDistributor()
-        _pushDistributor.value = savedPushDistributor
+        val currentPushDistributor = pushRegistrationManager.getCurrentDistributor()
+        _pushDistributor.value = currentPushDistributor
 
         val pushDistributors = pushRegistrationManager.getDistributors()
             .map { pushDistributor ->

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsModel.kt
@@ -33,7 +33,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import org.unifiedpush.android.connector.UnifiedPush
 import javax.inject.Inject
 
 @HiltViewModel
@@ -136,10 +135,10 @@ class AppSettingsModel @Inject constructor(
      * - Makes sure the app is registered with UnifiedPush if there's already a distributor selected.
      */
     private fun loadPushDistributors() {
-        val savedPushDistributor = UnifiedPush.getSavedDistributor(context)
+        val savedPushDistributor = pushRegistrationManager.getDistributor()
         _pushDistributor.value = savedPushDistributor
 
-        val pushDistributors = UnifiedPush.getDistributors(context)
+        val pushDistributors = pushRegistrationManager.getDistributors()
             .map { pushDistributor ->
                 try {
                     val applicationInfo = pm.getApplicationInfo(pushDistributor, 0)
@@ -163,16 +162,7 @@ class AppSettingsModel @Inject constructor(
      */
     fun updatePushDistributor(pushDistributor: String?) {
         viewModelScope.launch(ioDispatcher) {
-            if (pushDistributor == null) {
-                // Disable UnifiedPush if the distributor given is null
-                UnifiedPush.removeDistributor(context)
-            } else {
-                // If a distributor was passed, store it
-                UnifiedPush.saveDistributor(context, pushDistributor)
-            }
-
-            // Update subscriptions
-            pushRegistrationManager.update()
+            pushRegistrationManager.setPushDistributor(pushDistributor)
 
             _pushDistributor.value = pushDistributor
         }


### PR DESCRIPTION
### Purpose
Subscription URLs are not reset when push distributor changes.

### Short description

- moved distributor get and set methods from model to PushRegistrationManager
- unsubscribe all collections (+reset subscription URLs) manually after user changes distributor
- add some more kdoc 

### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.

