### PR TITLE
Ignore `AccountSettingsMigration21Test.testCancelsSyncAndClearsPendingState` with flaky behaviour in CI

### DIFF
--- a/app/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration21Test.kt
+++ b/app/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration21Test.kt
@@ -25,6 +25,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assume
 import org.junit.Before
 import org.junit.BeforeClass
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import java.util.logging.Logger
@@ -72,6 +73,7 @@ class AccountSettingsMigration21Test {
     }
 
 
+    @Ignore("Flaky in CI")
     @SdkSuppress(minSdkVersion = 34)
     @Test
     fun testCancelsSyncAndClearsPendingState() = runBlocking {


### PR DESCRIPTION
### Purpose

The test `AccountSettingsMigration21Test.testCancelsSyncAndClearsPendingState` only sometimes fails in CI (non-deterministic/flaky) and we have a hard time figuring out why.

### Short description

- Add ignore annotation with description


### Checklist

- [X] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

