### PR TITLE
AGP 9.0: update Hilt, remove Kotlin Android plugin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.hilt)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
     alias(libs.plugins.mikepenz.aboutLibraries.android)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.hilt) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.ksp) apply false
 
     alias(libs.plugins.mikepenz.aboutLibraries.android) apply false

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,6 @@ org.gradle.parallel=true
 android.useAndroidX=true
 
 # Compatibility with AGP 9.0.0
-android.builtInKotlin=false
 android.newDsl=false
 
 # It's recommended to add these settings to your $GRADLE_USER_HOME/gradle.properties:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ conscrypt = "2.5.3"
 dnsjava = "3.6.4"
 glance = "1.1.1"
 guava = "33.5.0-android"
-hilt = "2.58"
+hilt = "2.59"
 # keep in sync with ksp version
 kotlin = "2.2.21"
 kotlinx-coroutines = "1.10.2"
@@ -120,7 +120,6 @@ unifiedpush-fcm = { module = "org.unifiedpush.android:embedded-fcm-distributor",
 android-application = { id = "com.android.application", version.ref = "android-agp" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 mikepenz-aboutLibraries-android = { id = "com.mikepenz.aboutlibraries.plugin.android", version.ref = "mikepenz-aboutLibraries" }


### PR DESCRIPTION
Hilt 2.59 now supports AGP 9.0, so we can remove the Android Kotlin plugin.