### PR TITLE
AppTheme: fallback to OSE theme when Hilt Application is unavailable

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/composable/AppTheme.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/composable/AppTheme.kt
@@ -29,6 +29,7 @@ import androidx.lifecycle.compose.LifecycleResumeEffect
 import at.bitfire.davdroid.di.qualifier.DarkColorScheme
 import at.bitfire.davdroid.di.qualifier.LightColorScheme
 import at.bitfire.davdroid.ui.ForegroundTracker
+import at.bitfire.davdroid.ui.OseTheme
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
@@ -50,10 +51,17 @@ fun AppTheme(
     windowInsets: WindowInsets = WindowInsets.safeDrawing,
     content: @Composable () -> Unit
 ) {
+    // get application-defined theme (from the Gradle project that actually defines the Application and theme)
     val context = LocalContext.current
-    val entryPoint by lazy { EntryPointAccessors.fromApplication<AppThemeEntryPoint>(context) }
-    val lightColorScheme = remember { entryPoint.lightColorScheme() }
-    val darkColorScheme = remember { entryPoint.darkColorScheme() }
+    val entryPoint: AppThemeEntryPoint? = try {
+        EntryPointAccessors.fromApplication<AppThemeEntryPoint>(context)
+    } catch (_: IllegalStateException) {
+        /* The core submodule doesn't define a Hilt Application, which is necessary to get an
+        application EntryPoint. So in that case we will use the OSE theme as fallback. */
+        null
+    }
+    val lightColorScheme = remember { entryPoint?.lightColorScheme() ?: OseTheme.lightScheme }
+    val darkColorScheme = remember { entryPoint?.darkColorScheme() ?: OseTheme.darkScheme }
 
     val activity = LocalActivity.current
     SideEffect {


### PR DESCRIPTION
### Purpose

This PR makes `@Preview` Composables that are in the core subproject and use `AppTheme` work again.

### Short description

- Added a fallback OSE theme to ensure the application has a default theme when the Hilt Application is not available.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.