### PR TITLE
[Ktor] Add MustBeClosed annotation to buildKtor method

### DIFF
--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
@@ -55,10 +55,11 @@ class HttpClientBuilderTest {
             .setResponseCode(200)
             .setBody("Some Content"))
 
-        val client = httpClientBuilder.get().buildKtor()
-        val response = client.get(server.url("/").toString())
-        assertEquals(200, response.status.value)
-        assertEquals("Some Content", response.bodyAsText())
+        httpClientBuilder.get().buildKtor().use { client ->
+            val response = client.get(server.url("/").toString())
+            assertEquals(200, response.status.value)
+            assertEquals("Some Content", response.bodyAsText())
+        }
     }
 
     @Test

--- a/app/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
@@ -19,6 +19,7 @@ import at.bitfire.davdroid.settings.Settings
 import at.bitfire.davdroid.settings.SettingsManager
 import at.bitfire.davdroid.ui.ForegroundTracker
 import com.google.common.net.HttpHeaders
+import com.google.errorprone.annotations.MustBeClosed
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
@@ -202,7 +203,6 @@ class HttpClientBuilder @Inject constructor(
      *
      * @throws IllegalStateException    on second and later calls
      */
-    @Deprecated("Use buildKtor instead", replaceWith = ReplaceWith("buildKtor()"))
     fun build(): OkHttpClient {
         if (alreadyBuilt)
             throw IllegalStateException("build() must only be called once; use Provider<HttpClientBuilder>")
@@ -378,7 +378,10 @@ class HttpClientBuilder @Inject constructor(
      *
      * However in this case the configuration of `client1` is still in `builder` and would be reused for `client2`,
      * which is usually not desired.
+     *
+     * @return the new HttpClient (with [OkHttp] engine) which **must be closed by the caller**
      */
+    @MustBeClosed
     fun buildKtor(): HttpClient {
         if (alreadyBuilt)
             throw IllegalStateException("build() must only be called once; use Provider<HttpClientBuilder>")


### PR DESCRIPTION
Ktor `HttpClient`s [must be closed](https://ktor.io/docs/client-create-and-configure.html#close-client) after using. This is now reflected in KDoc and with an annotation.