### PR TITLE
[ExternalUris] Add link to DAVx⁵ Select section on davx5.com homage in

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/ExternalUris.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/ExternalUris.kt
@@ -32,6 +32,7 @@ object ExternalUris {
         const val PATH_TESTED_SERVICES = "tested-with"
 
         const val PATH_ORGANIZATIONS = "organizations"
+        const val PATH_ORGANIZATIONS_DAVX5_SELECT = "davx5-select"
         const val PATH_ORGANIZATIONS_MANAGED = "managed-davx5"
         const val PATH_ORGANIZATIONS_TRY_IT = "try-it-for-free"
     }


### PR DESCRIPTION
For https://github.com/bitfireAT/davx5/pull/814

### Purpose

To be used in navigation drawer of DAVx⁵ Select.

### Short description

- ExternalUris: Add "organization/select" segment to DAVx⁵ Select section on davx5.com homage

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

