### PR TITLE
Fix DeadObjectException handling in SyncManager and Syncer

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -256,9 +256,10 @@ abstract class SyncManager<ResourceType: LocalResource, out CollectionType: Loca
             }
 
             when (e) {
-                // DeadObjectException (may occur when syncing takes too long and process is demoted to cached):
-                // re-throw to base Syncer → will cause soft error and restart the sync process
-                is DeadObjectException ->
+                /* LocalStorageException with cause DeadObjectException may occur when syncing takes too long
+                and process is demoted to cached. In this case, we re-throw to the base Syncer which will
+                treat it as a soft error and re-schedule the sync process. */
+                is LocalStorageException if e.cause is DeadObjectException ->
                     throw e
 
                 // sync was cancelled or account has been removed: re-throw to Syncer


### PR DESCRIPTION
### Purpose

Storage providers (like the calendar provider) can throw a `DeadObjectException` during normal operation:

- https://github.com/bitfireAT/davx5/issues/459
- https://github.com/bitfireAT/davx5/pull/578
- https://github.com/bitfireAT/davx5-ose/discussions/591), which doesn't seem to work correctly anymore.

In case of a such an exception, DAVx5 needs to ignore it and retry synchronization at a later time.

This functionality was already present but was lost because of a design change in synctools:

- Previousy, ical4android / vcard4android throwed the unwrapped `DeadObjectException` since https://github.com/bitfireAT/ical4android/commit/a3e886c738a9b87f0ea8e7a22e900316eacaf3ec so that DAVx5 could handle it differently from other `LocalStorageException`s.
- However now for consistence, synctools doesn't throw different exceptions anymore, but always throws a `LocalStorageException` that wraps the original exception.


### Short description

This PR now handles `LocalStorageException` with `cause=DeadObjectException` as previously direct `DeadObjectException`s were handled.


### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

