### PR TITLE
Improve IME integration on forms

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/AdvancedLogin.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/AdvancedLogin.kt
@@ -111,6 +111,19 @@ fun AdvancedLoginScreen(
                     .padding(vertical = 8.dp)
             )
 
+            val manualUrl = Constants.MANUAL_URL.buildUpon()
+                .appendPath(Constants.MANUAL_PATH_ACCOUNTS_COLLECTIONS)
+                .fragment(Constants.MANUAL_FRAGMENT_SERVICE_DISCOVERY)
+                .build()
+            val urlInfo = HtmlCompat.fromHtml(stringResource(R.string.login_base_url_info, manualUrl), HtmlCompat.FROM_HTML_MODE_COMPACT)
+            Text(
+                text = urlInfo.toAnnotatedString(),
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp, bottom = 16.dp)
+            )
+
             OutlinedTextField(
                 value = url,
                 onValueChange = onSetUrl,
@@ -127,19 +140,6 @@ fun AdvancedLoginScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .focusRequester(focusRequester)
-            )
-
-            val manualUrl = Constants.MANUAL_URL.buildUpon()
-                .appendPath(Constants.MANUAL_PATH_ACCOUNTS_COLLECTIONS)
-                .fragment(Constants.MANUAL_FRAGMENT_SERVICE_DISCOVERY)
-                .build()
-            val urlInfo = HtmlCompat.fromHtml(stringResource(R.string.login_base_url_info, manualUrl), HtmlCompat.FROM_HTML_MODE_COMPACT)
-            Text(
-                text = urlInfo.toAnnotatedString(),
-                style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 8.dp, bottom = 16.dp)
             )
 
             OutlinedTextField(

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/AdvancedLogin.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/AdvancedLogin.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
@@ -27,7 +26,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -97,11 +95,7 @@ fun AdvancedLoginScreen(
     canContinue: Boolean,
     onLogin: () -> Unit = {}
 ) {
-    val keyboardController = LocalSoftwareKeyboardController.current
-
-    val urlFocusRequester = remember { FocusRequester() }
-    val usernameFocusRequester = remember { FocusRequester() }
-    val passwordFocusRequester = remember { FocusRequester() }
+    val focusRequester = remember { FocusRequester() }
 
     Assistant(
         nextLabel = stringResource(R.string.login_login),
@@ -130,12 +124,9 @@ fun AdvancedLoginScreen(
                     keyboardType = KeyboardType.Uri,
                     imeAction = ImeAction.Next
                 ),
-                keyboardActions = KeyboardActions {
-                    usernameFocusRequester.requestFocus()
-                },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .focusRequester(urlFocusRequester)
+                    .focusRequester(focusRequester)
             )
 
             val manualUrl = Constants.MANUAL_URL.buildUpon()
@@ -161,14 +152,9 @@ fun AdvancedLoginScreen(
                 },
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Email,
-                    imeAction = ImeAction.Done
+                    imeAction = ImeAction.Next
                 ),
-                keyboardActions = KeyboardActions {
-                    passwordFocusRequester.requestFocus()
-                },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .focusRequester(usernameFocusRequester)
+                modifier = Modifier.fillMaxWidth()
             )
 
             PasswordTextField(
@@ -182,12 +168,7 @@ fun AdvancedLoginScreen(
                     keyboardType = KeyboardType.Password,
                     imeAction = ImeAction.Done
                 ),
-                keyboardActions = KeyboardActions {
-                    keyboardController?.hide()
-                },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .focusRequester(passwordFocusRequester)
+                modifier = Modifier.fillMaxWidth()
             )
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -208,7 +189,7 @@ fun AdvancedLoginScreen(
     }
 
     LaunchedEffect(Unit) {
-        urlFocusRequester.requestFocus()
+        focusRequester.requestFocus()
     }
 }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/AdvancedLogin.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/AdvancedLogin.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
@@ -25,8 +26,8 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -96,6 +97,8 @@ fun AdvancedLoginScreen(
     canContinue: Boolean,
     onLogin: () -> Unit = {}
 ) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+
     val urlFocusRequester = remember { FocusRequester() }
     val usernameFocusRequester = remember { FocusRequester() }
     val passwordFocusRequester = remember { FocusRequester() }
@@ -127,13 +130,12 @@ fun AdvancedLoginScreen(
                     keyboardType = KeyboardType.Uri,
                     imeAction = ImeAction.Next
                 ),
