### PR TITLE
Use `IntentCompat` for account fetching from intent extras

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsActivity.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsActivity.kt
@@ -10,6 +10,7 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.TaskStackBuilder
+import androidx.core.content.IntentCompat
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -20,7 +21,7 @@ class AccountSettingsActivity: AppCompatActivity() {
     }
 
     private val account by lazy {
-        intent.getParcelableExtra<Account>(EXTRA_ACCOUNT) ?: throw IllegalArgumentException("EXTRA_ACCOUNT must be set")
+        IntentCompat.getParcelableExtra(intent, EXTRA_ACCOUNT, Account::class.java) ?: throw IllegalArgumentException("EXTRA_ACCOUNT must be set")
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
### Purpose

Tries to fix a crash from Play Console that was caused by the `account` delegate of the activity.

### Short description

Migrated to the `IntentCompat.getParcelableExtra` implementation instead of the old deprecated `Intent.getParcelableExtra`.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

