### PR TITLE
Add commented includeBuild configurations for debugging

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,3 +38,21 @@ if (!buildCacheUrl.isNullOrEmpty()) {
 
 include(":app-ose")
 include(":core")
+
+// Uncomment for debugging / working in the subprojects.
+// Make sure that you have checked out the desired branch in the respective subproject!
+/*includeBuild("../cert4android") {
+    dependencySubstitution {
+        substitute(module("com.github.bitfireat:cert4android")).using(project(":lib"))
+    }
+}*/
+/*includeBuild("../dav4jvm") {
+    dependencySubstitution {
+        substitute(module("com.github.bitfireat:dav4jvm")).using(project(":"))
+    }
+}*/
+/*includeBuild("../synctools") {
+    dependencySubstitution {
+        substitute(module("com.github.bitfireAT:synctools")).using(project(":lib"))
+    }
+}*/


### PR DESCRIPTION
### Purpose

This PR adds commented `includeBuild` configurations to assist with subproject debugging.

> [!TIP]
> With this PR: If you want to work in davx5-ose and a subproject at the same time, you can just uncomment the respective lines from settings.gradle.kts.

Only make sure that you have checked out the subproject in the correct directory (like `../synctools` so that `synctools` is on the same directory level as `davx5-ose`) and with the correct branch etc.

See https://cloud.bitfire.at/call/iuai87nn#message_54925


### Short description

- Added commented `includeBuild` configurations for easier subproject debugging.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.