### PR TITLE
[Push] Update registration worker to actively select distributor

### DIFF
--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -149,6 +149,7 @@
             android:name=".ui.webdav.AddWebdavMountActivity"
             android:parentActivityName=".ui.webdav.WebdavMountsActivity"
             android:windowSoftInputMode="adjustResize" />
+        <activity android:name=".push.PushDistributorSelectionActivity" />
 
         <!-- account type "DAVx⁵" -->
         <service

--- a/core/src/main/kotlin/at/bitfire/davdroid/push/PushDistributorSelectionActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/push/PushDistributorSelectionActivity.kt
@@ -6,8 +6,14 @@ package at.bitfire.davdroid.push
 
 import android.content.Intent
 import android.os.Bundle
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.net.toUri
 import androidx.lifecycle.lifecycleScope
+import at.bitfire.davdroid.R
+import at.bitfire.davdroid.settings.Settings
+import at.bitfire.davdroid.settings.SettingsManager
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -22,11 +28,29 @@ class PushDistributorSelectionActivity : AppCompatActivity() {
     @Inject
     lateinit var registrationManager: PushRegistrationManager
 
+    @Inject
+    lateinit var settings : SettingsManager
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (!helper.startLinkActivityForResult()) {
             // No distributor found
-            finish()
+            AlertDialog.Builder(this)
+                .setTitle(R.string.push_no_distributor_title)
+                .setMessage(R.string.push_no_distributor_message)
+                .setPositiveButton(R.string.push_no_distributor_more_info) { _, _ ->
+                    startActivity(
+                        Intent(Intent.ACTION_VIEW, "https://manual.davx5.com/webdav_push.html".toUri())
+                    )
+                    finish()
+                }
+                .setNegativeButton(R.string.push_no_distributor_disable) { _, _ ->
+                    settings.putBoolean(Settings.PUSH_DISABLED, true)
+                    Toast.makeText(this, R.string.push_disabled_message, Toast.LENGTH_SHORT).show()
+                    finish()
+                }
+                .setOnCancelListener { finish() }
+                .show()
         }
     }
 
@@ -37,6 +61,7 @@ class PushDistributorSelectionActivity : AppCompatActivity() {
                 registrationManager.update()
 
                 withContext(Dispatchers.Main) {
+                    Toast.makeText(this@PushDistributorSelectionActivity, R.string.push_distributor_selected, Toast.LENGTH_LONG).show()
                     finish()
                 }
             }

