### PR TITLE
Use auto-sizing text for intro slogan

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/intro/WelcomePage.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/intro/WelcomePage.kt
@@ -96,7 +96,6 @@ class WelcomePage: IntroPage() {
                 maxLines = 2, // Important for TextAutoSize not to grow too big
                 color = { Color.White },
                 style = MaterialTheme.typography.labelLarge.copy(
-                    fontSize = 28.sp, // Minimum size, but TextAutoSize decreases below if missing space
                     lineHeight = 1.1.em,
                     textAlign = TextAlign.Center,
                 ),

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/intro/WelcomePage.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/intro/WelcomePage.kt
@@ -90,6 +90,8 @@ class WelcomePage: IntroPage() {
                     .padding(horizontal = 16.dp)
             )
 
+            // Note: We don't want words to break ever and get smaller instead,
+            // this current solution still breaks very long words however
             BasicText(
                 text = stringResource(R.string.intro_slogan2),
                 autoSize = TextAutoSize.StepBased(maxFontSize = 48.sp), // Don't make short words too big

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/intro/WelcomePage.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/intro/WelcomePage.kt
@@ -16,6 +16,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeContentPadding
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -87,12 +89,16 @@ class WelcomePage: IntroPage() {
                     .padding(horizontal = 16.dp)
             )
 
-            Text(
+            BasicText(
                 text = stringResource(R.string.intro_slogan2),
-                color = Color.White,
-                style = MaterialTheme.typography.labelLarge.copy(fontSize = 48.sp),
-                lineHeight = 52.sp,
-                textAlign = TextAlign.Center,
+                autoSize = TextAutoSize.StepBased(maxFontSize = 48.sp),
+                maxLines = 2, // Important for TextAutoSize not to grow too big
+                color = { Color.White },
+                style = MaterialTheme.typography.labelLarge.copy(
+                    fontSize = 28.sp, // Minimum size, but TextAutoSize decreases below if missing space
+                    lineHeight = 52.sp,
+                    textAlign = TextAlign.Center,
+                ),
                 modifier = Modifier
                     .fillMaxWidth()
                     .wrapContentHeight()

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/intro/WelcomePage.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/intro/WelcomePage.kt
@@ -92,7 +92,7 @@ class WelcomePage: IntroPage() {
 
             BasicText(
                 text = stringResource(R.string.intro_slogan2),
-                autoSize = TextAutoSize.StepBased(maxFontSize = 48.sp),
+                autoSize = TextAutoSize.StepBased(maxFontSize = 48.sp), // Don't make short words too big
                 maxLines = 2, // Important for TextAutoSize not to grow too big
                 color = { Color.White },
                 style = MaterialTheme.typography.labelLarge.copy(

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/intro/WelcomePage.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/intro/WelcomePage.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.ui.composable.AppTheme
@@ -96,7 +97,7 @@ class WelcomePage: IntroPage() {
                 color = { Color.White },
                 style = MaterialTheme.typography.labelLarge.copy(
                     fontSize = 28.sp, // Minimum size, but TextAutoSize decreases below if missing space
-                    lineHeight = 52.sp,
+                    lineHeight = 1.1.em,
                     textAlign = TextAlign.Center,
                 ),
                 modifier = Modifier


### PR DESCRIPTION
### Purpose

The intro slogan text could line break weirdly, this fixes it.


### Short description

- Use auto-sizing text for intro slogan

<details>

<summary>Screenshots</summary>


<img width="719" height="511" alt="Screenshot From 2026-04-20 11-30-55" src="https://github.com/user-attachments/assets/97e45ce2-3929-469f-be3b-6e525c6b22b0" />

<img width="696" height="604" alt="image" src="https://github.com/user-attachments/assets/18834e71-39aa-41ef-96de-e4119d3138aa" />


<img width="696" height="604" alt="Screenshot From 2026-04-20 11-38-11" src="https://github.com/user-attachments/assets/ad3019d2-1ca0-4ca5-a66a-1553aebaf788" />

<img width="696" height="604" alt="Screenshot From 2026-04-20 11-35-18" src="https://github.com/user-attachments/assets/f34c8804-f43b-49ff-9e78-324c21afbb8e" />


</details>

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

