### PR TITLE
Load weblate pages in webview 

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/composable/WebViewCompat.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/composable/WebViewCompat.kt
@@ -31,9 +31,14 @@ fun WebViewCompat(
                 this.layoutParams = layoutParams
                 webViewClient = object : WebViewClient() {
                     override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
-                        val intent = Intent(Intent.ACTION_VIEW, request.url)
-                        context.startActivity(intent)
-                        return true
+                        val loadingWeblatePage = request.url.toString().contains("weblate.org")
+                        return if (loadingWeblatePage) {
+                            false // Load Weblate pages in WebView (Don't override loading)
+                        } else {
+                            val intent = Intent(Intent.ACTION_VIEW, request.url)
+                            context.startActivity(intent) // Open external links in browser
+                            true // Abort non-weblate page load in webview
+                        }
                     }
                 }
                 loadUrl(url, mapOf(

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/composable/WebViewCompat.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/composable/WebViewCompat.kt
@@ -4,6 +4,7 @@
 
 package at.bitfire.davdroid.ui.composable
 
+import android.annotation.SuppressLint
 import android.content.Intent
 import android.view.ViewGroup
 import android.webkit.WebResourceRequest
@@ -15,6 +16,7 @@ import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.viewinterop.AndroidView
 import io.ktor.http.HttpHeaders
 
+@SuppressLint("SetJavaScriptEnabled")
 @Composable
 fun WebViewCompat(
     url: String,
@@ -29,6 +31,10 @@ fun WebViewCompat(
         factory = { context ->
             WebView(context).apply {
                 this.layoutParams = layoutParams
+                
+                // Enable JavaScript for are-you-human checks
+                settings.javaScriptEnabled = true
+
                 webViewClient = object : WebViewClient() {
                     override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
                         val loadingWeblatePage = request.url.toString().contains("weblate.org")

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/composable/WebViewCompat.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/composable/WebViewCompat.kt
@@ -35,6 +35,7 @@ fun WebViewCompat(
                 // Enable JavaScript for are-you-human checks
                 settings.javaScriptEnabled = true
 
+                // Load only weblate pages in WebView, other pages open in external browser
                 webViewClient = object : WebViewClient() {
                     override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
                         val loadingWeblatePage = request.url.toString().contains("weblate.org")


### PR DESCRIPTION
### Purpose

Translations webview was loading in browser, not in webview. Probably because of a redirect which causes a new page load which then opens in external browser view.


### Short description

Fix translations webview URL loading by returing the correct boolean value which ensures weblate pages are loaded (on redirect, user interaction, etc) in webview while all others will open in a new browser view. 

I have also enabled javascript because we need it for the anti-bot check. Otherwise I would always get blocked. I don't think we need to worry about XSS here because the content always comes from Weblate which is a trusted source and non-weblate links links open in new browser view.

### Checklist

- [X] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

