### PR TITLE
Set `Calendars.IS_PRIMARY` to `0` by default

### DIFF
--- a/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendarStore.kt
+++ b/app/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendarStore.kt
@@ -123,6 +123,8 @@ class LocalCalendarStore @Inject constructor(
         )
 
         // By default, set all new calendars as non-primary. Right now we do not support actually fetching the primary calendar.
+        // Google Calendar uses this field to determine whether to read the calendar name together with the account name in TalkBack:
+        //   if primary, the calendar name is excluded, and as such, all calendars in the account sound the same.
         values.put(Calendars.IS_PRIMARY, 0)
 
         if (withColor && info.color != null)


### PR DESCRIPTION
### Context

Google Calendar seems to be the most accessible calendar app right now on Android (at least that we know of). A user was "complaining" that Google accounts specified the specific calendar name after the account name when using TalkBack.

For example, event "Example event" from account example@gmail.com, in calendar "Family" would be read as:
> Example event, from 3:15 pm to 5:15 pm from example@gmail.com, Family

I understand how convenient this is. In our case, the second part is not read, just the account name, so for example, for an account named "Nextcloud", calendar "Family Calendar":
> Example event, from 3:15 pm to 5:15 pm from Nextcloud

But also, for the personal calendar, it would be:
> Example event, from 3:15 pm to 5:15 pm from Nextcloud

TalkBack does not read the specific calendar name.

After some investigation, I've found that this is determined by the [`IS_PRIMARY`](https://developer.android.com/reference/android/provider/CalendarContract.CalendarColumns#IS_PRIMARY) column of the Calendar table in the system's calendar provider. If this column is `1` (true), the calendar name is not read.

### Purpose

Until we actually support fetching the user's main calendar ([more details](https://github.com/bitfireAT/davx5-ose/pull/1945#issuecomment-3812287313)), we will set by default `IS_PRIMARY` to `0`, so that the calendar name is read in TalkBack. I have confirmed that this fixed the accessibility issue.

### Short description

- `Calendars.IS_PRIMARY` is now always set to `0`

<small>The column `IS_PRIMARY` was introduced in API 17 so no issues there.</small>

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

