### PR TITLE
Intro / battery optimizations warning: remove Samsung; change wording from "probably" to "may"

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/intro/BatteryOptimizationsPageModel.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/intro/BatteryOptimizationsPageModel.kt
@@ -56,7 +56,7 @@ class BatteryOptimizationsPageModel @Inject constructor(
          * See https://github.com/jaredrummler/AndroidDeviceNames/blob/master/json/ for manufacturer values.
          */
         private val evilManufacturers = arrayOf("asus", "huawei", "lenovo", "letv", "meizu", "nokia",
-            "oneplus", "oppo", "samsung", "sony", "vivo", "wiko", "xiaomi", "zte")
+            "oneplus", "oppo", "sony", "vivo", "wiko", "xiaomi", "zte")
 
         /**
          * Whether the device has been produced by an evil manufacturer.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,7 +45,7 @@
     <string name="intro_battery_text">For synchronization at regular intervals, %s must be allowed to run in the background. Otherwise, Android may pause synchronization at any time.</string>
     <string name="intro_battery_dont_show">I don\'t need regular sync intervals.*</string>
     <string name="intro_autostart_title">%s compatibility</string>
-    <string name="intro_autostart_text">This device probably blocks synchronization. If you\'re affected, you can only resolve this manually.</string>
+    <string name="intro_autostart_text">Vendor-specific firmware may block synchronization. If you\'re affected, you can only resolve this manually.</string>
     <string name="intro_autostart_dont_show">I have done the required settings. Don\'t remind me anymore.*</string>
     <string name="intro_leave_unchecked">* Leave unchecked to be reminded later. Can be reset in app settings / %s.</string>
     <string name="intro_more_info">More information</string>


### PR DESCRIPTION
Recently, there are much less problems with battery optimizations so the wording is changed from "probably" to "may".

Samsung devices seem to work fine now with the normal battery saving exemption, so they're removed from the list.