### PR TITLE
Use early entry point for sync adapter services

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncAdapterServices.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncAdapterServices.kt
@@ -6,9 +6,9 @@ package at.bitfire.davdroid.sync.adapter
 
 import android.app.Service
 import android.content.Intent
-import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
-import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.android.EarlyEntryPoint
+import dagger.hilt.android.EarlyEntryPoints
 import dagger.hilt.components.SingletonComponent
 
 abstract class SyncAdapterService: Service() {
@@ -17,7 +17,7 @@ abstract class SyncAdapterService: Service() {
      * We don't use @AndroidEntryPoint / @Inject because it's unavoidable that instrumented tests sometimes accidentally / asynchronously
      * create a [SyncAdapterService] instance before Hilt is initialized by the HiltTestRunner.
      */
-    @EntryPoint
+    @EarlyEntryPoint
     @InstallIn(SingletonComponent::class)
     interface SyncAdapterServicesEntryPoint {
         fun syncAdapter(): SyncAdapter
@@ -25,7 +25,7 @@ abstract class SyncAdapterService: Service() {
 
     // create syncAdapter on demand and cache it
     val syncAdapter by lazy {
-        val entryPoint = EntryPointAccessors.fromApplication<SyncAdapterServicesEntryPoint>(this)
+        val entryPoint = EarlyEntryPoints.get(applicationContext, SyncAdapterServicesEntryPoint::class.java)
         entryPoint.syncAdapter()
     }
 


### PR DESCRIPTION
`SyncAdapterService` is often created before the HiltTestRunner has initialized Hilt.

This causes unrelated tests to crash:

```
at.bitfire.davdroid.sync.worker.SyncWorkerManagerTest > enablePeriodic[virtual] FAILED 
	java.lang.IllegalStateException: The component was not created. Check that you have added the HiltAndroidRule.
		at dagger.hilt.internal.Preconditions.checkState(Preconditions.java:83)
Tests on virtual failed: There was 1 failure(s).

Finished 155 tests on virtual

> Task :app:virtualOseDebugAndroidTest FAILED
Test run failed to complete. Instrumentation run failed due to Process crashed.
Logcat of last crash: 
Process: at.bitfire.davdroid, PID: 1938
java.lang.RuntimeException: Unable to bind to service at.bitfire.davdroid.sync.adapter.OpenTasksSyncAdapterService@16f8231 with Intent { act=android.content.SyncAdapter cmp=at.bitfire.davdroid/.sync.adapter.OpenTasksSyncAdapterService }: java.lang.IllegalStateException: The component was not created. Check that you have added the HiltAndroidRule.
	at android.app.ActivityThread.handleBindService(ActivityThread.java:4696)
	at android.app.ActivityThread.-$$Nest$mhandleBindService(Unknown Source:0)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2272)
	at android.os.Handler.dispatchMessage(Handler.java:106)
	at android.os.Looper.loopOnce(Looper.java:205)
	at android.os.Looper.loop(Looper.java:294)
	at android.app.ActivityThread.main(ActivityThread.java:8177)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:971)
Caused by: java.lang.IllegalStateException: The component was not created. Check that you have added the HiltAndroidRule.
	at dagger.hilt.internal.Preconditions.checkState(Preconditions.java:83)
	at dagger.hilt.android.internal.testing.TestApplicationComponentManager.generatedComponent(TestApplicationComponentManager.java:96)
	at dagger.hilt.android.testing.HiltTestApplication.generatedComponent(HiltTestApplication.java:50)
	at dagger.hilt.EntryPoints.get(EntryPoints.java:59)
	at dagger.hilt.android.EntryPointAccessors.fromApplication(EntryPointAccessors.kt:35)
	at at.bitfire.davdroid.sync.adapter.SyncAdapterService.syncAdapter_delegate$lambda$0(SyncAdapterServices.kt:42)
	at at.bitfire.davdroid.sync.adapter.SyncAdapterService.$r8$lambda$Ns_Uyx_yBa40mOR1MXs11MzKhzo(Unknown Source:0)
	at at.bitfire.davdroid.sync.adapter.SyncAdapterService$$ExternalSyntheticLambda0.invoke(D8$$SyntheticClass:0)
	at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:86)
	at at.bitfire.davdroid.sync.adapter.SyncAdapterService.getSyncAdapter(SyncAdapterServices.kt:27)
	at at.bitfire.davdroid.sync.adapter.SyncAdapterService.onBind(SyncAdapterServices.kt:32)
	at android.app.ActivityThread.handleBindService(ActivityThread.java:4681)
```

This PR uses `EarlyEntryPoint` which can be used "before the SingletonComponent is available in tests".

A look into the `EarlyEntryPoints` code makes clear that this is only relevant for test environments (otherwise delegates to `EntryPoints.get`), so it shouldn't be dangerous.