### PR TITLE
Fix `AppLicenseInfoProvider` binding

### DIFF
--- a/app-ose/src/ose/kotlin/com/davx5/ose/di/AppLicenseInfoProviderModule.kt
+++ b/app-ose/src/ose/kotlin/com/davx5/ose/di/AppLicenseInfoProviderModule.kt
@@ -9,10 +9,10 @@ import com.davx5.ose.ui.about.OpenSourceLicenseInfoProvider
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.android.components.ActivityComponent
 
 @Module
-@InstallIn(ViewModelComponent::class)
+@InstallIn(ActivityComponent::class)
 interface AppLicenseInfoProviderModule {
     @Binds
     fun appLicenseInfoProvider(impl: OpenSourceLicenseInfoProvider): AboutActivity.AppLicenseInfoProvider


### PR DESCRIPTION
Fixes `AppLicenseInfoProvider` binding by using the Hilt component.