### PR TITLE
Add testedAbi for gradle managed device

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -113,6 +113,7 @@ android {
                     // Suspected reason: https://developer.android.com/about/versions/15/behavior-changes-all#background-network-access
                     apiLevel = 34
                     systemImageSource = "aosp-atd"
+                    testedAbi = "x86_64"
                 }
             }
         }


### PR DESCRIPTION
To avoid warning:

>virtual has an unspecified testedAbi. This presently defaults to
>"x86_64". However, in 9.0 this will change to "arm64-v8a"
>
>virtual specifies a system image that that does not support NDK translation,
>and will no longer be able to run tests in this environment. This
>device will wtill be able to run on ARM machines.
>To continue running tests with the current configuration, and not use
>NDK translation set testedAbi = "x86_64"
