### PR TITLE
Log warning instead of throwing exception on multiple build calls

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
@@ -190,7 +190,7 @@ class HttpClientBuilder @Inject constructor(
     /**
      * Builds an [OkHttpClient] with the configured settings.
      *
-     * [build] or [buildKtor] must be called only once because multiple calls indicate this wrong usage pattern:
+     * [build] or [buildKtor] is usually called only once because multiple calls indicate this wrong usage pattern:
      *
      * ```
      * val builder = HttpClientBuilder(/*injected*/)
@@ -200,12 +200,10 @@ class HttpClientBuilder @Inject constructor(
      *
      * However in this case the configuration of `client1` is still in `builder` and would be reused for `client2`,
      * which is usually not desired.
-     *
-     * @throws IllegalStateException    on second and later calls
      */
     fun build(): OkHttpClient {
         if (alreadyBuilt)
-            throw IllegalStateException("build() must only be called once; use Provider<HttpClientBuilder>")
+            logger.warning("build() should only be called once; use Provider<HttpClientBuilder> instead")
 
         val builder = OkHttpClient.Builder()
         configureOkHttp(builder)
@@ -384,7 +382,7 @@ class HttpClientBuilder @Inject constructor(
     @MustBeClosed
     fun buildKtor(): HttpClient {
         if (alreadyBuilt)
-            throw IllegalStateException("build() must only be called once; use Provider<HttpClientBuilder>")
+            logger.warning("buildKtor() should only be called once; use Provider<HttpClientBuilder> instead")
 
         val client = HttpClient(OkHttp) {
             // Ktor-level configuration here


### PR DESCRIPTION
### Purpose

Currently `HttpClientBuilder` throws an `IllegalStateException` without strict need, which may break functions which may work otherwise (although the API is used incorrectly, like in #1843).


### Short description

- Change `build()` to log a warning instead of throwing an exception on subsequent calls.
- Change `buildKtor()` to log a warning instead of throwing an exception on subsequent calls.


### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

