### PR TITLE
Remove redundant network connectivity check

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
@@ -114,12 +114,6 @@ abstract class BaseSyncWorker(
             else {
                 val syncConditions = syncConditionsFactory.create(accountSettings)
 
-                // check internet connection
-                if (!syncConditions.internetAvailable()) {
-                    logger.info("WorkManager started SyncWorker without Internet connection. Aborting.")
-                    return Result.success()
-                }
-
                 // check WiFi restriction
                 if (!syncConditions.wifiConditionsMet()) {
                     logger.info("WiFi conditions not met. Won't run periodic sync.")


### PR DESCRIPTION
SyncWorkerManager already applies a NetworkType.CONNECTED constraint.


https://github.com/bitfireAT/davx5-ose/blob/main-ose/app/src/main/kotlin/at/bitfire/davdroid/sync/worker/SyncWorkerManager.kt#L93