--- a/core/src/main/kotlin/at/bitfire/davdroid/push/PushDistributorSelectionActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/push/PushDistributorSelectionActivity.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.push
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.unifiedpush.android.connector.LinkActivityHelper
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class PushDistributorSelectionActivity : AppCompatActivity() {
+    private val helper = LinkActivityHelper(this)
+
+    @Inject
+    lateinit var registrationManager: PushRegistrationManager
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (!helper.startLinkActivityForResult()) {
+            // No distributor found
+            finish()
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        if (helper.onLinkActivityResult(requestCode, resultCode, data)) {
+            // The distributor is saved, reschedule worker
+            lifecycleScope.launch(Dispatchers.IO) {
+                registrationManager.update()
+
+                withContext(Dispatchers.Main) {
+                    finish()
+                }
+            }
+        } else {
+            // An error occurred, consider no distributor found for the moment
+            super.onActivityResult(requestCode, resultCode, data)
+            finish()
+        }
+    }
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/push/PushNotificationManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/push/PushNotificationManager.kt
@@ -8,6 +8,7 @@ import android.accounts.Account
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import androidx.annotation.DrawableRes
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.TaskStackBuilder
@@ -30,32 +31,53 @@ class PushNotificationManager @Inject constructor(
         return account.name.hashCode() + account.type.hashCode() + dataType.hashCode()
     }
 
+    fun notify(
+        id: Int,
+        channelId: String,
+        @DrawableRes icon: Int = R.drawable.ic_sync,
+        title: String,
+        text: String,
+        subText: String? = null,
+        intent: Intent,
+        priority: Int = NotificationCompat.PRIORITY_LOW,
+        category: String = NotificationCompat.CATEGORY_STATUS,
+        autoCancel: Boolean = true,
+        onlyAlertOnce: Boolean = true
+    ) {
+        notificationRegistry.notifyIfPossible(id) {
+            NotificationCompat.Builder(context, channelId)
+                .setSmallIcon(icon)
+                .setContentTitle(title)
+                .setContentText(text)
+                .setSubText(subText)
+                .setPriority(priority)
+                .setCategory(category)
+                .setAutoCancel(autoCancel)
+                .setOnlyAlertOnce(onlyAlertOnce)
+                .setContentIntent(
+                    TaskStackBuilder.create(context)
+                        .addNextIntentWithParentStack(intent)
+                        .getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+                )
+                .build()
+        }
+    }
+
     /**
      * Sends a notification to inform the user that a push notification has been received, the
      * sync has been scheduled, but it still has not run.
      */
     fun notify(account: Account, dataType: SyncDataType) {
-        notificationRegistry.notifyIfPossible(notificationId(account, dataType)) {
-            NotificationCompat.Builder(context, notificationRegistry.CHANNEL_STATUS)
-                .setSmallIcon(R.drawable.ic_sync)
-                .setContentTitle(context.getString(R.string.sync_notification_pending_push_title))
-                .setContentText(context.getString(R.string.sync_notification_pending_push_message))
-                .setSubText(account.name)
-                .setPriority(NotificationCompat.PRIORITY_LOW)
-                .setCategory(NotificationCompat.CATEGORY_STATUS)
-                .setAutoCancel(true)
-                .setOnlyAlertOnce(true)
-                .setContentIntent(
-                    TaskStackBuilder.create(context)
-                        .addNextIntentWithParentStack(
-                            Intent(context, AccountActivity::class.java).apply {
-                                putExtra(AccountActivity.EXTRA_ACCOUNT, account)
-                            }
-                        )
-                        .getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
-                )
-                .build()
-        }
+        notify(
+            id = notificationId(account, dataType),
+            channelId = notificationRegistry.CHANNEL_STATUS,
+            title = context.getString(R.string.sync_notification_pending_push_title),
+            text = context.getString(R.string.sync_notification_pending_push_message),
+            subText = account.name,
+            intent = Intent(context, AccountActivity::class.java).apply {
+                putExtra(AccountActivity.EXTRA_ACCOUNT, account)
+            }
+        )
     }
 
     /**

--- a/core/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
@@ -27,6 +27,8 @@ import at.bitfire.davdroid.push.PushRegistrationManager.Companion.mutex
 import at.bitfire.davdroid.repository.AccountRepository
 import at.bitfire.davdroid.repository.DavCollectionRepository
 import at.bitfire.davdroid.repository.DavServiceRepository
+import at.bitfire.davdroid.settings.Settings
+import at.bitfire.davdroid.settings.SettingsManager
 import at.bitfire.davdroid.sync.account.InvalidAccountException
 import dagger.Lazy
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -39,6 +41,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.unifiedpush.android.connector.UnifiedPush
 import org.unifiedpush.android.connector.data.PushEndpoint
+import org.unifiedpush.android.connector.data.ResolvedDistributor
 import java.io.StringWriter
 import java.time.Duration
 import java.time.Instant
@@ -62,6 +65,7 @@ class PushRegistrationManager @Inject constructor(
     @ApplicationContext private val context: Context,
     private val httpClientBuilder: Provider<HttpClientBuilder>,
     private val logger: Logger,
+    private val settings: SettingsManager,
     private val serviceRepository: DavServiceRepository
 ) {
 
@@ -85,7 +89,59 @@ class PushRegistrationManager @Inject constructor(
         }
     }
 
+    @Deprecated("Use getDistributorToUse", ReplaceWith("getDistributorToUse"))
     fun getCurrentDistributor() = UnifiedPush.getSavedDistributor(context)
+
+    /**
+     * Tries to resolve a distributor to use automatically.
+     * @return The package name of the distributor to use.
+     * @throws IllegalStateException push has been disabled manually by the user
+     * @throws RuntimeException there are multiple distributors available, the user must choose one
+     * @throws NoSuchElementException there is no distributor available
+     */
+    suspend fun getDistributorToUse(): String {
+        val pushDisabled = settings.getBooleanOrNull(Settings.PUSH_DISABLED) ?: false
+        if (pushDisabled) {
+            logger.fine("Push is disabled. Unregistering all instance, and unsubscribing from all services")
+            unregisterAndUnsubscribeFromAll()
+            throw IllegalStateException("Push is disabled")
+        }
+
+        // get ACK distributor: saved distributor, which is correctly configured
+        val savedDistributor = UnifiedPush.getAckDistributor(context)
+        if (savedDistributor != null) return savedDistributor
+
+        // there's no distributor saved, try to resolve it with UP
+        when (val res = UnifiedPush.resolveDefaultDistributor(context)) {
+            // If Found is returned, the new distributor has been saved, and getAckDistributor will fetch it in the next call
+            is ResolvedDistributor.Found -> return res.packageName
+            // There are multiple distributors available, the user must choose one
+            ResolvedDistributor.ToSelect -> {
+                // Make sure to unsubscribe from all services. This is in case there was indeed a distributor selected, but it's no longer available
+                unregisterAndUnsubscribeFromAll()
+                throw RuntimeException("User interaction required")
+            }
+            // There's no custom distributor installed, and FCM is not available
+            ResolvedDistributor.NoneAvailable -> throw NoSuchElementException("There's no distributor in the system available")
+        }
+    }
+
+    /**
+     * Same as [getDistributorToUse], but all exceptions result in `null`.
+     * @return The package name of the distributor to use, if one is available. `null` otherwise.
+     */
+    suspend fun getDistributorToUseOrNull(): String? = try {
+        getDistributorToUse()
+    } catch (_: IllegalStateException) {
+        // push is disabled
+        return null
+    } catch (_: RuntimeException) {
+        // multiple distributors available
+        return null
+    } catch (_: NoSuchElementException) {
+        // no distributors available
+        return null
+    }
 
     fun getDistributors() = UnifiedPush.getDistributors(context)
 
@@ -126,8 +182,8 @@ class PushRegistrationManager @Inject constructor(
         // use service ID from database as UnifiedPush instance name
         val instance = serviceId.toString()
 
-        val distributorAvailable = getCurrentDistributor() != null
-        if (distributorAvailable)
+        val distributorAvailable = getDistributorToUseOrNull() != null
+        if (distributorAvailable) {
             try {
                 val vapid = collectionRepository.getVapidKey(serviceId)
                 if (vapid != null) {    // only register when there's a VAPID key
@@ -145,14 +201,21 @@ class PushRegistrationManager @Inject constructor(
             } catch (e: UnifiedPush.VapidNotValidException) {
                 logger.log(Level.WARNING, "Couldn't register invalid VAPID key for service $serviceId", e)
             }
-        else {
-            logger.fine("No push distributor, unregistering UnifiedPush service $serviceId / ${service.accountName}")
-            UnifiedPush.unregister(context, instance)   // doesn't call UnifiedPushService.onUnregistered
-            unsubscribeAll(service)
         }
 
         // UnifiedPush has now been called. It will do its work and then asynchronously call back to UnifiedPushService, which
         // will then call processSubscription or removeSubscription.
+    }
+
+    /**
+     * Unregisters instances and unsubscribes from all services.
+     */
+    private suspend fun unregisterAndUnsubscribeFromAll() {
+        for (service in serviceRepository.getAll()) {
+            val instance = service.id.toString()
+            UnifiedPush.unregister(context, instance)   // doesn't call UnifiedPushService.onUnregistered
+            unsubscribeAll(service)
+        }
     }
 
     /**

--- a/core/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
@@ -195,22 +195,28 @@ class PushRegistrationManager @Inject constructor(
             logger.fine("Push is disabled. Cannot update service $serviceId")
         } catch (_: RuntimeException) {
             // multiple distributors available
-            withContext(Dispatchers.Main) {
-                notificationManager.notify(
-                    id = NotificationRegistry.NOTIFY_SELECT_PUSH_DISTRIBUTOR,
-                    channelId = notificationRegistry.CHANNEL_SYNC_ERRORS,
-                    title = context.getString(R.string.push_multiple_distributor_title),
-                    text = context.getString(R.string.push_multiple_distributor_message),
-                    intent = Intent(context, PushDistributorSelectionActivity::class.java)
-                )
-            }
+            logger.log(Level.WARNING, "There are multiple push distributors available")
+            notifyDistributorSelection()
         } catch (_: NoSuchElementException) {
             // no distributors available
             logger.log(Level.WARNING, "Tried to update service $serviceId, but no push distributors are available")
+            notifyDistributorSelection()
         }
 
         // UnifiedPush has now been called. It will do its work and then asynchronously call back to UnifiedPushService, which
         // will then call processSubscription or removeSubscription.
+    }
+
+    private suspend fun notifyDistributorSelection() {
+        withContext(Dispatchers.Main) {
+            notificationManager.notify(
+                id = NotificationRegistry.NOTIFY_SELECT_PUSH_DISTRIBUTOR,
+                channelId = notificationRegistry.CHANNEL_SYNC_ERRORS,
+                title = context.getString(R.string.push_distributor_selection_required_title),
+                text = context.getString(R.string.push_distributor_selection_required_message),
+                intent = Intent(context, PushDistributorSelectionActivity::class.java)
+            )
+        }
     }
 
     /**

--- a/core/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
@@ -5,6 +5,7 @@
 package at.bitfire.davdroid.push
 
 import android.content.Context
+import android.content.Intent
 import androidx.work.BackoffPolicy
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
@@ -20,6 +21,7 @@ import at.bitfire.dav4jvm.ktor.DavResource
 import at.bitfire.dav4jvm.ktor.exception.DavException
 import at.bitfire.dav4jvm.ktor.toUrlOrNull
 import at.bitfire.dav4jvm.property.push.WebDAVPush
+import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service
 import at.bitfire.davdroid.network.HttpClientBuilder
@@ -30,6 +32,7 @@ import at.bitfire.davdroid.repository.DavServiceRepository
 import at.bitfire.davdroid.settings.Settings
 import at.bitfire.davdroid.settings.SettingsManager
 import at.bitfire.davdroid.sync.account.InvalidAccountException
+import at.bitfire.davdroid.ui.NotificationRegistry
 import dagger.Lazy
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.ktor.client.HttpClient
@@ -37,8 +40,10 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.Url
 import io.ktor.http.content.TextContent
 import io.ktor.http.isSuccess
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import org.unifiedpush.android.connector.UnifiedPush
 import org.unifiedpush.android.connector.data.PushEndpoint
 import org.unifiedpush.android.connector.data.ResolvedDistributor
@@ -66,7 +71,9 @@ class PushRegistrationManager @Inject constructor(
     private val httpClientBuilder: Provider<HttpClientBuilder>,
     private val logger: Logger,
     private val settings: SettingsManager,
-    private val serviceRepository: DavServiceRepository
+    private val serviceRepository: DavServiceRepository,
+    private val notificationManager: PushNotificationManager,
+    private val notificationRegistry: NotificationRegistry
 ) {
 
     /**
@@ -126,23 +133,6 @@ class PushRegistrationManager @Inject constructor(
         }
     }
 
-    /**
-     * Same as [getDistributorToUse], but all exceptions result in `null`.
-     * @return The package name of the distributor to use, if one is available. `null` otherwise.
-     */
-    suspend fun getDistributorToUseOrNull(): String? = try {
-        getDistributorToUse()
-    } catch (_: IllegalStateException) {
-        // push is disabled
-        return null
-    } catch (_: RuntimeException) {
-        // multiple distributors available
-        return null
-    } catch (_: NoSuchElementException) {
-        // no distributors available
-        return null
-    }
-
     fun getDistributors() = UnifiedPush.getDistributors(context)
 
 
@@ -182,25 +172,41 @@ class PushRegistrationManager @Inject constructor(
         // use service ID from database as UnifiedPush instance name
         val instance = serviceId.toString()
 
-        val distributorAvailable = getDistributorToUseOrNull() != null
-        if (distributorAvailable) {
-            try {
-                val vapid = collectionRepository.getVapidKey(serviceId)
-                if (vapid != null) {    // only register when there's a VAPID key
-                    logger.fine("Registering UnifiedPush instance for service $instance / ${service.accountName}")
+        try {
+            getDistributorToUse() // try to resolve the distributor to use
 
-                    // message for distributor
-                    val message = "${service.accountName} (${service.type})"
+            val vapid = collectionRepository.getVapidKey(serviceId)
+            if (vapid != null) {    // only register when there's a VAPID key
+                logger.fine("Registering UnifiedPush instance for service $instance / ${service.accountName}")
 
-                    UnifiedPush.register(context, instance, message, vapid)
-                } else {
-                    logger.fine("No VAPID key for service $serviceId / ${service.accountName}")
-                    /* We don't call UnifiedPush.unregister(context, instance) here because it can
-                    remove the push distributor. May be improved in the future. */
-                }
-            } catch (e: UnifiedPush.VapidNotValidException) {
-                logger.log(Level.WARNING, "Couldn't register invalid VAPID key for service $serviceId", e)
+                // message for distributor
+                val message = "${service.accountName} (${service.type})"
+
+                UnifiedPush.register(context, instance, message, vapid)
+            } else {
+                logger.fine("No VAPID key for service $serviceId / ${service.accountName}")
+                /* We don't call UnifiedPush.unregister(context, instance) here because it can
+                remove the push distributor. May be improved in the future. */
             }
+        } catch (e: UnifiedPush.VapidNotValidException) {
+            logger.log(Level.WARNING, "Couldn't register invalid VAPID key for service $serviceId", e)
+        } catch (_: IllegalStateException) {
+            // push is disabled
+            logger.fine("Push is disabled. Cannot update service $serviceId")
+        } catch (_: RuntimeException) {
+            // multiple distributors available
+            withContext(Dispatchers.Main) {
+                notificationManager.notify(
+                    id = NotificationRegistry.NOTIFY_SELECT_PUSH_DISTRIBUTOR,
+                    channelId = notificationRegistry.CHANNEL_SYNC_ERRORS,
+                    title = context.getString(R.string.push_multiple_distributor_title),
+                    text = context.getString(R.string.push_multiple_distributor_message),
+                    intent = Intent(context, PushDistributorSelectionActivity::class.java)
+                )
+            }
+        } catch (_: NoSuchElementException) {
+            // no distributors available
+            logger.log(Level.WARNING, "Tried to update service $serviceId, but no push distributors are available")
         }
 
         // UnifiedPush has now been called. It will do its work and then asynchronously call back to UnifiedPushService, which

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/Settings.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/Settings.kt
@@ -58,6 +58,9 @@ object Settings {
     /** regular expression to match URLs of collections to be excluded from pre-selection */
     const val PRESELECT_COLLECTIONS_EXCLUDED = "preselect_collections_excluded"
 
+    /** If `true`, the user has manually chosen to disable Push */
+    const val PUSH_DISABLED = "push_disabled"
+
 
     /** whether all address books are forced to be read-only */
     const val FORCE_READ_ONLY_ADDRESSBOOKS = "force_read_only_addressbooks"

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/NotificationRegistry.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/NotificationRegistry.kt
@@ -50,6 +50,7 @@ class NotificationRegistry @Inject constructor(
         const val NOTIFY_SYNC_EXPEDITED = 14
         const val NOTIFY_TASKS_PROVIDER_TOO_OLD = 20
         const val NOTIFY_PERMISSIONS = 21
+        const val NOTIFY_SELECT_PUSH_DISTRIBUTOR = 22
 
         /**
          * Used in build variants when a [at.bitfire.davdroid.sync.SyncValidator]

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -570,8 +570,16 @@
     <string name="sync_invalid_resources_ignoring">Ignoring one or more invalid resources</string>
     <string name="sync_notification_pending_push_title">Sync pending</string>
     <string name="sync_notification_pending_push_message">Remote data have changed</string>
-    <string name="push_multiple_distributor_title">Multiple distributors available</string>
-    <string name="push_multiple_distributor_message">There are multiple distributors available in your system. Tap to select one</string>
+
+    <!-- push -->
+    <string name="push_no_distributor_title">No distributor available</string>
+    <string name="push_no_distributor_message">There are no UnifiedPush distributors installed in your device, and Google Play Services are not available. Instant updates are not possible on your system.</string>
+    <string name="push_no_distributor_more_info">More info</string>
+    <string name="push_no_distributor_disable">Disable Push</string>
+    <string name="push_distributor_selected">Push distributor updated</string>
+    <string name="push_distributor_selection_required_title">Distributor selection required</string>
+    <string name="push_distributor_selection_required_message">A default UnifiedPush distributor could not be resolved. Tap to select one</string>
+    <string name="push_disabled_message">Push disabled</string>
 
     <!-- widgets -->
     <string name="widget_sync_all">Sync all</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -570,6 +570,8 @@
     <string name="sync_invalid_resources_ignoring">Ignoring one or more invalid resources</string>
     <string name="sync_notification_pending_push_title">Sync pending</string>
     <string name="sync_notification_pending_push_message">Remote data have changed</string>
+    <string name="push_multiple_distributor_title">Multiple distributors available</string>
+    <string name="push_multiple_distributor_message">There are multiple distributors available in your system. Tap to select one</string>
 
     <!-- widgets -->
     <string name="widget_sync_all">Sync all</string>


### PR DESCRIPTION
### Purpose

Implements the automatic push distributor selection logic detailed in #2153

Depends on #2155

### Short description

- Add automatic push distributor resolution
- Add notification for instances where a distributor cannot be resolved automatically (no distributor, or more than one available)
  <details>
    <summary>Screenshots</summary>

    <img width="1080" height="2424" alt="Screenshot_20260423_124617" src="https://github.com/user-attachments/assets/b5a25ebb-152a-465f-82af-75fb784f1ed4" />

    <img width="1080" height="2424" alt="Screenshot_20260423_124625" src="https://github.com/user-attachments/assets/51871732-d767-4f40-8eb2-cfee23515649" />

    <img width="1080" height="2424" alt="Screenshot_20260423_125839" src="https://github.com/user-attachments/assets/cbe522cc-ecbb-4b4c-9f83-153ed0db86bb" />
  </details>

_Maybe `PushDistributorSelectionActivity` can be moved into `AppSettingsActivity`_

### Checklist

- [x] The PR has a proper title, description and label.
- [ ] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