+                keyboardActions = KeyboardActions {
+                    usernameFocusRequester.requestFocus()
+                },
                 modifier = Modifier
                     .fillMaxWidth()
                     .focusRequester(urlFocusRequester)
-                    .focusProperties {
-                        next = usernameFocusRequester
-                        down = next
-                    }
             )
 
             val manualUrl = Constants.MANUAL_URL.buildUpon()
@@ -159,17 +161,14 @@ fun AdvancedLoginScreen(
                 },
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Email,
-                    imeAction = ImeAction.Next
+                    imeAction = ImeAction.Done
                 ),
+                keyboardActions = KeyboardActions {
+                    passwordFocusRequester.requestFocus()
+                },
                 modifier = Modifier
                     .fillMaxWidth()
                     .focusRequester(usernameFocusRequester)
-                    .focusProperties {
-                        previous = urlFocusRequester
-                        up = previous
-                        next = passwordFocusRequester
-                        down = next
-                    }
             )
 
             PasswordTextField(
@@ -181,15 +180,14 @@ fun AdvancedLoginScreen(
                 },
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Password,
-                    imeAction = ImeAction.Next
+                    imeAction = ImeAction.Done
                 ),
+                keyboardActions = KeyboardActions {
+                    keyboardController?.hide()
+                },
                 modifier = Modifier
                     .fillMaxWidth()
                     .focusRequester(passwordFocusRequester)
-                    .focusProperties {
-                        previous = usernameFocusRequester
-                        up = previous
-                    }
             )
 
             Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/AdvancedLogin.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/AdvancedLogin.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -95,7 +96,10 @@ fun AdvancedLoginScreen(
     canContinue: Boolean,
     onLogin: () -> Unit = {}
 ) {
-    val focusRequester = remember { FocusRequester() }
+    val urlFocusRequester = remember { FocusRequester() }
+    val usernameFocusRequester = remember { FocusRequester() }
+    val passwordFocusRequester = remember { FocusRequester() }
+
     Assistant(
         nextLabel = stringResource(R.string.login_login),
         nextEnabled = canContinue,
@@ -125,7 +129,11 @@ fun AdvancedLoginScreen(
                 ),
                 modifier = Modifier
                     .fillMaxWidth()
-                    .focusRequester(focusRequester)
+                    .focusRequester(urlFocusRequester)
+                    .focusProperties {
+                        next = usernameFocusRequester
+                        down = next
+                    }
             )
 
             val manualUrl = Constants.MANUAL_URL.buildUpon()
@@ -153,7 +161,15 @@ fun AdvancedLoginScreen(
                     keyboardType = KeyboardType.Email,
                     imeAction = ImeAction.Next
                 ),
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(usernameFocusRequester)
+                    .focusProperties {
+                        previous = urlFocusRequester
+                        up = previous
+                        next = passwordFocusRequester
+                        down = next
+                    }
             )
 
             PasswordTextField(
@@ -167,7 +183,13 @@ fun AdvancedLoginScreen(
                     keyboardType = KeyboardType.Password,
                     imeAction = ImeAction.Next
                 ),
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(passwordFocusRequester)
+                    .focusProperties {
+                        previous = usernameFocusRequester
+                        up = previous
+                    }
             )
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -188,7 +210,7 @@ fun AdvancedLoginScreen(
     }
 
     LaunchedEffect(Unit) {
-        focusRequester.requestFocus()
+        urlFocusRequester.requestFocus()
     }
 }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/EmailLogin.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/EmailLogin.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -111,13 +110,12 @@ fun EmailLoginScreen(
                     keyboardType = KeyboardType.Email,
                     imeAction = ImeAction.Next
                 ),
+                keyboardActions = KeyboardActions {
+                    passwordFocusRequester.requestFocus()
+                },
                 modifier = Modifier
                     .fillMaxWidth()
                     .focusRequester(emailFocusRequester)
-                    .focusProperties {
-                        next = passwordFocusRequester
-                        down = next
-                    }
             )
 
             val manualUrl = Constants.MANUAL_URL.buildUpon()
@@ -144,16 +142,12 @@ fun EmailLoginScreen(
                     keyboardType = KeyboardType.Password,
                     imeAction = ImeAction.Done
                 ),
