### PR TITLE
Testing sync adapter framework cancelation

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettings.kt
@@ -354,6 +354,11 @@ class AccountSettings @AssistedInject constructor(
 
     companion object {
 
+        /**
+         * Current (usually the newest) account settings version. It's used to
+         * determine whether a migration ([AccountSettingsMigration])
+         * should be performed.
+         */
         const val CURRENT_VERSION = 21
         const val KEY_SETTINGS_VERSION = "version"
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettings.kt
@@ -354,7 +354,7 @@ class AccountSettings @AssistedInject constructor(
 
     companion object {
 
-        const val CURRENT_VERSION = 20
+        const val CURRENT_VERSION = 21
         const val KEY_SETTINGS_VERSION = "version"
 
         const val KEY_SYNC_INTERVAL_ADDRESSBOOKS = "sync_interval_addressbooks"

--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration.kt
@@ -10,7 +10,8 @@ import at.bitfire.davdroid.settings.AccountSettings
 interface AccountSettingsMigration {
 
     /**
-     * Migrate the account settings from the old version to the new version set in [AccountSettings.CURRENT_VERSION].
+     * Migrate the account settings from the old version to the new version which
+     * is set in [AccountSettings.CURRENT_VERSION].
      *
      * **The new (target) version number is registered in the Hilt module as [Int] key of the multi-binding of [AccountSettings].**
      *

--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration.kt
@@ -10,7 +10,7 @@ import at.bitfire.davdroid.settings.AccountSettings
 interface AccountSettingsMigration {
 
     /**
-     * Migrate the account settings from the old version to the new version.
+     * Migrate the account settings from the old version to the new version set in [AccountSettings.CURRENT_VERSION].
      *
      * **The new (target) version number is registered in the Hilt module as [Int] key of the multi-binding of [AccountSettings].**
      *

--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration21.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration21.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.settings.migration
+
+import android.accounts.Account
+import android.accounts.AccountManager
+import android.content.ContentResolver
+import android.content.Context
+import android.content.SyncRequest
+import android.provider.ContactsContract
+import at.bitfire.davdroid.R
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntKey
+import dagger.multibindings.IntoMap
+import javax.inject.Inject
+
+/**
+ * On Android 14+ the pending sync state of the Sync Adapter Framework is not handled correctly.
+ * As a workaround we cancel incoming sync requests (clears pending flag) after enqueuing our own
+ * sync worker (work manager). With version 4.5.3 we started cancelling pending syncs for DAVx5
+ * accounts, but forgot to do that for address book accounts. With version 4.5.4 we also cancel
+ * those, but only once contact data of an address book has been edited.
+ *
+ * This migration cancels (once only) any wrongly pending address book account syncs that might still lie
+ * dormant.
+ */
+class AccountSettingsMigration21 @Inject constructor(
+    private val context: Context
+): AccountSettingsMigration {
+
+    private val accountManager = AccountManager.get(context)
+
+    override fun migrate(account: Account) {
+        val addressBookAccountType = context.getString(R.string.account_type_address_book)
+        accountManager.getAccountsByType(addressBookAccountType).forEach { addressBookAccount ->
+            ContentResolver.cancelSync(
+                SyncRequest.Builder()
+                    .setSyncAdapter(addressBookAccount, ContactsContract.AUTHORITY)
+                    .syncOnce()
+                    .build()
+            )
+        }
+    }
+
+    @Module
+    @InstallIn(SingletonComponent::class)
+    abstract class AccountSettingsMigrationModule {
+        @Binds @IntoMap
+        @IntKey(21)
+        abstract fun provide(impl: AccountSettingsMigration21): AccountSettingsMigration
+    }
+
+}

--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration21.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration21.kt
@@ -7,6 +7,7 @@ package at.bitfire.davdroid.settings.migration
 import android.accounts.Account
 import android.accounts.AccountManager
 import android.content.Context
+import android.os.Build
 import android.os.Bundle
 import android.provider.CalendarContract
 import android.provider.ContactsContract
@@ -43,11 +44,13 @@ class AccountSettingsMigration21 @Inject constructor(
     private val addressBookAccountType = context.getString(R.string.account_type_address_book)
 
     override fun migrate(account: Account) {
-        // Cancel the (after an update) possibly forever pending calendar account syncs
-        cancelSyncs(calendarAccountType, CalendarContract.AUTHORITY)
+        if (Build.VERSION.SDK_INT >= 34) {
+            // Cancel the (after an update) possibly forever pending calendar account syncs
+            cancelSyncs(calendarAccountType, CalendarContract.AUTHORITY)
 
-        // Cancel the (after an update) possibly forever pending address book account syncs
-        cancelSyncs(addressBookAccountType, ContactsContract.AUTHORITY)
+            // Cancel the (after an update) possibly forever pending address book account syncs
+            cancelSyncs(addressBookAccountType, ContactsContract.AUTHORITY)
+        }
     }
 
     /**
@@ -55,7 +58,7 @@ class AccountSettingsMigration21 @Inject constructor(
      */
     private fun cancelSyncs(accountType: String, authority: String) {
         accountManager.getAccountsByType(accountType).forEach { account ->
-            logger.info("Canceling (possibly forever pending) sync for $account")
+            logger.info("Android 14+: Canceling (possibly forever pending) sync for $account")
             syncFrameworkIntegration.cancelSync(account, authority, Bundle())
         }
     }

--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration21.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration21.kt
@@ -14,6 +14,7 @@ import at.bitfire.davdroid.R
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntKey
 import dagger.multibindings.IntoMap
@@ -30,7 +31,7 @@ import javax.inject.Inject
  * dormant.
  */
 class AccountSettingsMigration21 @Inject constructor(
-    private val context: Context
+    @ApplicationContext private val context: Context
 ): AccountSettingsMigration {
 
     private val accountManager = AccountManager.get(context)

--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration21.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration21.kt
@@ -6,10 +6,10 @@ package at.bitfire.davdroid.settings.migration
 
 import android.accounts.Account
 import android.accounts.AccountManager
+import android.content.ContentResolver
 import android.content.Context
 import android.os.Build
 import at.bitfire.davdroid.R
-import at.bitfire.davdroid.sync.adapter.SyncFrameworkIntegration
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -32,7 +32,6 @@ import javax.inject.Inject
  */
 class AccountSettingsMigration21 @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val syncFrameworkIntegration: SyncFrameworkIntegration,
     private val logger: Logger
 ): AccountSettingsMigration {
 
@@ -58,7 +57,7 @@ class AccountSettingsMigration21 @Inject constructor(
     private fun cancelSyncs(accountType: String) {
         accountManager.getAccountsByType(accountType).forEach { account ->
             logger.info("Android 14+: Canceling all (possibly forever pending) syncs for $account")
-            syncFrameworkIntegration.cancelSync(account, null)
+            ContentResolver.cancelSync(account, null)
         }
     }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration21.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration21.kt
@@ -9,8 +9,10 @@ import android.accounts.AccountManager
 import android.content.ContentResolver
 import android.content.Context
 import android.content.SyncRequest
+import android.os.Bundle
 import android.provider.ContactsContract
 import at.bitfire.davdroid.R
+import at.bitfire.davdroid.sync.adapter.SyncFrameworkIntegration
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -33,6 +35,7 @@ import javax.inject.Inject
  */
 class AccountSettingsMigration21 @Inject constructor(
     @ApplicationContext private val context: Context,
+    private val syncFrameworkIntegration: SyncFrameworkIntegration,
     private val logger: Logger
 ): AccountSettingsMigration {
 
@@ -42,12 +45,7 @@ class AccountSettingsMigration21 @Inject constructor(
         val addressBookAccountType = context.getString(R.string.account_type_address_book)
         accountManager.getAccountsByType(addressBookAccountType).forEach { addressBookAccount ->
             logger.info("Canceling pending sync for address book account $addressBookAccount")
-            ContentResolver.cancelSync(
-                SyncRequest.Builder()
-                    .setSyncAdapter(addressBookAccount, ContactsContract.AUTHORITY)
-                    .syncOnce()
-                    .build()
-            )
+            syncFrameworkIntegration.cancelSync(addressBookAccount, ContactsContract.AUTHORITY, Bundle())
         }
     }
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration21.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration21.kt
@@ -44,21 +44,16 @@ class AccountSettingsMigration21 @Inject constructor(
 
     override fun migrate(account: Account) {
         // Cancel the (after an update) possibly forever pending calendar account syncs
-        cancelSyncsByAccountType(calendarAccountType)
+        cancelSyncs(calendarAccountType, CalendarContract.AUTHORITY)
 
         // Cancel the (after an update) possibly forever pending address book account syncs
-        cancelSyncsByAccountType(addressBookAccountType)
+        cancelSyncs(addressBookAccountType, ContactsContract.AUTHORITY)
     }
 
     /**
      * Cancels any (possibly forever pending) syncs for the accounts of given type.
      */
-    private fun cancelSyncsByAccountType(accountType: String) {
-        val authority = when (accountType) {
-            calendarAccountType -> CalendarContract.AUTHORITY
-            addressBookAccountType -> ContactsContract.AUTHORITY
-            else -> return
-        }
+    private fun cancelSyncs(accountType: String, authority: String) {
         accountManager.getAccountsByType(accountType).forEach { account ->
             logger.info("Canceling (possibly forever pending) sync for $account")
             syncFrameworkIntegration.cancelSync(account, authority, Bundle())

--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration21.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration21.kt
@@ -6,9 +6,7 @@ package at.bitfire.davdroid.settings.migration
 
 import android.accounts.Account
 import android.accounts.AccountManager
-import android.content.ContentResolver
 import android.content.Context
-import android.content.SyncRequest
 import android.os.Bundle
 import android.provider.ContactsContract
 import at.bitfire.davdroid.R

--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration21.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration21.kt
@@ -51,7 +51,7 @@ class AccountSettingsMigration21 @Inject constructor(
     }
 
     /**
-     * Cancels any (possibly forever pending) syncs for the accounts of given type.
+     * Cancels any (possibly forever pending) syncs for the accounts of given type and authority.
      */
     private fun cancelSyncs(accountType: String, authority: String) {
         accountManager.getAccountsByType(accountType).forEach { account ->

--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration21.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration21.kt
@@ -26,10 +26,9 @@ import javax.inject.Inject
  * As a workaround we cancel incoming sync requests (clears pending flag) after enqueuing our own
  * sync worker (work manager). With version 4.5.3 we started cancelling pending syncs for DAVx5
  * accounts, but forgot to do that for address book accounts. With version 4.5.4 we also cancel
- * those, but only once contact data of an address book has been edited.
+ * those, but only when contact data of an address book has been edited.
  *
- * This migration cancels (once only) any wrongly pending address book account syncs that might still lie
- * dormant.
+ * This migration cancels (once only) any wrongly pending address book account syncs.
  */
 class AccountSettingsMigration21 @Inject constructor(
     @ApplicationContext private val context: Context,

--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration21.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration21.kt
@@ -18,6 +18,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntKey
 import dagger.multibindings.IntoMap
+import java.util.logging.Logger
 import javax.inject.Inject
 
 /**
@@ -31,7 +32,8 @@ import javax.inject.Inject
  * dormant.
  */
 class AccountSettingsMigration21 @Inject constructor(
-    @ApplicationContext private val context: Context
+    @ApplicationContext private val context: Context,
+    private val logger: Logger
 ): AccountSettingsMigration {
 
     private val accountManager = AccountManager.get(context)
@@ -39,6 +41,7 @@ class AccountSettingsMigration21 @Inject constructor(
     override fun migrate(account: Account) {
         val addressBookAccountType = context.getString(R.string.account_type_address_book)
         accountManager.getAccountsByType(addressBookAccountType).forEach { addressBookAccount ->
+            logger.info("Canceling pending sync for address book account $addressBookAccount")
             ContentResolver.cancelSync(
                 SyncRequest.Builder()
                     .setSyncAdapter(addressBookAccount, ContactsContract.AUTHORITY)

--- a/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration21.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration21.kt
@@ -41,7 +41,7 @@ class AccountSettingsMigration21 @Inject constructor(
     override fun migrate(account: Account) {
         val addressBookAccountType = context.getString(R.string.account_type_address_book)
         accountManager.getAccountsByType(addressBookAccountType).forEach { addressBookAccount ->
-            logger.info("Canceling pending sync for address book account $addressBookAccount")
+            logger.info("Canceling forever pending sync for address book account $addressBookAccount")
             syncFrameworkIntegration.cancelSync(addressBookAccount, ContactsContract.AUTHORITY, Bundle())
         }
     }

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncAdapterImpl.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncAdapterImpl.kt
@@ -11,6 +11,7 @@ import android.content.ContentProviderClient
 import android.content.ContentResolver
 import android.content.Context
 import android.content.SyncResult
+import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
 import androidx.work.WorkInfo
@@ -59,6 +60,7 @@ class SyncAdapterImpl @Inject constructor(
     @ApplicationContext context: Context,
     private val logger: Logger,
     private val syncConditionsFactory: SyncConditions.Factory,
+    private val syncFrameworkIntegration: SyncFrameworkIntegration,
     private val syncWorkerManager: SyncWorkerManager
 ): AbstractThreadedSyncAdapter(
     /* context = */ context,
@@ -117,11 +119,11 @@ class SyncAdapterImpl @Inject constructor(
         // Android 14+ does not handle pending sync state correctly.
         // As a defensive workaround, we can cancel specifically this still pending sync only
         // See: https://github.com/bitfireAT/davx5-ose/issues/1458
-//        if (Build.VERSION.SDK_INT >= 34) {
-//            logger.fine("Android 14+ bug: Canceling forever pending sync adapter framework sync request for " +
-//                    "account=$accountOrAddressBookAccount authority=$authority upload=$upload")
-//            syncFrameworkIntegration.cancelSync(accountOrAddressBookAccount, authority, extras)
-//        }
+        if (Build.VERSION.SDK_INT >= 34) {
+            logger.fine("Android 14+ bug: Canceling forever pending sync adapter framework sync request for " +
+                    "account=$accountOrAddressBookAccount authority=$authority upload=$upload")
+            syncFrameworkIntegration.cancelSync(accountOrAddressBookAccount, authority, extras)
+        }
 
         /* Because we are not allowed to observe worker state on a background thread, we can not
         use it to block the sync adapter. Instead we use a Flow to get notified when the sync

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncFrameworkIntegration.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncFrameworkIntegration.kt
@@ -191,12 +191,6 @@ class SyncFrameworkIntegration @Inject constructor(
      */
     @OptIn(ExperimentalCoroutinesApi::class)
     fun isSyncPending(account: Account, dataTypes: Iterable<SyncDataType>): Flow<Boolean> {
-        // Android 14+ does not handle pending sync state correctly.
-        // For now we simply always return false
-        // See also sync cancellation in [SyncAdapterImpl.onPerformSync]
-        if (Build.VERSION.SDK_INT >= 34)
-            return flowOf(false)
-
         // Determine the pending state for each data type of the account as separate flows
         val pendingStateFlows: List<Flow<Boolean>> = dataTypes.mapNotNull { dataType ->
             // Map datatype to authority

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncFrameworkIntegration.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncFrameworkIntegration.kt
@@ -101,11 +101,9 @@ class SyncFrameworkIntegration @Inject constructor(
     }
 
     /**
-     * Cancels the sync request in the Sync Framework for Android 14+.
-     * This is a workaround for the bug that the sync framework does not handle pending syncs correctly
-     * on Android 14+ (API level 34+).
-     *
-     * See: https://github.com/bitfireAT/davx5-ose/issues/1458
+     * Cancels the sync request in the Sync Adapter Framework by sync request. This
+     * is the defensive approach canceling only one specific sync request with matching
+     * sync extras.
      *
      * @param account The account for which the sync request should be canceled.
      * @param authority The authority for which the sync request should be canceled.
@@ -122,6 +120,17 @@ class SyncFrameworkIntegration @Inject constructor(
         // Cancel it
         ContentResolver.cancelSync(syncRequest)
     }
+
+    /**
+     * Cancels all Sync Adapter Framework syncs (system wide) for given account and
+     * authority. If authority is null, all syncs for the given account
+     * regardless of authority are canceled.
+     *
+     * @param account The account for which syncs should be canceled.
+     * @param authority Null or the authority for which syncs should be canceled.
+     */
+    fun cancelSync(account: Account, authority: String?) =
+        ContentResolver.cancelSync(account, authority)
 
     /**
      * Enables/disables sync adapter automatic sync (content triggered sync) for the given

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncFrameworkIntegration.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncFrameworkIntegration.kt
@@ -122,17 +122,6 @@ class SyncFrameworkIntegration @Inject constructor(
     }
 
     /**
-     * Cancels all Sync Adapter Framework syncs (system wide) for given account and
-     * authority. If authority is null, all syncs for the given account
-     * regardless of authority are canceled.
-     *
-     * @param account The account for which syncs should be canceled.
-     * @param authority Null or the authority for which syncs should be canceled.
-     */
-    fun cancelSync(account: Account, authority: String?) =
-        ContentResolver.cancelSync(account, authority)
-
-    /**
      * Enables/disables sync adapter automatic sync (content triggered sync) for the given
      * account and authority. Does *not* call [ContentResolver.setIsSyncable].
      *

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.BatterySaver
+import androidx.compose.material.icons.filled.CancelScheduleSend
 import androidx.compose.material.icons.filled.DataSaverOn
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.NotificationsOff
@@ -111,6 +112,7 @@ fun AccountsScreen(
     }
 
     AccountsScreen(
+        cancelSyncAdapterSyncs = { model.cancelSyncAdapterSyncs() },
         accountsDrawerHandler = accountsDrawerHandler,
         accounts = accounts,
         showSyncAll = showSyncAll,
@@ -131,6 +133,7 @@ fun AccountsScreen(
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalPermissionsApi::class)
 @Composable
 fun AccountsScreen(
+    cancelSyncAdapterSyncs: () -> Unit,
     accountsDrawerHandler: AccountsDrawerHandler,
     accounts: List<AccountsModel.AccountInfo>,
     showSyncAll: Boolean = true,
@@ -228,6 +231,17 @@ fun AccountsScreen(
                                     contentDescription = stringResource(R.string.accounts_sync_all)
                                 )
                             }
+                        FloatingActionButton(
+                            onClick = cancelSyncAdapterSyncs,
+                            containerColor = MaterialTheme.colorScheme.secondary,
+                            contentColor = MaterialTheme.colorScheme.onSecondary,
+                            modifier = Modifier.padding(top = 24.dp)
+                        ) {
+                            Icon(
+                                Icons.Default.CancelScheduleSend,
+                                contentDescription = stringResource(R.string.accounts_sync_all)
+                            )
+                        }
                     }
                 },
                 snackbarHost = { SnackbarHost(snackbarHostState) }
@@ -321,6 +335,7 @@ fun AccountsScreen(
 @Preview
 fun AccountsScreen_Preview_Empty() {
     AccountsScreen(
+        cancelSyncAdapterSyncs = {},
         accountsDrawerHandler = object: AccountsDrawerHandler() {
             @Composable
             override fun MenuEntries(snackbarHostState: SnackbarHostState) {
@@ -337,6 +352,7 @@ fun AccountsScreen_Preview_Empty() {
 @Preview
 fun AccountsScreen_Preview_OneAccount() {
     AccountsScreen(
+        cancelSyncAdapterSyncs = {},
         accountsDrawerHandler = object: AccountsDrawerHandler() {
             @Composable
             override fun MenuEntries(snackbarHostState: SnackbarHostState) {


### PR DESCRIPTION
### Purpose

Not meant to be merged. Only for testing.

List active, pending and periodic syncs with:
`adb shell dumpsys content | grep -A 10 "Active Syncs"`

### Short description
- added a new third FAB in accounts overview, which cancels all sync adapter syncs 


