### PR TITLE
Disable pending sync indicator on Android 14+

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncAdapterImpl.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncAdapterImpl.kt
@@ -11,7 +11,6 @@ import android.content.ContentProviderClient
 import android.content.ContentResolver
 import android.content.Context
 import android.content.SyncResult
-import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
 import androidx.work.WorkInfo
@@ -60,7 +59,6 @@ class SyncAdapterImpl @Inject constructor(
     @ApplicationContext context: Context,
     private val logger: Logger,
     private val syncConditionsFactory: SyncConditions.Factory,
-    private val syncFrameworkIntegration: SyncFrameworkIntegration,
     private val syncWorkerManager: SyncWorkerManager
 ): AbstractThreadedSyncAdapter(
     /* context = */ context,
@@ -119,11 +117,11 @@ class SyncAdapterImpl @Inject constructor(
         // Android 14+ does not handle pending sync state correctly.
         // As a defensive workaround, we can cancel specifically this still pending sync only
         // See: https://github.com/bitfireAT/davx5-ose/issues/1458
-        if (Build.VERSION.SDK_INT >= 34) {
-            logger.fine("Android 14+ bug: Canceling forever pending sync adapter framework sync request for " +
-                    "account=$accountOrAddressBookAccount authority=$authority upload=$upload")
-            syncFrameworkIntegration.cancelSync(accountOrAddressBookAccount, authority, extras)
-        }
+//        if (Build.VERSION.SDK_INT >= 34) {
+//            logger.fine("Android 14+ bug: Canceling forever pending sync adapter framework sync request for " +
+//                    "account=$accountOrAddressBookAccount authority=$authority upload=$upload")
+//            syncFrameworkIntegration.cancelSync(accountOrAddressBookAccount, authority, extras)
+//        }
 
         /* Because we are not allowed to observe worker state on a background thread, we can not
         use it to block the sync adapter. Instead we use a Flow to get notified when the sync

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncFrameworkIntegration.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncFrameworkIntegration.kt
@@ -8,6 +8,7 @@ import android.accounts.Account
 import android.content.ContentResolver
 import android.content.Context
 import android.content.SyncRequest
+import android.os.Build
 import android.os.Bundle
 import androidx.annotation.WorkerThread
 import at.bitfire.davdroid.resource.LocalAddressBookStore
@@ -192,6 +193,12 @@ class SyncFrameworkIntegration @Inject constructor(
      */
     @OptIn(ExperimentalCoroutinesApi::class)
     fun isSyncPending(account: Account, dataTypes: Iterable<SyncDataType>): Flow<Boolean> {
+        // Android 14+ does not handle pending sync state correctly.
+        // For now we simply always return false
+        // See also sync cancellation in [SyncAdapterImpl.onPerformSync]
+        if (Build.VERSION.SDK_INT >= 34)
+            return flowOf(false)
+
         // Determine the pending state for each data type of the account as separate flows
         val pendingStateFlows: List<Flow<Boolean>> = dataTypes.mapNotNull { dataType ->
             // Map datatype to authority


### PR DESCRIPTION
### Purpose

The pending sync flag does not work properly on Android 14+. It stays pending forever, even though the sync has run already. We are trying to fix this in:

- https://github.com/bitfireAT/davx5-ose/pull/1463
- https://github.com/bitfireAT/davx5-ose/issues/1641
- https://github.com/bitfireAT/davx5-ose/pull/1676

... but the issue is especially cumbersome to deal with when it comes to migrating into a clean state where no pending syncs are left. See https://github.com/bitfireAT/davx5-ose/pull/1676#issuecomment-3248708281

So we decided to postpone for now and disable Sync Adapter Frameworks pending sync indicator on Android 14+.

Development should continue in https://github.com/bitfireAT/davx5-ose/issues/1660

### Short description

- always return a flow of value false when on Android 14+

### Checklist

- [x] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.

