### PR TITLE
[Push] Invalidate all subscriptions after changing push distributor

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/db/CollectionDao.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/CollectionDao.kt
@@ -97,6 +97,9 @@ interface CollectionDao {
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insertAsync(collection: Collection): Long
 
+    @Query("UPDATE collection SET pushSubscriptionExpires=NULL")
+    suspend fun invalidatePushSubscriptions()
+
     @Update
     fun update(collection: Collection)
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/push/PushCoordinator.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/push/PushCoordinator.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.push
+
+import javax.inject.Inject
+
+class PushCoordinator @Inject constructor(
+    private val pushDistributorManager: PushDistributorManager,
+    private val pushRegistrationManager: PushRegistrationManager
+) {
+    /**
+     * Sets or removes (disable push) the distributor by updating the UnifiedPush settings.
+     *
+     * Then invalidates all subscriptions to refresh them and re-registers subscriptions.
+     *
+     * @param pushDistributor  new distributor or `null` to explicitly disable Push
+     */
+    suspend fun setPushDistributor(pushDistributor: String?) {
+        @Suppress("DEPRECATION")
+        pushDistributorManager.setPushDistributor(pushDistributor)
+        pushRegistrationManager.update()
+    }
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/push/PushDistributorManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/push/PushDistributorManager.kt
@@ -40,8 +40,14 @@ class PushDistributorManager @Inject constructor(
      *
      * Does not re-register subscriptions. A call to [PushRegistrationManager.update] may be needed.
      *
+     * **Intended to be used by [PushCoordinator], call [PushCoordinator.setPushDistributor] instead.**
+     *
      * @param pushDistributor  new distributor or `null` to explicitly disable Push
      */
+    @Deprecated(
+        "Intended to be used only by PushCoordinator",
+        replaceWith = ReplaceWith("pushCoordinator.setPushDistributor(pushDistributor)")
+    )
     suspend fun setPushDistributor(pushDistributor: String?): Unit = mutex.withLock {
         if (pushDistributor != null && getCurrentDistributor() == pushDistributor) {
             // Distributor hasn't changed

--- a/core/src/main/kotlin/at/bitfire/davdroid/push/PushDistributorManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/push/PushDistributorManager.kt
@@ -7,6 +7,8 @@ package at.bitfire.davdroid.push
 import android.content.Context
 import at.bitfire.davdroid.repository.DavCollectionRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.unifiedpush.android.connector.UnifiedPush
 import javax.inject.Inject
 
@@ -15,13 +17,15 @@ class PushDistributorManager @Inject constructor(
     @ApplicationContext private val context: Context
 ) {
 
+    private val mutex = Mutex()
+
     /**
      * Get the distributor registered by the user.
      *
      * @return The distributor package name if any, else `null`. Will also return `null`
      * if the previously selected distributor isn't installed anymore.
      */
-    fun getCurrentDistributor() = UnifiedPush.getSavedDistributor(context)
+    suspend fun getCurrentDistributor() = mutex.withLock { UnifiedPush.getSavedDistributor(context) }
 
     /**
      * Get a list of available distributors installed on the system.
@@ -34,9 +38,11 @@ class PushDistributorManager @Inject constructor(
      *
      * Then invalidates all subscriptions to refresh them.
      *
+     * Does not re-register subscriptions. A call to [PushRegistrationManager.update] may be needed.
+     *
      * @param pushDistributor  new distributor or `null` to explicitly disable Push
      */
-    suspend fun setPushDistributor(pushDistributor: String?) {
+    suspend fun setPushDistributor(pushDistributor: String?): Unit = mutex.withLock {
         if (pushDistributor != null && getCurrentDistributor() == pushDistributor) {
             // Distributor hasn't changed
             return

--- a/core/src/main/kotlin/at/bitfire/davdroid/push/PushDistributorManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/push/PushDistributorManager.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.push
+
+import android.content.Context
+import at.bitfire.davdroid.repository.DavCollectionRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
+import org.unifiedpush.android.connector.UnifiedPush
+import javax.inject.Inject
+
+class PushDistributorManager @Inject constructor(
+    private val collectionRepository: DavCollectionRepository,
+    @ApplicationContext private val context: Context
+) {
+
+    /**
+     * Get the distributor registered by the user.
+     *
+     * @return The distributor package name if any, else `null`. Will also return `null`
+     * if the previously selected distributor isn't installed anymore.
+     */
+    fun getCurrentDistributor() = UnifiedPush.getSavedDistributor(context)
+
+    /**
+     * Get a list of available distributors installed on the system.
+     * @return The list of distributor's package name.
+     */
+    fun getDistributors() = UnifiedPush.getDistributors(context)
+
+    /**
+     * Sets or removes (disable push) the distributor by updating the UnifiedPush settings.
+     *
+     * Then invalidates all subscriptions to refresh them.
+     *
+     * @param pushDistributor  new distributor or `null` to explicitly disable Push
+     */
+    suspend fun setPushDistributor(pushDistributor: String?) {
+        if (pushDistributor != null && getCurrentDistributor() == pushDistributor) {
+            // Distributor hasn't changed
+            return
+        }
+
+        // Disable UnifiedPush and remove all subscriptions
+        UnifiedPush.removeDistributor(context)
+        invalidateSubscriptions()
+
+        if (pushDistributor != null) {
+            // If a distributor was passed, store it and create/register subscriptions
+            UnifiedPush.saveDistributor(context, pushDistributor)
+        }
+    }
+
+    private suspend fun invalidateSubscriptions() = collectionRepository.invalidatePushSubscriptions()
+
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
@@ -62,33 +62,9 @@ class PushRegistrationManager @Inject constructor(
     @ApplicationContext private val context: Context,
     private val httpClientBuilder: Provider<HttpClientBuilder>,
     private val logger: Logger,
-    private val serviceRepository: DavServiceRepository
+    private val serviceRepository: DavServiceRepository,
+    private val pushDistributorManager: PushDistributorManager
 ) {
-
-    /**
-     * Sets or removes (disable push) the distributor and updates the subscriptions + worker.
-     *
-     * Uses [update] which is protected by [mutex] so creating/deleting subscriptions doesn't
-     * interfere with other operations.
-     *
-     * @param pushDistributor  new distributor or `null` to disable Push
-     */
-    suspend fun setPushDistributor(pushDistributor: String?) {
-        // Disable UnifiedPush and remove all subscriptions
-        UnifiedPush.removeDistributor(context)
-        update()
-
-        if (pushDistributor != null) {
-            // If a distributor was passed, store it and create/register subscriptions
-            UnifiedPush.saveDistributor(context, pushDistributor)
-            update()
-        }
-    }
-
-    fun getCurrentDistributor() = UnifiedPush.getSavedDistributor(context)
-
-    fun getDistributors() = UnifiedPush.getDistributors(context)
-
 
     /**
      * Updates all push registrations and subscriptions so that if Push is available, it's up-to-date and
@@ -126,7 +102,7 @@ class PushRegistrationManager @Inject constructor(
         // use service ID from database as UnifiedPush instance name
         val instance = serviceId.toString()
 
-        val distributorAvailable = getCurrentDistributor() != null
+        val distributorAvailable = pushDistributorManager.getCurrentDistributor() != null
         if (distributorAvailable)
             try {
                 val vapid = collectionRepository.getVapidKey(serviceId)
@@ -160,7 +136,7 @@ class PushRegistrationManager @Inject constructor(
      *
      * Uses the subscription to subscribe to syncable collections, and then unsubscribes from non-syncable collections.
      */
-    suspend fun processSubscription(serviceId: Long, endpoint: PushEndpoint) = mutex.withLock {
+    suspend fun processSubscription(serviceId: Long, endpoint: PushEndpoint): Unit = mutex.withLock {
         val service = serviceRepository.get(serviceId) ?: return
 
         try {
@@ -207,7 +183,7 @@ class PushRegistrationManager @Inject constructor(
      *
      * Unsubscribes from all subscribed collections.
      */
-    suspend fun removeSubscription(serviceId: Long) = mutex.withLock {
+    suspend fun removeSubscription(serviceId: Long): Unit = mutex.withLock {
         val service = serviceRepository.get(serviceId) ?: return
         unsubscribeAll(service)
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
@@ -277,6 +277,13 @@ class DavCollectionRepository @Inject constructor(
     }
 
     /**
+     * Sets the `expires` of all push subscriptions to `null`.
+     */
+    suspend fun invalidatePushSubscriptions() {
+        dao.invalidatePushSubscriptions()
+    }
+
+    /**
      * Deletes the collection locally
      */
     fun delete(collection: Collection) {

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsModel.kt
@@ -14,7 +14,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import at.bitfire.cert4android.CustomCertStore
 import at.bitfire.davdroid.di.qualifier.IoDispatcher
-import at.bitfire.davdroid.push.PushRegistrationManager
+import at.bitfire.davdroid.push.PushDistributorManager
 import at.bitfire.davdroid.repository.PreferenceRepository
 import at.bitfire.davdroid.settings.Settings
 import at.bitfire.davdroid.settings.SettingsManager
@@ -44,7 +44,7 @@ class AppSettingsModel @Inject constructor(
     private val customCertStore: Optional<CustomCertStore>,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     private val preferences: PreferenceRepository,
-    private val pushRegistrationManager: PushRegistrationManager,
+    private val pushDistributorManager: PushDistributorManager,
     private val settings: SettingsManager,
     tasksAppManager: TasksAppManager
 ) : ViewModel() {
@@ -141,10 +141,10 @@ class AppSettingsModel @Inject constructor(
      * - Makes sure the app is registered with UnifiedPush if there's already a distributor selected.
      */
     private fun loadPushDistributors() {
-        val currentPushDistributor = pushRegistrationManager.getCurrentDistributor()
+        val currentPushDistributor = pushDistributorManager.getCurrentDistributor()
         _pushDistributor.value = currentPushDistributor
 
-        val pushDistributors = pushRegistrationManager.getDistributors()
+        val pushDistributors = pushDistributorManager.getDistributors()
             .map { pushDistributor ->
                 try {
                     val applicationInfo = pm.getApplicationInfo(pushDistributor, 0)
@@ -168,7 +168,7 @@ class AppSettingsModel @Inject constructor(
      */
     fun updatePushDistributor(pushDistributor: String?) {
         viewModelScope.launch(ioDispatcher) {
-            pushRegistrationManager.setPushDistributor(pushDistributor)
+            pushDistributorManager.setPushDistributor(pushDistributor)
 
             _pushDistributor.value = pushDistributor
         }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsModel.kt
@@ -14,8 +14,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import at.bitfire.cert4android.CustomCertStore
 import at.bitfire.davdroid.di.qualifier.IoDispatcher
+import at.bitfire.davdroid.push.PushCoordinator
 import at.bitfire.davdroid.push.PushDistributorManager
-import at.bitfire.davdroid.push.PushRegistrationManager
 import at.bitfire.davdroid.repository.PreferenceRepository
 import at.bitfire.davdroid.settings.Settings
 import at.bitfire.davdroid.settings.SettingsManager
@@ -46,7 +46,7 @@ class AppSettingsModel @Inject constructor(
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     private val preferences: PreferenceRepository,
     private val pushDistributorManager: PushDistributorManager,
-    private val pushRegistrationManager: PushRegistrationManager,
+    private val pushCoordinator: PushCoordinator,
     private val settings: SettingsManager,
     tasksAppManager: TasksAppManager
 ) : ViewModel() {
@@ -170,8 +170,7 @@ class AppSettingsModel @Inject constructor(
      */
     fun updatePushDistributor(pushDistributor: String?) {
         viewModelScope.launch(ioDispatcher) {
-            pushDistributorManager.setPushDistributor(pushDistributor)
-            pushRegistrationManager.update()
+            pushCoordinator.setPushDistributor(pushDistributor)
 
             _pushDistributor.value = pushDistributor
         }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsModel.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.viewModelScope
 import at.bitfire.cert4android.CustomCertStore
 import at.bitfire.davdroid.di.qualifier.IoDispatcher
 import at.bitfire.davdroid.push.PushDistributorManager
+import at.bitfire.davdroid.push.PushRegistrationManager
 import at.bitfire.davdroid.repository.PreferenceRepository
 import at.bitfire.davdroid.settings.Settings
 import at.bitfire.davdroid.settings.SettingsManager
@@ -45,6 +46,7 @@ class AppSettingsModel @Inject constructor(
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     private val preferences: PreferenceRepository,
     private val pushDistributorManager: PushDistributorManager,
+    private val pushRegistrationManager: PushRegistrationManager,
     private val settings: SettingsManager,
     tasksAppManager: TasksAppManager
 ) : ViewModel() {
@@ -140,7 +142,7 @@ class AppSettingsModel @Inject constructor(
      * - If there's only one push distributor available, and none is selected, it's selected automatically.
      * - Makes sure the app is registered with UnifiedPush if there's already a distributor selected.
      */
-    private fun loadPushDistributors() {
+    private suspend fun loadPushDistributors() {
         val currentPushDistributor = pushDistributorManager.getCurrentDistributor()
         _pushDistributor.value = currentPushDistributor
 
@@ -169,6 +171,7 @@ class AppSettingsModel @Inject constructor(
     fun updatePushDistributor(pushDistributor: String?) {
         viewModelScope.launch(ioDispatcher) {
             pushDistributorManager.setPushDistributor(pushDistributor)
+            pushRegistrationManager.update()
 
             _pushDistributor.value = pushDistributor
         }


### PR DESCRIPTION
### Purpose

Right now, when changing the push distributor, the subscriptions are not invalidated, and as such, not refreshed.

### Short description

Invalidate the subscriptions after changing distributor (since the old ones are no longer valid).

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

