### PR TITLE
[core/ose] Required changes for Android 17

### DIFF
--- a/app-ose/build.gradle.kts
+++ b/app-ose/build.gradle.kts
@@ -11,11 +11,11 @@ plugins {
 }
 
 android {
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 24        // Android 7.0
-        targetSdk = 36     // Android 16
+        targetSdk = 37     // Android 17
 
         applicationId = "at.bitfire.davdroid"
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 
 // Android configuration
 android {
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 24        // Android 7.0

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.READ_SYNC_SETTINGS"/>
     <uses-permission android:name="android.permission.READ_SYNC_STATS"/>

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/DetectResourcesPage.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/DetectResourcesPage.kt
@@ -4,7 +4,11 @@
 
 package at.bitfire.davdroid.ui.setup
 
+import android.Manifest
 import android.content.Intent
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -14,6 +18,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Block
 import androidx.compose.material.icons.filled.CloudOff
+import androidx.compose.material.icons.filled.Security
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
@@ -40,13 +45,25 @@ import at.bitfire.davdroid.ui.composable.ProgressBar
 fun DetectResourcesPage(
     model: LoginScreenModel = viewModel()
 ) {
+    val permissionRequestLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) model.retryResourceDetection()
+    }
+
     val uiState = model.detectResourcesUiState
     DetectResourcesPageContent(
         loading = uiState.loading,
         foundNothing = uiState.foundNothing,
         encountered401 = uiState.encountered401,
         loginValidationFailed = uiState.loginValidationFailed,
-        logs = uiState.logs
+        logs = uiState.logs,
+        missingLocalPermission = uiState.missingLocalPermission,
+        onRequestLocalPermissionRequest = {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.CINNAMON_BUN) {
+                permissionRequestLauncher.launch(Manifest.permission.ACCESS_LOCAL_NETWORK)
+            }
+        }
     )
 }
 
