### PR TITLE
Remove unused launcher colors

### DIFF
--- a/core/src/main/res/values/launcher_colors.xml
+++ b/core/src/main/res/values/launcher_colors.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="primaryColor">#7cb342</color>
-    <color name="primaryLightColor">#aee571</color>
-    <color name="primaryDarkColor">#4b830d</color>
 </resources>


### PR DESCRIPTION
Required for https://github.com/bitfireAT/davx5/pull/798

### Purpose

Clean codebase.

### Short description

Rename `colors.xml` to `launcher_colors.xml` and remove unusued colors. Keep only `primaryColor`.

### Checklist

- [x] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

