### PR TITLE
Skip flaky test when not moving into anticipated forever pending sync state

### DIFF
--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration21Test.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration21Test.kt
@@ -83,8 +83,7 @@ class AccountSettingsMigration21Test {
             inPendingState.first { it }
         }
 
-        // Assume that we are now in the forever pending state
-        // (sometimes we don't manage to move into forever pending state)
+        // Assume that we are now in the forever pending state (Skips test otherwise)
         Assume.assumeTrue(ContentResolver.isSyncPending(account, authority))
 
         // Run the migration which should cancel the forever pending sync for all accounts


### PR DESCRIPTION
### Purpose

Sometimes we don't manage to move into the forever pending sync state. In those cases the test should be skipped.

### Short description

Check using `Assume.assumeTrue` (instead of assert) that we have moved into the forever pending sync state. If not then the test will be skipped.

### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.

