### PR TITLE
Correctly handle `SecurityException` for `acquireContentProvider`

### DIFF
--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncerTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncerTest.kt
@@ -189,7 +189,7 @@ class SyncerTest {
         override val authority: String
             get() = throw NotImplementedError()
 
-        override fun acquireContentProvider(): ContentProviderClient? {
+        override fun acquireContentProvider(throwOnMissingPermissions: Boolean): ContentProviderClient? {
             throw NotImplementedError()
         }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
@@ -78,10 +78,11 @@ class LocalAddressBookStore @Inject constructor(
         return sb.toString()
     }
 
-    override fun acquireContentProvider() = try {
+    override fun acquireContentProvider(throwOnMissingPermissions: Boolean) = try {
         context.contentResolver.acquireContentProviderClient(authority)
-    } catch (_: SecurityException) {
+    } catch (e: SecurityException) {
         // The content provider is not available for some reason. Probably because the permission is no longer granted.
+        if (throwOnMissingPermissions) throw e
         null
     }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
@@ -78,8 +78,12 @@ class LocalAddressBookStore @Inject constructor(
         return sb.toString()
     }
 
-    override fun acquireContentProvider() =
+    override fun acquireContentProvider() = try {
         context.contentResolver.acquireContentProviderClient(authority)
+    } catch (_: SecurityException) {
+        // The content provider is not available for some reason. Probably because the permission is no longer granted.
+        null
+    }
 
     override fun create(provider: ContentProviderClient, fromCollection: Collection): LocalAddressBook? {
         val service = serviceRepository.getBlocking(fromCollection.serviceId) ?: throw IllegalArgumentException("Couldn't fetch DB service from collection")

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
@@ -81,9 +81,10 @@ class LocalAddressBookStore @Inject constructor(
     override fun acquireContentProvider(throwOnMissingPermissions: Boolean) = try {
         context.contentResolver.acquireContentProviderClient(authority)
     } catch (e: SecurityException) {
-        // The content provider is not available for some reason. Probably because the permission is no longer granted.
-        if (throwOnMissingPermissions) throw e
-        null
+        if (throwOnMissingPermissions)
+            throw e
+        else
+            /* return */ null
     }
 
     override fun create(provider: ContentProviderClient, fromCollection: Collection): LocalAddressBook? {

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendarStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendarStore.kt
@@ -42,9 +42,10 @@ class LocalCalendarStore @Inject constructor(
     override fun acquireContentProvider(throwOnMissingPermissions: Boolean) = try {
         context.contentResolver.acquireContentProviderClient(authority)
     } catch (e: SecurityException) {
-        // The content provider is not available for some reason. Probably because the permission is no longer granted.
-        if (throwOnMissingPermissions) throw e
-        null
+        if (throwOnMissingPermissions)
+            throw e
+        else
+            /* return */ null
     }
 
     override fun create(client: ContentProviderClient, fromCollection: Collection): LocalCalendar? {

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendarStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendarStore.kt
@@ -39,10 +39,11 @@ class LocalCalendarStore @Inject constructor(
     override val authority: String
         get() = CalendarContract.AUTHORITY
 
-    override fun acquireContentProvider() = try {
+    override fun acquireContentProvider(throwOnMissingPermissions: Boolean) = try {
         context.contentResolver.acquireContentProviderClient(authority)
-    } catch (_: SecurityException) {
+    } catch (e: SecurityException) {
         // The content provider is not available for some reason. Probably because the permission is no longer granted.
+        if (throwOnMissingPermissions) throw e
         null
     }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendarStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendarStore.kt
@@ -39,8 +39,12 @@ class LocalCalendarStore @Inject constructor(
     override val authority: String
         get() = CalendarContract.AUTHORITY
 
-    override fun acquireContentProvider() =
+    override fun acquireContentProvider() = try {
         context.contentResolver.acquireContentProviderClient(authority)
+    } catch (_: SecurityException) {
+        // The content provider is not available for some reason. Probably because the permission is no longer granted.
+        null
+    }
 
     override fun create(client: ContentProviderClient, fromCollection: Collection): LocalCalendar? {
         val service = serviceRepository.getBlocking(fromCollection.serviceId) ?: throw IllegalArgumentException("Couldn't fetch DB service from collection")

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalDataStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalDataStore.kt
@@ -25,9 +25,10 @@ interface LocalDataStore<T: LocalCollection<*>> {
      *
      * **The caller is responsible for closing the content provider client!**
      *
-     * @param throwOnMissingPermissions If `true`, the function will throw [SecurityException] if permissions are not granted. Defaults to `false`.
+     * @param throwOnMissingPermissions If `true`, the function will throw [SecurityException] if permissions are not granted.
      *
-     * @return the content provider client, or `null` if the content provider could not be acquired (or permissions are not granted and [throwOnMissingPermissions] is `false`)
+     * @return the content provider client, or `null` if the content provider could not be acquired (or permissions are not
+     * granted and [throwOnMissingPermissions] is `false`)
      *
      * @throws SecurityException on missing permissions
      */
@@ -36,7 +37,7 @@ interface LocalDataStore<T: LocalCollection<*>> {
     /**
      * Creates a new local collection from the given (remote) collection info.
      *
-     * @param provider       the content provider client
+     * @param client        the content provider client
      * @param fromCollection collection info
      *
      * @return the new local collection, or `null` if creation failed
@@ -48,7 +49,7 @@ interface LocalDataStore<T: LocalCollection<*>> {
      * [Collection] entry.
      *
      * @param account  the account that the data store is associated with
-     * @param provider the content provider client
+     * @param client   the content provider client
      *
      * @return a list of all local collections
      */
@@ -57,7 +58,7 @@ interface LocalDataStore<T: LocalCollection<*>> {
     /**
      * Updates the local collection with the data from the given (remote) collection info.
      *
-     * @param provider        the content provider client
+     * @param client          the content provider client
      * @param localCollection the local collection to update
      * @param fromCollection  collection info
      */

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalDataStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalDataStore.kt
@@ -25,11 +25,13 @@ interface LocalDataStore<T: LocalCollection<*>> {
      *
      * **The caller is responsible for closing the content provider client!**
      *
-     * @return the content provider client, or `null` if the content provider could not be acquired
+     * @param throwOnMissingPermissions If `true`, the function will throw [SecurityException] if permissions are not granted. Defaults to `false`.
+     *
+     * @return the content provider client, or `null` if the content provider could not be acquired (or permissions are not granted and [throwOnMissingPermissions] is `false`)
      *
      * @throws SecurityException on missing permissions
      */
-    fun acquireContentProvider(): ContentProviderClient?
+    fun acquireContentProvider(throwOnMissingPermissions: Boolean = false): ContentProviderClient?
 
     /**
      * Creates a new local collection from the given (remote) collection info.

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollectionStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollectionStore.kt
@@ -40,9 +40,10 @@ class LocalJtxCollectionStore @Inject constructor(
     override fun acquireContentProvider(throwOnMissingPermissions: Boolean) = try {
         context.contentResolver.acquireContentProviderClient(authority)
     } catch (e: SecurityException) {
-        // The content provider is not available for some reason. Probably because the permission is no longer granted.
-        if (throwOnMissingPermissions) throw e
-        null
+        if (throwOnMissingPermissions)
+            throw e
+        else
+            /* return */ null
     }
 
     override fun create(provider: ContentProviderClient, fromCollection: Collection): LocalJtxCollection? {

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollectionStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollectionStore.kt
@@ -37,10 +37,11 @@ class LocalJtxCollectionStore @Inject constructor(
     override val authority: String
         get() = JtxContract.AUTHORITY
 
-    override fun acquireContentProvider() = try {
+    override fun acquireContentProvider(throwOnMissingPermissions: Boolean) = try {
         context.contentResolver.acquireContentProviderClient(authority)
-    } catch (_: SecurityException) {
+    } catch (e: SecurityException) {
         // The content provider is not available for some reason. Probably because the permission is no longer granted.
+        if (throwOnMissingPermissions) throw e
         null
     }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollectionStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollectionStore.kt
@@ -37,8 +37,12 @@ class LocalJtxCollectionStore @Inject constructor(
     override val authority: String
         get() = JtxContract.AUTHORITY
 
-    override fun acquireContentProvider() =
-        context.contentResolver.acquireContentProviderClient(JtxContract.AUTHORITY)
+    override fun acquireContentProvider() = try {
+        context.contentResolver.acquireContentProviderClient(authority)
+    } catch (_: SecurityException) {
+        // The content provider is not available for some reason. Probably because the permission is no longer granted.
+        null
+    }
 
     override fun create(provider: ContentProviderClient, fromCollection: Collection): LocalJtxCollection? {
         val service = serviceDao.get(fromCollection.serviceId) ?: throw IllegalArgumentException("Couldn't fetch DB service from collection")

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskListStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskListStore.kt
@@ -47,10 +47,11 @@ class LocalTaskListStore @AssistedInject constructor(
     override val authority: String
         get() = providerName.authority
 
-    override fun acquireContentProvider() = try {
+    override fun acquireContentProvider(throwOnMissingPermissions: Boolean) = try {
         context.contentResolver.acquireContentProviderClient(authority)
-    } catch (_: SecurityException) {
+    } catch (e: SecurityException) {
         // The content provider is not available for some reason. Probably because the permission is no longer granted.
+        if (throwOnMissingPermissions) throw e
         null
     }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskListStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskListStore.kt
@@ -47,8 +47,12 @@ class LocalTaskListStore @AssistedInject constructor(
     override val authority: String
         get() = providerName.authority
 
-    override fun acquireContentProvider() =
+    override fun acquireContentProvider() = try {
         context.contentResolver.acquireContentProviderClient(authority)
+    } catch (_: SecurityException) {
+        // The content provider is not available for some reason. Probably because the permission is no longer granted.
+        null
+    }
 
     override fun create(provider: ContentProviderClient, fromCollection: Collection): LocalTaskList? {
         val service = serviceDao.get(fromCollection.serviceId) ?: throw IllegalArgumentException("Couldn't fetch DB service from collection")

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskListStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskListStore.kt
@@ -50,9 +50,10 @@ class LocalTaskListStore @AssistedInject constructor(
     override fun acquireContentProvider(throwOnMissingPermissions: Boolean) = try {
         context.contentResolver.acquireContentProviderClient(authority)
     } catch (e: SecurityException) {
-        // The content provider is not available for some reason. Probably because the permission is no longer granted.
-        if (throwOnMissingPermissions) throw e
-        null
+        if (throwOnMissingPermissions)
+            throw e
+        else
+            /* return */ null
     }
 
     override fun create(provider: ContentProviderClient, fromCollection: Collection): LocalTaskList? {

--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration20.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration20.kt
@@ -65,12 +65,7 @@ class AccountSettingsMigration20 @Inject constructor(
 
     @OpenForTesting
     internal fun migrateAddressBooks(account: Account, cardDavServiceId: Long) {
-        try {
-            addressBookStore.acquireContentProvider()
-        } catch (_: SecurityException) {
-            // no contacts permission
-            null
-        }?.use { provider ->
+        addressBookStore.acquireContentProvider()?.use { provider ->
             for (addressBook in addressBookStore.getAll(account, provider)) {
                 val url = accountManager.getUserData(addressBook.addressBookAccount, ADDRESS_BOOK_USER_DATA_URL) ?: continue
                 val collection = collectionRepository.getByServiceAndUrl(cardDavServiceId, url) ?: continue
@@ -81,12 +76,7 @@ class AccountSettingsMigration20 @Inject constructor(
 
     @OpenForTesting
     internal fun migrateCalendars(account: Account, calDavServiceId: Long) {
-        try {
-            calendarStore.acquireContentProvider()
-        } catch (_: SecurityException) {
-            // no contacts permission
-            null
-        }?.use { client ->
+        calendarStore.acquireContentProvider()?.use { client ->
             val calendarProvider = AndroidCalendarProvider(account, client)
             // for each calendar, assign _SYNC_ID := ID if collection (identified by NAME field = URL)
             for (calendar in calendarProvider.findCalendars()) {
@@ -104,12 +94,7 @@ class AccountSettingsMigration20 @Inject constructor(
     @OpenForTesting
     internal fun migrateTaskLists(account: Account, calDavServiceId: Long) {
         val taskListStore = tasksAppManager.getDataStore() ?: /* no tasks app */ return
-        try {
-            taskListStore.acquireContentProvider()
-        } catch (_: SecurityException) {
-            // no tasks permission
-            null
-        }?.use { provider ->
+        taskListStore.acquireContentProvider()?.use { provider ->
             for (taskList in taskListStore.getAll(account, provider)) {
                 when (taskList) {
                     is LocalTaskList -> {       // tasks.org, OpenTasks

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
@@ -234,7 +234,7 @@ abstract class Syncer<StoreType: LocalDataStore<CollectionType>, CollectionType:
         logger.info("${dataStore.authority} sync of $account initiated (resync=$resync)")
 
         try {
-            dataStore.acquireContentProvider()
+            dataStore.acquireContentProvider(throwOnMissingPermissions = true)
         } catch (e: SecurityException) {
             logger.log(Level.WARNING, "Missing permissions for content provider authority ${dataStore.authority}", e)
             /* Don't show a notification here without possibility to permanently dismiss it!


### PR DESCRIPTION
### Purpose

In some cases where the specific authority permission has been revoked or not granted, it's possible that the app still tries to access the content provider, throwing a `SecurityException`. This must be handled.

### Short description

Added a try-catch inside each `acquireContentProvider` call to return null whenever `ContentResolver.acquireContentProviderClient` throws a `SecurityException`. Caller should handle the null state.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

