### PR TITLE
Add calendar local-only name override

### DIFF
--- a/core/schemas/at.bitfire.davdroid.db.AppDatabase/19.json
+++ b/core/schemas/at.bitfire.davdroid.db.AppDatabase/19.json
@@ -1,0 +1,575 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 19,
+    "identityHash": "c7a25ca8d8ab8024266ea18b0d7c675a",
+    "entities": [
+      {
+        "tableName": "service",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `accountName` TEXT NOT NULL, `type` TEXT NOT NULL, `principal` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountName",
+            "columnName": "accountName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "principal",
+            "columnName": "principal",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": ["id"]
+        },
+        "indices": [
+          {
+            "name": "index_service_accountName_type",
+            "unique": true,
+            "columnNames": ["accountName", "type"],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_service_accountName_type` ON `${TABLE_NAME}` (`accountName`, `type`)"
+          }
+        ]
+      },
+      {
+        "tableName": "homeset",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `serviceId` INTEGER NOT NULL, `personal` INTEGER NOT NULL, `url` TEXT NOT NULL, `privBind` INTEGER NOT NULL, `displayName` TEXT, FOREIGN KEY(`serviceId`) REFERENCES `service`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serviceId",
+            "columnName": "serviceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personal",
+            "columnName": "personal",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "privBind",
+            "columnName": "privBind",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": ["id"]
+        },
+        "indices": [
+          {
+            "name": "index_homeset_serviceId_url",
+            "unique": true,
+            "columnNames": ["serviceId", "url"],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_homeset_serviceId_url` ON `${TABLE_NAME}` (`serviceId`, `url`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "service",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": ["serviceId"],
+            "referencedColumns": ["id"]
+          }
+        ]
+      },
+      {
+        "tableName": "collection",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `serviceId` INTEGER NOT NULL, `homeSetId` INTEGER, `ownerId` INTEGER, `type` TEXT NOT NULL, `url` TEXT NOT NULL, `privWriteContent` INTEGER NOT NULL, `privUnbind` INTEGER NOT NULL, `forceReadOnly` INTEGER NOT NULL, `displayName` TEXT, `localDisplayName` TEXT, `description` TEXT, `color` INTEGER, `timezoneId` TEXT, `supportsVEVENT` INTEGER, `supportsVTODO` INTEGER, `supportsVJOURNAL` INTEGER, `source` TEXT, `sync` INTEGER NOT NULL, `pushTopic` TEXT, `supportsWebPush` INTEGER NOT NULL DEFAULT 0, `pushVapidKey` TEXT, `pushSubscription` TEXT, `pushSubscriptionExpires` INTEGER, `pushSubscriptionCreated` INTEGER, FOREIGN KEY(`serviceId`) REFERENCES `service`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`homeSetId`) REFERENCES `homeset`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL , FOREIGN KEY(`ownerId`) REFERENCES `principal`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serviceId",
+            "columnName": "serviceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "homeSetId",
+            "columnName": "homeSetId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "privWriteContent",
+            "columnName": "privWriteContent",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "privUnbind",
+            "columnName": "privUnbind",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "forceReadOnly",
+            "columnName": "forceReadOnly",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localDisplayName",
+            "columnName": "localDisplayName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "timezoneId",
+            "columnName": "timezoneId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "supportsVEVENT",
+            "columnName": "supportsVEVENT",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "supportsVTODO",
+            "columnName": "supportsVTODO",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "supportsVJOURNAL",
+            "columnName": "supportsVJOURNAL",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sync",
+            "columnName": "sync",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pushTopic",
+            "columnName": "pushTopic",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "supportsWebPush",
+            "columnName": "supportsWebPush",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "pushVapidKey",
+            "columnName": "pushVapidKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pushSubscription",
+            "columnName": "pushSubscription",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pushSubscriptionExpires",
+            "columnName": "pushSubscriptionExpires",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pushSubscriptionCreated",
+            "columnName": "pushSubscriptionCreated",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": ["id"]
+        },
+        "indices": [
+          {
+            "name": "index_collection_serviceId_type",
+            "unique": false,
+            "columnNames": ["serviceId", "type"],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_serviceId_type` ON `${TABLE_NAME}` (`serviceId`, `type`)"
+          },
+          {
+            "name": "index_collection_homeSetId_type",
+            "unique": false,
+            "columnNames": ["homeSetId", "type"],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_homeSetId_type` ON `${TABLE_NAME}` (`homeSetId`, `type`)"
+          },
+          {
+            "name": "index_collection_ownerId_type",
+            "unique": false,
+            "columnNames": ["ownerId", "type"],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_ownerId_type` ON `${TABLE_NAME}` (`ownerId`, `type`)"
+          },
+          {
+            "name": "index_collection_pushTopic_type",
+            "unique": false,
+            "columnNames": ["pushTopic", "type"],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_pushTopic_type` ON `${TABLE_NAME}` (`pushTopic`, `type`)"
+          },
+          {
+            "name": "index_collection_url",
+            "unique": false,
+            "columnNames": ["url"],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_url` ON `${TABLE_NAME}` (`url`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "service",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": ["serviceId"],
+            "referencedColumns": ["id"]
+          },
+          {
+            "table": "homeset",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": ["homeSetId"],
+            "referencedColumns": ["id"]
+          },
+          {
+            "table": "principal",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": ["ownerId"],
+            "referencedColumns": ["id"]
+          }
+        ]
+      },
+      {
+        "tableName": "principal",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `serviceId` INTEGER NOT NULL, `url` TEXT NOT NULL, `displayName` TEXT, FOREIGN KEY(`serviceId`) REFERENCES `service`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serviceId",
+            "columnName": "serviceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": ["id"]
+        },
+        "indices": [
+          {
+            "name": "index_principal_serviceId_url",
+            "unique": true,
+            "columnNames": ["serviceId", "url"],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_principal_serviceId_url` ON `${TABLE_NAME}` (`serviceId`, `url`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "service",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": ["serviceId"],
+            "referencedColumns": ["id"]
+          }
+        ]
+      },
+      {
+        "tableName": "syncstats",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `collectionId` INTEGER NOT NULL, `dataType` TEXT NOT NULL, `lastSync` INTEGER NOT NULL, FOREIGN KEY(`collectionId`) REFERENCES `collection`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dataType",
+            "columnName": "dataType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSync",
+            "columnName": "lastSync",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": ["id"]
+        },
+        "indices": [
+          {
+            "name": "index_syncstats_collectionId_dataType",
+            "unique": true,
+            "columnNames": ["collectionId", "dataType"],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_syncstats_collectionId_dataType` ON `${TABLE_NAME}` (`collectionId`, `dataType`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "collection",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": ["collectionId"],
+            "referencedColumns": ["id"]
+          }
+        ]
+      },
+      {
+        "tableName": "webdav_document",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `mountId` INTEGER NOT NULL, `parentId` INTEGER, `name` TEXT NOT NULL, `isDirectory` INTEGER NOT NULL, `displayName` TEXT, `mimeType` TEXT, `eTag` TEXT, `lastModified` INTEGER, `size` INTEGER, `mayBind` INTEGER, `mayUnbind` INTEGER, `mayWriteContent` INTEGER, `quotaAvailable` INTEGER, `quotaUsed` INTEGER, FOREIGN KEY(`mountId`) REFERENCES `webdav_mount`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`parentId`) REFERENCES `webdav_document`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mountId",
+            "columnName": "mountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDirectory",
+            "columnName": "isDirectory",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mimeType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "eTag",
+            "columnName": "eTag",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mayBind",
+            "columnName": "mayBind",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mayUnbind",
+            "columnName": "mayUnbind",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mayWriteContent",
+            "columnName": "mayWriteContent",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "quotaAvailable",
+            "columnName": "quotaAvailable",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "quotaUsed",
+            "columnName": "quotaUsed",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": ["id"]
+        },
+        "indices": [
+          {
+            "name": "index_webdav_document_mountId_parentId_name",
+            "unique": true,
+            "columnNames": ["mountId", "parentId", "name"],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_webdav_document_mountId_parentId_name` ON `${TABLE_NAME}` (`mountId`, `parentId`, `name`)"
+          },
+          {
+            "name": "index_webdav_document_parentId",
+            "unique": false,
+            "columnNames": ["parentId"],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_webdav_document_parentId` ON `${TABLE_NAME}` (`parentId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "webdav_mount",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": ["mountId"],
+            "referencedColumns": ["id"]
+          },
+          {
+            "table": "webdav_document",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": ["parentId"],
+            "referencedColumns": ["id"]
+          }
+        ]
+      },
+      {
+        "tableName": "webdav_mount",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `url` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": ["id"]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c7a25ca8d8ab8024266ea18b0d7c675a')"
+    ]
+  }
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/db/AppDatabase.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/AppDatabase.kt
@@ -50,7 +50,8 @@ import javax.inject.Singleton
     SyncStats::class,
     WebDavDocument::class,
     WebDavMount::class
