### PR TITLE
Show explanation on http 405 and others

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoScreen.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoScreen.kt
@@ -111,6 +111,7 @@ fun DebugInfoScreen(
                 when {
                     cause.statusCode == 403 -> R.string.debug_info_http_403_description
                     cause.statusCode == 404 -> R.string.debug_info_http_404_description
+                    cause.statusCode == 405 -> R.string.debug_info_http_405_description
                     cause.isServerError -> R.string.debug_info_http_5xx_description
                     else -> R.string.debug_info_unexpected_error
                 }

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/composable/ExceptionInfoDialog.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/composable/ExceptionInfoDialog.kt
@@ -61,8 +61,16 @@ fun ExceptionInfoDialog(
             }
         },
         text = {
+            val message = if (exception is HttpException) {
+                 when (exception.statusCode) {
+                    403 -> context.getString(R.string.debug_info_http_403_description)
+                    404 -> context.getString(R.string.debug_info_http_404_description)
+                    405 -> context.getString(R.string.debug_info_http_405_description)
+                    else -> null
+                }
+            } else null
             Text(
-                exception::class.java.name + "\n" + exception.localizedMessage,
+                text = message ?: "${exception::class.java.name}\n${exception.localizedMessage}",
                 style = MaterialTheme.typography.bodyLarge
             )
         },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -464,6 +464,7 @@
     <string name="debug_info_io_error">I/O Error</string>
     <string name="debug_info_http_403_description">The request has been denied. Check involved resources and debug info for details.</string>
     <string name="debug_info_http_404_description">The requested resource doesn\'t exist (anymore). Check involved resources and debug info for details.</string>
+    <string name="debug_info_http_405_description">The server doesn\'t allow the requested type of operation.</string>
     <string name="debug_info_http_5xx_description">A server-side problem occured. Please contact your server support.</string>
     <string name="debug_info_unexpected_error">An unexpected error has occured. View debug info for details.</string>
     <string name="debug_info_view_details">View details</string>


### PR DESCRIPTION
### Purpose

Show a more user friendly message on 405 exception and some others.

### Short description

- add generic 405 message and use it in `DebugInfoScreen`: "The server doesn't allow the requested type of operation."
- add all status code messages to be shown in `ExceptionInfoDialog` too
- fall back to exception name and localized message as was before

### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [ ] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.

