### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,8 @@
 # See https://docs.github.com/de/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# For combination with "Require review from code owners" for main-ose branch.
 
-# For combination with "Require review from code owners" for main-ose branch:
-*      @bitfireAT/app-dev
+# Dependabot
+gradle/**   @bitfireAT/app-dev
+
+# everything else
+*   @rfc2822


### PR DESCRIPTION
As an experiment to improve the workflow and reduce the @bitfireAT/app-dev "spam", I have set myself as code owner again.

That doesn't mean that I want to actually review everything, but it will help me to keep the overview. And because our usual workflow is like that anyway, I thought I'd update the codeowners.

@ArnyminerZ @sunkup Please still assign each other as reviewer. Ideally all PRs are already reviewed and then I'll have just a quick look, see what's changed and approve it.

For me it's also important that everyone has repo maintainer permissions so when I'm for instance not available for longer time and there's an urgent thing you can always override the restriction.

Let's look how that works. Comments / feedback as always welcome.