### PR TITLE
Fix bottom bar color on custom tabs

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/NextcloudLogin.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/NextcloudLogin.kt
@@ -5,6 +5,7 @@
 package at.bitfire.davdroid.ui.setup
 
 import android.content.Intent
+import android.graphics.Color
 import android.net.Uri
 import android.provider.Browser
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -90,6 +91,7 @@ object NextcloudLogin : LoginType {
                     @Suppress("DEPRECATION")
                     val browser = CustomTabsIntent.Builder()
                         .setToolbarColor(context.resources.getColor(R.color.primaryColor))
+                        .setNavigationBarColor(Color.WHITE)
                         .build()
                     browser.intent.data = loginUri
                     browser.intent.putExtra(

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/NextcloudLogin.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/setup/NextcloudLogin.kt
@@ -5,7 +5,6 @@
 package at.bitfire.davdroid.ui.setup
 
 import android.content.Intent
-import android.graphics.Color
 import android.net.Uri
 import android.provider.Browser
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -90,8 +89,6 @@ object NextcloudLogin : LoginType {
                     // Custom Tabs are available
                     @Suppress("DEPRECATION")
                     val browser = CustomTabsIntent.Builder()
-                        .setToolbarColor(context.resources.getColor(R.color.primaryColor))
-                        .setNavigationBarColor(Color.WHITE)
                         .build()
                     browser.intent.data = loginUri
                     browser.intent.putExtra(


### PR DESCRIPTION
### Purpose

Bottom bar's default color on Custom Tabs is not correct, it's not readable.

See #1639 for screenshot.

### Short description

Set the color to white, in order to display accent color correctly.

<details>
<summary>Screenshot for gesture navigation</summary>

<img width="1080" height="2400" alt="Screenshot_20250804_160918" src="https://github.com/user-attachments/assets/6610a7ea-0645-476d-8fb0-201f25adfacc" />

</details>

<details>
<summary>Screenshot for 3-button navigation</summary>

<img width="1080" height="2400" alt="Screenshot_20250804_161024" src="https://github.com/user-attachments/assets/d7709947-5088-4b00-82c9-d6a3834f08ba" />


</details>

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

