### PR TITLE
Enable HTTP connection reuse for okhttp

### DIFF
--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
@@ -50,7 +50,7 @@ class HttpClientBuilderTest {
 
 
     @Test
-    fun testBuild_ReusesConnectionAndDispatcher() {
+    fun testBuild_SharesConnectionPoolAndDispatcher() {
         val client1 = httpClientBuilder.get().build()
         val client2 = httpClientBuilder.get().build()
         assertEquals(client1.connectionPool, client2.connectionPool)

--- a/app/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
@@ -80,6 +80,9 @@ class HttpClientBuilder @Inject constructor(
          *
          * We need custom settings for each actual client, but we can use a shared client as a base. This also
          * enables sharing resources like connection and thread pool.
+         *
+         * The shared client is available for the lifetime of the application and must not be shut down or
+         * closed (which is not necessary, according to its documentation).
          */
         val sharedOkHttpClient = OkHttpClient.Builder()
             .connectTimeout(15, TimeUnit.SECONDS)
@@ -220,6 +223,8 @@ class HttpClientBuilder @Inject constructor(
      *
      * However in this case the configuration of `client1` is still in `builder` and would be reused for `client2`,
      * which is usually not desired.
+     *
+     * Closing/shutting down the client is not necessary.
      */
     fun build(): OkHttpClient {
         if (alreadyBuilt)


### PR DESCRIPTION
### Purpose

Enable HTTP connection reuse and keep-alive for WebDAV connections to improve performance and reduce connection overhead.

This only applies to okhttp connections and not to Ktor, which manages engine client reuse itself (can be verified / tested at a later time).

It applies to all HTTP operations, so both sync and WebDAV.

### Short description

- Create a shared `OkHttpClient` instance for connection pooling
- Utilize `sharedOkHttpClient.newBuilder()` for new client instances instead of creating new clients from scratch
- Move timeout configuration to the shared client to ensure consistent settings
- Remove the now-redundant `buildTimeouts()` method

This change allows OkHttp to reuse connections and share thread pools across different HTTP clients, which is especially beneficial for WebDAV operations that often involve multiple sequential requests to the same server.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.