### PR TITLE
Make "sync pending" work in AccountsScreen and AccountScreen

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncDataType.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncDataType.kt
@@ -33,14 +33,9 @@ enum class SyncDataType {
      */
     fun possibleAuthorities(): List<String> =
         when (this) {
-            CONTACTS -> listOf(
-                ContactsContract.AUTHORITY
-            )
-            EVENTS -> listOf(
-                CalendarContract.AUTHORITY
-            )
-            TASKS ->
-                TaskProvider.ProviderName.entries.map { it.authority }
+            CONTACTS -> listOf(ContactsContract.AUTHORITY)
+            EVENTS -> listOf(CalendarContract.AUTHORITY)
+            TASKS -> TaskProvider.ProviderName.entries.map { it.authority }
         }
 
     /**
@@ -54,15 +49,13 @@ enum class SyncDataType {
     fun authority(context: Context): String? =
         when (this) {
             CONTACTS -> ContactsContract.AUTHORITY
-
             EVENTS -> CalendarContract.AUTHORITY
-
             TASKS -> EntryPointAccessors.fromApplication<SyncDataTypeEntryPoint>(context)
                 .tasksAppManager()
                 .currentProvider()
                 ?.authority
-
         }
+
 
     companion object {
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncDataType.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncDataType.kt
@@ -46,7 +46,7 @@ enum class SyncDataType {
      * @param context android context used to determine the active/selected tasks provider
      * @return the authority matching this data type or *null* for [TASKS] if no tasks app is installed
      */
-    fun authority(context: Context): String? =
+    fun currentAuthority(context: Context): String? =
         when (this) {
             CONTACTS -> ContactsContract.AUTHORITY
             EVENTS -> CalendarContract.AUTHORITY

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncDataType.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncDataType.kt
@@ -44,9 +44,9 @@ enum class SyncDataType {
         }
 
     /**
-     * Returns the authority for this datatype.
-     * When more than one tasks provider exists (tasks apps installed) the active
-     * (user selected) authority is returned.
+     * Returns the authority corresponding to this datatype.
+     * When more than one tasks provider exists (tasks apps installed) the authority for the active
+     * tasks provider (user selected tasks app) is returned.
      *
      * @param context android context used to determine the active/selected tasks provider
      * @return the authority matching this data type or *null* for [TASKS] if no tasks app is installed

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncDataType.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncDataType.kt
@@ -27,7 +27,7 @@ enum class SyncDataType {
 
     /**
      * Returns authorities which exist for this sync data type. Used on [TASKS] the method
-     * may return an empty list if there are no task providers (installed tasks apps).
+     * may return an empty list if there are no tasks providers (installed tasks apps).
      *
      * @return list of authorities matching this data type
      */

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncDataType.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncDataType.kt
@@ -51,7 +51,7 @@ enum class SyncDataType {
      * @param context android context used to determine the active/selected tasks provider
      * @return the authority matching this data type or *null* for [TASKS] if no tasks app is installed
      */
-    fun selectedAuthority(context: Context): String? =
+    fun authority(context: Context): String? =
         when (this) {
             CONTACTS -> ContactsContract.AUTHORITY
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncFrameworkIntegration.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncFrameworkIntegration.kt
@@ -195,7 +195,7 @@ class SyncFrameworkIntegration @Inject constructor(
         // Determine the pending state for each data type of the account as separate flows
         val pendingStateFlows: List<Flow<Boolean>> = dataTypes.mapNotNull { dataType ->
             // Map datatype to authority
-            dataType.authority(context)?.let { authority ->
+            dataType.currentAuthority(context)?.let { authority ->
                 // If checking contacts, we need to check all address book accounts instead of the single main account
                 val accountsFlow: Flow<List<Account>> = when (dataType) {
                     SyncDataType.CONTACTS -> localAddressBookStore.get().getAddressBookAccountsFlow(account)

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncFrameworkIntegration.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncFrameworkIntegration.kt
@@ -194,7 +194,7 @@ class SyncFrameworkIntegration @Inject constructor(
     fun isSyncPending(account: Account, dataTypes: Iterable<SyncDataType>): Flow<Boolean> {
         // Map given data types to authorities
         val authorities = dataTypes.mapNotNull { dataType ->
-            dataType.selectedAuthority(context)
+            dataType.authority(context)
         }
 
         // Determine the pending states for the different data types of the account as separate flows

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncFrameworkIntegration.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncFrameworkIntegration.kt
@@ -6,12 +6,14 @@ package at.bitfire.davdroid.sync.adapter
 
 import android.accounts.Account
 import android.content.ContentResolver
+import android.content.Context
 import android.content.SyncRequest
 import android.os.Bundle
 import androidx.annotation.WorkerThread
 import at.bitfire.davdroid.resource.LocalAddressBookStore
 import at.bitfire.davdroid.sync.SyncDataType
 import dagger.Lazy
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -30,6 +32,7 @@ import javax.inject.Inject
  * Sync requests from the Sync Adapter Framework are handled by [SyncAdapterService].
  */
 class SyncFrameworkIntegration @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val localAddressBookStore: Lazy<LocalAddressBookStore>,
     private val logger: Logger
 ) {
@@ -188,7 +191,9 @@ class SyncFrameworkIntegration @Inject constructor(
      */
     @OptIn(ExperimentalCoroutinesApi::class)
     fun isSyncPending(account: Account, dataTypes: Iterable<SyncDataType>): Flow<Boolean> {
-        val authorities = dataTypes.flatMap { it.possibleAuthorities() }
+        val authorities = dataTypes.mapNotNull { dataType ->
+            dataType.selectedAuthority(context)
+        }
 
         // Use address book accounts if needed
         val accountsFlow = if (dataTypes.contains(SyncDataType.CONTACTS))

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncFrameworkIntegration.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncFrameworkIntegration.kt
@@ -215,7 +215,7 @@ class SyncFrameworkIntegration @Inject constructor(
 
     /**
      * Maps the given accounts flow to a simple boolean flow telling us whether any of the accounts
-     * has a pending sync for any of the given authority.
+     * has a pending sync for given authority.
      *
      * @param accountsFlow accounts to check sync status for
      * @param authority authority to check sync status for

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncFrameworkIntegration.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncFrameworkIntegration.kt
@@ -215,13 +215,13 @@ class SyncFrameworkIntegration @Inject constructor(
 
     /**
      * Maps the given accounts flow to a simple boolean flow telling us whether any of the accounts
-     * has a pending sync for any of the given authorities.
+     * has a pending sync for any of the given authority.
      *
      * @param accountsFlow accounts to check sync status for
-     * @param authority authorities to check sync status for
+     * @param authority authority to check sync status for
      *
      * @return returns flow which emits *true* if any of the accounts has a sync pending for
-     * any of the given authorities and *false* otherwise
+     * the given authority and *false* otherwise
      */
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun anyPendingSyncFlow(

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncFrameworkIntegration.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncFrameworkIntegration.kt
@@ -246,12 +246,12 @@ class SyncFrameworkIntegration @Inject constructor(
     }
 
     /**
-     * Check if any of the given accounts and authorities have a sync pending.
+     * Check if any of the given accounts have a sync pending for given authority.
      *
      * @param accounts  accounts to check sync status for
      * @param authority authority to check sync status for
      *
-     * @return true if any of the given accounts and authorities has a sync pending, false otherwise
+     * @return *true* if any of the given accounts has a sync pending for given authority; *false* otherwise
      */
     private fun anyPendingSync(accounts: List<Account>, authority: String): Boolean =
         accounts.any { account ->


### PR DESCRIPTION
### Purpose
Accounts screen doesn't show pending  syncs correctly yet (tried with calendar sync).

### Short description
- [Update sync pending UI logic to use selected authorities only](https://github.com/bitfireAT/davx5-ose/pull/1615/commits/5ccc7326b1819d7e1ec1a205ddf5efd21899d523)
- [Fix `SyncFrameworkIntegration.isSyncPending()` wrongly handling multiple data types](https://github.com/bitfireAT/davx5-ose/pull/1615/commits/0f378827fe1dcca70c82a7d69fc331ac3a80c676)
- [Extract the mapping logic from accounts flow to boolean flow](https://github.com/bitfireAT/davx5-ose/pull/1615/commits/c3ff879d8a67392f82f5014009db023579f8585b) to a separate function

**Note:**
The Contacts sync still shows a pending sync state forever, but that's due to our workaround not canceling sync requests for address books but only for their main account. See https://github.com/bitfireAT/davx5-ose/issues/1641

### Checklist

- [X] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.

