### PR TITLE
Update Kotlin and KSP versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,11 +21,7 @@ updates:
       app-dependencies:
         patterns: ["*"]
     ignore:
-      # kotlin and ksp must be aligned and should only be updated together and manually
-      - dependency-name: "org.jetbrains.kotlin:kotlin-stdlib"
-      - dependency-name: "org.jetbrains.kotlin.plugin.compose"
-      - dependency-name: "org.jetbrains.kotlin.android"
-      - dependency-name: "com.google.devtools.ksp"
       # dependencies without semantic versioning
+      - dependency-name: "com.github.bitfireat:cert4android"
       - dependency-name: "com.github.bitfireat:dav4jvm"
       - dependency-name: "com.github.bitfireat:synctools"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,10 +28,9 @@ glance = "1.1.1"
 guava = "33.5.0-android"
 hilt = "2.57.2"
 # keep in sync with ksp version
-kotlin = "2.2.20"
+kotlin = "2.2.21"
 kotlinx-coroutines = "1.10.2"
-# see https://github.com/google/ksp/releases for version numbers
-ksp = "2.2.20-2.0.3"
+ksp = "2.3.0"
 mikepenz-aboutLibraries = "13.1.0"
 mockk = "1.14.5"
 okhttp = "5.2.1"


### PR DESCRIPTION
- Update Kotlin and KSP (KSP version is now decoupled from Kotlin version)
- Remove Dependabot restrictions for Kotlin/KSP
- Add Dependabot ignore rule for cert4android