### PR TITLE
Recreate collections pagers when collections amount changes in DB

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/db/CollectionDao.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/db/CollectionDao.kt
@@ -69,6 +69,12 @@ interface CollectionDao {
     @Query("SELECT * FROM collection WHERE serviceId=:serviceId AND url=:url")
     fun getByServiceAndUrl(serviceId: Long, url: String): Collection?
 
+    /**
+     * Returns the amount of collections currently stored in database
+     */
+    @Query("SELECT COUNT(*) FROM collection")
+    fun getCountFlow(): Flow<Int>
+
     @Query("SELECT * FROM collection WHERE serviceId=:serviceId AND type='${Collection.TYPE_CALENDAR}' AND supportsVEVENT AND sync ORDER BY displayName COLLATE NOCASE, url COLLATE NOCASE")
     fun getSyncCalendars(serviceId: Long): List<Collection>
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
@@ -27,6 +27,7 @@ import at.bitfire.davdroid.servicedetection.RefreshCollectionsWorker
 import at.bitfire.davdroid.util.DavUtils
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.runInterruptible
 import net.fortuna.ical4j.model.Calendar
 import net.fortuna.ical4j.model.Component
@@ -195,6 +196,8 @@ class DavCollectionRepository @Inject constructor(
     fun getByServiceAndUrl(serviceId: Long, url: String) = dao.getByServiceAndUrl(serviceId, url)
 
     fun getByServiceAndSync(serviceId: Long) = dao.getByServiceAndSync(serviceId)
+
+    fun getCollectionCountFlow(): Flow<Int> = dao.getCountFlow()
 
     fun getSyncCalendars(serviceId: Long) = dao.getSyncCalendars(serviceId)
 

--- a/app/src/main/kotlin/at/bitfire/davdroid/ui/account/GetServiceCollectionPagerUseCase.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/ui/account/GetServiceCollectionPagerUseCase.kt
@@ -50,7 +50,7 @@ class GetServiceCollectionPagerUseCase @Inject constructor(
                 val dataFlow = Pager(
                     config = PagingConfig(PAGER_SIZE),
                     pagingSourceFactory = {
-                        if (onlyPersonal == true)
+                        if (onlyPersonal)
                             collectionRepository.pagePersonalByServiceAndType(service.id, collectionType)
                         else
                             collectionRepository.pageByServiceAndType(service.id, collectionType)


### PR DESCRIPTION
### Purpose

Sometimes not all collections are shown in the UI, even though they have been detected and are availble in the database. Exiting and reentering the collections screen then shows them all.

### Short description
Removing pagination solves the problem and so does implementing our own PagingSource. The important aspect is apparently the invalidation of pagers (in Paging 3 invalidation is handled by recreation of the pagers). 

So we need to recreate the pager automatically when the amount of collections changes during collection detection. We can do so by adding a collection count flow `Flow<Int>` to the combine method which emits the amount of collections on change. 

- `CollectionDao`: added `@Query("SELECT COUNT(*) FROM collection") fun getCountFlow(): Flow<Int>` 
- `GetServiceCollectionPagerUseCase`: added collection count flow to the flow combine method. 

### Checklist

- [X] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

