### PR TITLE
Return null when owner account does not exist to skip flaky test

### DIFF
--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalCalendarStoreTest.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalCalendarStoreTest.kt
@@ -96,7 +96,7 @@ class LocalCalendarStoreTest {
             )
         )!!.asSyncAdapter(account)
 
-    private fun getOwnerAccount(): String {
+    private fun getOwnerAccount(): String? {
         provider.query(
             calendarUri,
             arrayOf(Calendars.OWNER_ACCOUNT),
@@ -104,7 +104,8 @@ class LocalCalendarStoreTest {
             arrayOf(account.name),
             null
         )!!.use { cursor ->
-            cursor.moveToNext()
+            if (!cursor.moveToNext())
+                return null
             return cursor.getString(0)
         }
     }


### PR DESCRIPTION
### Purpose

There is still a CursorIndexOutOfBounds error.

### Short description

Return null when owner account does not exist (we can't move to the next index). The assume should fail then and the test will be skipped properly.

### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.

