### PR TITLE
Don't disable sync-ability of address books when set to manual only

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -234,7 +234,7 @@ open class LocalAddressBook @AssistedInject constructor(
         if (syncInterval != null)
             syncFramework.enableSyncOnContentChange(addressBookAccount, ContactsContract.AUTHORITY)
         else
-            syncFramework.disableSyncAbility(addressBookAccount, ContactsContract.AUTHORITY)
+            syncFramework.disableSyncOnContentChange(addressBookAccount, ContactsContract.AUTHORITY)
     }
 
 


### PR DESCRIPTION
### Purpose

When sync interval is set to "only manually" for address books, we disable sync-ability completely (!) when we should only be disabling the sync on content changes.

### Short description

It's obviously wrong to disable the sync entirely, but I could not reproduce the behaviour @devvv4ever described in the issue with my samsung phone (Android 10) and the samsung contacts app installed, so maybe you can check again with the PR version.

- disable only content change triggered syncs


### Checklist

- [X] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added reasonable tests or consciously decided to not add tests.
