### PR TITLE
Add account to beforeSync validation

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncValidator.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncValidator.kt
@@ -4,6 +4,7 @@
 
 package at.bitfire.davdroid.sync
 
+import android.accounts.Account
 import dagger.BindsOptionalOf
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -14,9 +15,10 @@ interface SyncValidator {
     /**
      * Called before synchronization when a sync adapter is started. Can be used for license checks etc. Must be thread-safe.
      *
+     * @param account The account about to be synchronized
      * @return whether synchronization shall take place (false to abort)
      */
-    fun beforeSync(): Boolean
+    fun beforeSync(account: Account): Boolean
 
 }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
@@ -263,7 +263,7 @@ abstract class Syncer<StoreType: LocalDataStore<CollectionType>, CollectionType:
             try {
                 val runSync = syncValidator.getOrNull()?.let { instance ->
                     logger.info("Registered sync validator: ${instance::class.java.name}")
-                    instance.beforeSync()
+                    instance.beforeSync(account)
                 } ?: /* no sync validator, in OSE for example */ true
 
                 if (runSync)


### PR DESCRIPTION
### Purpose

Necessary for https://github.com/bitfireAT/davx5/pull/807

We need the account in `SyncValidator.beforeSync` to determine whether we should sync that specific account or not.

### Short description

- add Account to interface method `SyncValidator.beforeSync` 
- pass along account in `Syncer`


### Checklist

- [X] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.