-], exportSchema = true, version = 18, autoMigrations = [
+], exportSchema = true, version = 19, autoMigrations = [
+    AutoMigration(from = 18, to = 19),      // collection: add localDisplayName
     AutoMigration(from = 17, to = 18, spec = AutoMigration18::class),
     AutoMigration(from = 16, to = 17),      // collection: add VAPID key
     AutoMigration(from = 15, to = 16, spec = AutoMigration16::class),

--- a/core/src/main/kotlin/at/bitfire/davdroid/db/Collection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/Collection.kt
@@ -107,8 +107,10 @@ data class Collection(
      */
     val displayName: String? = null,
     /**
-     * User-defined local name that overrides [displayName] when shown in the app and to the
-     * Android system (e.g. CalendarProvider). The server-side name is never changed.
+     * User-defined local name that overrides [displayName] when shown in the app and, for
+     * calendar collections, when synced to the Android CalendarProvider. The server-side
+     * name is never changed.
+     *
      * `null` means no local override (use the server's [displayName]).
      */
     val localDisplayName: String? = null,

--- a/core/src/main/kotlin/at/bitfire/davdroid/db/Collection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/Collection.kt
@@ -107,6 +107,12 @@ data class Collection(
      */
     val displayName: String? = null,
     /**
+     * User-defined local name that overrides [displayName] when shown in the app and to the
+     * Android system (e.g. CalendarProvider). The server-side name is never changed.
+     * `null` means no local override (use the server's [displayName]).
+     */
+    val localDisplayName: String? = null,
+    /**
      * Human-readable description of the collection
      */
     val description: String? = null,
@@ -262,7 +268,7 @@ data class Collection(
 
     // calculated properties
 
-    fun title() = displayName ?: url.lastSegment
+    fun title() = localDisplayName ?: displayName ?: url.lastSegment
     fun readOnly() = forceReadOnly || !privWriteContent
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/db/CollectionDao.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/CollectionDao.kt
@@ -103,6 +103,9 @@ interface CollectionDao {
     @Query("UPDATE collection SET forceReadOnly=:forceReadOnly WHERE id=:id")
     suspend fun updateForceReadOnly(id: Long, forceReadOnly: Boolean)
 
+    @Query("UPDATE collection SET localDisplayName=:localDisplayName WHERE id=:id")
+    suspend fun updateLocalDisplayName(id: Long, localDisplayName: String?)
+
     @Query("UPDATE collection SET pushSubscription=:pushSubscription, pushSubscriptionExpires=:pushSubscriptionExpires, pushSubscriptionCreated=:updatedAt WHERE id=:id")
     suspend fun updatePushSubscription(id: Long, pushSubscription: String?, pushSubscriptionExpires: Long?, updatedAt: Long = System.currentTimeMillis()/1000)
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/db/CollectionDao.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/CollectionDao.kt
@@ -32,7 +32,7 @@ interface CollectionDao {
     @Query("SELECT * FROM collection WHERE serviceId=:serviceId AND homeSetId IS :homeSetId")
     fun getByServiceAndHomeset(serviceId: Long, homeSetId: Long?): List<Collection>
 
-    @Query("SELECT * FROM collection WHERE serviceId=:serviceId AND type=:type ORDER BY displayName COLLATE NOCASE, url COLLATE NOCASE")
+    @Query("SELECT * FROM collection WHERE serviceId=:serviceId AND type=:type ORDER BY COALESCE(localDisplayName, displayName) COLLATE NOCASE, url COLLATE NOCASE")
     fun getByServiceAndType(serviceId: Long, @CollectionType type: String): List<Collection>
 
     @Query("SELECT * FROM collection WHERE pushTopic=:topic AND sync")
@@ -57,25 +57,25 @@ interface CollectionDao {
      *   - have supportsVEVENT = supportsVTODO = null (= address books)
      */
     @Query("SELECT * FROM collection WHERE serviceId=:serviceId AND type=:type " +
-            "AND (supportsVTODO OR supportsVEVENT OR supportsVJOURNAL OR (supportsVEVENT IS NULL AND supportsVTODO IS NULL AND supportsVJOURNAL IS NULL)) ORDER BY displayName COLLATE NOCASE, URL COLLATE NOCASE")
+            "AND (supportsVTODO OR supportsVEVENT OR supportsVJOURNAL OR (supportsVEVENT IS NULL AND supportsVTODO IS NULL AND supportsVJOURNAL IS NULL)) ORDER BY COALESCE(localDisplayName, displayName) COLLATE NOCASE, URL COLLATE NOCASE")
     fun pageByServiceAndType(serviceId: Long, @CollectionType type: String): PagingSource<Int, Collection>
 
     @Query("SELECT * FROM collection WHERE serviceId=:serviceId AND sync")
     fun getByServiceAndSync(serviceId: Long): List<Collection>
 
-    @Query("SELECT collection.* FROM collection, homeset WHERE collection.serviceId=:serviceId AND type=:type AND homeSetId=homeset.id AND homeset.personal ORDER BY collection.displayName COLLATE NOCASE, collection.url COLLATE NOCASE")
+    @Query("SELECT collection.* FROM collection, homeset WHERE collection.serviceId=:serviceId AND type=:type AND homeSetId=homeset.id AND homeset.personal ORDER BY COALESCE(collection.localDisplayName, collection.displayName) COLLATE NOCASE, collection.url COLLATE NOCASE")
     fun pagePersonalByServiceAndType(serviceId: Long, @CollectionType type: String): PagingSource<Int, Collection>
 
     @Query("SELECT * FROM collection WHERE serviceId=:serviceId AND url=:url")
     fun getByServiceAndUrl(serviceId: Long, url: String): Collection?
 
-    @Query("SELECT * FROM collection WHERE serviceId=:serviceId AND type='${Collection.TYPE_CALENDAR}' AND supportsVEVENT AND sync ORDER BY displayName COLLATE NOCASE, url COLLATE NOCASE")
+    @Query("SELECT * FROM collection WHERE serviceId=:serviceId AND type='${Collection.TYPE_CALENDAR}' AND supportsVEVENT AND sync ORDER BY COALESCE(localDisplayName, displayName) COLLATE NOCASE, url COLLATE NOCASE")
     fun getSyncCalendars(serviceId: Long): List<Collection>
 
-    @Query("SELECT * FROM collection WHERE serviceId=:serviceId AND type='${Collection.TYPE_CALENDAR}' AND (supportsVTODO OR supportsVJOURNAL) AND sync ORDER BY displayName COLLATE NOCASE, url COLLATE NOCASE")
+    @Query("SELECT * FROM collection WHERE serviceId=:serviceId AND type='${Collection.TYPE_CALENDAR}' AND (supportsVTODO OR supportsVJOURNAL) AND sync ORDER BY COALESCE(localDisplayName, displayName) COLLATE NOCASE, url COLLATE NOCASE")
     fun getSyncJtxCollections(serviceId: Long): List<Collection>
 
-    @Query("SELECT * FROM collection WHERE serviceId=:serviceId AND type='${Collection.TYPE_CALENDAR}' AND supportsVTODO AND sync ORDER BY displayName COLLATE NOCASE, url COLLATE NOCASE")
+    @Query("SELECT * FROM collection WHERE serviceId=:serviceId AND type='${Collection.TYPE_CALENDAR}' AND supportsVTODO AND sync ORDER BY COALESCE(localDisplayName, displayName) COLLATE NOCASE, url COLLATE NOCASE")
     fun getSyncTaskLists(serviceId: Long): List<Collection>
 
     /**

--- a/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
@@ -25,6 +25,7 @@ import at.bitfire.davdroid.di.qualifier.IoDispatcher
 import at.bitfire.davdroid.network.HttpClientBuilder
 import at.bitfire.davdroid.servicedetection.RefreshCollectionsWorker
 import at.bitfire.davdroid.util.DavUtils
+import at.bitfire.davdroid.util.trimToNull
 import dagger.Lazy
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
@@ -271,7 +272,7 @@ class DavCollectionRepository @Inject constructor(
      * Does not change the collection on the server.
      */
     suspend fun setLocalDisplayName(id: Long, localDisplayName: String?) {
-        dao.updateLocalDisplayName(id, localDisplayName?.trim()?.ifEmpty { null })
+        dao.updateLocalDisplayName(id, localDisplayName.trimToNull())
     }
 
     /**

--- a/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
@@ -262,6 +262,14 @@ class DavCollectionRepository @Inject constructor(
     }
 
     /**
+     * Sets the local display name override (or clears it when [localDisplayName] is null/blank).
+     * Does not change the collection on the server.
+     */
+    suspend fun setLocalDisplayName(id: Long, localDisplayName: String?) {
+        dao.updateLocalDisplayName(id, localDisplayName?.trim()?.ifEmpty { null })
+    }
+
+    /**
      * Whether or not the local collection should be synced with the server
      */
     suspend fun setSync(id: Long, forceReadOnly: Boolean) {

--- a/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
@@ -215,9 +215,10 @@ class DavCollectionRepository @Inject constructor(
     /**
      * Inserts or updates the collection.
      *
-     * On update, it will _not_ update the flags
-     *  - [Collection.sync] and
-     *  - [Collection.forceReadOnly],
+     * On update, it will _not_ update the user-controlled fields
+     *  - [Collection.sync],
+     *  - [Collection.forceReadOnly] and
+     *  - [Collection.localDisplayName],
      *  but use the values of the already existing collection.
      *
      * @param newCollection Collection to be inserted or updated
@@ -228,7 +229,11 @@ class DavCollectionRepository @Inject constructor(
             val oldCollection = dao.getByServiceAndUrl(newCollection.serviceId, newCollection.url.toString())
             val newCollectionWithFlags =
                 if (oldCollection != null)
-                    newCollection.copy(sync = oldCollection.sync, forceReadOnly = oldCollection.forceReadOnly)
+                    newCollection.copy(
+                        sync = oldCollection.sync,
+                        forceReadOnly = oldCollection.forceReadOnly,
+                        localDisplayName = oldCollection.localDisplayName
+                    )
                 else
                     newCollection
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendarStore.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendarStore.kt
@@ -104,10 +104,10 @@ class LocalCalendarStore @Inject constructor(
     }
 
     private fun valuesFromCollectionInfo(info: Collection, withColor: Boolean): ContentValues {
+        val serverDisplayName = if (info.displayName.isNullOrBlank()) info.url.lastSegment else info.displayName
         val values = contentValuesOf(
             Calendars._SYNC_ID to info.id,
-            Calendars.CALENDAR_DISPLAY_NAME to
-                    if (info.displayName.isNullOrBlank()) info.url.lastSegment else info.displayName,
+            Calendars.CALENDAR_DISPLAY_NAME to (info.localDisplayName ?: serverDisplayName),
 
             Calendars.ALLOWED_AVAILABILITY to arrayOf(
                 Events.AVAILABILITY_BUSY,

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionScreen.kt
@@ -66,6 +66,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import at.bitfire.davdroid.R
+import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.repository.DavSyncStatsRepository
 import at.bitfire.davdroid.sync.SyncDataType
 import at.bitfire.davdroid.ui.composable.AppTheme
@@ -139,6 +140,7 @@ fun CollectionScreen(
     displayName: String? = null,
     localDisplayName: String? = null,
     onSetLocalDisplayName: (String?) -> Unit = {},
+    supportsLocalRename: Boolean = false,
     description: String? = null,
     owner: String? = null,
     lastSynced: List<DavSyncStatsRepository.LastSynced> = emptyList(),
@@ -254,31 +256,33 @@ fun CollectionScreen(
                         }
                     )
 
-                    var showRenameDialog by remember { mutableStateOf(false) }
-                    CollectionScreen_Entry(
-                        icon = Icons.Default.DriveFileRenameOutline,
-                        title = stringResource(R.string.collection_local_rename),
-                        text = localDisplayName ?: stringResource(R.string.collection_local_rename_off),
-                        onClick = { showRenameDialog = true },
-                        control = {
-                            Switch(
-                                checked = localDisplayName != null,
-                                onCheckedChange = { enabled ->
-                                    if (enabled) showRenameDialog = true
-                                    else onSetLocalDisplayName(null)
-                                }
-                            )
-                        }
-                    )
-                    if (showRenameDialog)
-                        LocalRenameDialog(
-                            initialName = localDisplayName ?: displayName ?: title,
-                            onDismiss = { showRenameDialog = false },
-                            onConfirm = { newName ->
-                                onSetLocalDisplayName(newName)
-                                showRenameDialog = false
+                    if (supportsLocalRename) {
+                        var showRenameDialog by remember { mutableStateOf(false) }
+                        CollectionScreen_Entry(
+                            icon = Icons.Default.DriveFileRenameOutline,
+                            title = stringResource(R.string.collection_local_rename),
+                            text = localDisplayName ?: stringResource(R.string.collection_local_rename_off),
+                            onClick = { showRenameDialog = true },
+                            control = {
+                                Switch(
+                                    checked = localDisplayName != null,
+                                    onCheckedChange = { enabled ->
+                                        if (enabled) showRenameDialog = true
+                                        else onSetLocalDisplayName(null)
+                                    }
+                                )
                             }
                         )
+                        if (showRenameDialog)
+                            LocalRenameDialog(
+                                initialName = localDisplayName ?: displayName ?: title,
+                                onDismiss = { showRenameDialog = false },
+                                onConfirm = { newName ->
+                                    onSetLocalDisplayName(newName)
+                                    showRenameDialog = false
+                                }
+                            )
+                    }
 
                     if (displayName != null)
                         CollectionScreen_Entry(
@@ -454,6 +458,7 @@ fun CollectionScreen_Preview() {
         title = "Some Calendar, with some additional text to make it wrap around and stuff.",
         displayName = "Some Calendar, with some additional text to make it wrap around and stuff.",
         localDisplayName = "My Local Name",
+        supportsLocalRename = true,
         description = "This is some description of the calendar. It can be long and wrap around.",
         owner = "Some One",
         lastSynced = listOf(

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionScreen.kt
@@ -109,6 +109,7 @@ fun CollectionScreen(
         displayName = collection.displayName,
         localDisplayName = collection.localDisplayName,
         onSetLocalDisplayName = model::setLocalDisplayName,
+        supportsLocalRename = collection.type == Collection.TYPE_CALENDAR || collection.type == Collection.TYPE_WEBCAL,
         description = collection.description,
         owner = model.owner.collectAsStateWithLifecycle(null).value,
         localItemCounts = model.localItemCounts.collectAsStateWithLifecycle(initialValue = emptyList()).value,

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionScreen.kt
@@ -264,8 +264,10 @@ fun CollectionScreen(
                             text = localDisplayName ?: stringResource(R.string.collection_local_rename_off),
                             onClick = { showRenameDialog = true },
                             control = {
+                                // Reflect "pending on" while the dialog is open so the switch state
+                                // matches the user's tap immediately (flips back if they cancel).
                                 Switch(
-                                    checked = localDisplayName != null,
+                                    checked = localDisplayName != null || showRenameDialog,
                                     onCheckedChange = { enabled ->
                                         if (enabled) showRenameDialog = true
                                         else onSetLocalDisplayName(null)
@@ -406,7 +408,9 @@ fun CollectionScreen_Entry(
 ) {
     Row(
         verticalAlignment = if (content != null) Alignment.Top else Alignment.CenterVertically,
-        modifier = if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier
+        modifier = Modifier
+            .fillMaxWidth()
+            .let { if (onClick != null) it.clickable(onClick = onClick) else it }
     ) {
         if (icon != null)
             Icon(

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionScreen.kt
@@ -5,6 +5,7 @@
 package at.bitfire.davdroid.ui.account
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -15,6 +16,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -24,6 +27,7 @@ import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.CloudSync
 import androidx.compose.material.icons.filled.DeleteForever
 import androidx.compose.material.icons.filled.DoNotDisturbOn
+import androidx.compose.material.icons.filled.DriveFileRenameOutline
 import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -37,18 +41,25 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -96,6 +107,8 @@ fun CollectionScreen(
         onSetForceReadOnly = model::setForceReadOnly,
         title = collection.title(),
         displayName = collection.displayName,
+        localDisplayName = collection.localDisplayName,
+        onSetLocalDisplayName = model::setLocalDisplayName,
         description = collection.description,
         owner = model.owner.collectAsStateWithLifecycle(null).value,
         localItemCounts = model.localItemCounts.collectAsStateWithLifecycle(initialValue = emptyList()).value,
@@ -123,6 +136,8 @@ fun CollectionScreen(
     onSetForceReadOnly: (Boolean) -> Unit = {},
     title: String,
     displayName: String? = null,
+    localDisplayName: String? = null,
+    onSetLocalDisplayName: (String?) -> Unit = {},
     description: String? = null,
     owner: String? = null,
     lastSynced: List<DavSyncStatsRepository.LastSynced> = emptyList(),
@@ -238,10 +253,36 @@ fun CollectionScreen(
                         }
                     )
 
+                    var showRenameDialog by remember { mutableStateOf(false) }
+                    CollectionScreen_Entry(
+                        icon = Icons.Default.DriveFileRenameOutline,
+                        title = stringResource(R.string.collection_local_rename),
+                        text = localDisplayName ?: stringResource(R.string.collection_local_rename_off),
+                        onClick = { showRenameDialog = true },
+                        control = {
+                            Switch(
+                                checked = localDisplayName != null,
+                                onCheckedChange = { enabled ->
+                                    if (enabled) showRenameDialog = true
+                                    else onSetLocalDisplayName(null)
+                                }
+                            )
+                        }
+                    )
+                    if (showRenameDialog)
+                        LocalRenameDialog(
+                            initialName = localDisplayName ?: displayName ?: title,
+                            onDismiss = { showRenameDialog = false },
+                            onConfirm = { newName ->
+                                onSetLocalDisplayName(newName)
+                                showRenameDialog = false
+                            }
+                        )
+
                     if (displayName != null)
                         CollectionScreen_Entry(
                             title = stringResource(R.string.collection_title),
-                            text = title
+                            text = displayName
                         )
 
                     if (description != null)
@@ -354,11 +395,13 @@ fun CollectionScreen_Entry(
     title: String? = null,
     text: String? = null,
     isLast: Boolean = false,
+    onClick: (() -> Unit)? = null,
     control: @Composable (() -> Unit)? = null,
     content: @Composable (() -> Unit)? = null
 ) {
     Row(
-        verticalAlignment = if (content != null) Alignment.Top else Alignment.CenterVertically
+        verticalAlignment = if (content != null) Alignment.Top else Alignment.CenterVertically,
+        modifier = if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier
     ) {
         if (icon != null)
             Icon(
@@ -409,6 +452,7 @@ fun CollectionScreen_Preview() {
         url = "https://example.com/calendar",
         title = "Some Calendar, with some additional text to make it wrap around and stuff.",
         displayName = "Some Calendar, with some additional text to make it wrap around and stuff.",
+        localDisplayName = "My Local Name",
         description = "This is some description of the calendar. It can be long and wrap around.",
         owner = "Some One",
         lastSynced = listOf(
@@ -475,4 +519,65 @@ fun DeleteCollectionDialog_Preview() {
     DeleteCollectionDialog(
         displayName = "Some Calendar"
     )
+}
+
+
+@Composable
+fun LocalRenameDialog(
+    initialName: String,
+    onDismiss: () -> Unit = {},
+    onConfirm: (newName: String) -> Unit = {}
+) {
+    var name by remember {
+        mutableStateOf(TextFieldValue(initialName, selection = TextRange(initialName.length)))
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = { Icon(Icons.Default.DriveFileRenameOutline, contentDescription = null) },
+        title = { Text(stringResource(R.string.collection_local_rename)) },
+        text = {
+            Column {
+                Text(
+                    stringResource(R.string.collection_local_rename_description),
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+
+                val focusRequester = remember { FocusRequester() }
+                TextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text(stringResource(R.string.collection_local_rename_label)) },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    keyboardActions = KeyboardActions(
+                        onDone = { if (name.text.isNotBlank()) onConfirm(name.text) }
+                    ),
+                    modifier = Modifier.focusRequester(focusRequester)
+                )
+                LaunchedEffect(Unit) {
+                    focusRequester.requestFocus()
+                }
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = { onConfirm(name.text) },
+                enabled = name.text.isNotBlank()
+            ) {
+                Text(stringResource(R.string.dialog_save))
+            }
+        },
+        dismissButton = {
+            OutlinedButton(onClick = onDismiss) {
+                Text(stringResource(android.R.string.cancel))
+            }
+        }
+    )
+}
+
+@Composable
+@Preview
+fun LocalRenameDialog_Preview() {
+    LocalRenameDialog(initialName = "My Calendar")
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.input.ImeAction
@@ -410,7 +411,7 @@ fun CollectionScreen_Entry(
         verticalAlignment = if (content != null) Alignment.Top else Alignment.CenterVertically,
         modifier = Modifier
             .fillMaxWidth()
-            .let { if (onClick != null) it.clickable(onClick = onClick) else it }
+            .let { if (onClick != null) it.clickable(role = Role.Button, onClick = onClick) else it }
     ) {
         if (icon != null)
             Icon(

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionScreenModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionScreenModel.kt
@@ -196,6 +196,13 @@ class CollectionScreenModel @AssistedInject constructor(
         }
     }
 
+    fun setLocalDisplayName(localDisplayName: String?) {
+        viewModelScope.launch {
+            collectionRepository.setLocalDisplayName(collectionId, localDisplayName)
+            collectionSelectedUseCase.get().handleWithDelay(collectionId)
+        }
+    }
+
     fun setSync(sync: Boolean) {
         viewModelScope.launch {
             collectionRepository.setSync(collectionId, sync)

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="dialog_remove">Remove</string>
     <string name="dialog_deny">Cancel</string>
     <string name="dialog_enable">Enable</string>
+    <string name="dialog_save">Save</string>
     <string name="field_required">This field is required</string>
     <string name="help">Help</string>
     <string name="navigate_up">Navigate up</string>
@@ -458,6 +459,10 @@
     <string name="collection_read_only_by_setting">Read-only (by policy)</string>
     <string name="collection_read_only_forced">Read-only (only locally)</string>
     <string name="collection_read_write">Read/write</string>
+    <string name="collection_local_rename">Local rename</string>
+    <string name="collection_local_rename_off">Use server name</string>
+    <string name="collection_local_rename_label">Local name</string>
+    <string name="collection_local_rename_description">Show this collection under a different name on this device. The name on the server is not changed.</string>
     <string name="collection_title">Title</string>
     <string name="collection_description">Description</string>
     <string name="collection_owner">Owner</string>


### PR DESCRIPTION
### Purpose

Let users give calendars a local-only display name that differs from the server-side one. The override is shown in DAVx5 and used as `CALENDAR_DISPLAY_NAME` in the Android CalendarProvider, while the DAV collection on the server remains unchanged. This is useful when the server-provided name is generic, duplicated across accounts, or just not how the user wants to see the calendar on their device.

### Short description

- Added nullable `localDisplayName` column to the `Collection` entity (auto-migration 18 → 19).
- `Collection.title()` now prefers `localDisplayName` over the server `displayName`.
- `LocalCalendarStore` writes `localDisplayName` (if set) to `Calendars.CALENDAR_DISPLAY_NAME`, so renames are picked up by the CalendarProvider on the next update.
- Added `DavCollectionRepository.setLocalDisplayName()` (trims blanks → `null`) and wired it through `CollectionScreenModel`.
- UI: new "Local rename" entry on the collection screen with a `Switch` and a rename dialog. Entry is gated to `TYPE_CALENDAR` and `TYPE_WEBCAL` — address books are excluded for now.
- `insertOrUpdateByUrlRememberSync` preserves `localDisplayName` in addition to `sync` and `forceReadOnly`, so a "Refresh list" dose not wipe the override.

Not included: local rename for address books (requires a separate decision because Android Contacts shows the raw account name, not a per-account-local name).

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

