### PR TITLE
Move OSE code to separate package

### DIFF
--- a/app/src/ose/kotlin/com/davx5/ose/DebugInfoCrashHandler.kt
+++ b/app/src/ose/kotlin/com/davx5/ose/DebugInfoCrashHandler.kt
@@ -1,8 +1,8 @@
-/***************************************************************************************************
+/*
  * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
- **************************************************************************************************/
+ */
 
-package at.bitfire.davdroid
+package com.davx5.ose
 
 import android.content.Context
 import at.bitfire.davdroid.ui.DebugInfoActivity

--- a/app/src/ose/kotlin/com/davx5/ose/di/CustomCertManagerModule.kt
+++ b/app/src/ose/kotlin/com/davx5/ose/di/CustomCertManagerModule.kt
@@ -2,7 +2,7 @@
  * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
-package at.bitfire.davdroid.di
+package com.davx5.ose.di
 
 import android.content.Context
 import at.bitfire.cert4android.CustomCertManager

--- a/app/src/ose/kotlin/com/davx5/ose/di/OseColorSchemesModule.kt
+++ b/app/src/ose/kotlin/com/davx5/ose/di/OseColorSchemesModule.kt
@@ -2,12 +2,12 @@
  * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
-package at.bitfire.davdroid.di
+package com.davx5.ose.di
 
 import androidx.compose.material3.ColorScheme
 import at.bitfire.davdroid.di.scope.DarkColorScheme
 import at.bitfire.davdroid.di.scope.LightColorScheme
-import at.bitfire.davdroid.ui.OseTheme
+import com.davx5.ose.ui.OseTheme
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn

--- a/app/src/ose/kotlin/com/davx5/ose/di/OseFlavorModule.kt
+++ b/app/src/ose/kotlin/com/davx5/ose/di/OseFlavorModule.kt
@@ -2,16 +2,16 @@
  * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
-package at.bitfire.davdroid.di
+package com.davx5.ose.di
 
 import at.bitfire.davdroid.ui.AccountsDrawerHandler
 import at.bitfire.davdroid.ui.OseAccountsDrawerHandler
 import at.bitfire.davdroid.ui.about.AboutActivity
-import at.bitfire.davdroid.ui.about.OpenSourceLicenseInfoProvider
 import at.bitfire.davdroid.ui.intro.IntroPageFactory
-import at.bitfire.davdroid.ui.intro.OseIntroPageFactory
 import at.bitfire.davdroid.ui.setup.LoginTypesProvider
-import at.bitfire.davdroid.ui.setup.StandardLoginTypesProvider
+import com.davx5.ose.ui.about.OpenSourceLicenseInfoProvider
+import com.davx5.ose.ui.intro.OseIntroPageFactory
+import com.davx5.ose.ui.setup.StandardLoginTypesProvider
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn

--- a/app/src/ose/kotlin/com/davx5/ose/ui/OseTheme.kt
+++ b/app/src/ose/kotlin/com/davx5/ose/ui/OseTheme.kt
@@ -2,7 +2,7 @@
  * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
-package at.bitfire.davdroid.ui
+package com.davx5.ose.ui
 
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme

--- a/app/src/ose/kotlin/com/davx5/ose/ui/about/OpenSourceLicenseInfoProvider.kt
+++ b/app/src/ose/kotlin/com/davx5/ose/ui/about/OpenSourceLicenseInfoProvider.kt
@@ -2,7 +2,7 @@
  * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
-package at.bitfire.davdroid.ui.about
+package com.davx5.ose.ui.about
 
 import android.app.Application
 import android.text.Spanned
@@ -18,6 +18,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.compose.viewModel
 import at.bitfire.davdroid.ui.UiUtils.toAnnotatedString
+import at.bitfire.davdroid.ui.about.AboutActivity
 import com.google.common.io.CharStreams
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers

--- a/app/src/ose/kotlin/com/davx5/ose/ui/intro/OseIntroPageFactory.kt
+++ b/app/src/ose/kotlin/com/davx5/ose/ui/intro/OseIntroPageFactory.kt
@@ -2,8 +2,15 @@
  * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
-package at.bitfire.davdroid.ui.intro
+package com.davx5.ose.ui.intro
 
+import at.bitfire.davdroid.ui.intro.BackupsPage
+import at.bitfire.davdroid.ui.intro.BatteryOptimizationsPage
+import at.bitfire.davdroid.ui.intro.IntroPageFactory
+import at.bitfire.davdroid.ui.intro.OpenSourcePage
+import at.bitfire.davdroid.ui.intro.PermissionsIntroPage
+import at.bitfire.davdroid.ui.intro.TasksIntroPage
+import at.bitfire.davdroid.ui.intro.WelcomePage
 import javax.inject.Inject
 
 class OseIntroPageFactory @Inject constructor(

--- a/app/src/ose/kotlin/com/davx5/ose/ui/setup/StandardLoginTypePage.kt
+++ b/app/src/ose/kotlin/com/davx5/ose/ui/setup/StandardLoginTypePage.kt
@@ -2,7 +2,7 @@
  * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
-package at.bitfire.davdroid.ui.setup
+package com.davx5.ose.ui.setup
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -25,6 +25,8 @@ import at.bitfire.davdroid.ui.ExternalUris
 import at.bitfire.davdroid.ui.ExternalUris.withStatParams
 import at.bitfire.davdroid.ui.UiUtils.toAnnotatedString
 import at.bitfire.davdroid.ui.composable.Assistant
+import at.bitfire.davdroid.ui.setup.LoginInfo
+import at.bitfire.davdroid.ui.setup.LoginType
 
 @Composable
 fun StandardLoginTypePage(

--- a/app/src/ose/kotlin/com/davx5/ose/ui/setup/StandardLoginTypesProvider.kt
+++ b/app/src/ose/kotlin/com/davx5/ose/ui/setup/StandardLoginTypesProvider.kt
@@ -2,12 +2,22 @@
  * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
-package at.bitfire.davdroid.ui.setup
+package com.davx5.ose.ui.setup
 
 import android.content.Intent
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
+import at.bitfire.davdroid.ui.setup.AdvancedLogin
+import at.bitfire.davdroid.ui.setup.EmailLogin
+import at.bitfire.davdroid.ui.setup.FastmailLogin
+import at.bitfire.davdroid.ui.setup.GoogleLogin
+import at.bitfire.davdroid.ui.setup.LoginActivity
+import at.bitfire.davdroid.ui.setup.LoginInfo
+import at.bitfire.davdroid.ui.setup.LoginType
+import at.bitfire.davdroid.ui.setup.LoginTypesProvider
 import at.bitfire.davdroid.ui.setup.LoginTypesProvider.LoginAction
+import at.bitfire.davdroid.ui.setup.NextcloudLogin
+import at.bitfire.davdroid.ui.setup.UrlLogin
 import java.util.logging.Logger
 import javax.inject.Inject
 


### PR DESCRIPTION
- Move DebugInfoCrashHandler.kt to com.davx5.ose
- Move StandardLoginTypePage.kt to com.davx5.ose.ui.setup
- Move StandardLoginTypesProvider.kt to com.davx5.ose.ui.setup
- Move CustomCertManagerModule.kt to com.davx5.ose.di
- Move OseIntroPageFactory.kt to com.davx5.ose.ui.intro
- Move OseColorSchemesModule.kt to com.davx5.ose.di
- Move OseFlavorModule.kt to com.davx5.ose.di
- Move OpenSourceLicenseInfoProvider.kt to com.davx5.ose.ui.about
- Move OseTheme.kt to com.davx5.ose.ui