-                keyboardActions = KeyboardActions(
-                    onDone = { if (canContinue) onLogin() }
-                ),
+                keyboardActions = KeyboardActions {
+                    if (canContinue) onLogin()
+                },
                 modifier = Modifier
                     .fillMaxWidth()
                     .focusRequester(passwordFocusRequester)
-                    .focusProperties {
-                        previous = emailFocusRequester
-                        up = previous
-                    }
             )
         }
     }

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/EmailLogin.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/EmailLogin.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -81,6 +82,9 @@ fun EmailLoginScreen(
     canContinue: Boolean,
     onLogin: () -> Unit = {}
 ) {
+    val emailFocusRequester = remember { FocusRequester() }
+    val passwordFocusRequester = remember { FocusRequester() }
+
     Assistant(
         nextLabel = stringResource(R.string.login_login),
         nextEnabled = canContinue,
@@ -95,7 +99,6 @@ fun EmailLoginScreen(
                     .padding(vertical = 8.dp)
             )
 
-            val focusRequester = remember { FocusRequester() }
             OutlinedTextField(
                 value = email,
                 onValueChange = onSetEmail,
@@ -110,11 +113,12 @@ fun EmailLoginScreen(
                 ),
                 modifier = Modifier
                     .fillMaxWidth()
-                    .focusRequester(focusRequester)
+                    .focusRequester(emailFocusRequester)
+                    .focusProperties {
+                        next = passwordFocusRequester
+                        down = next
+                    }
             )
-            LaunchedEffect(Unit) {
-                focusRequester.requestFocus()
-            }
 
             val manualUrl = Constants.MANUAL_URL.buildUpon()
                 .appendPath(Constants.MANUAL_PATH_ACCOUNTS_COLLECTIONS)
@@ -143,9 +147,19 @@ fun EmailLoginScreen(
                 keyboardActions = KeyboardActions(
                     onDone = { if (canContinue) onLogin() }
                 ),
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(passwordFocusRequester)
+                    .focusProperties {
+                        previous = emailFocusRequester
+                        up = previous
+                    }
             )
         }
+    }
+
+    LaunchedEffect(Unit) {
+        emailFocusRequester.requestFocus()
     }
 }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/EmailLogin.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/EmailLogin.kt
@@ -97,6 +97,19 @@ fun EmailLoginScreen(
                     .padding(vertical = 8.dp)
             )
 
+            val manualUrl = Constants.MANUAL_URL.buildUpon()
+                .appendPath(Constants.MANUAL_PATH_ACCOUNTS_COLLECTIONS)
+                .fragment(Constants.MANUAL_FRAGMENT_SERVICE_DISCOVERY)
+                .build()
+            val emailInfo = HtmlCompat.fromHtml(stringResource(R.string.login_email_address_info, manualUrl), HtmlCompat.FROM_HTML_MODE_COMPACT)
+            Text(
+                text = emailInfo.toAnnotatedString(),
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp, bottom = 16.dp)
+            )
+
             OutlinedTextField(
                 value = email,
                 onValueChange = onSetEmail,
@@ -112,19 +125,6 @@ fun EmailLoginScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .focusRequester(focusRequester)
-            )
-
-            val manualUrl = Constants.MANUAL_URL.buildUpon()
-                .appendPath(Constants.MANUAL_PATH_ACCOUNTS_COLLECTIONS)
-                .fragment(Constants.MANUAL_FRAGMENT_SERVICE_DISCOVERY)
-                .build()
-            val emailInfo = HtmlCompat.fromHtml(stringResource(R.string.login_email_address_info, manualUrl), HtmlCompat.FROM_HTML_MODE_COMPACT)
-            Text(
-                text = emailInfo.toAnnotatedString(),
-                style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 8.dp, bottom = 16.dp)
             )
 
             PasswordTextField(

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/EmailLogin.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/EmailLogin.kt
@@ -19,11 +19,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -81,9 +77,6 @@ fun EmailLoginScreen(
     canContinue: Boolean,
     onLogin: () -> Unit = {}
 ) {
-    val emailFocusRequester = remember { FocusRequester() }
-    val passwordFocusRequester = remember { FocusRequester() }
-
     Assistant(
         nextLabel = stringResource(R.string.login_login),
         nextEnabled = canContinue,
@@ -110,12 +103,7 @@ fun EmailLoginScreen(
                     keyboardType = KeyboardType.Email,
                     imeAction = ImeAction.Next
                 ),
-                keyboardActions = KeyboardActions {
-                    passwordFocusRequester.requestFocus()
-                },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .focusRequester(emailFocusRequester)
+                modifier = Modifier.fillMaxWidth()
             )
 
             val manualUrl = Constants.MANUAL_URL.buildUpon()
@@ -145,15 +133,9 @@ fun EmailLoginScreen(
                 keyboardActions = KeyboardActions {
                     if (canContinue) onLogin()
                 },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .focusRequester(passwordFocusRequester)
+                modifier = Modifier.fillMaxWidth()
             )
         }
-    }
-
-    LaunchedEffect(Unit) {
-        emailFocusRequester.requestFocus()
     }
 }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/EmailLogin.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/EmailLogin.kt
