### PR TITLE
Provide login validation for app variants

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncValidator.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncValidator.kt
@@ -9,8 +9,22 @@ import dagger.BindsOptionalOf
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import okhttp3.HttpUrl
 
+
+/**
+ * Used to decide on whether login and sync are allowed to happen.
+ */
 interface SyncValidator {
+
+    /**
+     * Called before login/setup to validate if the server is allowed for this app variant.
+     * Must be thread-safe.
+     *
+     * @param baseUrl The base URL of the server to validate
+     * @return whether login/setup shall proceed (false to abort)
+     */
+    fun beforeLogin(baseUrl: HttpUrl): Boolean
 
     /**
      * Called before synchronization when a sync adapter is started. Can be used for license checks etc. Must be thread-safe.

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/ExternalUris.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/ExternalUris.kt
@@ -30,6 +30,7 @@ object ExternalUris {
         const val PATH_OPEN_SOURCE = "donate"
         const val PATH_PRIVACY = "privacy"
         const val PATH_TESTED_SERVICES = "tested-with"
+        const val PATH_DOWNLOAD = "download"
 
         const val PATH_ORGANIZATIONS = "organizations"
         const val PATH_ORGANIZATIONS_DAVX5_SELECT = "davx5-select"

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/DetectResourcesPage.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/DetectResourcesPage.kt
@@ -4,6 +4,7 @@
 
 package at.bitfire.davdroid.ui.setup
 
+import android.content.Intent
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -11,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Block
 import androidx.compose.material.icons.filled.CloudOff
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -24,6 +26,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import androidx.core.text.HtmlCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import at.bitfire.davdroid.R
@@ -42,6 +45,7 @@ fun DetectResourcesPage(
         loading = uiState.loading,
         foundNothing = uiState.foundNothing,
         encountered401 = uiState.encountered401,
+        loginValidationFailed = uiState.loginValidationFailed,
         logs = uiState.logs
     )
 }
@@ -51,6 +55,7 @@ fun DetectResourcesPageContent(
     loading: Boolean,
     foundNothing: Boolean,
     encountered401: Boolean,
+    loginValidationFailed: Boolean,
     logs: String?
 ) {
     Column(Modifier
@@ -59,6 +64,8 @@ fun DetectResourcesPageContent(
     ) {
         if (loading)
             DetectResourcesPageContent_InProgress()
+        else if (loginValidationFailed)
+            DetectResourcesPageContent_LoginValidationFailed()
         else if (foundNothing)
             DetectResourcesPageContent_NothingFound(
                 encountered401 = encountered401,
@@ -166,6 +173,56 @@ fun DetectResourcesPageContent_NothingFound(
 }
 
 @Composable
+fun DetectResourcesPageContent_LoginValidationFailed() {
+    Column(Modifier.padding(8.dp)) {
+        Text(
+            stringResource(R.string.login_configuration_detection),
+            style = MaterialTheme.typography.headlineMedium,
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
+
+        Card(Modifier.fillMaxWidth()) {
+            Column(Modifier.padding(8.dp)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(Icons.Default.Block, contentDescription = null, modifier = Modifier.padding(end = 8.dp))
+                    Text(
+                        stringResource(R.string.login_invalid_use_case),
+                        style = MaterialTheme.typography.headlineSmall,
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+
+                Text(
+                    stringResource(R.string.login_invalid_use_case_info, "(${stringResource(R.string.app_name)})"),
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.padding(top = 16.dp, bottom = 8.dp)
+                )
+
+                val context = LocalContext.current
+                val urlDownload = ExternalUris.Homepage.baseUrl.buildUpon()
+                    .appendPath(ExternalUris.Homepage.PATH_DOWNLOAD)
+                    .withStatParams(context, "LoginValidationFailedPage")
+                    .build()
+                Text(
+                    text = HtmlCompat.fromHtml(
+                        stringResource(R.string.login_download_regular_davx5, urlDownload),
+                        HtmlCompat.FROM_HTML_MODE_COMPACT
+                    ).toAnnotatedString(),
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.padding(vertical = 8.dp)
+                )
+
+                Button(onClick = {
+                    context.startActivity(Intent(Intent.ACTION_VIEW, urlDownload.toString().toUri()))
+                }) {
+                    Text(stringResource(R.string.login_download_button))
+                }
+            }
+        }
+    }
+}
+
+@Composable
 @Preview
 fun DetectResourcesPageContent_NothingFound() {
     DetectResourcesPageContent_NothingFound(
@@ -181,4 +238,10 @@ fun DetectResourcesPage_NothingFound_401() {
         encountered401 = true,
         logs = ""
     )
+}
+
+@Composable
+@Preview
+fun DetectResourcesPage_ValidationFailed() {
+    DetectResourcesPageContent_LoginValidationFailed()
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
@@ -16,6 +16,7 @@ import at.bitfire.davdroid.repository.AccountRepository
 import at.bitfire.davdroid.servicedetection.DavResourceFinder
 import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.settings.SettingsManager
+import at.bitfire.davdroid.sync.SyncValidator
 import at.bitfire.vcard4android.GroupMethod
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -34,6 +35,8 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withContext
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import java.util.Optional
 import java.util.logging.Logger
 
 @HiltViewModel(assistedFactory = LoginScreenModel.Factory::class)
@@ -47,7 +50,8 @@ class LoginScreenModel @AssistedInject constructor(
     private val logger: Logger,
     val loginTypesProvider: LoginTypesProvider,
     private val resourceFinderFactory: DavResourceFinder.Factory,
-    settingsManager: SettingsManager
+    settingsManager: SettingsManager,
+    private val syncValidator: Optional<SyncValidator>
 ): ViewModel() {
 
     @AssistedFactory
@@ -181,6 +185,7 @@ class LoginScreenModel @AssistedInject constructor(
         val loading: Boolean = false,
         val foundNothing: Boolean = false,
         val encountered401: Boolean = false,
+        val loginValidationFailed: Boolean = false,
         val logs: String? = null
     )
 
@@ -193,6 +198,24 @@ class LoginScreenModel @AssistedInject constructor(
     private fun detectResources() {
         detectResourcesUiState = detectResourcesUiState.copy(loading = true)
         detectResourcesJob = viewModelScope.launch {
+            // First, if we have a validator, validate the server
+            val httpUrl = loginInfo.baseUri!!.toHttpUrlOrNull()
+            if (syncValidator.isPresent && httpUrl != null) {
+                val isValid = withContext(Dispatchers.IO) {
+                    runInterruptible {
+                        syncValidator.get().beforeLogin(httpUrl)
+                    }
+                }
+                if (!isValid) {
+                    detectResourcesUiState = detectResourcesUiState.copy(
+                        loading = false,
+                        loginValidationFailed = true
+                    )
+                    return@launch
+                }
+            }
+
+            // Then, find initial configuration
             val result = withContext(Dispatchers.IO) {
                  runInterruptible {
                      val finder = resourceFinderFactory.create(loginInfo.baseUri!!, loginInfo.credentials)

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -336,6 +336,10 @@
     <string name="login_check_credentials">Please also double-check authentication (usually username and password).</string>
     <string name="login_logs_available">Further technical information is available in the logs.</string>
     <string name="login_view_logs">View logs</string>
+    <string name="login_invalid_use_case">Invalid use-case</string>
+    <string name="login_invalid_use_case_info"><![CDATA[This variant %s of the app can only be used with selected services.]]></string>
+    <string name="login_download_regular_davx5"><![CDATA[Instead, please use <a href="%s">DAVx⁵</a>, which can be used with all services.]]></string>
+    <string name="login_download_button">Download DAVx⁵</string>
 
     <!-- AccountSettingsActivity -->
     <string name="settings_sync">Synchronization</string>


### PR DESCRIPTION
Required for https://github.com/bitfireAT/davx5/pull/862

### Purpose

Add support for login validation in other DAVx5 flavors.

### Short description

- add the login validation in `detectResources()`
- add a login validation failed page `DetectResourcesPageContent_LoginValidationFailed`
- show that page when login validation fails
- have validation code live in its own `valdidation` package

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

