### PR TITLE
Ignore failing test: `testVerifySyncAlwaysPending_wrongBehaviour_android14`

### DIFF
--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/AndroidSyncFrameworkTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/sync/AndroidSyncFrameworkTest.kt
@@ -88,11 +88,11 @@ class AndroidSyncFrameworkTest: SyncStatusObserver {
         )
     }
 
-    /**
+    /* SHOULD BE FIXED WITH https://github.com/bitfireAT/davx5-ose/issues/1748
      * Wrong behaviour of the sync framework on Android 14+.
      * Pending state stays true forever (after initial run), active state behaves correctly
      */
-    @SdkSuppress(minSdkVersion = 34 /*, maxSdkVersion = 36 */)
+    /*@SdkSuppress(minSdkVersion = 34 /*, maxSdkVersion = 36 */)
     @Test
     fun testVerifySyncAlwaysPending_wrongBehaviour_android14() {
         verifySyncStates(
@@ -103,7 +103,7 @@ class AndroidSyncFrameworkTest: SyncStatusObserver {
                 State(pending = true, active = false)                   // ... and finishes, but stays pending
             )
         )
-    }
+    }*/
 
 
     // helpers


### PR DESCRIPTION
The occasionally failing `testVerifySyncAlwaysPending_wrongBehaviour_android14` test (see #1748) becomes annoying because it blocks reviewing other PRs.

Should be fixed in a separate PR. This PR only comments out the test so that it doesn't block CI anymore.