### PR TITLE
Fix pager state recreation on page count change

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -247,7 +248,7 @@ fun AccountScreen(
             (if (idxCalDav != null) 1 else 0) +
                     (if (idxCardDav != null) 1 else 0) +
                     (if (idxWebcal != null) 1 else 0)
-        val pagerState = rememberPagerState(pageCount = { nrPages })
+        val pagerState = key(nrPages) { rememberPagerState(pageCount = { nrPages }) }
 
         val calDavScrollState = rememberLazyListState()
         val cardDavScrollState = rememberLazyListState()


### PR DESCRIPTION
### Purpose

This PR fixes the pager state recreation issue that occurs when the page count changes. Closes #1920.

### Short description

- Fixed the pager state recreation logic to handle page count changes correctly.

Without PR: crashes [when doing this](https://github.com/bitfireAT/davx5-ose/issues/1920#issuecomment-3807401858). With PR: stays in view, CardDAV tab just disappears.


### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.