### PR TITLE
Replace ical4android and vcard4android with synctools

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -174,8 +174,7 @@ dependencies {
         exclude(group="junit")
         exclude(group="org.ogce", module="xpp3")    // Android has its own XmlPullParser implementation
     }
-    implementation(libs.bitfire.ical4android)
-    implementation(libs.bitfire.vcard4android)
+    implementation(libs.bitfire.synctools)
 
     // third-party libs
     @Suppress("RedundantSuppression")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,8 +20,7 @@ androidx-test-junit = "1.2.1"
 androidx-work = "2.10.1"
 bitfire-cert4android = "b67ba86d31"
 bitfire-dav4jvm = "05fb8ecda6"
-bitfire-ical4android = "240f756bab"
-bitfire-vcard4android = "59eb998f29"
+bitfire-synctools = "7aa709f6b6"
 compose-accompanist = "0.37.3"
 compose-bom = "2025.06.00"
 dnsjava = "3.6.2"
@@ -42,7 +41,7 @@ room = "2.7.1"
 unifiedpush = "3.0.9"
 unifiedpush-fcm = "3.0.0"
 
-# Other libraries, especially ical4android/ical4j, require Apache Commons. Some recent versions of Apache
+# Other libraries, especially ical4j, require Apache Commons. Some recent versions of Apache
 # Commons require a newer Java version than our minSdk provides. So we require these strict versions here:
 commons-codec = { strictly = "1.17.1" }
 commons-lang = { strictly = "3.15.0" }
@@ -72,8 +71,7 @@ androidx-work-base = { module = "androidx.work:work-runtime-ktx", version.ref = 
 androidx-work-testing = { module = "androidx.work:work-testing", version.ref = "androidx-work" }
 bitfire-cert4android = { module = "com.github.bitfireat:cert4android", version.ref = "bitfire-cert4android" }
 bitfire-dav4jvm = { module = "com.github.bitfireat:dav4jvm", version.ref = "bitfire-dav4jvm" }
-bitfire-ical4android = { module = "com.github.bitfireat:ical4android", version.ref = "bitfire-ical4android" }
-bitfire-vcard4android = { module = "com.github.bitfireat:vcard4android", version.ref = "bitfire-vcard4android" }
+bitfire-synctools = { module = "com.github.bitfireat:synctools", version.ref = "bitfire-synctools" }
 commons-codec = { module = "commons-codec:commons-codec", version.ref = "commons-codec" }
 commons-lang = { module = "org.apache.commons:commons-lang3", version.ref = "commons-lang" }
 compose-accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "compose-accompanist" }


### PR DESCRIPTION
ical4android and vcard4android have been merged into synctools.

This PR replaces the dependencies accordingly.