@@ -19,7 +19,11 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -77,6 +81,8 @@ fun EmailLoginScreen(
     canContinue: Boolean,
     onLogin: () -> Unit = {}
 ) {
+    val focusRequester = remember { FocusRequester() }
+
     Assistant(
         nextLabel = stringResource(R.string.login_login),
         nextEnabled = canContinue,
@@ -103,7 +109,9 @@ fun EmailLoginScreen(
                     keyboardType = KeyboardType.Email,
                     imeAction = ImeAction.Next
                 ),
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(focusRequester)
             )
 
             val manualUrl = Constants.MANUAL_URL.buildUpon()
@@ -136,6 +144,10 @@ fun EmailLoginScreen(
                 modifier = Modifier.fillMaxWidth()
             )
         }
+    }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
     }
 }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/UrlLogin.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/UrlLogin.kt
@@ -87,9 +87,7 @@ fun UrlLoginScreen(
     canContinue: Boolean,
     onLogin: () -> Unit = {}
 ) {
-    val urlFocusRequester = remember { FocusRequester() }
-    val usernameFocusRequester = remember { FocusRequester() }
-    val passwordFocusRequester = remember { FocusRequester() }
+    val focusRequester = remember { FocusRequester() }
 
     Assistant(
         nextLabel = stringResource(R.string.login_login),
@@ -118,12 +116,9 @@ fun UrlLoginScreen(
                     keyboardType = KeyboardType.Uri,
                     imeAction = ImeAction.Next
                 ),
-                keyboardActions = KeyboardActions {
-                    usernameFocusRequester.requestFocus()
-                },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .focusRequester(urlFocusRequester)
+                    .focusRequester(focusRequester)
             )
 
             val manualUrl = Constants.MANUAL_URL.buildUpon()
@@ -151,12 +146,7 @@ fun UrlLoginScreen(
                     keyboardType = KeyboardType.Email,
                     imeAction = ImeAction.Next
                 ),
-                keyboardActions = KeyboardActions {
-                    passwordFocusRequester.requestFocus()
-                },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .focusRequester(usernameFocusRequester)
+                modifier = Modifier.fillMaxWidth()
             )
 
             PasswordTextField(
@@ -173,15 +163,13 @@ fun UrlLoginScreen(
                 keyboardActions = KeyboardActions {
                     if (canContinue) onLogin()
                 },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .focusRequester(passwordFocusRequester)
+                modifier = Modifier.fillMaxWidth()
             )
         }
     }
 
     LaunchedEffect(Unit) {
-        urlFocusRequester.requestFocus()
+        focusRequester.requestFocus()
     }
 }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/UrlLogin.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/UrlLogin.kt
@@ -103,6 +103,19 @@ fun UrlLoginScreen(
                     .padding(vertical = 8.dp)
             )
 