@@ -56,6 +73,8 @@ fun DetectResourcesPageContent(
     foundNothing: Boolean,
     encountered401: Boolean,
     loginValidationFailed: Boolean,
+    missingLocalPermission: Boolean,
+    onRequestLocalPermissionRequest: () -> Unit,
     logs: String?
 ) {
     Column(Modifier
@@ -66,6 +85,8 @@ fun DetectResourcesPageContent(
             DetectResourcesPageContent_InProgress()
         else if (loginValidationFailed)
             DetectResourcesPageContent_LoginValidationFailed()
+        else if(missingLocalPermission)
+            DetectResourcesPageContent_MissingPermission(onRequestLocalPermissionRequest)
         else if (foundNothing)
             DetectResourcesPageContent_NothingFound(
                 encountered401 = encountered401,
@@ -223,6 +244,42 @@ fun DetectResourcesPageContent_LoginValidationFailed() {
 }
 
 @Composable
+fun DetectResourcesPageContent_MissingPermission(onRequestPermissionRequest: () -> Unit) {
+    Column(Modifier.padding(8.dp)) {
+        Text(
+            stringResource(R.string.login_configuration_detection),
+            style = MaterialTheme.typography.headlineMedium,
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
+
+        Card(Modifier.fillMaxWidth()) {
+            Column(Modifier.padding(8.dp)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(Icons.Default.Security, contentDescription = null, modifier = Modifier.padding(end = 8.dp))
+                    Text(
+                        stringResource(R.string.login_permission_required),
+                        style = MaterialTheme.typography.headlineSmall,
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+
+                Text(
+                    stringResource(R.string.login_local_permission),
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.padding(top = 16.dp, bottom = 8.dp)
+                )
+
+                Button(
+                    onClick = onRequestPermissionRequest
+                ) {
+                    Text(stringResource(R.string.login_permission_grant))
+                }
+            }
+        }
+    }
+}
+
+@Composable
 @Preview
 fun DetectResourcesPageContent_NothingFound() {
     DetectResourcesPageContent_NothingFound(
@@ -244,4 +301,10 @@ fun DetectResourcesPage_NothingFound_401() {
 @Preview
 fun DetectResourcesPage_ValidationFailed() {
     DetectResourcesPageContent_LoginValidationFailed()
+}
+
+@Composable
+@Preview
+fun DetectResourcesPageContent_MissingPermission() {
+    DetectResourcesPageContent_MissingPermission(onRequestPermissionRequest = {})
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
@@ -4,11 +4,14 @@
 
 package at.bitfire.davdroid.ui.setup
 
+import android.Manifest
 import android.accounts.Account
 import android.content.Context
+import android.content.pm.PackageManager
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import at.bitfire.davdroid.di.qualifier.DefaultDispatcher
@@ -35,6 +38,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import java.net.InetAddress
+import java.net.UnknownHostException
 import java.util.Optional
 import java.util.logging.Logger
 
@@ -185,6 +190,7 @@ class LoginScreenModel @AssistedInject constructor(
         val foundNothing: Boolean = false,
         val encountered401: Boolean = false,
         val loginValidationFailed: Boolean = false,
+        val missingLocalPermission: Boolean = false,
         val logs: String? = null
     )
 
@@ -194,11 +200,18 @@ class LoginScreenModel @AssistedInject constructor(
     private var foundConfig: DavResourceFinder.Configuration? = null
     private var detectResourcesJob: Job? = null
 
+    fun retryResourceDetection() {
+        if (page == Page.DetectResources) {
+            detectResources()
+        }
+    }
+
     private fun detectResources() {
         detectResourcesUiState = detectResourcesUiState.copy(loading = true)
         detectResourcesJob = viewModelScope.launch {
+            val baseUri = loginInfo.baseUri!!
             // First, if we have a validator, validate the server
-            val httpUrl = loginInfo.baseUri!!.toHttpUrlOrNull()
+            val httpUrl = baseUri.toHttpUrlOrNull()
             if (loginValidator.isPresent && httpUrl != null) {
                 val isValid = withContext(Dispatchers.IO) {
                     runInterruptible {
@@ -214,10 +227,29 @@ class LoginScreenModel @AssistedInject constructor(
                 }
             }
 
-            // Then, find initial configuration
+            // Then, check if the uri is local. If that's the case, we need to request ACCESS_LOCAL_NETWORK on Android 17+
+            val isLocal = withContext(Dispatchers.IO) {
+                try {
+                    val addresses = InetAddress.getAllByName(baseUri.host)
+                    addresses.any { it.isSiteLocalAddress || it.isLinkLocalAddress }
+                } catch (_: UnknownHostException) {
+                    // Treat unresolvable .local as local
+                    baseUri.host.endsWith(".local", ignoreCase = true)
+                }
+            }
+            if (isLocal && !hasLocalNetworkPermission()) {
+                foundConfig = null
+                detectResourcesUiState = detectResourcesUiState.copy(
+                    loading = false,
+                    missingLocalPermission = true,
+                )
+                return@launch
+            }
+
+            // Finally, find initial configuration
             val result = withContext(Dispatchers.IO) {
                  runInterruptible {
-                     val finder = resourceFinderFactory.create(loginInfo.baseUri!!, loginInfo.credentials)
+                     val finder = resourceFinderFactory.create(baseUri, loginInfo.credentials)
                      finder.findInitialConfiguration()
                  }
             }
@@ -240,6 +272,13 @@ class LoginScreenModel @AssistedInject constructor(
 
     private fun cancelResourceDetection() {
         detectResourcesJob?.cancel()
+    }
+
+    /**
+     * Checks whether the `ACCESS_LOCAL_NETWORK` permission is granted.
+     */
+    private fun hasLocalNetworkPermission(): Boolean {
+        return ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_LOCAL_NETWORK) == PackageManager.PERMISSION_GRANTED
     }
 
 

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -342,6 +342,9 @@
     <string name="login_invalid_use_case_info"><![CDATA[This variant %s of the app can only be used with selected services.]]></string>
     <string name="login_download_regular_davx5"><![CDATA[Instead, please use <a href="%s">DAVx⁵</a>, which can be used with all services.]]></string>
     <string name="login_download_button">Download DAVx⁵</string>
+    <string name="login_permission_required">Permission Required</string>
+    <string name="login_local_permission">You must grant access to your local network to access this server.</string>
+    <string name="login_permission_grant">Grant Permission</string>
 
     <!-- AccountSettingsActivity -->
     <string name="settings_sync">Synchronization</string>


### PR DESCRIPTION
### Purpose

Increase SDK level and do minimal changes required for the app to work on Android 17.

[CT](https://developer.android.com/privacy-and-security/security-config#CertificateTransparencySummary) is not an issue, we already have `<certificates src="user" />` in the trust anchors of the network config.

[ECH](https://developer.android.com/privacy-and-security/security-config#EncryptedClientHelloSummary) should not be an issue. Extra feature, and should be implemented by okhttp.

[Cleartext traffic](https://developer.android.com/privacy-and-security/security-config#CleartextTraffic) is already properly configured in the network config.

### Short description

- Increase target and compile SDKs to 37.
- Handle `ACCESS_LOCAL_NETWORK` permission when configuring servers on the local network.

> [!TIP]
> non-ose should also be updated, though it shouldn't need any changes, just increase SDK.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

