### PR TITLE
Bump version to 4.5.12-beta.1 and update Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,13 +26,13 @@ Use [Conventional Comments](https://conventionalcomments.org/) to format review 
 [optional discussion]
 ```
 
-The subject is usually not longer than one line. If more information is required to understand the comment, it belongs to the optional discussion part.
+The subject is usually not longer than one short line/sentence. If more information is required to understand the comment, it belongs to the optional discussion part.
 
 Use these labels:
 
 - `issue:` Issues highlight specific problems with the subject under review.
 - `suggestion:` Suggestions propose improvements to the current subject. It’s important to be explicit and clear on what is being suggested and why it is an improvement.
-- `todo:` TODO’s are small, trivial, but necessary changes.
+- `todo:` TODOs are small, trivial, but necessary changes.
 - `typo:` Typo comments are like todo comments, where the main issue is a misspelling.
 - `quibble:` Use that one instead of `nitpick` for trivial preference- or style-based requests. These should be non-blocking by nature.
 - `polish:` Polish comments are like a suggestion, where there is nothing necessarily wrong with the relevant content, there’s just some ways to immediately improve the quality.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,7 +18,20 @@ For automated reviews focus on:
 
 ## Conventional Comments
 
-Use [Conventional Comments](https://conventionalcomments.org/) to label review feedback. Especially make a difference between more critical labels like `issue` or `todo` and less critical ones like `suggestion`, `typo` or `polish`. Use `quibble` instead of `nitpick`. You may use the `(non-blocking)`, `(blocking)` and `(if-minor)` decorations after the label.
+Use [Conventional Comments](https://conventionalcomments.org/) to label review feedback. Especially make a difference between more critical labels like `issue` or
+`todo` and less critical ones like `suggestion`, `typo` or `polish`. Use `quibble` instead of `nitpick`.
+
+You may use the `(non-blocking)`, `(blocking)` and `(if-minor)` decorations after the label, but only if it really improves the value.
+
+Keep the comments short and in this format:
+
+```
+<label> [decorations]: <subject>
+
+[optional discussion]
+```
+
+The subject is usually not longer than one or two sentences. If more information is required to understand the comment, it belongs to the optional disussion part.
 
 
 # Auto-generating PR descriptions

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,20 +18,31 @@ For automated reviews focus on:
 
 ## Conventional Comments
 
-Use [Conventional Comments](https://conventionalcomments.org/) to label review feedback. Especially make a difference between more critical labels like `issue` or
-`todo` and less critical ones like `suggestion`, `typo` or `polish`. Use `quibble` instead of `nitpick`.
-
-You may use the `(non-blocking)`, `(blocking)` and `(if-minor)` decorations after the label, but only if it really improves the value.
-
-Keep the comments short and in this format:
+Use [Conventional Comments](https://conventionalcomments.org/) to format review feedback:
 
 ```
-<label> [decorations]: <subject>
+**<label> [decorations]:** <subject>
 
 [optional discussion]
 ```
 
-The subject is usually not longer than one or two sentences. If more information is required to understand the comment, it belongs to the optional disussion part.
+The subject is usually not longer than one line. If more information is required to understand the comment, it belongs to the optional discussion part.
+
+Use these labels:
+
+- `issue:` Issues highlight specific problems with the subject under review.
+- `suggestion:` Suggestions propose improvements to the current subject. It’s important to be explicit and clear on what is being suggested and why it is an improvement.
+- `todo:` TODO’s are small, trivial, but necessary changes.
+- `typo:` Typo comments are like todo comments, where the main issue is a misspelling.
+- `quibble:` Use that one instead of `nitpick` for trivial preference- or style-based requests. These should be non-blocking by nature.
+- `polish:` Polish comments are like a suggestion, where there is nothing necessarily wrong with the relevant content, there’s just some ways to immediately improve the quality.
+- `note:` Notes are always non-blocking and simply highlight something the reader should take note of.
+
+You may use decorations after the label, but only if it really improves the value:
+
+- `(blocking)` A comment with this decoration should prevent the subject under review from being accepted, until it is resolved.
+- `(non-blocking)` A comment with this decoration should not prevent the subject under review from being accepted.
+- `(if-minor)` This decoration gives some freedom to the author that they should resolve the comment only if the changes end up being minor or trivial.
 
 
 # Auto-generating PR descriptions

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,7 +18,7 @@ For automated reviews focus on:
 
 ## Conventional Comments
 
-Use [Conventional Comments](https://conventionalcomments.org/) to format review feedback:
+Use [Conventional Comments](https://conventionalcomments.org/) to format review feedback exactly like this:
 
 ```
 **<label> [decorations]:** <subject>
@@ -26,17 +26,17 @@ Use [Conventional Comments](https://conventionalcomments.org/) to format review 
 [optional discussion]
 ```
 
-The subject is usually not longer than one short line/sentence. If more information is required to understand the comment, it belongs to the optional discussion part.
+The subject should not be more than one short line/sentence. If more information is required to understand the comment, put in into the discussion part.
 
 Use these labels:
 
-- `issue:` Issues highlight specific problems with the subject under review.
-- `suggestion:` Suggestions propose improvements to the current subject. It’s important to be explicit and clear on what is being suggested and why it is an improvement.
-- `todo:` TODOs are small, trivial, but necessary changes.
-- `typo:` Typo comments are like todo comments, where the main issue is a misspelling.
-- `quibble:` Use that one instead of `nitpick` for trivial preference- or style-based requests. These should be non-blocking by nature.
-- `polish:` Polish comments are like a suggestion, where there is nothing necessarily wrong with the relevant content, there’s just some ways to immediately improve the quality.
-- `note:` Notes are always non-blocking and simply highlight something the reader should take note of.
+- `issue`: Issues highlight specific problems with the subject under review.
+- `suggestion`: Suggestions propose improvements to the current subject. It’s important to be explicit and clear on what is being suggested and why it is an improvement.
+- `todo`: TODOs are small, trivial, but necessary changes.
+- `typo`: Typo comments are like todo comments, where the main issue is a misspelling.
+- `quibble`: Use that one instead of `nitpick` for trivial preference- or style-based requests. These should be non-blocking by nature.
+- `polish`: Polish comments are like a suggestion, where there is nothing necessarily wrong with the relevant content, there are just some ways to immediately improve the quality.
+- `note`: Notes are always non-blocking and simply highlight something the reader should take note of.
 
 You may use decorations after the label, but only if it really improves the value:
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,7 +26,7 @@ Use [Conventional Comments](https://conventionalcomments.org/) to format review 
 [optional discussion]
 ```
 
-The subject should not be more than one short line/sentence. If more information is required to understand the comment, put in into the discussion part.
+The subject should not be more than one short line/sentence. If more information is required to understand the comment, put it into the discussion part.
 
 Use these labels:
 

--- a/app-ose/build.gradle.kts
+++ b/app-ose/build.gradle.kts
@@ -30,7 +30,9 @@ android {
          * - M is the major version (`4` in the example)
          * - mm the minor version (two decimal digits, `05` in the example),
          * - pp the patch level (two decimal digits, `12` in the example), and
-         * - IIII an increasing number (four decimal digits) that starts with `0000` and is increased for every pre-release (alpha-1, alpha-2, beta-1 etc.)
+         * - IIII an increasing number (four decimal digits) that starts with `0000` and is increased for
+         *   every release with the same major/minor/patch version (alpha-1, alpha-2, beta-1, ..., final).
+         *   So usually the first pre-release has `0000` and the final version has the greatest number.
          */
         versionCode = 405120000
         versionName = "4.5.12-beta.1"

--- a/app-ose/build.gradle.kts
+++ b/app-ose/build.gradle.kts
@@ -19,8 +19,8 @@ android {
 
         applicationId = "at.bitfire.davdroid"
 
-        versionCode = 405110001
-        versionName = "4.5.11-rc.1"
+        versionCode = 405120000
+        versionName = "4.5.12-beta.1"
 
         base.archivesName = "davx5-$versionCode-$versionName"
 

--- a/app-ose/build.gradle.kts
+++ b/app-ose/build.gradle.kts
@@ -30,7 +30,7 @@ android {
          * - M is the major version (`4` in the example)
          * - mm the minor version (two decimal digits, `05` in the example),
          * - pp the patch level (two decimal digits, `12` in the example), and
-         * - IIII an increasing number (four decimal digits) that starts with `0000` and is increased for every pre-release identifier (alpha, beta, rc, final).
+         * - IIII an increasing number (four decimal digits) that starts with `0000` and is increased for every pre-release (alpha-1, alpha-2, beta-1 etc.)
          */
         versionCode = 405120000
         versionName = "4.5.12-beta.1"

--- a/app-ose/build.gradle.kts
+++ b/app-ose/build.gradle.kts
@@ -19,18 +19,18 @@ android {
 
         applicationId = "at.bitfire.davdroid"
 
-        /**
+        /*
          * Version names use Semantic Versioning. Pre-release identifiers are "alpha" (closed alpha in
          * internal track), "beta" (public beta track) and "rc" (public beta track).
          *
          * Version codes are derived from the version name like this:
          *
-         * <M><mm><pp><IIII>   (example `405120000`)   where
+         * MmmppIIII   (example `405120000`)   where
          *
          * - M is the major version (`4` in the example)
          * - mm the minor version (two decimal digits, `05` in the example),
          * - pp the patch level (two decimal digits, `12` in the example), and
-         * - IIII an increasing number (four decimal digits) that starts with `0000` and is increased for every release, including pre-releases.
+         * - IIII an increasing number (four decimal digits) that starts with `0000` and is increased for every pre-release identifier (alpha, beta, rc, final).
          */
         versionCode = 405120000
         versionName = "4.5.12-beta.1"

--- a/app-ose/build.gradle.kts
+++ b/app-ose/build.gradle.kts
@@ -19,6 +19,19 @@ android {
 
         applicationId = "at.bitfire.davdroid"
 
+        /**
+         * Version names use Semantic Versioning. Pre-release identifiers are "alpha" (closed alpha in
+         * internal track), "beta" (public beta track) and "rc" (public beta track).
+         *
+         * Version codes are derived from the version name like this:
+         *
+         * <M><mm><pp><IIII>   (example `405120000`)   where
+         *
+         * - M is the major version (`4` in the example)
+         * - mm the minor version (two decimal digits, `05` in the example),
+         * - pp the patch level (two decimal digits, `12` in the example), and
+         * - IIII an increasing number (four decimal digits) that starts with `0000` and is increased for every release, including pre-releases.
+         */
         versionCode = 405120000
         versionName = "4.5.12-beta.1"
 


### PR DESCRIPTION
This pull request updates documentation for code review conventions and bumps the app version for a new beta release. The most important changes are grouped below:

Documentation improvements:

* Expanded the Conventional Comments section in `.github/copilot-instructions.md` to provide detailed formatting guidelines, clarify the use of labels and decorations, and explain their intended purposes for code review feedback.

Release version update:

* Updated `app-ose/build.gradle.kts` to set `versionCode` to `405120000` and `versionName` to `4.5.12-beta.1`, and added comments explaining the versioning scheme.