### PR TITLE
Rename dismissInvalidResource to dismissCollectionError

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -136,7 +136,7 @@ abstract class SyncManager<LocalType: LocalResource, out CollectionType: LocalCo
 
     suspend fun performSync() = withContext(syncDispatcher) {
         // dismiss previous error notifications
-        syncNotificationManager.dismissInvalidResource(localCollectionTag = localCollection.tag)
+        syncNotificationManager.dismissCollectionError(localCollectionTag = localCollection.tag)
 
         try {
             logger.info("Preparing synchronization")

--- a/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncNotificationManager.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/sync/SyncNotificationManager.kt
@@ -159,7 +159,7 @@ class SyncNotificationManager @AssistedInject constructor(
     /**
      * Sends a notification to inform the user that a push notification has been received, the
      * sync has been scheduled, but it still has not run.
-     * Use [dismissInvalidResource] to dismiss the notification.
+     * Use [dismissCollectionError] to dismiss the notification.
      *
      * @param dataType          The type of data which was synced.
      * @param notificationTag   The tag to use for the notification.
@@ -200,7 +200,7 @@ class SyncNotificationManager @AssistedInject constructor(
      *
      * @param localCollectionTag The tag of the local collection which is used as notification tag also.
      */
-    fun dismissInvalidResource(localCollectionTag: String) =
+    fun dismissCollectionError(localCollectionTag: String) =
         dismissNotification(localCollectionTag)
 
 


### PR DESCRIPTION
### Purpose

Unclear name of the method.

### Short description

- Rename `dismissInvalidResource` to `dismissCollectionError`

I see that it's not really always an "error", I think error is fine for the case of an "invalid resource" too though. Otherwise we could also name it "dismissCollection", "dismissCollectionNotification", "dismissCollectionIssue". Just some ideas.

### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.

