### PR TITLE
SyncManager: directly wrap HTTP calls with `runInterruptible`

### DIFF
--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/TestSyncManager.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/TestSyncManager.kt
@@ -63,7 +63,7 @@ class TestSyncManager @AssistedInject constructor(
     }
 
     var didQueryCapabilities = false
-    override fun queryCapabilities(): SyncState? {
+    override suspend fun queryCapabilities(): SyncState? {
         if (didQueryCapabilities)
             throw IllegalStateException("queryCapabilities() must not be called twice")
         didQueryCapabilities = true
@@ -89,7 +89,7 @@ class TestSyncManager @AssistedInject constructor(
 
     var listAllRemoteResult = emptyList<Pair<Response, Response.HrefRelation>>()
     var didListAllRemote = false
-    override fun listAllRemote(callback: MultiResponseCallback) {
+    override suspend fun listAllRemote(callback: MultiResponseCallback) {
         if (didListAllRemote)
             throw IllegalStateException("listAllRemote() must not be called twice")
         didListAllRemote = true
@@ -99,7 +99,7 @@ class TestSyncManager @AssistedInject constructor(
 
     var assertDownloadRemote = emptyMap<HttpUrl, String>()
     var didDownloadRemote = false
-    override fun downloadRemote(bunch: List<HttpUrl>) {
+    override suspend fun downloadRemote(bunch: List<HttpUrl>) {
         didDownloadRemote = true
         assertEquals(assertDownloadRemote.keys.toList(), bunch)
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
@@ -125,7 +125,7 @@ class CalendarSyncManager @AssistedInject constructor(
         else
             SyncAlgorithm.COLLECTION_SYNC
 
-    override fun processLocallyDeleted(): Boolean {
+    override suspend fun processLocallyDeleted(): Boolean {
         if (localCollection.readOnly) {
             var modified = false
             for (event in localCollection.findDeleted()) {

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
@@ -202,7 +202,7 @@ class ContactsSyncManager @AssistedInject constructor(
         else
             SyncAlgorithm.PROPFIND_REPORT
 
-    override fun processLocallyDeleted() =
+    override suspend fun processLocallyDeleted() =
             if (localCollection.readOnly) {
                 var modified = false
                 for (group in localCollection.findDeletedGroups()) {

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
@@ -125,28 +125,30 @@ class JtxSyncManager @AssistedInject constructor(
         }
     }
 
-    override fun downloadRemote(bunch: List<HttpUrl>) {
+    override suspend fun downloadRemote(bunch: List<HttpUrl>) {
         logger.info("Downloading ${bunch.size} iCalendars: $bunch")
         // multiple iCalendars, use calendar-multi-get
-        SyncException.wrapWithRemoteResource(collection.url) {
-            davCollection.multiget(bunch) { response, _ ->
-                // See CalendarSyncManager for more information about the multi-get response
-                SyncException.wrapWithRemoteResource(response.href) wrapResource@ {
-                    if (!response.isSuccess()) {
-                        logger.warning("Ignoring non-successful multi-get response for ${response.href}")
-                        return@wrapResource
+        SyncException.wrapWithRemoteResourceSuspending(collection.url) {
+            runInterruptible {
+                davCollection.multiget(bunch) { response, _ ->
+                    // See CalendarSyncManager for more information about the multi-get response
+                    SyncException.wrapWithRemoteResource(response.href) wrapResource@{
+                        if (!response.isSuccess()) {
+                            logger.warning("Ignoring non-successful multi-get response for ${response.href}")
+                            return@wrapResource
+                        }
+
+                        val iCal = response[CalendarData::class.java]?.iCalendar
+                        if (iCal == null) {
+                            logger.warning("Ignoring multi-get response without calendar-data")
+                            return@wrapResource
+                        }
+
+                        val eTag = response[GetETag::class.java]?.eTag
+                            ?: throw DavException("Received multi-get response without ETag")
+
+                        processICalObject(response.href.lastSegment, eTag, StringReader(iCal))
                     }
-
-                    val iCal = response[CalendarData::class.java]?.iCalendar
-                    if (iCal == null) {
-                        logger.warning("Ignoring multi-get response without calendar-data")
-                        return@wrapResource
-                    }
-
-                    val eTag = response[GetETag::class.java]?.eTag
-                        ?: throw DavException("Received multi-get response without ETag")
-
-                    processICalObject(response.href.lastSegment, eTag, StringReader(iCal))
                 }
             }
         }

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
@@ -31,6 +31,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.runInterruptible
 import okhttp3.HttpUrl
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -79,16 +80,18 @@ class JtxSyncManager @AssistedInject constructor(
         return true
     }
 
-    override fun queryCapabilities() =
-        SyncException.wrapWithRemoteResource(collection.url) {
+    override suspend fun queryCapabilities() =
+        SyncException.wrapWithRemoteResourceSuspending(collection.url) {
             var syncState: SyncState? = null
-            davCollection.propfind(0, GetCTag.NAME, MaxResourceSize.NAME, SyncToken.NAME) { response, relation ->
-                if (relation == Response.HrefRelation.SELF) {
-                    response[MaxResourceSize::class.java]?.maxSize?.let { maxSize ->
-                        logger.info("Collection accepts resources up to ${Formatter.formatFileSize(context, maxSize)}")
-                    }
+            runInterruptible {
+                davCollection.propfind(0, GetCTag.NAME, MaxResourceSize.NAME, SyncToken.NAME) { response, relation ->
+                    if (relation == Response.HrefRelation.SELF) {
+                        response[MaxResourceSize::class.java]?.maxSize?.let { maxSize ->
+                            logger.info("Collection accepts resources up to ${Formatter.formatFileSize(context, maxSize)}")
+                        }
 
-                    syncState = syncState(response)
+                        syncState = syncState(response)
+                    }
                 }
             }
             syncState
@@ -104,16 +107,20 @@ class JtxSyncManager @AssistedInject constructor(
 
     override fun syncAlgorithm() = SyncAlgorithm.PROPFIND_REPORT
 
-    override fun listAllRemote(callback: MultiResponseCallback) {
-        SyncException.wrapWithRemoteResource(collection.url) {
+    override suspend fun listAllRemote(callback: MultiResponseCallback) {
+        SyncException.wrapWithRemoteResourceSuspending(collection.url) {
             if (localCollection.supportsVTODO) {
                 logger.info("Querying tasks")
-                davCollection.calendarQuery("VTODO", null, null, callback)
+                runInterruptible {
+                    davCollection.calendarQuery("VTODO", null, null, callback)
+                }
             }
 
             if (localCollection.supportsVJOURNAL) {
                 logger.info("Querying journals")
-                davCollection.calendarQuery("VJOURNAL", null, null, callback)
+                runInterruptible {
+                    davCollection.calendarQuery("VJOURNAL", null, null, callback)
+                }
             }
         }
     }

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncException.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncException.kt
@@ -26,6 +26,22 @@ class SyncException(cause: Throwable): Exception(cause) {
                 throw e
             } catch (e: Throwable) {
                 throw
+                if (localResource != null)
+                    SyncException(e).setLocalResourceIfNull(localResource)
+                else
+                    e
+            }
+        }
+
+        suspend fun<T> wrapWithLocalResourceSuspending(localResource: LocalResource<*>?, body: suspend () -> T): T {
+            try {
+                return body()
+            } catch (e: SyncException) {
+                if (localResource != null)
+                    e.setLocalResourceIfNull(localResource)
+                throw e
+            } catch (e: Throwable) {
+                throw
                     if (localResource != null)
                         SyncException(e).setLocalResourceIfNull(localResource)
                     else
@@ -46,6 +62,22 @@ class SyncException(cause: Throwable): Exception(cause) {
                         SyncException(e).setRemoteResourceIfNull(remoteResource)
                     else
                         e
+            }
+        }
+
+        suspend fun<T> wrapWithRemoteResourceSuspending(remoteResource: HttpUrl?, body: suspend () -> T): T {
+            try {
+                return body()
+            } catch (e: SyncException) {
+                if (remoteResource != null)
+                    e.setRemoteResourceIfNull(remoteResource)
+                throw e
+            } catch (e: Throwable) {
+                throw
+                if (remoteResource != null)
+                    SyncException(e).setRemoteResourceIfNull(remoteResource)
+                else
+                    e
             }
         }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncException.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncException.kt
@@ -11,13 +11,13 @@ import okhttp3.HttpUrl
  * Exception that wraps another notification together with potential information about
  * a local and/or remote resource that is related to the exception.
  */
-class SyncException(cause: Throwable): Exception(cause) {
+class SyncException(cause: Throwable) : Exception(cause) {
 
     companion object {
 
         // provide lambda wrappers for setting the local/remote resource
 
-        fun<T> wrapWithLocalResource(localResource: LocalResource<*>?, body: () -> T): T {
+        fun <T> wrapWithLocalResource(localResource: LocalResource<*>?, body: () -> T): T {
             try {
                 return body()
             } catch (e: SyncException) {
@@ -25,15 +25,14 @@ class SyncException(cause: Throwable): Exception(cause) {
                     e.setLocalResourceIfNull(localResource)
                 throw e
             } catch (e: Throwable) {
-                throw
-                if (localResource != null)
+                throw if (localResource != null)
                     SyncException(e).setLocalResourceIfNull(localResource)
                 else
                     e
             }
         }
 
-        suspend fun<T> wrapWithLocalResourceSuspending(localResource: LocalResource<*>?, body: suspend () -> T): T {
+        suspend fun <T> wrapWithLocalResourceSuspending(localResource: LocalResource<*>?, body: suspend () -> T): T {
             try {
                 return body()
             } catch (e: SyncException) {
@@ -41,15 +40,14 @@ class SyncException(cause: Throwable): Exception(cause) {
                     e.setLocalResourceIfNull(localResource)
                 throw e
             } catch (e: Throwable) {
-                throw
-                    if (localResource != null)
-                        SyncException(e).setLocalResourceIfNull(localResource)
-                    else
-                        e
+                throw if (localResource != null)
+                    SyncException(e).setLocalResourceIfNull(localResource)
+                else
+                    e
             }
         }
 
-        fun<T> wrapWithRemoteResource(remoteResource: HttpUrl?, body: () -> T): T {
+        fun <T> wrapWithRemoteResource(remoteResource: HttpUrl?, body: () -> T): T {
             try {
                 return body()
             } catch (e: SyncException) {
@@ -57,15 +55,14 @@ class SyncException(cause: Throwable): Exception(cause) {
                     e.setRemoteResourceIfNull(remoteResource)
                 throw e
             } catch (e: Throwable) {
-                throw
-                    if (remoteResource != null)
-                        SyncException(e).setRemoteResourceIfNull(remoteResource)
-                    else
-                        e
+                throw if (remoteResource != null)
+                    SyncException(e).setRemoteResourceIfNull(remoteResource)
+                else
+                    e
             }
         }
 
-        suspend fun<T> wrapWithRemoteResourceSuspending(remoteResource: HttpUrl?, body: suspend () -> T): T {
+        suspend fun <T> wrapWithRemoteResourceSuspending(remoteResource: HttpUrl?, body: suspend () -> T): T {
             try {
                 return body()
             } catch (e: SyncException) {
@@ -73,8 +70,7 @@ class SyncException(cause: Throwable): Exception(cause) {
                     e.setRemoteResourceIfNull(remoteResource)
                 throw e
             } catch (e: Throwable) {
-                throw
-                if (remoteResource != null)
+                throw if (remoteResource != null)
                     SyncException(e).setRemoteResourceIfNull(remoteResource)
                 else
                     e

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncException.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncException.kt
@@ -5,6 +5,7 @@
 package at.bitfire.davdroid.sync
 
 import at.bitfire.davdroid.resource.LocalResource
+import kotlinx.coroutines.runBlocking
 import okhttp3.HttpUrl
 
 /**
@@ -17,20 +18,10 @@ class SyncException(cause: Throwable) : Exception(cause) {
 
         // provide lambda wrappers for setting the local/remote resource
 
-        fun <T> wrapWithLocalResource(localResource: LocalResource<*>?, body: () -> T): T {
-            try {
-                return body()
-            } catch (e: SyncException) {
-                if (localResource != null)
-                    e.setLocalResourceIfNull(localResource)
-                throw e
-            } catch (e: Throwable) {
-                throw if (localResource != null)
-                    SyncException(e).setLocalResourceIfNull(localResource)
-                else
-                    e
+        fun <T> wrapWithLocalResource(localResource: LocalResource<*>?, body: () -> T): T =
+            runBlocking {
+                wrapWithLocalResourceSuspending(localResource, body)
             }
-        }
 
         suspend fun <T> wrapWithLocalResourceSuspending(localResource: LocalResource<*>?, body: suspend () -> T): T {
             try {
@@ -47,20 +38,10 @@ class SyncException(cause: Throwable) : Exception(cause) {
             }
         }
 
-        fun <T> wrapWithRemoteResource(remoteResource: HttpUrl?, body: () -> T): T {
-            try {
-                return body()
-            } catch (e: SyncException) {
-                if (remoteResource != null)
-                    e.setRemoteResourceIfNull(remoteResource)
-                throw e
-            } catch (e: Throwable) {
-                throw if (remoteResource != null)
-                    SyncException(e).setRemoteResourceIfNull(remoteResource)
-                else
-                    e
+        fun <T> wrapWithRemoteResource(remoteResource: HttpUrl?, body: () -> T): T =
+            runBlocking {
+                wrapWithRemoteResourceSuspending(remoteResource, body)
             }
-        }
 
         suspend fun <T> wrapWithRemoteResourceSuspending(remoteResource: HttpUrl?, body: suspend () -> T): T {
             try {

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -674,7 +674,7 @@ abstract class SyncManager<ResourceType: LocalResource<*>, out CollectionType: L
      *      but not a single one (or vice versa). So only one method is more user-friendly.
      *   5. March 2020: iCloud now crashes with HTTP 500 upon CardDAV GET requests.
      */
-    protected abstract fun downloadRemote(bunch: List<HttpUrl>)
+    protected abstract suspend fun downloadRemote(bunch: List<HttpUrl>)
 
     /**
      * Locally deletes entries which are

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -48,10 +48,10 @@ import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl
 import okhttp3.RequestBody
 import java.io.IOException
-import java.io.InterruptedIOException
 import java.net.HttpURLConnection
 import java.security.cert.CertificateException
 import java.util.LinkedList
+import java.util.concurrent.CancellationException
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -260,9 +260,8 @@ abstract class SyncManager<ResourceType: LocalResource<*>, out CollectionType: L
                 is DeadObjectException ->
                     throw e
 
-                // sync was cancelled or account has been removed: re-throw to BaseSyncer
-                is InterruptedException,
-                is InterruptedIOException,
+                // sync was cancelled or account has been removed: re-throw to Syncer
+                is CancellationException,
                 is InvalidAccountException ->
                     throw e
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
@@ -122,28 +122,30 @@ class TasksSyncManager @AssistedInject constructor(
         }
     }
 
-    override fun downloadRemote(bunch: List<HttpUrl>) {
+    override suspend fun downloadRemote(bunch: List<HttpUrl>) {
         logger.info("Downloading ${bunch.size} iCalendars: $bunch")
         // multiple iCalendars, use calendar-multi-get
-        SyncException.wrapWithRemoteResource(collection.url) {
-            davCollection.multiget(bunch) { response, _ ->
-                // See CalendarSyncManager for more information about the multi-get response
-                SyncException.wrapWithRemoteResource(response.href) wrapResource@ {
-                    if (!response.isSuccess()) {
-                        logger.warning("Ignoring non-successful multi-get response for ${response.href}")
-                        return@wrapResource
+        SyncException.wrapWithRemoteResourceSuspending(collection.url) {
+            runInterruptible {
+                davCollection.multiget(bunch) { response, _ ->
+                    // See CalendarSyncManager for more information about the multi-get response
+                    SyncException.wrapWithRemoteResource(response.href) wrapResource@{
+                        if (!response.isSuccess()) {
+                            logger.warning("Ignoring non-successful multi-get response for ${response.href}")
+                            return@wrapResource
+                        }
+
+                        val iCal = response[CalendarData::class.java]?.iCalendar
+                        if (iCal == null) {
+                            logger.warning("Ignoring multi-get response without calendar-data")
+                            return@wrapResource
+                        }
+
+                        val eTag = response[GetETag::class.java]?.eTag
+                            ?: throw DavException("Received multi-get response without ETag")
+
+                        processVTodo(response.href.lastSegment, eTag, StringReader(iCal))
                     }
-
-                    val iCal = response[CalendarData::class.java]?.iCalendar
-                    if (iCal == null) {
-                        logger.warning("Ignoring multi-get response without calendar-data")
-                        return@wrapResource
-                    }
-
-                    val eTag = response[GetETag::class.java]?.eTag
-                        ?: throw DavException("Received multi-get response without ETag")
-
-                    processVTodo(response.href.lastSegment, eTag, StringReader(iCal))
                 }
             }
         }

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
@@ -37,7 +37,6 @@ import at.bitfire.davdroid.ui.NotificationRegistry
 import at.bitfire.ical4android.TaskProvider
 import dagger.Lazy
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.runInterruptible
 import java.util.Collections
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -180,9 +179,7 @@ abstract class BaseSyncWorker(
         }
 
         // Start syncing
-        runInterruptible {
-            syncer()
-        }
+        syncer()
 
         // convert SyncResult from Syncers to worker Data
         val output = Data.Builder()


### PR DESCRIPTION
Part 2 of #1451

- Move `runInterruptible` to the most specific call so that all code except the direct HTTP request (and possible callbacks) uses only coroutine cancellation
- Make required methods suspending

Also fixes #1470 by ignoring `CancellationException` (instead of `Interrupted[IO]Exception`) in `Syncer`.