### PR TITLE
Configure Dependabot for Gradle dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,5 +22,7 @@ updates:
         patterns: ["*"]
     ignore:
       # kotlin and ksp must be aligned and should only be updated together and manually
-      - dependency-name: "kotlin"
-      - dependency-name: "ksp"
+      - dependency-name: "org.jetbrains.kotlin:kotlin-stdlib"
+      - dependency-name: "org.jetbrains.kotlin.plugin.compose"
+      - dependency-name: "org.jetbrains.kotlin.android"
+      - dependency-name: "com.google.devtools.ksp"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,15 @@ updates:
     groups:
       ci-actions:
         patterns: ["*"]
+        
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      lib-dependencies:
+        patterns: ["*"]
+    ignore:
+      # kotlin and ksp must be aligned and should only be updated together and manually
+      - dependency-name: "kotlin"
+      - dependency-name: "ksp"


### PR DESCRIPTION
As Dependabot with grouping works for the other repos, I'd give it a try for davx5-ose.

I excluded kotlin and ksp because they must be updated together and aligned. We also still have to update cert4android etc. and the davx5 (non-ose) dependencies manually.