### PR TITLE
Delegate `fileName` into `DmfsTask.syncId`

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalTask.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalTask.kt
@@ -23,7 +23,9 @@ import java.util.Optional
  */
 class LocalTask: DmfsTask, LocalResource {
 
-    override var fileName: String? = null
+    override var fileName: String?
+        get() = syncId
+        set(value) { syncId = value }
 
     /**
      * Note: Schedule-Tag for tasks is not supported


### PR DESCRIPTION
### Purpose

Fixes #1869.

### Short description

`LocalTask.fileName` was not being correctly initialized after a3a952d875e3a886ee7319d0f9ff23c93eff7176, which didn't allow task deletion, because it detected the ask as not uploaded to the server.

Delegated the property into `DmfsTask.syncId` so that it's linked and updated correctly.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

