### PR TITLE
[CI] Run tests on pull requests instead of git pushes

### DIFF
--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -1,6 +1,6 @@
 name: Development tests
 on:
-  pull_request
+  pull_request    # test when PR is created
 
 concurrency:
   group: test-dev-${{ github.ref }}

--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -1,8 +1,6 @@
 name: Development tests
 on:
-  push:
-    branches:
-      - '*'
+  pull_request
 
 concurrency:
   group: test-dev-${{ github.ref }}

--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -1,6 +1,6 @@
 name: Development tests
 on:
-  pull_request    # test when PR is created
+  pull_request
 
 concurrency:
   group: test-dev-${{ github.ref }}


### PR DESCRIPTION
### Purpose

Currently the tests run when code is pushed to the repo, which is sometimes not useful:

- Sometimes tests on the main branch are randomly cancelled, presumably when a new branch is pushed with the same commit/ref as the main branch (#1478)
- We don't need tests for experimental branches. The PR is the thing that should really cause tests so that we can see whether the changes can be merged or not.
- PRs from forked repos don't push code to our repo but should still run tests.


### Short description

Replaces [push](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#push) trigger by [pull_request](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request).

I didn't specify main-ose so that PRs that target other branches will also run tests. We don't use this now but if we do, I think every merge should have successful tests.