### PR TITLE
WebDAV: remove notifications, timeout logic

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -188,7 +188,6 @@ dependencies {
     implementation(libs.dnsjava)
     implementation(libs.guava)
     implementation(libs.mikepenz.aboutLibraries)
-    implementation(libs.nsk90.kstatemachine)
     implementation(libs.okhttp.base)
     implementation(libs.okhttp.brotli)
     implementation(libs.okhttp.logging)

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/NotificationRegistry.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/NotificationRegistry.kt
@@ -47,7 +47,6 @@ class NotificationRegistry @Inject constructor(
         const val NOTIFY_DATABASE_CORRUPTED = 4
         const val NOTIFY_SYNC_ERROR = 10
         const val NOTIFY_INVALID_RESOURCE = 11
-        const val NOTIFY_WEBDAV_ACCESS = 12
         const val NOTIFY_SYNC_EXPEDITED = 14
         const val NOTIFY_TASKS_PROVIDER_TOO_OLD = 20
         const val NOTIFY_PERMISSIONS = 21

--- a/app/src/main/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallback.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallback.kt
@@ -93,10 +93,10 @@ class RandomAccessCallback @AssistedInject constructor(
     /**
      * Returns a random-access file descriptor that can be used in a DocumentsProvider.
      */
-    fun fileDescriptor(modeFlags: Int): ParcelFileDescriptor {
+    fun fileDescriptor(): ParcelFileDescriptor {
         val storageManager = context.getSystemService<StorageManager>()!!
         val handler = Handler(Looper.getMainLooper())
-        return storageManager.openProxyFileDescriptor(modeFlags, this, handler)
+        return storageManager.openProxyFileDescriptor(ParcelFileDescriptor.MODE_READ_ONLY, this, handler)
     }
 
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallback.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallback.kt
@@ -41,10 +41,11 @@ import okhttp3.MediaType
 import java.io.InterruptedIOException
 import java.net.HttpURLConnection
 import java.util.logging.Logger
+import javax.annotation.WillClose
 
 @RequiresApi(26)
 class RandomAccessCallback @AssistedInject constructor(
-    @Assisted private val httpClient: HttpClient,
+    @Assisted @WillClose private val httpClient: HttpClient,
     @Assisted private val url: HttpUrl,
     @Assisted private val mimeType: MediaType?,
     @Assisted headResponse: HeadResponse,

--- a/app/src/main/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallbackWrapper.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallbackWrapper.kt
@@ -25,7 +25,7 @@ import okhttp3.MediaType
  * is unloaded. See https://issuetracker.google.com/issues/208788568.
  * - (2024/08/24) [Fixed in Android.](https://android.googlesource.com/platform/frameworks/base/+/e7dbf78143ba083af7a8ecadd839a9dbf6f01655%5E%21/#F0)
  *
- * **All fields of this class must be set to `null` when [onRelease] is called!**
+ * **All fields of objects of this class must be set to `null` when [onRelease] is called!**
  * Otherwise they will leak memory.
  *
  * @param httpClient    HTTP client ([RandomAccessCallbackWrapper] is responsible to close it)
@@ -36,7 +36,7 @@ class RandomAccessCallbackWrapper @AssistedInject constructor(
     @Assisted url: HttpUrl,
     @Assisted mimeType: MediaType?,
     @Assisted headResponse: HeadResponse,
-    @Assisted  externalScope: CoroutineScope,
+    @Assisted externalScope: CoroutineScope,
     callbackFactory: RandomAccessCallback.Factory
 ): ProxyFileDescriptorCallback() {
 
@@ -49,7 +49,7 @@ class RandomAccessCallbackWrapper @AssistedInject constructor(
     // callback reference
 
     /**
-     * This field contains a strong reference to the callback. It is cleared when
+     * This field is initialized with a strong reference to the callback. It is cleared when
      * [onRelease] is called so that the garbage collector can remove the actual [RandomAccessCallback].
      */
     private var callbackRef: RandomAccessCallback? =

--- a/app/src/main/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallbackWrapper.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallbackWrapper.kt
@@ -56,13 +56,13 @@ class RandomAccessCallbackWrapper @AssistedInject constructor(
         callbackFactory.create(httpClient, url, mimeType, headResponse, externalScope)
 
     private fun requireCallback(functionName: String): RandomAccessCallback =
-        callbackRef ?: throw ErrnoException(functionName, OsConstants.ECANCELED)
+        callbackRef ?: throw ErrnoException(functionName, OsConstants.EBADF)
 
 
     // non-interface delegates
 
-    fun fileDescriptor(modeFlags: Int) =
-        requireCallback("fileDescriptor").fileDescriptor(modeFlags)
+    fun fileDescriptor() =
+        requireCallback("fileDescriptor").fileDescriptor()
 
 
     // delegating implementation of ProxyFileDescriptorCallback
@@ -79,7 +79,7 @@ class RandomAccessCallbackWrapper @AssistedInject constructor(
         requireCallback("onWrite").onWrite(offset, size, data)
 
     override fun onRelease() {
-        requireCallback("onWrite").onRelease()
+        requireCallback("onRelease").onRelease()
 
         // remove reference to allow garbage collection
         callbackRef = null

--- a/app/src/main/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallbackWrapper.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallbackWrapper.kt
@@ -4,70 +4,41 @@
 
 package at.bitfire.davdroid.webdav
 
-import android.content.Context
-import android.os.Handler
-import android.os.HandlerThread
-import android.os.ParcelFileDescriptor
 import android.os.ProxyFileDescriptorCallback
-import android.os.storage.StorageManager
+import android.system.ErrnoException
+import android.system.OsConstants
 import androidx.annotation.RequiresApi
-import androidx.core.content.getSystemService
 import at.bitfire.davdroid.network.HttpClient
-import at.bitfire.davdroid.webdav.RandomAccessCallbackWrapper.Companion.TIMEOUT_INTERVAL
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import okhttp3.HttpUrl
 import okhttp3.MediaType
-import ru.nsk.kstatemachine.event.Event
-import ru.nsk.kstatemachine.state.State
-import ru.nsk.kstatemachine.state.finalState
-import ru.nsk.kstatemachine.state.initialState
-import ru.nsk.kstatemachine.state.onEntry
-import ru.nsk.kstatemachine.state.onExit
-import ru.nsk.kstatemachine.state.onFinished
-import ru.nsk.kstatemachine.state.state
-import ru.nsk.kstatemachine.state.transitionOn
-import ru.nsk.kstatemachine.statemachine.StateMachine
-import ru.nsk.kstatemachine.statemachine.createStdLibStateMachine
-import ru.nsk.kstatemachine.statemachine.processEventBlocking
-import java.util.Timer
-import java.util.TimerTask
-import java.util.logging.Logger
-import kotlin.concurrent.schedule
 
 /**
- * (2021/12/02) Currently Android's `StorageManager.openProxyFileDescriptor` has a memory leak:
+ * Use this wrapper to ensure that all memory is released as soon as [onRelease] is called.
+ *
+ * - (2021/12/02) Currently Android's `StorageManager.openProxyFileDescriptor` has a memory leak:
  * the given callback is registered in `com.android.internal.os.AppFuseMount` (which adds it to
  * a [Map]), but is not unregistered anymore. So it stays in the memory until the whole mount
- * is unloaded. See https://issuetracker.google.com/issues/208788568
+ * is unloaded. See https://issuetracker.google.com/issues/208788568.
+ * - (2024/08/24) [Fixed in Android.](https://android.googlesource.com/platform/frameworks/base/+/e7dbf78143ba083af7a8ecadd839a9dbf6f01655%5E%21/#F0)
  *
- * Use this wrapper to
+ * **All fields of this class must be set to `null` when [onRelease] is called!**
+ * Otherwise they will leak memory.
  *
- * - ensure that all memory is released as soon as [onRelease] is called,
- * - provide timeout functionality: [RandomAccessCallback] will be closed when not
- *
- * used for more than [TIMEOUT_INTERVAL] ms and re-created when necessary.
- *
- * @param httpClient    HTTP client – [RandomAccessCallbackWrapper] is responsible to close it
+ * @param httpClient    HTTP client ([RandomAccessCallbackWrapper] is responsible to close it)
  */
 @RequiresApi(26)
 class RandomAccessCallbackWrapper @AssistedInject constructor(
-    @Assisted private val httpClient: HttpClient,
-    @Assisted private val url: HttpUrl,
-    @Assisted private val mimeType: MediaType?,
-    @Assisted private val headResponse: HeadResponse,
-    @Assisted private val externalScope: CoroutineScope,
-    @ApplicationContext private val context: Context,
-    private val logger: Logger,
-    private val callbackFactory: RandomAccessCallback.Factory
+    @Assisted httpClient: HttpClient,
+    @Assisted url: HttpUrl,
+    @Assisted mimeType: MediaType?,
+    @Assisted headResponse: HeadResponse,
+    @Assisted  externalScope: CoroutineScope,
+    callbackFactory: RandomAccessCallback.Factory
 ): ProxyFileDescriptorCallback() {
-
-    companion object {
-        const val TIMEOUT_INTERVAL = 15000L
-    }
 
     @AssistedFactory
     interface Factory {
@@ -75,132 +46,43 @@ class RandomAccessCallbackWrapper @AssistedInject constructor(
     }
 
 
-    // state machine
-
-    sealed class Events {
-        object Transfer : Event
-        object NowIdle : Event
-        object GoStandby : Event
-        object Close : Event
-    }
-
-    /* We don't use a sealed class for states here because the states would then be singletons, while we can have
-    multiple instances of the state machine (which require multiple instances of the states, too). */
-    private val machine = createStdLibStateMachine {
-        lateinit var activeIdleState: State
-        lateinit var activeTransferringState: State
-        lateinit var standbyState: State
-        lateinit var closedState: State
-
-        initialState("active") {
-            onEntry {
-                _callback = callbackFactory.create(httpClient, url, mimeType, headResponse, externalScope)
-            }
-            onExit {
-                _callback?.onRelease()
-                _callback = null
-            }
-
-            transitionOn<Events.GoStandby> { targetState = { standbyState } }
-            transitionOn<Events.Close> { targetState = { closedState } }
-
-            // active has two nested states: transferring (I/O running) and idle (starts timeout timer)
-            activeIdleState = initialState("idle") {
-                val timer: Timer = Timer(true)
-                var timeout: TimerTask? = null
-
-                onEntry {
-                    timeout = timer.schedule(TIMEOUT_INTERVAL) {
-                        machine.processEventBlocking(Events.GoStandby)
-                    }
-                }
-                onExit {
-                    timeout?.cancel()
-                    timeout = null
-                }
-                onFinished {
-                    timer.cancel()
-                }
-
-                transitionOn<Events.Transfer> { targetState = { activeTransferringState } }
-            }
-
-            activeTransferringState = state("transferring") {
-                transitionOn<Events.NowIdle> { targetState = { activeIdleState } }
-            }
-        }
-
-        standbyState = state("standby") {
-            transitionOn<Events.Transfer> { targetState = { activeTransferringState } }
-            transitionOn<Events.NowIdle> { targetState = { activeIdleState } }
-            transitionOn<Events.Close> { targetState = { closedState } }
-        }
-
-        closedState = finalState("closed")
-        onFinished {
-            shutdown()
-        }
-
-        logger = StateMachine.Logger { message ->
-            this@RandomAccessCallbackWrapper.logger.finer(message())
-        }
-    }
-
-    private val workerThread = HandlerThread(javaClass.simpleName).apply { start() }
-    val workerHandler: Handler = Handler(workerThread.looper)
-
-
     // callback reference
 
-    private var _callback: RandomAccessCallback? = null
-
-    private fun<T> requireCallback(block: (callback: RandomAccessCallback) -> T): T {
-        machine.processEventBlocking(Events.Transfer)
-        try {
-            return block(_callback ?: throw IllegalStateException())
-        } finally {
-            machine.processEventBlocking(Events.NowIdle)
-        }
-    }
-
-
-    // operations
-
     /**
-     * Returns a random-access file descriptor that can be used in a DocumentsProvider.
+     * This field contains a strong reference to the callback. It is cleared when
+     * [onRelease] is called so that the garbage collector can remove the actual [RandomAccessCallback].
      */
-    fun fileDescriptor(modeFlags: Int): ParcelFileDescriptor {
-        val storageManager = context.getSystemService<StorageManager>()!!
-        return storageManager.openProxyFileDescriptor(modeFlags, this, workerHandler)
-    }
+    private var callbackRef: RandomAccessCallback? =
+        callbackFactory.create(httpClient, url, mimeType, headResponse, externalScope)
 
-    @Synchronized
-    private fun shutdown() {
-        httpClient.close()
-        workerThread.quit()
-    }
+    private fun requireCallback(functionName: String): RandomAccessCallback =
+        callbackRef ?: throw ErrnoException(functionName, OsConstants.ECANCELED)
+
+
+    // non-interface delegates
+
+    fun fileDescriptor(modeFlags: Int) =
+        requireCallback("fileDescriptor").fileDescriptor(modeFlags)
 
 
     // delegating implementation of ProxyFileDescriptorCallback
 
-    @Synchronized
     override fun onFsync() { /* not used */ }
 
-    @Synchronized
     override fun onGetSize() =
-        requireCallback { it.onGetSize() }
+        requireCallback("onGetSize").onGetSize()
 
-    @Synchronized
     override fun onRead(offset: Long, size: Int, data: ByteArray) =
-        requireCallback { it.onRead(offset, size, data) }
+        requireCallback("onRead").onRead(offset, size, data)
 
-    @Synchronized
     override fun onWrite(offset: Long, size: Int, data: ByteArray) =
-        requireCallback { it.onWrite(offset, size, data) }
+        requireCallback("onWrite").onWrite(offset, size, data)
 
-    @Synchronized
     override fun onRelease() {
-        machine.processEventBlocking(Events.Close)
+        requireCallback("onWrite").onRelease()
+
+        // remove reference to allow garbage collection
+        callbackRef = null
     }
 
 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/webdav/StreamingFileDescriptor.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/webdav/StreamingFileDescriptor.kt
@@ -6,16 +6,11 @@ package at.bitfire.davdroid.webdav
 
 import android.content.Context
 import android.os.ParcelFileDescriptor
-import android.text.format.Formatter
 import androidx.annotation.WorkerThread
-import androidx.core.app.NotificationCompat
-import androidx.core.app.NotificationManagerCompat
 import at.bitfire.dav4jvm.DavResource
 import at.bitfire.dav4jvm.exception.HttpException
-import at.bitfire.davdroid.R
 import at.bitfire.davdroid.di.IoDispatcher
 import at.bitfire.davdroid.network.HttpClient
-import at.bitfire.davdroid.ui.NotificationRegistry
 import at.bitfire.davdroid.util.DavUtils
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -44,8 +39,7 @@ class StreamingFileDescriptor @AssistedInject constructor(
     @Assisted private val finishedCallback: OnSuccessCallback,
     @ApplicationContext private val context: Context,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
-    private val logger: Logger,
-    private val notificationRegistry: NotificationRegistry
+    private val logger: Logger
 ) {
 
     companion object {
@@ -60,16 +54,6 @@ class StreamingFileDescriptor @AssistedInject constructor(
 
     val dav = DavResource(client.okHttpClient, url)
     var transferred: Long = 0
-
-    private val notificationManager = NotificationManagerCompat.from(context)
-    private val notification = NotificationCompat.Builder(context, notificationRegistry.CHANNEL_STATUS)
-        .setPriority(NotificationCompat.PRIORITY_LOW)
-        .setCategory(NotificationCompat.CATEGORY_STATUS)
-        .setContentText(dav.fileName())
-        .setSmallIcon(R.drawable.ic_storage_notify)
-        .setOngoing(true)
-    val notificationTag = url.toString()
-
 
     fun download() = doStreaming(false)
     fun upload() = doStreaming(true)
@@ -98,8 +82,6 @@ class StreamingFileDescriptor @AssistedInject constructor(
                 writeFd.close()
             } catch (_: IOException) {}
 
-            notificationManager.cancel(notificationTag, NotificationRegistry.NOTIFY_WEBDAV_ACCESS)
-
             finishedCallback.onSuccess(transferred)
         }
 
@@ -116,33 +98,12 @@ class StreamingFileDescriptor @AssistedInject constructor(
                 if (response.isSuccessful) {
                     val length = body.contentLength()
 
-                    notification.setContentTitle(context.getString(R.string.webdav_notification_download))
-                    if (length == -1L)
-                        // unknown file size, show notification now (no updates on progress)
-                        notificationRegistry.notifyIfPossible(NotificationRegistry.NOTIFY_WEBDAV_ACCESS, notificationTag) {
-                            notification
-                                .setProgress(100, 0, true)
-                                .build()
-                        }
-                    else
-                        // known file size
-                        notification.setSubText(Formatter.formatFileSize(context, length))
-
                     ParcelFileDescriptor.AutoCloseOutputStream(writeFd).use { output ->
                         val buffer = ByteArray(BUFFER_SIZE)
                         body.byteStream().use { source ->
                             // read first chunk
                             var bytes = source.read(buffer)
                             while (bytes != -1) {
-                                // update notification (if file size is known)
-                                if (length > 0)
-                                    notificationRegistry.notifyIfPossible(NotificationRegistry.NOTIFY_WEBDAV_ACCESS, notificationTag) {
-                                        val progress = (transferred*100/length).toInt()
-                                        notification
-                                            .setProgress(100, progress, false)
-                                            .build()
-                                    }
-
                                 // write chunk
                                 output.write(buffer, 0, bytes)
                                 transferred += bytes
@@ -166,12 +127,6 @@ class StreamingFileDescriptor @AssistedInject constructor(
             override fun contentType(): MediaType? = mimeType
             override fun isOneShot() = true
             override fun writeTo(sink: BufferedSink) {
-                notificationRegistry.notifyIfPossible(NotificationRegistry.NOTIFY_WEBDAV_ACCESS, notificationTag) {
-                    notification
-                        .setContentTitle(context.getString(R.string.webdav_notification_upload))
-                        .build()
-                }
-
                 ParcelFileDescriptor.AutoCloseInputStream(readFd).use { input ->
                     val buffer = ByteArray(BUFFER_SIZE)
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/webdav/operation/CreateDocumentOperation.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/webdav/operation/CreateDocumentOperation.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.runInterruptible
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.RequestBody
 import java.io.FileNotFoundException
 import java.util.logging.Logger
 import javax.inject.Inject
@@ -56,7 +56,7 @@ class CreateDocumentOperation @Inject constructor(
                                 // directory successfully created
                             }
                         else
-                            doc.put("".toRequestBody(null), ifNoneMatch = true) {
+                            doc.put(RequestBody.EMPTY, ifNoneMatch = true) {
                                 // document successfully created
                             }
                     }
@@ -66,8 +66,11 @@ class CreateDocumentOperation @Inject constructor(
                             mountId = parent.mountId,
                             parentId = parent.id,
                             name = newName,
+                            isDirectory = createDirectory,
                             mimeType = mimeType.toMediaTypeOrNull(),
-                            isDirectory = createDirectory
+                            eTag = null,
+                            lastModified = null,
+                            size = if (createDirectory) null else 0
                         )
                     )
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/webdav/operation/OpenDocumentOperation.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/webdav/operation/OpenDocumentOperation.kt
@@ -79,8 +79,10 @@ class OpenDocumentOperation @Inject constructor(
 
         } else {
             logger.fine("Creating StreamingFileDescriptor for $url")
-            val fd = streamingFileDescriptorFactory.create(client, url, doc.mimeType, accessScope) { transferred ->
+            val fd = streamingFileDescriptorFactory.create(client, url, doc.mimeType, accessScope) { transferred, success ->
                 // called when transfer is finished
+                if (!success)
+                    return@create
 
                 val now = System.currentTimeMillis()
                 if (!readOnlyMode /* write access */) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,6 @@ kotlinx-coroutines = "1.10.2"
 # see https://github.com/google/ksp/releases for version numbers
 ksp = "2.2.0-2.0.2"
 mikepenz-aboutLibraries = "12.2.4"
-nsk90-kstatemachine = "0.33.0"
 mockk = "1.14.5"
 okhttp = "5.1.0"
 openid-appauth = "0.11.1"
@@ -96,7 +95,6 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 mikepenz-aboutLibraries = { module = "com.mikepenz:aboutlibraries-compose-m3", version.ref = "mikepenz-aboutLibraries" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockk" }
-nsk90-kstatemachine = { module = "io.github.nsk90:kstatemachine-jvm", version.ref = "nsk90-kstatemachine" }
 okhttp-base = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okhttp-brotli = { module = "com.squareup.okhttp3:okhttp-brotli", version.ref = "okhttp" }
 okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }


### PR DESCRIPTION
### Purpose

The current implementation of the WebDAV

- memory leak workaround and
- timeout functionality

seemed over-complex and error prone.

TBD: Check that main thread looper is OK for file access + UI - or https://developer.android.com/reference/android/os/HandlerThread ?


### Short description

- `RandomAccessCallbackWrapper` is now only responsible to workaround the memory leak (which is already fixed in recent Android versions → KDoc)
- WebDAV access notifications are removed:
  - `onRelease` is always called, but often with large delay. This may cause confusion for users because the (permanent) notifications stay active although the file is not used actively anymore. Previously this was addressed by the timeout solution, but we can remove the notification completely.
  - Performance reasons (many notification updates when large files like videos are accessed).
  - It doesn't seem to bring any benefit in preventing being killed (#1350).
- Minor improvements like using Kotlin I/O `copyTo()` for copying between streams
- kstatemachine dependency removed


### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.