### PR TITLE
Assume initial state for test updatesOwnerAccount

### DIFF
--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalCalendarStoreTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalCalendarStoreTest.kt
@@ -65,7 +65,7 @@ class LocalCalendarStoreTest {
     @Test
     fun testUpdateAccount_updatesOwnerAccount() {
         // Verify initial state (assume to skip and prevent flaky test failures)
-        Assume.assumeTrue("InitialAccountName" == getOwnerAccount(provider))
+        Assume.assumeTrue("InitialAccountName" == getOwnerAccount())
 
         // Rename account
         val oldAccount = account
@@ -75,7 +75,7 @@ class LocalCalendarStoreTest {
         localCalendarStore.updateAccount(oldAccount, account, provider)
 
         // Verify [Calendar.OWNER_ACCOUNT] of local calendar was updated
-        assertEquals("ChangedAccountName", getOwnerAccount(provider))
+        assertEquals("ChangedAccountName", getOwnerAccount())
 
     }
 
@@ -96,7 +96,7 @@ class LocalCalendarStoreTest {
             )
         )!!.asSyncAdapter(account)
 
-    private fun getOwnerAccount(provider: ContentProviderClient): String {
+    private fun getOwnerAccount(): String {
         provider.query(
             calendarUri,
             arrayOf(Calendars.OWNER_ACCOUNT),


### PR DESCRIPTION
### Purpose

testUpdateAccount_updatesOwnerAccount is a flaky test. 

### Short description

As a workaround for non-deterministic results: Assume the initial state instead of asserting it, which will skip the test, if assumption is not met.

### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.

