### PR TITLE
Fix HTTP Client provider for contact resource sync from URL

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
@@ -50,8 +50,8 @@ import kotlinx.coroutines.runInterruptible
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.MediaType
-import okhttp3.OkHttpClient
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.ByteArrayOutputStream
@@ -60,6 +60,7 @@ import java.io.Reader
 import java.io.StringReader
 import java.util.Optional
 import java.util.logging.Level
+import javax.inject.Provider
 import kotlin.jvm.optionals.getOrNull
 
 /**
@@ -110,7 +111,7 @@ class ContactsSyncManager @AssistedInject constructor(
     @Assisted val syncFrameworkUpload: Boolean,
     val dirtyVerifier: Optional<ContactDirtyVerifier>,
     accountSettingsFactory: AccountSettings.Factory,
-    private val httpClientBuilder: HttpClientBuilder,
+    private val httpClientBuilder: Provider<HttpClientBuilder>,
     @SyncDispatcher syncDispatcher: CoroutineDispatcher
 ): SyncManager<LocalAddress, LocalAddressBook, DavAddressBook>(
     account,
@@ -488,6 +489,7 @@ class ContactsSyncManager @AssistedInject constructor(
 
             // authenticate only against a certain host, and only upon request
             val hostHttpClient = httpClientBuilder
+                .get()
                 .fromAccount(account, onlyHost = baseUrl.host)
                 .followRedirects(true)      // allow redirects
                 .build()


### PR DESCRIPTION
### Purpose

`httpClientBuilder.build` was called every time `ResourceDownloader.download` is called, which is not allowed.

### Short description

Use a `Provider` so that a new client is given every time a download is requested.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

