### PR TITLE
Update dependencies, including our libs

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
@@ -8,6 +8,7 @@ import android.accounts.Account
 import android.content.Context
 import androidx.annotation.WorkerThread
 import at.bitfire.cert4android.CustomCertManager
+import at.bitfire.cert4android.CustomCertStore
 import at.bitfire.dav4jvm.okhttp.BasicDigestAuthHandler
 import at.bitfire.dav4jvm.okhttp.UrlUtils
 import at.bitfire.davdroid.BuildConfig
@@ -284,7 +285,7 @@ class HttpClientBuilder @Inject constructor(
         if (BuildConfig.allowCustomCerts) {
             // use cert4android for custom certificate handling
             customTrustManager = CustomCertManager(
-                context = context,
+                certStore = CustomCertStore.getInstance(context),
                 trustSystemCerts = !settingsManager.getBoolean(Settings.DISTRUST_SYSTEM_CERTIFICATES),
                 appInForeground = ForegroundTracker.inForeground
             )

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
@@ -33,7 +33,7 @@ import at.bitfire.synctools.icalendar.CalendarUidSplitter
 import at.bitfire.synctools.icalendar.ICalendarGenerator
 import at.bitfire.synctools.icalendar.ICalendarParser
 import at.bitfire.synctools.mapping.calendar.AndroidEventBuilder
-import at.bitfire.synctools.mapping.calendar.AndroidEventProcessor
+import at.bitfire.synctools.mapping.calendar.AndroidEventHandler
 import at.bitfire.synctools.mapping.calendar.DefaultProdIdGenerator
 import at.bitfire.synctools.mapping.calendar.SequenceUpdater
 import dagger.assisted.Assisted
@@ -189,11 +189,11 @@ class CalendarSyncManager @AssistedInject constructor(
         val updatedSequence = SequenceUpdater().increaseSequence(localEvent.main)
 
         // map Android event to iCalendar (also generates UID, if necessary)
-        val processor = AndroidEventProcessor(
+        val handler = AndroidEventHandler(
             accountName = resource.recurringCalendar.calendar.account.name,
             prodIdGenerator = DefaultProdIdGenerator(Constants.iCalProdId)
         )
-        val mappedEvents = processor.mapToVEvents(localEvent)
+        val mappedEvents = handler.mapToVEvents(localEvent)
 
         // persist UID if it was generated
         if (mappedEvents.generatedUid)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 # Comments apply to next line
 
 [versions]
-android-agp = "8.13.0"
+android-agp = "8.13.1"
 android-desugaring = "2.1.5"
 androidx-activityCompose = "1.11.0"
 androidx-appcompat = "1.7.1"
@@ -18,9 +18,9 @@ androidx-test-runner = "1.7.0"
 androidx-test-rules = "1.7.0"
 androidx-test-junit = "1.3.0"
 androidx-work = "2.11.0"
-bitfire-cert4android = "b3160b02b8"
-bitfire-dav4jvm = "0979bd7e56"
-bitfire-synctools = "5fc6688ff6"
+bitfire-cert4android = "42d883e958"
+bitfire-dav4jvm = "ad80cdccac"
+bitfire-synctools = "730c3c5f0a"
 compose-accompanist = "0.37.3"
 compose-bom = "2025.11.00"
 conscrypt = "2.5.3"


### PR DESCRIPTION
Update dependencies. Notable changes:

- cert4android: explicitly pass `CustomCertStore` instead of `Context`
- synctools: event "processors" have been renamed to "handlers" 
- synctools: PRODID generator doesn't add mutator packages anymore