### PR TITLE
Rename NOTIFY_LICENSE to more generic NOTIFY_VALIDATION

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/NotificationRegistry.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/NotificationRegistry.kt
@@ -52,8 +52,8 @@ class NotificationRegistry @Inject constructor(
         const val NOTIFY_PERMISSIONS = 21
 
         /**
-         * Used in managed and select flavors when a [at.bitfire.davdroid.sync.SyncValidator]
-         * prevents sync due to invalid license or failed server validation.
+         * Used in build variants when a [at.bitfire.davdroid.sync.SyncValidator]
+         * prevents sync, for instance due to invalid license or failed server validation.
          */
         @Suppress("unused")     // for build variants
         const val NOTIFY_VALIDATION = 100


### PR DESCRIPTION
Should be reviewed with: https://github.com/bitfireAT/davx5/pull/851

### Purpose

The term "license" only applies to managed flavor. This PR renames the constant, so we can use the same notification ID for sync validation related notifications across flavors. 

### Short description

 - [Rename NOTIFY_LICENSE to more generic NOTIFY_VALIDATION](https://github.com/bitfireAT/davx5-ose/commit/86e25a45e9d57f4acd4b4aa0e79929212f54c426)


### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

