### PR TITLE
[Push] Append sync when already syncing

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
@@ -93,6 +93,10 @@ abstract class BaseSyncWorker(
             return Result.success()
         }
 
+        // FIXME
+        logger.warning("Delaying sync for 2min")
+        delay(120000)
+
         // Dismiss any pending push notification
         pushNotificationManager.dismiss(account, dataType)
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
@@ -93,10 +93,6 @@ abstract class BaseSyncWorker(
             return Result.success()
         }
 
-        // FIXME
-        logger.warning("Delaying sync for 2min")
-        delay(120000)
-
         // Dismiss any pending push notification
         pushNotificationManager.dismiss(account, dataType)
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/SyncWorkerManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/SyncWorkerManager.kt
@@ -154,7 +154,7 @@ class SyncWorkerManager @Inject constructor(
 
             However, we want to append only one work request, regardless of how many
             push requests came in. So we have to append the work one time, and as soon
-            as there is already a pending appended work, don't add more work. */
+            as there is already a pending appended work, stop adding more work. */
 
             synchronized(SyncWorkerManager::class.java) {
                 val currentWork = workManager.getWorkInfosForUniqueWork(name).get()

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/SyncWorkerManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/SyncWorkerManager.kt
@@ -158,7 +158,9 @@ class SyncWorkerManager @Inject constructor(
 
             synchronized(SyncWorkerManager::class.java) {
                 val currentWork = workManager.getWorkInfosForUniqueWork(name).get()
-                val alreadyAppended = currentWork.any { it.state == WorkInfo.State.BLOCKED }
+                val alreadyAppended = currentWork.any {
+                    it.state in setOf(WorkInfo.State.BLOCKED, WorkInfo.State.ENQUEUED)
+                }
                 if (!alreadyAppended) {
                     val op = workManager.enqueueUniqueWork(name, ExistingWorkPolicy.APPEND_OR_REPLACE, request)
                     // for synchronization: wait until work is actually enqueued


### PR DESCRIPTION
### Purpose

If a push message triggers a sync for an account that already has an ongoing sync, there's a risk of losing remote changes made near the end of the existing sync. To address this, we can always append an additional sync worker when triggered by a push request, but restrict it to at most one pending/blocked worker.

### Short description

When sync request comes from push:
- use synchronized block to avoid race conditions for the check, that ...
- ... there is not already blocked or enqueued work for same unique work (given pair of account + data type)
- if there is not, then enqueue with `ExistingWorkPolicy.APPEND_OR_REPLACE`
- access enqueue operation result object (listenable future), to force waiting until work is enqueued

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

