### PR TITLE
Fix NPE when `Event._ID` is larger than `Integer.MAX_VALUE`

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
@@ -123,7 +123,7 @@ class LocalCalendar @AssistedInject constructor(
 
             // delete event and possible exceptions (content provider doesn't delete exceptions itself)
             batch += BatchOperation.CpoBuilder
-                .newDelete(Events.CONTENT_URI.asSyncAdapter(androidCalendar.account))
+                .newDelete(androidCalendar.eventsUri)
                 .withSelection("${Events._ID}=? OR ${Events.ORIGINAL_ID}=?", arrayOf(id.toString(), id.toString()))
         }
         return batch.commit()

--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
@@ -119,7 +119,7 @@ class LocalCalendar @AssistedInject constructor(
             "${Events.CALENDAR_ID}=? AND NOT ${Events.DIRTY} AND ${Events.ORIGINAL_ID} IS NULL AND ${AndroidEvent2.COLUMN_FLAGS}=?",
             arrayOf(androidCalendar.id.toString(), flags.toString())
         ) { values ->
-            val id = values.getAsInteger(Events._ID)
+            val id = values.getAsLong(Events._ID)
 
             // delete event and possible exceptions (content provider doesn't delete exceptions itself)
             batch += BatchOperation.CpoBuilder


### PR DESCRIPTION
Would be interesting if you find other cases.

I searched DAVx5 and synctools for other cases of using Integer for provider IDs, but didn't find any.


### Checklist

- [ ] The PR has a proper title, description and label.
- [ ] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [ ] I have added documentation to complex functions and functions that can be used by other modules.
- [ ] I have added reasonable tests or consciously decided to not add tests.

