### PR TITLE
[Sync] Replace `extras` Bundle by explicit arguments

### DIFF
--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/JtxSyncManagerTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/JtxSyncManagerTest.kt
@@ -93,12 +93,12 @@ class JtxSyncManagerTest {
         localJtxCollection = localJtxCollectionStore.create(provider, dbCollection)!!
         syncManager = jtxSyncManagerFactory.jtxSyncManager(
             account = account,
-            extras = arrayOf(),
             httpClient = httpClientBuilder.build(),
             authority = JtxContract.AUTHORITY,
             syncResult = SyncResult(),
             localCollection = localJtxCollection,
-            collection = dbCollection
+            collection = dbCollection,
+            resync = null
         )
     }
 

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncManagerTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncManagerTest.kt
@@ -494,7 +494,6 @@ class SyncManagerTest {
         }
     ) = syncManagerFactory.create(
         account,
-        arrayOf(),
         "TestAuthority",
         httpClientBuilder.build(),
         syncResult,

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncerTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncerTest.kt
@@ -37,7 +37,7 @@ class SyncerTest {
 
     @SpyK
     @InjectMockKs
-    var syncer = TestSyncer(mockk(relaxed = true), emptyArray(), SyncResult(), dataStore)
+    var syncer = TestSyncer(mockk(relaxed = true), null, SyncResult(), dataStore)
 
 
     @Test
@@ -155,12 +155,12 @@ class SyncerTest {
 
     // Test helpers
 
-    class TestSyncer (
+    class TestSyncer(
         account: Account,
-        extras: Array<String>,
+        resyncType: ResyncType?,
         syncResult: SyncResult,
         theDataStore: LocalTestStore
-    ) : Syncer<LocalTestStore, LocalTestCollection>(account, extras, syncResult) {
+    ) : Syncer<LocalTestStore, LocalTestCollection>(account, resyncType, syncResult) {
 
         override val dataStore: LocalTestStore =
             theDataStore

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/TestSyncManager.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/TestSyncManager.kt
@@ -26,7 +26,6 @@ import org.junit.Assert.assertEquals
 
 class TestSyncManager @AssistedInject constructor(
     @Assisted account: Account,
-    @Assisted extras: Array<String>,
     @Assisted authority: String,
     @Assisted httpClient: HttpClient,
     @Assisted syncResult: SyncResult,
@@ -36,11 +35,11 @@ class TestSyncManager @AssistedInject constructor(
 ): SyncManager<LocalTestResource, LocalTestCollection, DavCollection>(
     account,
     httpClient,
-    extras,
     authority,
     syncResult,
     localCollection,
     collection,
+    resync = null,
     syncDispatcher
 ) {
 
@@ -48,7 +47,6 @@ class TestSyncManager @AssistedInject constructor(
     interface Factory {
         fun create(
             account: Account,
-            extras: Array<String>,
             authority: String,
             httpClient: HttpClient,
             syncResult: SyncResult,

--- a/app/src/main/kotlin/at/bitfire/davdroid/servicedetection/DavResourceFinder.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/servicedetection/DavResourceFinder.kt
@@ -13,7 +13,6 @@ import at.bitfire.dav4jvm.UrlUtils
 import at.bitfire.dav4jvm.exception.DavException
 import at.bitfire.dav4jvm.exception.HttpException
 import at.bitfire.dav4jvm.exception.UnauthorizedException
-import at.bitfire.dav4jvm.property.*
 import at.bitfire.dav4jvm.property.caldav.CalendarColor
 import at.bitfire.dav4jvm.property.caldav.CalendarDescription
 import at.bitfire.dav4jvm.property.caldav.CalendarHomeSet
@@ -43,7 +42,7 @@ import java.io.InterruptedIOException
 import java.net.SocketTimeoutException
 import java.net.URI
 import java.net.URISyntaxException
-import java.util.*
+import java.util.LinkedList
 import java.util.logging.Level
 import java.util.logging.Logger
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
@@ -26,16 +26,22 @@ import java.util.logging.Level
  */
 class AddressBookSyncer @AssistedInject constructor(
     @Assisted account: Account,
-    @Assisted extras: Array<String>,
+    @Assisted resyncType: ResyncType?,
+    @Assisted val syncFrameworkUpload: Boolean,
     @Assisted syncResult: SyncResult,
     addressBookStore: LocalAddressBookStore,
     private val accountSettingsFactory: AccountSettings.Factory,
     private val contactsSyncManagerFactory: ContactsSyncManager.Factory
-): Syncer<LocalAddressBookStore, LocalAddressBook>(account, extras, syncResult) {
+): Syncer<LocalAddressBookStore, LocalAddressBook>(account, resyncType, syncResult) {
 
     @AssistedFactory
     interface Factory {
-        fun create(account: Account, extras: Array<String>, syncResult: SyncResult): AddressBookSyncer
+        fun create(
+            account: Account,
+            resyncType: ResyncType?,
+            syncFrameworkUpload: Boolean,
+            syncResult: SyncResult
+        ): AddressBookSyncer
     }
 
     override val dataStore = addressBookStore
@@ -52,7 +58,6 @@ class AddressBookSyncer @AssistedInject constructor(
         syncAddressBook(
             account = account,
             addressBook = localCollection,
-            extras = extras,
             httpClient = httpClient,
             provider = provider,
             syncResult = syncResult,
@@ -73,7 +78,6 @@ class AddressBookSyncer @AssistedInject constructor(
     private fun syncAddressBook(
         account: Account,
         addressBook: LocalAddressBook,
-        extras: Array<String>,
         httpClient: Lazy<HttpClient>,
         provider: ContentProviderClient,
         syncResult: SyncResult,
@@ -102,12 +106,13 @@ class AddressBookSyncer @AssistedInject constructor(
             val syncManager = contactsSyncManagerFactory.contactsSyncManager(
                 account,
                 httpClient.value,
-                extras,
                 dataStore.authority,
                 syncResult,
                 provider,
                 addressBook,
-                collection
+                collection,
+                resyncType,
+                syncFrameworkUpload
             )
             runBlocking {
                 syncManager.performSync()

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
@@ -26,13 +26,13 @@ import java.util.logging.Level
  */
 class AddressBookSyncer @AssistedInject constructor(
     @Assisted account: Account,
-    @Assisted resyncType: ResyncType?,
+    @Assisted resync: ResyncType?,
     @Assisted val syncFrameworkUpload: Boolean,
     @Assisted syncResult: SyncResult,
     addressBookStore: LocalAddressBookStore,
     private val accountSettingsFactory: AccountSettings.Factory,
     private val contactsSyncManagerFactory: ContactsSyncManager.Factory
-): Syncer<LocalAddressBookStore, LocalAddressBook>(account, resyncType, syncResult) {
+): Syncer<LocalAddressBookStore, LocalAddressBook>(account, resync, syncResult) {
 
     @AssistedFactory
     interface Factory {
@@ -69,8 +69,6 @@ class AddressBookSyncer @AssistedInject constructor(
      * Synchronizes an address book
      *
      * @param addressBook local address book
-     * @param extras Sync specific instructions. IE [Syncer.SYNC_EXTRAS_FULL_RESYNC]
-     * @param httpClient
      * @param provider Content provider to access android contacts
      * @param syncResult Stores hard and soft sync errors
      * @param collection The database collection associated with this address book
@@ -111,7 +109,7 @@ class AddressBookSyncer @AssistedInject constructor(
                 provider,
                 addressBook,
                 collection,
-                resyncType,
+                resync,
                 syncFrameworkUpload
             )
             runBlocking {

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
@@ -52,22 +52,22 @@ import java.util.logging.Level
  */
 class CalendarSyncManager @AssistedInject constructor(
     @Assisted account: Account,
-    @Assisted extras: Array<String>,
     @Assisted httpClient: HttpClient,
     @Assisted authority: String,
     @Assisted syncResult: SyncResult,
     @Assisted localCalendar: LocalCalendar,
     @Assisted collection: Collection,
+    @Assisted resync: ResyncType?,
     accountSettingsFactory: AccountSettings.Factory,
     @SyncDispatcher syncDispatcher: CoroutineDispatcher
 ): SyncManager<LocalEvent, LocalCalendar, DavCalendar>(
     account,
     httpClient,
-    extras,
     authority,
     syncResult,
     localCalendar,
     collection,
+    resync,
     syncDispatcher
 ) {
 
@@ -75,12 +75,12 @@ class CalendarSyncManager @AssistedInject constructor(
     interface Factory {
         fun calendarSyncManager(
             account: Account,
-            extras: Array<String>,
             httpClient: HttpClient,
             authority: String,
             syncResult: SyncResult,
             localCalendar: LocalCalendar,
-            collection: Collection
+            collection: Collection,
+            resync: ResyncType?
         ): CalendarSyncManager
     }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncer.kt
@@ -22,16 +22,16 @@ import kotlinx.coroutines.runBlocking
  */
 class CalendarSyncer @AssistedInject constructor(
     @Assisted account: Account,
-    @Assisted extras: Array<String>,
+    @Assisted resyncType: ResyncType?,
     @Assisted syncResult: SyncResult,
     calendarStore: LocalCalendarStore,
     private val accountSettingsFactory: AccountSettings.Factory,
     private val calendarSyncManagerFactory: CalendarSyncManager.Factory
-): Syncer<LocalCalendarStore, LocalCalendar>(account, extras, syncResult) {
+): Syncer<LocalCalendarStore, LocalCalendar>(account, resyncType, syncResult) {
 
     @AssistedFactory
     interface Factory {
-        fun create(account: Account, extras: Array<String>, syncResult: SyncResult): CalendarSyncer
+        fun create(account: Account, resyncType: ResyncType?, syncResult: SyncResult): CalendarSyncer
     }
 
     override val dataStore = calendarStore
@@ -58,12 +58,12 @@ class CalendarSyncer @AssistedInject constructor(
 
         val syncManager = calendarSyncManagerFactory.calendarSyncManager(
             account,
-            extras,
             httpClient.value,
             dataStore.authority,
             syncResult,
             localCollection,
-            remoteCollection
+            remoteCollection,
+            resyncType
         )
         runBlocking {
             syncManager.performSync()

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncer.kt
@@ -22,12 +22,12 @@ import kotlinx.coroutines.runBlocking
  */
 class CalendarSyncer @AssistedInject constructor(
     @Assisted account: Account,
-    @Assisted resyncType: ResyncType?,
+    @Assisted resync: ResyncType?,
     @Assisted syncResult: SyncResult,
     calendarStore: LocalCalendarStore,
     private val accountSettingsFactory: AccountSettings.Factory,
     private val calendarSyncManagerFactory: CalendarSyncManager.Factory
-): Syncer<LocalCalendarStore, LocalCalendar>(account, resyncType, syncResult) {
+): Syncer<LocalCalendarStore, LocalCalendar>(account, resync, syncResult) {
 
     @AssistedFactory
     interface Factory {
@@ -63,7 +63,7 @@ class CalendarSyncer @AssistedInject constructor(
             syncResult,
             localCollection,
             remoteCollection,
-            resyncType
+            resync
         )
         runBlocking {
             syncManager.performSync()

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
@@ -41,21 +41,21 @@ import java.util.logging.Level
 
 class JtxSyncManager @AssistedInject constructor(
     @Assisted account: Account,
-    @Assisted extras: Array<String>,
     @Assisted httpClient: HttpClient,
     @Assisted authority: String,
     @Assisted syncResult: SyncResult,
     @Assisted localCollection: LocalJtxCollection,
     @Assisted collection: Collection,
+    @Assisted resync: ResyncType?,
     @SyncDispatcher syncDispatcher: CoroutineDispatcher
 ): SyncManager<LocalJtxICalObject, LocalJtxCollection, DavCalendar>(
     account,
     httpClient,
-    extras,
     authority,
     syncResult,
     localCollection,
     collection,
+    resync,
     syncDispatcher
 ) {
 
@@ -63,12 +63,12 @@ class JtxSyncManager @AssistedInject constructor(
     interface Factory {
         fun jtxSyncManager(
             account: Account,
-            extras: Array<String>,
             httpClient: HttpClient,
             authority: String,
             syncResult: SyncResult,
             localCollection: LocalJtxCollection,
-            collection: Collection
+            collection: Collection,
+            resync: ResyncType?
         ): JtxSyncManager
     }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncer.kt
@@ -23,12 +23,12 @@ import kotlinx.coroutines.runBlocking
  */
 class JtxSyncer @AssistedInject constructor(
     @Assisted account: Account,
-    @Assisted resyncType: ResyncType?,
+    @Assisted resync: ResyncType?,
     @Assisted syncResult: SyncResult,
     localJtxCollectionStore: LocalJtxCollectionStore,
     private val jtxSyncManagerFactory: JtxSyncManager.Factory,
     private val tasksAppManager: dagger.Lazy<TasksAppManager>
-): Syncer<LocalJtxCollectionStore, LocalJtxCollection>(account, resyncType, syncResult) {
+): Syncer<LocalJtxCollectionStore, LocalJtxCollection>(account, resync, syncResult) {
 
     @AssistedFactory
     interface Factory {
@@ -76,7 +76,7 @@ class JtxSyncer @AssistedInject constructor(
             syncResult,
             localCollection,
             remoteCollection,
-            resyncType
+            resync
         )
         runBlocking {
             syncManager.performSync()

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncer.kt
@@ -23,16 +23,16 @@ import kotlinx.coroutines.runBlocking
  */
 class JtxSyncer @AssistedInject constructor(
     @Assisted account: Account,
-    @Assisted extras: Array<String>,
+    @Assisted resyncType: ResyncType?,
     @Assisted syncResult: SyncResult,
     localJtxCollectionStore: LocalJtxCollectionStore,
     private val jtxSyncManagerFactory: JtxSyncManager.Factory,
     private val tasksAppManager: dagger.Lazy<TasksAppManager>
-): Syncer<LocalJtxCollectionStore, LocalJtxCollection>(account, extras, syncResult) {
+): Syncer<LocalJtxCollectionStore, LocalJtxCollection>(account, resyncType, syncResult) {
 
     @AssistedFactory
     interface Factory {
-        fun create(account: Account, extras: Array<String>, syncResult: SyncResult): JtxSyncer
+        fun create(account: Account, resyncType: ResyncType?, syncResult: SyncResult): JtxSyncer
     }
 
     override val dataStore = localJtxCollectionStore
@@ -71,12 +71,12 @@ class JtxSyncer @AssistedInject constructor(
 
         val syncManager = jtxSyncManagerFactory.jtxSyncManager(
             account,
-            extras,
             httpClient.value,
             dataStore.authority,
             syncResult,
             localCollection,
-            remoteCollection
+            remoteCollection,
+            resyncType
         )
         runBlocking {
             syncManager.performSync()

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/ResyncType.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/ResyncType.kt
@@ -10,22 +10,22 @@ package at.bitfire.davdroid.sync
 enum class ResyncType {
 
     /**
-     * Normal re-synchronization: all remote entries shall be listed regardless of the
+     * **(Normal) re-synchronization**: all remote entries shall be listed regardless of the
      * sync-token (or CTag) of the collection. Modified entries will then be downloaded as usual.
      *
      * Sample use-case: the past event time range setting has been modified, and we want
      * to get the new list of all events (regardless of the sync-token).
      */
-    RESYNC,
+    RESYNC_LIST,
 
     /**
-     * Full re-synchronization: all remote entries shall be listed regardless of the
+     * **Full re-synchronization**: all remote entries shall be listed regardless of the
      * sync-token (or CTag) of the collection, and all entries will be downloaded again,
      * either if they were not changed on the server since the last sync.
      *
      * Sample use-case: Contact group type setting is changed, and all vCards have to
      * be downloaded and parsed again to determine their group memberships.
      */
-    FULL_RESYNC
+    RESYNC_ENTRIES
 
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/ResyncType.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/ResyncType.kt
@@ -6,6 +6,9 @@ package at.bitfire.davdroid.sync
 
 /**
  * Used to signal that re-synchronization is requested during a sync.
+ *
+ * Re-synchronization means that synchronization shouldn't skip listing/downloading
+ * the entries even when then `sync-token` (or CTag) didn't change since the last sync.
  */
 enum class ResyncType {
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/ResyncType.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/ResyncType.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.sync
+
+/**
+ * Used to signal that re-synchronization is requested during a sync.
+ */
+enum class ResyncType {
+
+    /**
+     * Normal re-synchronization: all remote entries shall be listed regardless of the
+     * sync-token (or CTag) of the collection. Modified entries will then be downloaded as usual.
+     *
+     * Sample use-case: the past event time range setting has been modified, and we want
+     * to get the new list of all events (regardless of the sync-token).
+     */
+    RESYNC,
+
+    /**
+     * Full re-synchronization: all remote entries shall be listed regardless of the
+     * sync-token (or CTag) of the collection, and all entries will be downloaded again,
+     * either if they were not changed on the server since the last sync.
+     *
+     * Sample use-case: Contact group type setting is changed, and all vCards have to
+     * be downloaded and parsed again to determine their group memberships.
+     */
+    FULL_RESYNC
+
+}

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncAdapterServices.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncAdapterServices.kt
@@ -158,7 +158,7 @@ abstract class SyncAdapterService: Service() {
             }
 
             logger.fine("Starting OneTimeSyncWorker for $account $authority and waiting for it")
-            val workerName = syncWorkerManager.enqueueOneTime(account, dataType = SyncDataType.fromAuthority(authority), upload = upload)
+            val workerName = syncWorkerManager.enqueueOneTime(account, dataType = SyncDataType.fromAuthority(authority), syncFrameworkUpload = upload)
 
             /* Because we are not allowed to observe worker state on a background thread, we can not
             use it to block the sync adapter. Instead we use a Flow to get notified when the sync

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -71,7 +71,7 @@ import javax.net.ssl.SSLHandshakeException
  * @param syncResult            receiver for result of the synchronization (will be updated by [performSync])
  * @param localCollection       local collection to synchronize (interface to content provider)
  * @param collection            collection info in the database
- * @param resync                whether partial or full re-synchronization is requested
+ * @param resync                whether re-synchronization is requested
  */
 abstract class SyncManager<ResourceType: LocalResource<*>, out CollectionType: LocalCollection<ResourceType>, RemoteType: DavCollection>(
     val account: Account,

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -149,7 +149,7 @@ abstract class SyncManager<ResourceType: LocalResource<*>, out CollectionType: L
             val modificationsPresent =
                 processLocallyDeleted() or uploadDirty()     // bitwise OR guarantees that both expressions are evaluated
 
-            if (resync == ResyncType.FULL_RESYNC) {
+            if (resync == ResyncType.RESYNC_ENTRIES) {
                 logger.info("Forcing re-synchronization of all entries")
 
                 // forget sync state of collection (→ initial sync in case of SyncAlgorithm.COLLECTION_SYNC)

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
@@ -27,35 +27,16 @@ import javax.inject.Inject
  * Base class for sync code.
  *
  * Contains generic sync code, equal for all sync authorities.
+ *
+ * @param account       account to synchronize
+ * @param resync        whether re-synchronization is requested (`null` for normal sync)
+ * @param syncResult    synchronization result, to be modified during sync
  */
 abstract class Syncer<StoreType: LocalDataStore<CollectionType>, CollectionType: LocalCollection<*>>(
     protected val account: Account,
-    protected val resyncType: ResyncType?,
+    protected val resync: ResyncType?,
     protected val syncResult: SyncResult
 ) {
-
-    companion object {
-
-        /**
-         * Requests a re-synchronization of all entries. For instance, if this extra is
-         * set for a calendar sync, all remote events will be listed and checked for remote
-         * changes again.
-         *
-         * Useful if settings which modify the remote resource list (like the CalDAV setting
-         * "sync events n days in the past") have been changed.
-         */
-        const val SYNC_EXTRAS_RESYNC = "resync"
-
-        /**
-         * Requests a full re-synchronization of all entries. For instance, if this extra is
-         * set for an address book sync, all contacts will be downloaded again and updated in the
-         * local storage.
-         *
-         * Useful if settings which modify parsing/local behavior have been changed.
-         */
-        const val SYNC_EXTRAS_FULL_RESYNC = "full_resync"
-
-    }
 
     abstract val dataStore: StoreType
 
@@ -250,7 +231,7 @@ abstract class Syncer<StoreType: LocalDataStore<CollectionType>, CollectionType:
      * - handle occurring sync errors
      */
     operator fun invoke() {
-        logger.info("${dataStore.authority} sync of $account initiated")
+        logger.info("${dataStore.authority} sync of $account initiated (resync=$resync)")
 
         try {
             dataStore.acquireContentProvider()

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
@@ -30,7 +30,7 @@ import javax.inject.Inject
  */
 abstract class Syncer<StoreType: LocalDataStore<CollectionType>, CollectionType: LocalCollection<*>>(
     protected val account: Account,
-    protected val extras: Array<String>,
+    protected val resyncType: ResyncType?,
     protected val syncResult: SyncResult
 ) {
 
@@ -250,7 +250,7 @@ abstract class Syncer<StoreType: LocalDataStore<CollectionType>, CollectionType:
      * - handle occurring sync errors
      */
     operator fun invoke() {
-        logger.log(Level.INFO, "${dataStore.authority} sync of $account initiated", extras.joinToString(", "))
+        logger.info("${dataStore.authority} sync of $account initiated")
 
         try {
             dataStore.acquireContentProvider()
@@ -294,10 +294,7 @@ abstract class Syncer<StoreType: LocalDataStore<CollectionType>, CollectionType:
             } finally {
                 if (httpClient.isInitialized())
                     httpClient.value.close()
-                logger.log(
-                    Level.INFO,
-                    "${dataStore.authority} sync of $account finished",
-                    extras.joinToString(", "))
+                logger.info("${dataStore.authority} sync of $account finished")
             }
         }
     }

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/TaskSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/TaskSyncer.kt
@@ -24,16 +24,16 @@ import kotlinx.coroutines.runBlocking
 class TaskSyncer @AssistedInject constructor(
     @Assisted account: Account,
     @Assisted val providerName: TaskProvider.ProviderName,
-    @Assisted extras: Array<String>,
+    @Assisted resyncType: ResyncType,
     @Assisted syncResult: SyncResult,
     localTaskListStoreFactory: LocalTaskListStore.Factory,
     private val tasksAppManager: dagger.Lazy<TasksAppManager>,
     private val tasksSyncManagerFactory: TasksSyncManager.Factory,
-): Syncer<LocalTaskListStore, LocalTaskList>(account, extras, syncResult) {
+): Syncer<LocalTaskListStore, LocalTaskList>(account, resyncType, syncResult) {
 
     @AssistedFactory
     interface Factory {
-        fun create(account: Account, providerName: TaskProvider.ProviderName, extras: Array<String>, syncResult: SyncResult): TaskSyncer
+        fun create(account: Account, providerName: TaskProvider.ProviderName, resyncType: ResyncType?, syncResult: SyncResult): TaskSyncer
     }
 
     override val dataStore = localTaskListStoreFactory.create(providerName)
@@ -73,11 +73,11 @@ class TaskSyncer @AssistedInject constructor(
         val syncManager = tasksSyncManagerFactory.tasksSyncManager(
             account,
             httpClient.value,
-            extras,
             dataStore.authority,
             syncResult,
             localCollection,
-            remoteCollection
+            remoteCollection,
+            resyncType
         )
         runBlocking {
             syncManager.performSync()

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/TaskSyncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/TaskSyncer.kt
@@ -24,12 +24,12 @@ import kotlinx.coroutines.runBlocking
 class TaskSyncer @AssistedInject constructor(
     @Assisted account: Account,
     @Assisted val providerName: TaskProvider.ProviderName,
-    @Assisted resyncType: ResyncType,
+    @Assisted resync: ResyncType,
     @Assisted syncResult: SyncResult,
     localTaskListStoreFactory: LocalTaskListStore.Factory,
     private val tasksAppManager: dagger.Lazy<TasksAppManager>,
     private val tasksSyncManagerFactory: TasksSyncManager.Factory,
-): Syncer<LocalTaskListStore, LocalTaskList>(account, resyncType, syncResult) {
+): Syncer<LocalTaskListStore, LocalTaskList>(account, resync, syncResult) {
 
     @AssistedFactory
     interface Factory {
@@ -77,7 +77,7 @@ class TaskSyncer @AssistedInject constructor(
             syncResult,
             localCollection,
             remoteCollection,
-            resyncType
+            resync
         )
         runBlocking {
             syncManager.performSync()

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
@@ -44,20 +44,20 @@ import java.util.logging.Level
 class TasksSyncManager @AssistedInject constructor(
     @Assisted account: Account,
     @Assisted httpClient: HttpClient,
-    @Assisted extras: Array<String>,
     @Assisted authority: String,
     @Assisted syncResult: SyncResult,
     @Assisted localCollection: LocalTaskList,
     @Assisted collection: Collection,
+    @Assisted resync: ResyncType?,
     @SyncDispatcher syncDispatcher: CoroutineDispatcher
 ): SyncManager<LocalTask, LocalTaskList, DavCalendar>(
     account,
     httpClient,
-    extras,
     authority,
     syncResult,
     localCollection,
     collection,
+    resync,
     syncDispatcher
 ) {
 
@@ -66,11 +66,11 @@ class TasksSyncManager @AssistedInject constructor(
         fun tasksSyncManager(
             account: Account,
             httpClient: HttpClient,
-            extras: Array<String>,
             authority: String,
             syncResult: SyncResult,
             localCollection: LocalTaskList,
-            collection: Collection
+            collection: Collection,
+            resync: ResyncType?
         ): TasksSyncManager
     }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
@@ -151,8 +151,6 @@ abstract class BaseSyncWorker(
         // Comes in through SyncAdapterService and is used only by ContactsSyncManager for an Android 7 workaround.
         val syncFrameworkUpload = inputData.getBoolean(INPUT_UPLOAD, false)
 
-        // We still use the sync adapter framework's SyncResult to pass the sync results, but this
-        // is only for legacy reasons and can be replaced by our own result class in the future.
         val syncResult = SyncResult()
 
         // What are we going to sync? Select syncer based on authority

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
@@ -28,9 +28,9 @@ import at.bitfire.davdroid.sync.SyncResult
 import at.bitfire.davdroid.sync.TaskSyncer
 import at.bitfire.davdroid.sync.TasksAppManager
 import at.bitfire.davdroid.sync.account.InvalidAccountException
-import at.bitfire.davdroid.sync.worker.BaseSyncWorker.Companion.FULL_RESYNC
 import at.bitfire.davdroid.sync.worker.BaseSyncWorker.Companion.NO_RESYNC
-import at.bitfire.davdroid.sync.worker.BaseSyncWorker.Companion.RESYNC
+import at.bitfire.davdroid.sync.worker.BaseSyncWorker.Companion.RESYNC_ENTRIES
+import at.bitfire.davdroid.sync.worker.BaseSyncWorker.Companion.RESYNC_LIST
 import at.bitfire.davdroid.sync.worker.BaseSyncWorker.Companion.commonTag
 import at.bitfire.davdroid.ui.NotificationRegistry
 import at.bitfire.ical4android.TaskProvider
@@ -143,8 +143,8 @@ abstract class BaseSyncWorker(
 
         // pass supplied parameters to the selected syncer
         val resyncType: ResyncType? = when (inputData.getInt(INPUT_RESYNC, NO_RESYNC)) {
-            FULL_RESYNC -> ResyncType.FULL_RESYNC
-            RESYNC -> ResyncType.RESYNC
+            RESYNC_ENTRIES -> ResyncType.RESYNC_ENTRIES
+            RESYNC_LIST -> ResyncType.RESYNC_LIST
             else -> null
         }
 
@@ -246,25 +246,25 @@ abstract class BaseSyncWorker(
     companion object {
 
         // common worker input parameters
-        const val INPUT_ACCOUNT_NAME = "accountName"
-        const val INPUT_ACCOUNT_TYPE = "accountType"
-        const val INPUT_DATA_TYPE = "dataType"
+        internal const val INPUT_ACCOUNT_NAME = "accountName"
+        internal const val INPUT_ACCOUNT_TYPE = "accountType"
+        internal const val INPUT_DATA_TYPE = "dataType"
 
         /** set to `true` for user-initiated sync that skips network checks */
-        const val INPUT_MANUAL = "manual"
+        internal const val INPUT_MANUAL = "manual"
 
-        /** set to `true` for syncs that are caused by local changes */
-        const val INPUT_UPLOAD = "upload"
+        /** set to `true` for syncs that are caused because the sync framework notified us about local changes */
+        internal const val INPUT_UPLOAD = "upload"
 
-        /** Whether re-synchronization is requested. One of [NO_RESYNC] (default), [RESYNC] or [FULL_RESYNC]. */
-        const val INPUT_RESYNC = "resync"
-        @IntDef(NO_RESYNC, RESYNC, FULL_RESYNC)
+        /** Whether re-synchronization is requested. One of [NO_RESYNC] (default), [RESYNC_LIST] or [RESYNC_ENTRIES]. */
+        internal const val INPUT_RESYNC = "resync"
+        @IntDef(NO_RESYNC, RESYNC_LIST, RESYNC_ENTRIES)
         annotation class InputResync
-        const val NO_RESYNC = 0
-        /** Re-synchronization is requested. See [Syncer.SYNC_EXTRAS_RESYNC] for details. */
-        const val RESYNC = 1
-        /** Full re-synchronization is requested. See [Syncer.SYNC_EXTRAS_FULL_RESYNC] for details. */
-        const val FULL_RESYNC = 2
+        internal const val NO_RESYNC = 0
+        /** Re-synchronization is requested. See [ResyncType.RESYNC_LIST] for details. */
+        internal const val RESYNC_LIST = 1
+        /** Full re-synchronization is requested. See [ResyncType.RESYNC_ENTRIES] for details. */
+        internal const val RESYNC_ENTRIES = 2
 
         const val OUTPUT_TOO_MANY_RETRIES = "tooManyRetries"
 


### PR DESCRIPTION
### Purpose

Currently, we're using an `extras` `Bundle` to encode and pass around sync arguments:

1. resync type (full resync / resync / no resync) and
1. upload (initiated by sync framework).

This is not clean because it's not explicit what arguments can be passed over a `Bundle` and what arguments then are actually used. Also there can be conversion errors when converting from/to a `Bundle`.


### Short description

This PR removes the `Bundle` and replaces it by explicit parameters.

There's now an explicit `ResyncType` that explains the two types of re-synchronization.


### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

