### PR TITLE
Increase SDK to 36

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 
 // Android configuration
 android {
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "at.bitfire.davdroid"
@@ -25,7 +25,7 @@ android {
         setProperty("archivesBaseName", "davx5-ose-$versionName")
 
         minSdk = 24        // Android 7.0
-        targetSdk = 35     // Android 15
+        targetSdk = 36     // Android 16
 
         testInstrumentationRunner = "at.bitfire.davdroid.HiltTestRunner"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,7 +45,6 @@
     <application
         android:name=".App"
         android:allowBackup="false"
-        android:enableOnBackInvokedCallback="true"
         android:networkSecurityConfig="@xml/network_security_config"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+  -->
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
           android:installLocation="internalOnly">
@@ -41,6 +45,7 @@
     <application
         android:name=".App"
         android:allowBackup="false"
+        android:enableOnBackInvokedCallback="true"
         android:networkSecurityConfig="@xml/network_security_config"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"


### PR DESCRIPTION
### Purpose

With Android 16 scheduled for June, I think we should start the migration to SDK 36.

I've followed the official docs:
- https://developer.android.com/about/versions/16/behavior-changes-all
- https://developer.android.com/about/versions/16/behavior-changes-16
- https://developer.android.com/about/versions/16/features
- https://developer.android.com/about/versions/16/summary

### Short description

I'd say there isn't much to migrate. The only thing I've done is to forcefully enable `enableOnBackInvokedCallback` since it [will be enabled by default on Android 16](https://developer.android.com/about/versions/16/behavior-changes-16#predictive-back), and that would bring consistency.

I've tested it out, and it works fine specially after #1495.

The only thing that bothers me a bit is [this](https://developer.android.com/about/versions/16/behavior-changes-all#job-quota-opt), but I guess it's nothing new.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

