### PR TITLE
Display FCM instead of DAVx⁵ in distributor settings

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsScreen.kt
@@ -743,9 +743,14 @@ fun AppSettings_Integration(
         ) { showingDistributorDialog = false }
     }
 
-    val pushAppName = pushDistributor?.let {
-        pushDistributors?.find { it.packageName == pushDistributor }
-    }?.appName
+    val context = LocalContext.current
+    val pushAppName = if (pushDistributor == context.packageName) {
+        stringResource(R.string.app_settings_unifiedpush_distributor_fcm)
+    } else {
+        pushDistributor?.let {
+            pushDistributors?.find { it.packageName == pushDistributor }
+        }?.appName
+    }
     Setting(
         name = stringResource(R.string.app_settings_unifiedpush),
         summary = if (pushDistributor != null)

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsScreen.kt
@@ -747,9 +747,7 @@ fun AppSettings_Integration(
     val pushAppName = if (pushDistributor == context.packageName) {
         stringResource(R.string.app_settings_unifiedpush_distributor_fcm)
     } else {
-        pushDistributor?.let {
-            pushDistributors?.find { it.packageName == pushDistributor }
-        }?.appName
+        pushDistributors?.find { it.packageName == pushDistributor }?.appName
     }
     Setting(
         name = stringResource(R.string.app_settings_unifiedpush),


### PR DESCRIPTION
### Purpose

See #1466

### Short description

When the app's package name is detected, it displays FCM instead of DAVx⁵.

![image](https://github.com/user-attachments/assets/d01cb639-4554-47eb-a325-003a01509cf2)

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

