### PR TITLE
Pass state to modal drawer for automatic back handler

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
@@ -7,7 +7,6 @@ package at.bitfire.davdroid.ui
 import android.Manifest
 import android.accounts.Account
 import android.content.Intent
-import android.net.Uri
 import android.os.Build
 import android.provider.Settings
 import androidx.compose.foundation.Image
@@ -69,6 +68,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import at.bitfire.davdroid.BuildConfig
@@ -279,7 +279,7 @@ fun AccountsScreen(
                                 onManageDataSaver = {
                                     val intent = Intent(
                                         /* action = */ Settings.ACTION_IGNORE_BACKGROUND_DATA_RESTRICTIONS_SETTINGS,
-                                        /* uri = */ Uri.parse("package:${BuildConfig.APPLICATION_ID}")
+                                        /* uri = */ "package:${BuildConfig.APPLICATION_ID}".toUri()
                                     )
                                     if (intent.resolveActivity(context.packageManager) != null)
                                         context.startActivity(intent)

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
@@ -10,7 +10,6 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.provider.Settings
-import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -148,13 +147,7 @@ fun AccountsScreen(
     contactsStorageDisabled: Boolean = false
 ) {
     val scope = rememberCoroutineScope()
-
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
-    BackHandler(drawerState.isOpen) {
-        scope.launch {
-            drawerState.close()
-        }
-    }
 
     var isRefreshing by remember { mutableStateOf(false) }
     LaunchedEffect(isRefreshing) {
@@ -169,7 +162,7 @@ fun AccountsScreen(
         ModalNavigationDrawer(
             drawerState = drawerState,
             drawerContent = {
-                ModalDrawerSheet {
+                ModalDrawerSheet(drawerState) {
                     accountsDrawerHandler.AccountsDrawer(
                         snackbarHostState = snackbarHostState,
                         onCloseDrawer = {


### PR DESCRIPTION
### Purpose

The `ModalDrawerSheet` has an implementation which supports automatic handling of the back gesture, as well as providing predictive back.

### Short description

- Got rid of custom `BackHandler`
- Using overload of `ModalDrawerSheet` that takes `DrawerState` as argument.

<details>
<summary>Predictive back</summary>

[Screen_recording_20250527_152717.webm](https://github.com/user-attachments/assets/e6962a56-ce77-49e3-928f-a5c521d1df2a)

</details>

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

