### PR TITLE
Add comments on foreign key constraint enforcement

### DIFF
--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/db/migration/DatabaseMigrationTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/db/migration/DatabaseMigrationTest.kt
@@ -46,7 +46,7 @@ abstract class DatabaseMigrationTest(
      *
      * Note: SQLite's foreign key constraint enforcement is not enabled (always per
      * DB connection) in tests we need to enable it ourselves using
-     * execSQL("PRAGMA foreign_keys=ON;"); It's usually practical not do so however.
+     * execSQL("PRAGMA foreign_keys=ON;"); It's usually practical not to do so, however.
      * In production database connections room enables it for us.
      *
      * @param prepare      Callback to prepare the database. Will be run with database schema in version [toVersion] - 1.

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/db/migration/DatabaseMigrationTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/db/migration/DatabaseMigrationTest.kt
@@ -44,10 +44,10 @@ abstract class DatabaseMigrationTest(
     /**
      * Used for testing the migration process from [toVersion]-1 to [toVersion].
      *
-     * Note: SQLite's foreign key constraint enforcement is not enabled (always per
-     * DB connection) in tests we need to enable it ourselves using
-     * execSQL("PRAGMA foreign_keys=ON;"); It's usually practical not to do so, however.
-     * In production database connections room enables it for us.
+     * Note: SQLite's foreign key constraint enforcement is not enabled in tests. We need
+     * to enable it ourselves using setting "PRAGMA foreign_keys=ON" directly after opening
+     * a new database connection (works per connection). In tests it's usually more practical
+     * not to do so, however. In production database connections room enables it for us.
      *
      * @param prepare      Callback to prepare the database. Will be run with database schema in version [toVersion] - 1.
      * @param validate     Callback to validate the migration result. Will be run with database schema in version [toVersion].
@@ -67,7 +67,7 @@ abstract class DatabaseMigrationTest(
         val dbName = "test"
         helper.createDatabase(dbName, version = toVersion - 1).apply {
             // We could enable foreign key constraint enforcement here
-            // execSQL("PRAGMA foreign_keys=ON;");
+            // by setting "PRAGMA foreign_keys=ON".
             prepare(this)
             close()
         }

--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/db/migration/DatabaseMigrationTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/db/migration/DatabaseMigrationTest.kt
@@ -44,6 +44,11 @@ abstract class DatabaseMigrationTest(
     /**
      * Used for testing the migration process from [toVersion]-1 to [toVersion].
      *
+     * Note: SQLite's foreign key constraint enforcement is not enabled (always per
+     * DB connection) in tests we need to enable it ourselves using
+     * execSQL("PRAGMA foreign_keys=ON;"); It's usually practical not do so however.
+     * In production database connections room enables it for us.
+     *
      * @param prepare      Callback to prepare the database. Will be run with database schema in version [toVersion] - 1.
      * @param validate     Callback to validate the migration result. Will be run with database schema in version [toVersion].
      */
@@ -61,6 +66,8 @@ abstract class DatabaseMigrationTest(
         // Prepare the database with the initial version.
         val dbName = "test"
         helper.createDatabase(dbName, version = toVersion - 1).apply {
+            // We could enable foreign key constraint enforcement here
+            // execSQL("PRAGMA foreign_keys=ON;");
             prepare(this)
             close()
         }

--- a/app/src/main/kotlin/at/bitfire/davdroid/db/AppDatabase.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/db/AppDatabase.kt
@@ -35,6 +35,13 @@ import dagger.hilt.components.SingletonComponent
 import java.io.Writer
 import javax.inject.Singleton
 
+/**
+ * The app database. Managed via android jetpack room. Room provides an abstraction
+ * layer over SQLite.
+ *
+ * Note: In SQLite PRAGMA foreign_keys is off by default. Room activates it for
+ * production (non-test) databases.
+ */
 @Database(entities = [
     Service::class,
     HomeSet::class,


### PR DESCRIPTION
### Purpose

Document that foreign key constraint enforcement is not active in tests, but rather needs to be activated by us and that in production it gets activated by room.

### Short description

`testMigration()`:
- add note in kdoc
- add comment

### Checklist
- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.

