### PR TITLE
Fix exceptions being fetched as `Parcelable` instead of `Serializable` in `DebugInfoActivity`

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoActivity.kt
@@ -66,7 +66,7 @@ class DebugInfoActivity : AppCompatActivity() {
             DebugInfoScreen(
                 account = IntentCompat.getParcelableExtra(intent, EXTRA_ACCOUNT, Account::class.java),
                 syncDataType = extras?.getString(EXTRA_SYNC_DATA_TYPE),
-                cause = IntentCompat.getParcelableExtra(intent, EXTRA_CAUSE, Throwable::class.java),
+                cause = IntentCompat.getSerializableExtra(intent, EXTRA_CAUSE, Throwable::class.java),
                 localResource = extras?.getString(EXTRA_LOCAL_RESOURCE),
                 remoteResource = extras?.getString(EXTRA_REMOTE_RESOURCE),
                 logs = extras?.getString(EXTRA_LOGS),


### PR DESCRIPTION
### Purpose

Exceptions are passed to `DebugInfoActivity` in intent extras as `Serializable` (with the `putExtra` overload), but then they are fetched using `IntentCompat.getParcelableExtra`.

### Short description

Replace `IntentCompat.getParcelableExtra` with `IntentCompat.getSerializableExtra`.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

