### PR TITLE
Handle when AccountActivity is started without account

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountActivity.kt
@@ -38,10 +38,15 @@ class AccountActivity : AppCompatActivity() {
             intent.getParcelableExtra(EXTRA_ACCOUNT) as? Account
         }
 
-        // If account is not passed or does not exist, log and redirect to accounts overview
+        // If account is not passed or does not exist, log warning and redirect to accounts overview
         if (account == null || !accountRepository.exists(account.name)) {
             logger.warning("Account \"${account?.name}\" not found in intent extras or does not exist. Redirecting to accounts overview.")
-            Toast.makeText(this, R.string.account_account_missing, Toast.LENGTH_LONG).show()
+
+            // Show toast message to user
+            val toastMessage = getString(R.string.account_account_missing, account?.name ?: "null")
+            Toast.makeText(this, toastMessage, Toast.LENGTH_LONG).show()
+
+            // Redirect to accounts overview activity
             val intent = Intent(this, AccountsActivity::class.java).apply {
                 // Create a new root activity, do not allow going back.
                 addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountActivity.kt
@@ -7,6 +7,7 @@ package at.bitfire.davdroid.ui.account
 import AccountScreen
 import android.accounts.Account
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.compose.setContent
@@ -26,8 +27,12 @@ class AccountActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val account = intent.getParcelableExtra(EXTRA_ACCOUNT) as? Account
-
+        val account: Account? = if (Build.VERSION.SDK_INT >= 33) {
+            intent.getParcelableExtra(EXTRA_ACCOUNT, Account::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            intent.getParcelableExtra(EXTRA_ACCOUNT) as? Account
+        }
         // If account is null, log and redirect to accounts overview
         if (account == null) {
             logger.warning("Account not found in intent extras. Redirecting to accounts overview.")

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountActivity.kt
@@ -13,6 +13,7 @@ import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import at.bitfire.davdroid.R
+import at.bitfire.davdroid.repository.AccountRepository
 import at.bitfire.davdroid.ui.AccountsActivity
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.logging.Logger
@@ -20,6 +21,9 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class AccountActivity : AppCompatActivity() {
+
+    @Inject
+    lateinit var accountRepository: AccountRepository
 
     @Inject
     lateinit var logger: Logger
@@ -33,9 +37,10 @@ class AccountActivity : AppCompatActivity() {
             @Suppress("DEPRECATION")
             intent.getParcelableExtra(EXTRA_ACCOUNT) as? Account
         }
-        // If account is null, log and redirect to accounts overview
-        if (account == null) {
-            logger.warning("Account not found in intent extras. Redirecting to accounts overview.")
+
+        // If account is not passed or does not exist, log and redirect to accounts overview
+        if (account == null || !accountRepository.exists(account.name)) {
+            logger.warning("Account \"${account?.name}\" not found in intent extras or does not exist. Redirecting to accounts overview.")
             Toast.makeText(this, R.string.account_account_missing, Toast.LENGTH_LONG).show()
             val intent = Intent(this, AccountsActivity::class.java).apply {
                 // Create a new root activity, do not allow going back.

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountActivity.kt
@@ -15,10 +15,6 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class AccountActivity : AppCompatActivity() {
 
-    companion object {
-        const val EXTRA_ACCOUNT = "account"
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -53,6 +49,10 @@ class AccountActivity : AppCompatActivity() {
                 onFinish = ::finish
             )
         }
+    }
+
+    companion object {
+        const val EXTRA_ACCOUNT = "account"
     }
 
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountActivity.kt
@@ -8,18 +8,38 @@ import AccountScreen
 import android.accounts.Account
 import android.content.Intent
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
+import at.bitfire.davdroid.R
+import at.bitfire.davdroid.ui.AccountsActivity
 import dagger.hilt.android.AndroidEntryPoint
+import java.util.logging.Logger
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class AccountActivity : AppCompatActivity() {
+
+    @Inject
+    lateinit var logger: Logger
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         val account = intent.getParcelableExtra(EXTRA_ACCOUNT) as? Account
-            ?: throw IllegalArgumentException("AccountActivity requires EXTRA_ACCOUNT")
+
+        // If account is null, log and redirect to accounts overview
+        if (account == null) {
+            logger.warning("Account not found in intent extras. Redirecting to accounts overview.")
+            Toast.makeText(this, R.string.account_account_missing, Toast.LENGTH_LONG).show()
+            val intent = Intent(this, AccountsActivity::class.java).apply {
+                // Create a new root activity, do not allow going back.
+                addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            startActivity(intent)
+            finish()
+            return
+        }
 
         setContent {
             AccountScreen(

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreen.kt
@@ -7,6 +7,7 @@ import android.Manifest
 import android.accounts.Account
 import android.content.Intent
 import android.net.Uri
+import android.widget.Toast
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -200,8 +201,10 @@ fun AccountScreen(
         val context = LocalContext.current
         val scope = rememberCoroutineScope()
 
-        if (invalidAccount)
+        if (invalidAccount) {
+            Toast.makeText(LocalContext.current, R.string.account_invalid_account, Toast.LENGTH_LONG).show()
             onFinish()
+        }
 
         val snackbarHostState = remember { SnackbarHostState() }
         LaunchedEffect(error) {

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreen.kt
@@ -201,9 +201,11 @@ fun AccountScreen(
         val context = LocalContext.current
         val scope = rememberCoroutineScope()
 
-        if (invalidAccount) {
-            Toast.makeText(LocalContext.current, R.string.account_invalid_account, Toast.LENGTH_LONG).show()
-            onFinish()
+        LaunchedEffect(invalidAccount) {
+            if (invalidAccount) {
+                Toast.makeText(context, R.string.account_invalid_account, Toast.LENGTH_LONG).show()
+                onFinish()
+            }
         }
 
         val snackbarHostState = remember { SnackbarHostState() }

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginActivity.kt
@@ -39,7 +39,7 @@ class LoginActivity @Inject constructor(): AppCompatActivity() {
                 onFinish = { newAccount ->
                     finish()
 
-                    if (newAccount != null) {
+                    newAccount?.let { newAccount ->
                         val intent = Intent(this, AccountActivity::class.java)
                         intent.putExtra(AccountActivity.EXTRA_ACCOUNT, newAccount)
                         startActivity(intent)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -237,10 +237,8 @@
     <string name="app_settings_unifiedpush_distributor_fcm">FCM (Google Play)</string>
     <string name="app_settings_unifiedpush_encrypted">Push messages are always encrypted.</string>
 
-    <!-- AccountActivity -->
-    <string name="account_account_missing">Account does not exist: %s</string>
-
     <!-- AccountScreen -->
+    <string name="account_invalid_account">Account doesn\'t exist</string>
     <string name="account_carddav">CardDAV</string>
     <string name="account_caldav">CalDAV</string>
     <string name="account_webcal">Webcal</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -238,7 +238,7 @@
     <string name="app_settings_unifiedpush_encrypted">Push messages are always encrypted.</string>
 
     <!-- AccountActivity -->
-    <string name="account_account_missing">Account does not exist.</string>
+    <string name="account_account_missing">Account does not exist: %s</string>
 
     <!-- AccountScreen -->
     <string name="account_carddav">CardDAV</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -237,6 +237,9 @@
     <string name="app_settings_unifiedpush_distributor_fcm">FCM (Google Play)</string>
     <string name="app_settings_unifiedpush_encrypted">Push messages are always encrypted.</string>
 
+    <!-- AccountActivity -->
+    <string name="account_account_missing">Account missing in intent or does not exist</string>
+
     <!-- AccountScreen -->
     <string name="account_carddav">CardDAV</string>
     <string name="account_caldav">CalDAV</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -238,7 +238,7 @@
     <string name="app_settings_unifiedpush_encrypted">Push messages are always encrypted.</string>
 
     <!-- AccountActivity -->
-    <string name="account_account_missing">Account missing in intent or does not exist</string>
+    <string name="account_account_missing">Account does not exist.</string>
 
     <!-- AccountScreen -->
     <string name="account_carddav">CardDAV</string>


### PR DESCRIPTION
### Purpose

If AccountActivity is started without or with a non-existing account, we throw an exception, but it makes mroe sense to redirect to accounts overview and notify the user/developer who started the activity, that the account was missing.

### Short description

- if started without or non-existing account, redirect to accounts overview
- also log warning and show toast message
- handle deprecated `getParcelableExtra`
- Use `.let` construct to ensure account is passed as non-nullable.

### Checklist

- [X] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

