### PR TITLE
[Sync framework] Disable contacts content change triggered syncs if sync interval set to manual only

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -225,13 +225,13 @@ open class LocalAddressBook @AssistedInject constructor(
 
     /**
      * Enables or disables automatic synchronization (periodic and on content changes) for the address book account
-     * based on the current account setting.
+     * based on the current sync interval account setting.
      */
     fun updateAutomaticSync() {
         val accountSettings = accountSettingsFactory.create(account)
         val syncInterval = accountSettings.getSyncInterval(SyncDataType.CONTACTS)
 
-        // Enable/Disable sync-ability of contacts and content-triggered syncs
+        // Enable/Disable sync-ability and content triggered syncs of contacts authority for the address book account.
         if (syncInterval != null) {
             syncFramework.enableSyncAbility(addressBookAccount, ContactsContract.AUTHORITY)
             syncFramework.enableSyncOnContentChange(addressBookAccount, ContactsContract.AUTHORITY)

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -224,14 +224,14 @@ open class LocalAddressBook @AssistedInject constructor(
 
 
     /**
-     * Enables or disables automatic synchronization (periodic and on content changes) for the address book account
-     * based on the current sync interval account setting.
+     * Enables or disables sync on content changes for the address book account based on the current sync
+     * interval account setting.
      */
-    fun updateAutomaticSync() {
+    fun updateSyncFrameworkSettings() {
         val accountSettings = accountSettingsFactory.create(account)
         val syncInterval = accountSettings.getSyncInterval(SyncDataType.CONTACTS)
 
-        // Enable/Disable sync-ability and content triggered syncs of contacts authority for the address book account.
+        // Enable/Disable content triggered syncs for the address book account.
         if (syncInterval != null)
             syncFramework.enableSyncOnContentChange(addressBookAccount, ContactsContract.AUTHORITY)
         else

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -232,13 +232,10 @@ open class LocalAddressBook @AssistedInject constructor(
         val syncInterval = accountSettings.getSyncInterval(SyncDataType.CONTACTS)
 
         // Enable/Disable sync-ability and content triggered syncs of contacts authority for the address book account.
-        if (syncInterval != null) {
-            syncFramework.enableSyncAbility(addressBookAccount, ContactsContract.AUTHORITY)
+        if (syncInterval != null)
             syncFramework.enableSyncOnContentChange(addressBookAccount, ContactsContract.AUTHORITY)
-        } else {
+        else
             syncFramework.disableSyncAbility(addressBookAccount, ContactsContract.AUTHORITY)
-            syncFramework.disableSyncOnContentChange(addressBookAccount, ContactsContract.AUTHORITY)
-        }
     }
 
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -23,6 +23,7 @@ import at.bitfire.davdroid.repository.DavServiceRepository
 import at.bitfire.davdroid.resource.LocalAddressBook.Companion.USER_DATA_READ_ONLY
 import at.bitfire.davdroid.resource.workaround.ContactDirtyVerifier
 import at.bitfire.davdroid.settings.AccountSettings
+import at.bitfire.davdroid.sync.SyncDataType
 import at.bitfire.davdroid.sync.SyncFrameworkIntegration
 import at.bitfire.davdroid.sync.account.SystemAccountUtils
 import at.bitfire.davdroid.sync.account.setAndVerifyUserData
@@ -223,15 +224,21 @@ open class LocalAddressBook @AssistedInject constructor(
 
 
     /**
-     * Makes contacts of this address book available to be synced and activates synchronization upon
-     * contact data changes.
+     * Enables or disables automatic synchronization (periodic and on content changes) for the address book account
+     * based on the current account setting.
      */
-    fun updateSyncFrameworkSettings() {
-        // Enable sync-ability of contacts
-        syncFramework.enableSyncAbility(addressBookAccount, ContactsContract.AUTHORITY)
+    fun updateAutomaticSync() {
+        val accountSettings = accountSettingsFactory.create(account)
+        val syncInterval = accountSettings.getSyncInterval(SyncDataType.CONTACTS)
 
-        // Changes in contact data should trigger syncs
-        syncFramework.enableSyncOnContentChange(addressBookAccount, ContactsContract.AUTHORITY)
+        // Enable/Disable sync-ability of contacts and content-triggered syncs
+        if (syncInterval != null) {
+            syncFramework.enableSyncAbility(addressBookAccount, ContactsContract.AUTHORITY)
+            syncFramework.enableSyncOnContentChange(addressBookAccount, ContactsContract.AUTHORITY)
+        } else {
+            syncFramework.disableSyncAbility(addressBookAccount, ContactsContract.AUTHORITY)
+            syncFramework.disableSyncOnContentChange(addressBookAccount, ContactsContract.AUTHORITY)
+        }
     }
 
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
@@ -152,7 +152,7 @@ class LocalAddressBookStore @Inject constructor(
             localCollection.readOnly = nowReadOnly
         }
 
-        // update content-triggered syncs
+        // Update automatic synchronization
         localCollection.updateAutomaticSync()
     }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
@@ -95,7 +95,7 @@ class LocalAddressBookStore @Inject constructor(
         val addressBook = localAddressBookFactory.create(account, addressBookAccount, provider)
 
         // update settings
-        addressBook.updateAutomaticSync()
+        addressBook.updateSyncFrameworkSettings()
         addressBook.settings = contactsProviderSettings
         addressBook.readOnly = shouldBeReadOnly(fromCollection, forceAllReadOnly)
 
@@ -153,7 +153,7 @@ class LocalAddressBookStore @Inject constructor(
         }
 
         // Update automatic synchronization
-        localCollection.updateAutomaticSync()
+        localCollection.updateSyncFrameworkSettings()
     }
 
     /**

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
@@ -95,7 +95,7 @@ class LocalAddressBookStore @Inject constructor(
         val addressBook = localAddressBookFactory.create(account, addressBookAccount, provider)
 
         // update settings
-        addressBook.updateSyncFrameworkSettings()
+        addressBook.updateAutomaticSync()
         addressBook.settings = contactsProviderSettings
         addressBook.readOnly = shouldBeReadOnly(fromCollection, forceAllReadOnly)
 
@@ -152,8 +152,8 @@ class LocalAddressBookStore @Inject constructor(
             localCollection.readOnly = nowReadOnly
         }
 
-        // make sure it will still be synchronized when contacts are updated
-        localCollection.updateSyncFrameworkSettings()
+        // update content-triggered syncs
+        localCollection.updateAutomaticSync()
     }
 
     /**

--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettings.kt
@@ -177,7 +177,7 @@ class AccountSettings @AssistedInject constructor(
             SyncDataType.EVENTS -> KEY_SYNC_INTERVAL_CALENDARS
             SyncDataType.TASKS -> KEY_SYNC_INTERVAL_TASKS
         }
-        val newValue = if (seconds == null) SYNC_INTERVAL_MANUALLY else seconds
+        val newValue = seconds ?: SYNC_INTERVAL_MANUALLY
         accountManager.setAndVerifyUserData(account, key, newValue.toString())
 
         automaticSyncManager.updateAutomaticSync(account, dataType)

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/AutomaticSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/AutomaticSyncManager.kt
@@ -81,7 +81,7 @@ class AutomaticSyncManager @Inject constructor(
             // pass through request to update all existing address books
             localAddressBookStore.acquireContentProvider()?.use { provider ->
                 for (addressBookAccount in localAddressBookStore.getAll(account, provider))
-                    addressBookAccount.updateAutomaticSync()
+                    addressBookAccount.updateSyncFrameworkSettings()
             }
 
         } else {

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/AutomaticSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/AutomaticSyncManager.kt
@@ -75,7 +75,7 @@ class AutomaticSyncManager @Inject constructor(
         val authority: String? = when (dataType) {
             SyncDataType.CONTACTS -> {
                 // Automatic sync of contacts is handled per address book account
-                localAddressBookStore.acquireContentProvider()?.let { provider ->
+                localAddressBookStore.acquireContentProvider()?.use { provider ->
                     for (addressBookAccount in localAddressBookStore.getAll(account, provider))
                         addressBookAccount.updateAutomaticSync()
                 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncFrameworkIntegration.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncFrameworkIntegration.kt
@@ -57,6 +57,8 @@ class SyncFrameworkIntegration @Inject constructor(
 
     /**
      * Disable this account/provider to be syncable.
+     *
+     * If an authority is not syncable, this implies that there's no sync on content changes, too.
      */
     fun disableSyncAbility(account: Account, authority: String) {
         logger.fine("Disabling sync framework for account=$account, authority=$authority")
@@ -72,6 +74,9 @@ class SyncFrameworkIntegration @Inject constructor(
 
     /**
      * Enable syncing on content (contact, calendar event or task) changes.
+     *
+     * This implies that the [authority] is syncable, so this method makes the [authority]
+     * syncable if required.
      */
     fun enableSyncOnContentChange(account: Account, authority: String) {
         if (!isSyncable(account, authority))

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import at.bitfire.davdroid.Constants
 import at.bitfire.davdroid.R
+import at.bitfire.davdroid.settings.AccountSettings.Companion.SYNC_INTERVAL_MANUALLY
 import at.bitfire.davdroid.settings.Credentials
 import at.bitfire.davdroid.ui.AppTheme
 import at.bitfire.davdroid.ui.composable.ActionCard
@@ -505,7 +506,7 @@ fun SyncIntervalSetting(
         MultipleChoiceInputDialog(
             title = stringResource(name),
             namesAndValues = syncIntervalNames.zip(syncIntervalSeconds),
-            initialValue = syncInterval.toString(),
+            initialValue = (syncInterval ?: SYNC_INTERVAL_MANUALLY).toString(),
             onValueSelected = { newValue ->
                 try {
                     val seconds = newValue.toLong()


### PR DESCRIPTION
### Purpose

Fix the contacts sync being triggered when sync interval is set to manual only.

### Short description

- Disable contacts content change triggered syncs for address book accounts if sync interval set to manual only 
- Fix the UI not showing the state correctly when sync interval is set to manual only

### Checklist

- [X] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.

