### PR TITLE
Bind push distributor expiration to endpoint

### DIFF
--- a/core/schemas/at.bitfire.davdroid.db.AppDatabase/19.json
+++ b/core/schemas/at.bitfire.davdroid.db.AppDatabase/19.json
@@ -1,0 +1,653 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 19,
+    "identityHash": "4a533c4de0ba1548684768eba9612331",
+    "entities": [
+      {
+        "tableName": "service",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `accountName` TEXT NOT NULL, `type` TEXT NOT NULL, `principal` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountName",
+            "columnName": "accountName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "principal",
+            "columnName": "principal",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_service_accountName_type",
+            "unique": true,
+            "columnNames": [
+              "accountName",
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_service_accountName_type` ON `${TABLE_NAME}` (`accountName`, `type`)"
+          }
+        ]
+      },
+      {
+        "tableName": "homeset",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `serviceId` INTEGER NOT NULL, `personal` INTEGER NOT NULL, `url` TEXT NOT NULL, `privBind` INTEGER NOT NULL, `displayName` TEXT, FOREIGN KEY(`serviceId`) REFERENCES `service`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serviceId",
+            "columnName": "serviceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personal",
+            "columnName": "personal",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "privBind",
+            "columnName": "privBind",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_homeset_serviceId_url",
+            "unique": true,
+            "columnNames": [
+              "serviceId",
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_homeset_serviceId_url` ON `${TABLE_NAME}` (`serviceId`, `url`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "service",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serviceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "collection",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `serviceId` INTEGER NOT NULL, `homeSetId` INTEGER, `ownerId` INTEGER, `type` TEXT NOT NULL, `url` TEXT NOT NULL, `privWriteContent` INTEGER NOT NULL, `privUnbind` INTEGER NOT NULL, `forceReadOnly` INTEGER NOT NULL, `displayName` TEXT, `description` TEXT, `color` INTEGER, `timezoneId` TEXT, `supportsVEVENT` INTEGER, `supportsVTODO` INTEGER, `supportsVJOURNAL` INTEGER, `source` TEXT, `sync` INTEGER NOT NULL, `pushTopic` TEXT, `supportsWebPush` INTEGER NOT NULL DEFAULT 0, `pushVapidKey` TEXT, `pushSubscription` TEXT, `pushRegisteredEndpoint` TEXT, `pushSubscriptionExpires` INTEGER, `pushSubscriptionCreated` INTEGER, FOREIGN KEY(`serviceId`) REFERENCES `service`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`homeSetId`) REFERENCES `homeset`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL , FOREIGN KEY(`ownerId`) REFERENCES `principal`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serviceId",
+            "columnName": "serviceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "homeSetId",
+            "columnName": "homeSetId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "privWriteContent",
+            "columnName": "privWriteContent",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "privUnbind",
+            "columnName": "privUnbind",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "forceReadOnly",
+            "columnName": "forceReadOnly",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "timezoneId",
+            "columnName": "timezoneId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "supportsVEVENT",
+            "columnName": "supportsVEVENT",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "supportsVTODO",
+            "columnName": "supportsVTODO",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "supportsVJOURNAL",
+            "columnName": "supportsVJOURNAL",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sync",
+            "columnName": "sync",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pushTopic",
+            "columnName": "pushTopic",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "supportsWebPush",
+            "columnName": "supportsWebPush",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "pushVapidKey",
+            "columnName": "pushVapidKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pushSubscription",
+            "columnName": "pushSubscription",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pushRegisteredEndpoint",
+            "columnName": "pushRegisteredEndpoint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pushSubscriptionExpires",
+            "columnName": "pushSubscriptionExpires",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pushSubscriptionCreated",
+            "columnName": "pushSubscriptionCreated",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_collection_serviceId_type",
+            "unique": false,
+            "columnNames": [
+              "serviceId",
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_serviceId_type` ON `${TABLE_NAME}` (`serviceId`, `type`)"
+          },
+          {
+            "name": "index_collection_homeSetId_type",
+            "unique": false,
+            "columnNames": [
+              "homeSetId",
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_homeSetId_type` ON `${TABLE_NAME}` (`homeSetId`, `type`)"
+          },
+          {
+            "name": "index_collection_ownerId_type",
+            "unique": false,
+            "columnNames": [
+              "ownerId",
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_ownerId_type` ON `${TABLE_NAME}` (`ownerId`, `type`)"
+          },
+          {
+            "name": "index_collection_pushTopic_type",
+            "unique": false,
+            "columnNames": [
+              "pushTopic",
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_pushTopic_type` ON `${TABLE_NAME}` (`pushTopic`, `type`)"
+          },
+          {
+            "name": "index_collection_url",
+            "unique": false,
+            "columnNames": [
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collection_url` ON `${TABLE_NAME}` (`url`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "service",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serviceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "homeset",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "homeSetId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "principal",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "ownerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "principal",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `serviceId` INTEGER NOT NULL, `url` TEXT NOT NULL, `displayName` TEXT, FOREIGN KEY(`serviceId`) REFERENCES `service`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serviceId",
+            "columnName": "serviceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_principal_serviceId_url",
+            "unique": true,
+            "columnNames": [
+              "serviceId",
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_principal_serviceId_url` ON `${TABLE_NAME}` (`serviceId`, `url`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "service",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serviceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "syncstats",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `collectionId` INTEGER NOT NULL, `dataType` TEXT NOT NULL, `lastSync` INTEGER NOT NULL, FOREIGN KEY(`collectionId`) REFERENCES `collection`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dataType",
+            "columnName": "dataType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSync",
+            "columnName": "lastSync",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_syncstats_collectionId_dataType",
+            "unique": true,
+            "columnNames": [
+              "collectionId",
+              "dataType"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_syncstats_collectionId_dataType` ON `${TABLE_NAME}` (`collectionId`, `dataType`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "collection",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "collectionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "webdav_document",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `mountId` INTEGER NOT NULL, `parentId` INTEGER, `name` TEXT NOT NULL, `isDirectory` INTEGER NOT NULL, `displayName` TEXT, `mimeType` TEXT, `eTag` TEXT, `lastModified` INTEGER, `size` INTEGER, `mayBind` INTEGER, `mayUnbind` INTEGER, `mayWriteContent` INTEGER, `quotaAvailable` INTEGER, `quotaUsed` INTEGER, FOREIGN KEY(`mountId`) REFERENCES `webdav_mount`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`parentId`) REFERENCES `webdav_document`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mountId",
+            "columnName": "mountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDirectory",
+            "columnName": "isDirectory",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mimeType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "eTag",
+            "columnName": "eTag",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mayBind",
+            "columnName": "mayBind",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mayUnbind",
+            "columnName": "mayUnbind",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mayWriteContent",
+            "columnName": "mayWriteContent",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "quotaAvailable",
+            "columnName": "quotaAvailable",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "quotaUsed",
+            "columnName": "quotaUsed",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_webdav_document_mountId_parentId_name",
+            "unique": true,
+            "columnNames": [
+              "mountId",
+              "parentId",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_webdav_document_mountId_parentId_name` ON `${TABLE_NAME}` (`mountId`, `parentId`, `name`)"
+          },
+          {
+            "name": "index_webdav_document_parentId",
+            "unique": false,
+            "columnNames": [
+              "parentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_webdav_document_parentId` ON `${TABLE_NAME}` (`parentId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "webdav_mount",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "webdav_document",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "parentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "webdav_mount",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `url` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '4a533c4de0ba1548684768eba9612331')"
+    ]
+  }
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/db/AppDatabase.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/AppDatabase.kt
@@ -50,7 +50,8 @@ import javax.inject.Singleton
     SyncStats::class,
     WebDavDocument::class,
     WebDavMount::class
-], exportSchema = true, version = 18, autoMigrations = [
+], exportSchema = true, version = 19, autoMigrations = [
+    AutoMigration(from = 18, to = 19),      // collection: add pushRegisteredEndpoint
     AutoMigration(from = 17, to = 18, spec = AutoMigration18::class),
     AutoMigration(from = 16, to = 17),      // collection: add VAPID key
     AutoMigration(from = 15, to = 16, spec = AutoMigration16::class),

--- a/core/src/main/kotlin/at/bitfire/davdroid/db/Collection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/Collection.kt
@@ -142,13 +142,17 @@ data class Collection(
     /** WebDAV-Push: VAPID public key */
     val pushVapidKey: String? = null,
 
-    /** WebDAV-Push subscription URL */
+    /** WebDAV-Push: subscription URL */
     val pushSubscription: String? = null,
 
-    /** when the [pushSubscription] expires (timestamp, used to determine whether we need to re-subscribe) */
+    /** WebDAV-Push: push resource (= UP endpoint) that has been used to create/update [pushSubscription] */
+    val pushRegisteredEndpoint: String? = null,
+
+    /** WebDAV-Push: when the [pushSubscription] expires for the given [pushRegisteredEndpoint] (timestamp
+    in milliseconds, used to determine whether we need to re-subscribe) */
     val pushSubscriptionExpires: Long? = null,
 
-    /** when the [pushSubscription] was created/updated (timestamp) */
+    /** WebDAV-Push: when the [pushSubscription] was created/updated (timestamp) */
     val pushSubscriptionCreated: Long? = null
 
 ) {

--- a/core/src/main/kotlin/at/bitfire/davdroid/db/Collection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/Collection.kt
@@ -149,7 +149,7 @@ data class Collection(
     val pushRegisteredEndpoint: String? = null,
 
     /** WebDAV-Push: when the [pushSubscription] expires for the given [pushRegisteredEndpoint] (timestamp
-    in milliseconds, used to determine whether we need to re-subscribe) */
+    in epoch seconds, used to determine whether we need to re-subscribe) */
     val pushSubscriptionExpires: Long? = null,
 
     /** WebDAV-Push: when the [pushSubscription] was created/updated (timestamp) */

--- a/core/src/main/kotlin/at/bitfire/davdroid/db/CollectionDao.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/CollectionDao.kt
@@ -104,7 +104,13 @@ interface CollectionDao {
     suspend fun updateForceReadOnly(id: Long, forceReadOnly: Boolean)
 
     @Query("UPDATE collection SET pushSubscription=:pushSubscription, pushRegisteredEndpoint=:pushRegisteredEndpoint, pushSubscriptionExpires=:pushSubscriptionExpires, pushSubscriptionCreated=:updatedAt WHERE id=:id")
-    suspend fun updatePushSubscription(id: Long, pushSubscription: String?, pushRegisteredEndpoint: String?, pushSubscriptionExpires: Long?, updatedAt: Long = System.currentTimeMillis()/1000)
+    suspend fun updatePushSubscription(
+        id: Long,
+        pushRegisteredEndpoint: String?,
+        pushSubscription: String?,
+        pushSubscriptionExpires: Long?,
+        updatedAt: Long = System.currentTimeMillis() / 1000
+    )
 
     @Query("UPDATE collection SET sync=:sync WHERE id=:id")
     suspend fun updateSync(id: Long, sync: Boolean)

--- a/core/src/main/kotlin/at/bitfire/davdroid/db/CollectionDao.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/CollectionDao.kt
@@ -103,8 +103,8 @@ interface CollectionDao {
     @Query("UPDATE collection SET forceReadOnly=:forceReadOnly WHERE id=:id")
     suspend fun updateForceReadOnly(id: Long, forceReadOnly: Boolean)
 
-    @Query("UPDATE collection SET pushSubscription=:pushSubscription, pushSubscriptionExpires=:pushSubscriptionExpires, pushSubscriptionCreated=:updatedAt WHERE id=:id")
-    suspend fun updatePushSubscription(id: Long, pushSubscription: String?, pushSubscriptionExpires: Long?, updatedAt: Long = System.currentTimeMillis()/1000)
+    @Query("UPDATE collection SET pushSubscription=:pushSubscription, pushRegisteredEndpoint=:pushRegisteredEndpoint, pushSubscriptionExpires=:pushSubscriptionExpires, pushSubscriptionCreated=:updatedAt WHERE id=:id")
+    suspend fun updatePushSubscription(id: Long, pushSubscription: String?, pushRegisteredEndpoint: String?, pushSubscriptionExpires: Long?, updatedAt: Long = System.currentTimeMillis()/1000)
 
     @Query("UPDATE collection SET sync=:sync WHERE id=:id")
     suspend fun updateSync(id: Long, sync: Boolean)

--- a/core/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
@@ -189,13 +189,11 @@ class PushRegistrationManager @Inject constructor(
                     val expires = collection.pushSubscriptionExpires
                     // calculate next run time, but use the duplicate interval for safety (times are not exact)
                     val nextRun = Instant.now() + Duration.ofDays(2 * WORKER_INTERVAL_DAYS)
-                    if (expires != null && expires >= nextRun.epochSecond
-                            && collection.pushRegisteredEndpoint == endpoint.url)
+                    if (expires != null && expires >= nextRun.epochSecond && collection.pushRegisteredEndpoint == endpoint.url)
                         logger.fine("Push subscription for ${collection.url} is still valid until ${collection.pushSubscriptionExpires}")
                     else {
                         // endpoint changed: unsubscribe from old subscription first
-                        if (collection.pushRegisteredEndpoint != null
-                                && collection.pushRegisteredEndpoint != endpoint.url) {
+                        if (collection.pushRegisteredEndpoint != null && collection.pushRegisteredEndpoint != endpoint.url) {
                             logger.fine("Push endpoint changed for ${collection.url}, unsubscribing from old endpoint first")
                             collection.pushSubscription?.toUrlOrNull()?.let { oldUrl ->
                                 unsubscribe(httpClient, collection, oldUrl)

--- a/core/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
@@ -185,6 +185,9 @@ class PushRegistrationManager @Inject constructor(
         if (subscribeTo.isEmpty())
             return
 
+        // calculate next worker run (later needed to check expiry); duplicate days for safety (times are not exact)
+        val nextWorkerRun = Instant.now() + Duration.ofDays(2 * WORKER_INTERVAL_DAYS)
+
         val account = accountRepository.get().fromName(service.accountName)
         httpClientBuilder.get()
             .fromAccountAsync(account)
@@ -193,12 +196,10 @@ class PushRegistrationManager @Inject constructor(
             for (collection in subscribeTo) {
                 // update push subscription for the given collection
                 try {
-                    // determine whether the registered subscription is about to expire by comparing expiry with the next worker run time
-                    val nextWorkerRun = Instant.now() + Duration.ofDays(2 * WORKER_INTERVAL_DAYS)   // duplicate for safety (times are not exact)
+                    // determine whether the registered subscription will expire before the next worker run ...
                     val subscriptionAboutToExpire = collection.pushSubscriptionExpires?.let { nextWorkerRun.epochSecond >= it } ?: true
-
-                    // also check whether endpoint has changed
-                    val endpointChanged = collection.pushRegisteredEndpoint != null && collection.pushRegisteredEndpoint != endpoint.url
+                    // ... and also check whether endpoint has changed
+                    val endpointChanged = collection.pushRegisteredEndpoint == null || collection.pushRegisteredEndpoint != endpoint.url
                     if (!endpointChanged && !subscriptionAboutToExpire)
                         logger.fine("Push subscription for ${collection.url} is still valid until ${collection.pushSubscriptionExpires}")
                     else {

--- a/core/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
@@ -189,10 +189,19 @@ class PushRegistrationManager @Inject constructor(
                     val expires = collection.pushSubscriptionExpires
                     // calculate next run time, but use the duplicate interval for safety (times are not exact)
                     val nextRun = Instant.now() + Duration.ofDays(2 * WORKER_INTERVAL_DAYS)
-                    if (expires != null && expires >= nextRun.epochSecond)
+                    if (expires != null && expires >= nextRun.epochSecond
+                            && collection.pushRegisteredEndpoint == endpoint.url)
                         logger.fine("Push subscription for ${collection.url} is still valid until ${collection.pushSubscriptionExpires}")
                     else {
-                        // no existing subscription or expiring soon
+                        // endpoint changed: unsubscribe from old subscription first
+                        if (collection.pushRegisteredEndpoint != null
+                                && collection.pushRegisteredEndpoint != endpoint.url) {
+                            logger.fine("Push endpoint changed for ${collection.url}, unsubscribing from old endpoint first")
+                            collection.pushSubscription?.toUrlOrNull()?.let { oldUrl ->
+                                unsubscribe(httpClient, collection, oldUrl)
+                            }
+                        }
+                        // no existing subscription, expiring soon, or endpoint changed
                         logger.fine("Registering push subscription for ${collection.url}")
                         subscribe(httpClient, collection, endpoint)
                     }
@@ -276,6 +285,7 @@ class PushRegistrationManager @Inject constructor(
                 collectionRepository.updatePushSubscription(
                     id = collection.id,
                     subscriptionUrl = subscriptionUrl,
+                    registeredEndpoint = endpoint.url,
                     expires = expires?.epochSecond
                 )
             } else
@@ -316,6 +326,7 @@ class PushRegistrationManager @Inject constructor(
         collectionRepository.updatePushSubscription(
             id = collection.id,
             subscriptionUrl = null,
+            registeredEndpoint = null,
             expires = null
         )
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
@@ -76,13 +76,13 @@ class PushRegistrationManager @Inject constructor(
     suspend fun setPushDistributor(pushDistributor: String?) {
         // Disable UnifiedPush and remove all subscriptions
         UnifiedPush.removeDistributor(context)
-        update()
 
-        if (pushDistributor != null) {
-            // If a distributor was passed, store it and create/register subscriptions
+        // If a distributor was passed, store it
+        if (pushDistributor != null)
             UnifiedPush.saveDistributor(context, pushDistributor)
-            update()
-        }
+
+        // Update all subscriptions
+        update()
     }
 
     fun getCurrentDistributor() = UnifiedPush.getSavedDistributor(context)

--- a/core/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
@@ -174,6 +174,12 @@ class PushRegistrationManager @Inject constructor(
         }
     }
 
+    /**
+     * (Re-)subscribes to push notifications for syncable collections of a given service using the provided endpoint.
+     *
+     * @param service The service for which to subscribe to push notifications. Must not be null.
+     * @param endpoint The push endpoint to use for subscription. Must not be null.
+     */
     private suspend fun subscribeSyncable(service: Service, endpoint: PushEndpoint) {
         val subscribeTo = collectionRepository.getPushCapableAndSyncable(service.id)
         if (subscribeTo.isEmpty())
@@ -184,28 +190,30 @@ class PushRegistrationManager @Inject constructor(
             .fromAccountAsync(account)
             .buildKtor()
             .use { httpClient ->
-            for (collection in subscribeTo)
+            for (collection in subscribeTo) {
+                // Updates push subscription for the given collection
                 try {
-                    val expires = collection.pushSubscriptionExpires
-                    // calculate next run time, but use the duplicate interval for safety (times are not exact)
-                    val nextRun = Instant.now() + Duration.ofDays(2 * WORKER_INTERVAL_DAYS)
-                    if (expires != null && expires >= nextRun.epochSecond && collection.pushRegisteredEndpoint == endpoint.url)
+                    // Calculate next worker run time, but use the duplicate interval for safety (times are not exact)
+                    val nextWorkerRun = Instant.now() + Duration.ofDays(2 * WORKER_INTERVAL_DAYS)
+                    val subscriptionAboutToExpire = collection.pushSubscriptionExpires?.let { nextWorkerRun.epochSecond >= it } ?: true
+
+                    val endpointChanged = collection.pushRegisteredEndpoint != null && collection.pushRegisteredEndpoint != endpoint.url
+                    if (!endpointChanged && !subscriptionAboutToExpire)
                         logger.fine("Push subscription for ${collection.url} is still valid until ${collection.pushSubscriptionExpires}")
                     else {
-                        // endpoint changed: unsubscribe from old subscription first
-                        if (collection.pushRegisteredEndpoint != null && collection.pushRegisteredEndpoint != endpoint.url) {
+                        if (endpointChanged) {
                             logger.fine("Push endpoint changed for ${collection.url}, unsubscribing from old endpoint first")
                             collection.pushSubscription?.toUrlOrNull()?.let { oldUrl ->
                                 unsubscribe(httpClient, collection, oldUrl)
                             }
                         }
-                        // no existing subscription, expiring soon, or endpoint changed
                         logger.fine("Registering push subscription for ${collection.url}")
                         subscribe(httpClient, collection, endpoint)
                     }
                 } catch (e: Exception) {
                     logger.log(Level.WARNING, "Couldn't register subscription at CalDAV/CardDAV server", e)
                 }
+            }
         }
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
@@ -191,12 +191,13 @@ class PushRegistrationManager @Inject constructor(
             .buildKtor()
             .use { httpClient ->
             for (collection in subscribeTo) {
-                // Updates push subscription for the given collection
+                // update push subscription for the given collection
                 try {
-                    // Calculate next worker run time, but use the duplicate interval for safety (times are not exact)
-                    val nextWorkerRun = Instant.now() + Duration.ofDays(2 * WORKER_INTERVAL_DAYS)
+                    // determine whether the registered subscription is about to expire by comparing expiry with the next worker run time
+                    val nextWorkerRun = Instant.now() + Duration.ofDays(2 * WORKER_INTERVAL_DAYS)   // duplicate for safety (times are not exact)
                     val subscriptionAboutToExpire = collection.pushSubscriptionExpires?.let { nextWorkerRun.epochSecond >= it } ?: true
 
+                    // also check whether endpoint has changed
                     val endpointChanged = collection.pushRegisteredEndpoint != null && collection.pushRegisteredEndpoint != endpoint.url
                     if (!endpointChanged && !subscriptionAboutToExpire)
                         logger.fine("Push subscription for ${collection.url} is still valid until ${collection.pushSubscriptionExpires}")

--- a/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
@@ -268,10 +268,11 @@ class DavCollectionRepository @Inject constructor(
         dao.updateSync(id, forceReadOnly)
     }
 
-    suspend fun updatePushSubscription(id: Long, subscriptionUrl: String?, expires: Long?) {
+    suspend fun updatePushSubscription(id: Long, subscriptionUrl: String?, registeredEndpoint: String?, expires: Long?) {
         dao.updatePushSubscription(
             id = id,
             pushSubscription = subscriptionUrl,
+            pushRegisteredEndpoint = registeredEndpoint,
             pushSubscriptionExpires = expires
         )
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
@@ -268,11 +268,19 @@ class DavCollectionRepository @Inject constructor(
         dao.updateSync(id, forceReadOnly)
     }
 
+    /**
+     * Updates the push subscription details for a collection with the given ID.
+     *
+     * @param id ID of the collection to update.
+     * @param subscriptionUrl New push subscription URL (can be `null` to clear the value).
+     * @param registeredEndpoint New registered endpoint URL (can be `null` to clear the value).
+     * @param expires New expiration timestamp for the push subscription (can be `null` to clear the value).
+     */
     suspend fun updatePushSubscription(id: Long, subscriptionUrl: String?, registeredEndpoint: String?, expires: Long?) {
         dao.updatePushSubscription(
             id = id,
-            pushSubscription = subscriptionUrl,
             pushRegisteredEndpoint = registeredEndpoint,
+            pushSubscription = subscriptionUrl,
             pushSubscriptionExpires = expires
         )
     }


### PR DESCRIPTION
### Purpose

This PR adds endpoint change detection in PushRegistrationManager in order to fix #2095 in a proper way. Steps to reproduce are in the issue.

> [!NOTE]
> When the `PushRegistrationWorker` runs the first time after the migration, `pushRegisteredEndpoint` will be `null`, and all subscriptions will be updated on the server as if they were about to expire. That's OK.

### Short description

- Simplified push distributor updating by moving the `update()` call outside the conditional block.
- Optimized endpoint change detection and expiration checks with refactored subscription logic and clearer variable names.
- Added `pushRegisteredEndpoint` field to track push resources in the database.
- Improved code structure with explicit braces for loops and better documentation.
- Handled push endpoint changes by unsubscribing from the old endpoint and updating with new endpoint information.
- Reordered parameters in `CollectionDao.updatePushSubscription` for consistency.

### Outlook

In the future it could be helpful to extract the subscription values (`pushSubscription`, `pushRegisteredEndpoint`, `pushSubscriptionExpires`, `pushSubscriptionCreated`) into a separate `collection_subscription` table with a

**1 `collection` ↔ [0,1] `collection_subscription`**

relation.