### PR TITLE
Add app password hint under password field

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/Constants.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/Constants.kt
@@ -34,7 +34,7 @@ object Constants {
 
     const val MANUAL_PATH_WEBDAV_MOUNTS = "webdav_mounts.html"
 
-    const val MANUAL_PATH_FIRST_STEPS = "introduction.html#first-steps"
+    const val MANUAL_PATH_INTRODUCTION_FIRST_STEPS = "introduction.html#first-steps"
 
     val COMMUNITY_URL = "https://github.com/bitfireAT/davx5-ose/discussions".toUri()
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/Constants.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/Constants.kt
@@ -26,15 +26,15 @@ object Constants {
     const val MANUAL_PATH_ACCOUNTS_COLLECTIONS = "accounts_collections.html"
     const val MANUAL_FRAGMENT_SERVICE_DISCOVERY = "how-does-service-discovery-work"
 
+    const val MANUAL_PATH_INTRODUCTION = "introduction.html"
+    const val MANUAL_FRAGMENT_AUTHENTICATION_METHODS = "authentication-methods"
+
     const val MANUAL_PATH_SETTINGS = "settings.html"
     const val MANUAL_FRAGMENT_APP_SETTINGS = "app-wide-settings"
     const val MANUAL_FRAGMENT_ACCOUNT_SETTINGS = "account-settings"
 
     const val MANUAL_PATH_WEBDAV_PUSH = "webdav_push.html"
-
     const val MANUAL_PATH_WEBDAV_MOUNTS = "webdav_mounts.html"
-
-    const val MANUAL_PATH_INTRODUCTION_FIRST_STEPS = "introduction.html#first-steps"
 
     val COMMUNITY_URL = "https://github.com/bitfireAT/davx5-ose/discussions".toUri()
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/Constants.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/Constants.kt
@@ -34,6 +34,8 @@ object Constants {
 
     const val MANUAL_PATH_WEBDAV_MOUNTS = "webdav_mounts.html"
 
+    const val MANUAL_PATH_FIRST_STEPS = "introduction.html#first-steps"
+
     val COMMUNITY_URL = "https://github.com/bitfireAT/davx5-ose/discussions".toUri()
 
     val FEDIVERSE_HANDLE = "@davx5app@fosstodon.org"

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/composable/PasswordTextField.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/composable/PasswordTextField.kt
@@ -89,7 +89,8 @@ fun PasswordTextField(
 }
 
 fun appPasswordHelpUrl(): Uri = Constants.MANUAL_URL.buildUpon()
-    .appendEncodedPath(Constants.MANUAL_PATH_INTRODUCTION_FIRST_STEPS)
+    .appendPath(Constants.MANUAL_PATH_INTRODUCTION)
+    .fragment(Constants.MANUAL_FRAGMENT_AUTHENTICATION_METHODS)
     .build()
 
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/composable/PasswordTextField.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/composable/PasswordTextField.kt
@@ -89,7 +89,7 @@ fun PasswordTextField(
 }
 
 fun appPasswordHelpUrl(): Uri = Constants.MANUAL_URL.buildUpon()
-    .appendPath(Constants.MANUAL_PATH_FIRST_STEPS)
+    .appendEncodedPath(Constants.MANUAL_PATH_INTRODUCTION_FIRST_STEPS)
     .build()
 
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/composable/PasswordTextField.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/composable/PasswordTextField.kt
@@ -4,7 +4,10 @@
 
 package at.bitfire.davdroid.ui.composable
 
+import android.net.Uri
 import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -25,7 +28,11 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.core.text.HtmlCompat
+import at.bitfire.davdroid.Constants
 import at.bitfire.davdroid.R
+import at.bitfire.davdroid.ui.UiUtils.toAnnotatedString
 
 @Composable
 fun PasswordTextField(
@@ -42,32 +49,49 @@ fun PasswordTextField(
 ) {
     var passwordVisible by remember { mutableStateOf(false) }
 
-    OutlinedTextField(
-        value = password,
-        onValueChange = onPasswordChange,
-        label = labelText?.let { { Text(it) } },
-        leadingIcon = leadingIcon,
-        isError = isError,
-        singleLine = true,
-        enabled = enabled,
-        readOnly = readOnly,
-        modifier = modifier.focusGroup(),
-        keyboardOptions = keyboardOptions,
-        keyboardActions = keyboardActions,
-        visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
-        trailingIcon = {
-            IconButton(
-                enabled = enabled,
-                onClick = { passwordVisible = !passwordVisible }
-            ) {
-                if (passwordVisible)
-                    Icon(Icons.Default.VisibilityOff, stringResource(R.string.login_password_hide))
-                else
-                    Icon(Icons.Default.Visibility, stringResource(R.string.login_password_show))
+    Column {
+        OutlinedTextField(
+            value = password,
+            onValueChange = onPasswordChange,
+            label = labelText?.let { { Text(it) } },
+            leadingIcon = leadingIcon,
+            isError = isError,
+            singleLine = true,
+            enabled = enabled,
+            readOnly = readOnly,
+            modifier = modifier.focusGroup(),
+            keyboardOptions = keyboardOptions,
+            keyboardActions = keyboardActions,
+            visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
+            trailingIcon = {
+                IconButton(
+                    enabled = enabled,
+                    onClick = { passwordVisible = !passwordVisible }
+                ) {
+                    if (passwordVisible)
+                        Icon(Icons.Default.VisibilityOff, stringResource(R.string.login_password_hide))
+                    else
+                        Icon(Icons.Default.Visibility, stringResource(R.string.login_password_show))
+                }
             }
-        }
-    )
+        )
+        Text(
+            modifier = Modifier.padding(vertical = 8.dp),
+            text = HtmlCompat.fromHtml(
+                stringResource(
+                    R.string.settings_app_password_hint,
+                    appPasswordHelpUrl().toString()
+                ),
+                0
+            ).toAnnotatedString()
+        )
+    }
 }
+
+fun appPasswordHelpUrl(): Uri = Constants.MANUAL_URL.buildUpon()
+    .appendPath(Constants.MANUAL_PATH_FIRST_STEPS)
+    .build()
+
 
 @Composable
 @Preview

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -367,7 +367,8 @@
     <string name="settings_ignore_vpns_off">VPN without underlying validated Internet connection is enough to run synchronization</string>
     <string name="settings_authentication">Authentication</string>
     <string name="settings_username">User name</string>
-    <string name="settings_password">Password</string>
+    <string name="settings_password">Password or app password</string>
+    <string name="settings_app_password_hint"><![CDATA[You may want to use an app password. <a href="%1$s">Learn more</a>]]></string>
     <string name="settings_new_password">New password</string>
     <string name="settings_password_summary">Update the password according to your server.</string>
     <string name="settings_certificate_alias">Client certificate</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -368,7 +368,7 @@
     <string name="settings_authentication">Authentication</string>
     <string name="settings_username">User name</string>
     <string name="settings_password">Password or app password</string>
-    <string name="settings_app_password_hint"><![CDATA[You may prefer to use an app password. <a href="%1$s">Learn more</a>]]></string>
+    <string name="settings_app_password_hint"><![CDATA[You may prefer to use an <a href="%1$s">app password</a>.]]></string>
     <string name="settings_new_password">New password</string>
     <string name="settings_password_summary">Update the password according to your server.</string>
     <string name="settings_certificate_alias">Client certificate</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -368,7 +368,7 @@
     <string name="settings_authentication">Authentication</string>
     <string name="settings_username">User name</string>
     <string name="settings_password">Password or app password</string>
-    <string name="settings_app_password_hint"><![CDATA[You may want to use an app password. <a href="%1$s">Learn more</a>]]></string>
+    <string name="settings_app_password_hint"><![CDATA[You may prefer to use an app password. <a href="%1$s">Learn more</a>]]></string>
     <string name="settings_new_password">New password</string>
     <string name="settings_password_summary">Update the password according to your server.</string>
     <string name="settings_certificate_alias">Client certificate</string>


### PR DESCRIPTION
### Purpose

We need to store user passwords. It would be better if we only store app passwords, and not the main password of some service. If the users use an app password and it gets stolen/compromised, it would mean they only need to rotate/change this app password for DAVx5. While we can't force the users to use app passwords, we can point them towards it.


### Short description

- Add a hint under the password text  field about possibility to use app password with link to introduction#first-steps in the manual.

<details>

![image](https://github.com/user-attachments/assets/3a098207-3bb0-4093-b9be-f52d9914601d)


![image](https://github.com/user-attachments/assets/4abbc738-6502-4fd9-8c60-e6f12286582b)

</details>


### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [ ] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