+            val manualUrl = Constants.MANUAL_URL.buildUpon()
+                .appendPath(Constants.MANUAL_PATH_ACCOUNTS_COLLECTIONS)
+                .fragment(Constants.MANUAL_FRAGMENT_SERVICE_DISCOVERY)
+                .build()
+            val urlInfo = HtmlCompat.fromHtml(stringResource(R.string.login_base_url_info, manualUrl), HtmlCompat.FROM_HTML_MODE_COMPACT)
+            Text(
+                text = urlInfo.toAnnotatedString(),
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp, bottom = 16.dp)
+            )
+
             OutlinedTextField(
                 value = url,
                 onValueChange = onSetUrl,
@@ -119,19 +132,6 @@ fun UrlLoginScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .focusRequester(focusRequester)
-            )
-
-            val manualUrl = Constants.MANUAL_URL.buildUpon()
-                .appendPath(Constants.MANUAL_PATH_ACCOUNTS_COLLECTIONS)
-                .fragment(Constants.MANUAL_FRAGMENT_SERVICE_DISCOVERY)
-                .build()
-            val urlInfo = HtmlCompat.fromHtml(stringResource(R.string.login_base_url_info, manualUrl), HtmlCompat.FROM_HTML_MODE_COMPACT)
-            Text(
-                text = urlInfo.toAnnotatedString(),
-                style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 8.dp, bottom = 16.dp)
             )
 
             OutlinedTextField(

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/UrlLogin.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/UrlLogin.kt
@@ -24,7 +24,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -119,13 +118,12 @@ fun UrlLoginScreen(
                     keyboardType = KeyboardType.Uri,
                     imeAction = ImeAction.Next
                 ),
+                keyboardActions = KeyboardActions {
+                    usernameFocusRequester.requestFocus()
+                },
                 modifier = Modifier
                     .fillMaxWidth()
                     .focusRequester(urlFocusRequester)
-                    .focusProperties {
-                        next = usernameFocusRequester
-                        down = next
-                    }
             )
 
             val manualUrl = Constants.MANUAL_URL.buildUpon()
@@ -153,15 +151,12 @@ fun UrlLoginScreen(
                     keyboardType = KeyboardType.Email,
                     imeAction = ImeAction.Next
                 ),
+                keyboardActions = KeyboardActions {
+                    passwordFocusRequester.requestFocus()
+                },
                 modifier = Modifier
                     .fillMaxWidth()
                     .focusRequester(usernameFocusRequester)
-                    .focusProperties {
-                        previous = urlFocusRequester
-                        up = previous
-                        next = passwordFocusRequester
-                        down = next
-                    }
             )
 
             PasswordTextField(
@@ -175,16 +170,12 @@ fun UrlLoginScreen(
                     keyboardType = KeyboardType.Password,
                     imeAction = ImeAction.Done
                 ),
-                keyboardActions = KeyboardActions(
-                    onDone = { onLogin() }
-                ),
+                keyboardActions = KeyboardActions {
+                    if (canContinue) onLogin()
+                },
                 modifier = Modifier
                     .fillMaxWidth()
                     .focusRequester(passwordFocusRequester)
-                    .focusProperties {
-                        previous = usernameFocusRequester
-                        up = previous
-                    }
             )
         }
     }

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/UrlLogin.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/UrlLogin.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -87,7 +88,10 @@ fun UrlLoginScreen(
     canContinue: Boolean,
     onLogin: () -> Unit = {}
 ) {
-    val focusRequester = remember { FocusRequester() }
+    val urlFocusRequester = remember { FocusRequester() }
+    val usernameFocusRequester = remember { FocusRequester() }
+    val passwordFocusRequester = remember { FocusRequester() }
+
     Assistant(
         nextLabel = stringResource(R.string.login_login),
         nextEnabled = canContinue,
@@ -117,7 +121,11 @@ fun UrlLoginScreen(
                 ),
                 modifier = Modifier
                     .fillMaxWidth()
-                    .focusRequester(focusRequester)
+                    .focusRequester(urlFocusRequester)
+                    .focusProperties {
+                        next = usernameFocusRequester
+                        down = next
+                    }
             )
 
             val manualUrl = Constants.MANUAL_URL.buildUpon()
@@ -145,7 +153,15 @@ fun UrlLoginScreen(
                     keyboardType = KeyboardType.Email,
                     imeAction = ImeAction.Next
                 ),
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(usernameFocusRequester)
+                    .focusProperties {
+                        previous = urlFocusRequester
+                        up = previous
+                        next = passwordFocusRequester
+                        down = next
+                    }
             )
 
             PasswordTextField(
@@ -162,13 +178,19 @@ fun UrlLoginScreen(
                 keyboardActions = KeyboardActions(
                     onDone = { onLogin() }
                 ),
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(passwordFocusRequester)
+                    .focusProperties {
+                        previous = usernameFocusRequester
+                        up = previous
+                    }
             )
         }
     }
 
     LaunchedEffect(Unit) {
-        focusRequester.requestFocus()
+        urlFocusRequester.requestFocus()
     }
 }
 


### PR DESCRIPTION
### Purpose

Right now, when trying to switch between fields on the login screens using TAB, the field simply gets unselected. The focus should be switched to the next field.

### Short description

Set to each field the correct next/previous focus requesters.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

