### PR TITLE
Push Settings: Add action card to set default UnifiedPush distributor

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/composable/ActionCard.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/composable/ActionCard.kt
@@ -29,8 +29,8 @@ import androidx.compose.ui.unit.dp
 fun ActionCard(
     modifier: Modifier = Modifier,
     icon: ImageVector? = null,
-    actionText: String? = null,
-    onAction: () -> Unit = {},
+    actionText: String,
+    onAction: () -> Unit,
     content: @Composable () -> Unit
 ) {
     ActionCard(
@@ -46,8 +46,8 @@ fun ActionCard(
 fun ActionCard(
     modifier: Modifier = Modifier,
     painterIcon: Painter? = null,
-    actionText: String? = null,
-    onAction: () -> Unit = {},
+    actionText: String,
+    onAction: () -> Unit,
     content: @Composable () -> Unit
 ) {
     ActionCard(
@@ -74,7 +74,7 @@ private fun ActionCard(
     ) {
         Column(
             Modifier
-                .padding(top = 8.dp, start = 8.dp, end = 8.dp)
+                .padding(8.dp)
                 .fillMaxWidth(),
         ) {
             ProvideTextStyle(MaterialTheme.typography.bodyLarge) {
@@ -94,7 +94,7 @@ private fun ActionCard(
             if (actionText != null)
                 OutlinedButton(
                     onClick = onAction,
-                    modifier = Modifier.padding(vertical = 8.dp)
+                    modifier = Modifier.padding(top = 8.dp)
                 ) {
                     Text(actionText)
                 }
@@ -134,7 +134,8 @@ private fun Painter.buildComposable(): @Composable (RowScope.() -> Unit) {
 fun ActionCard_Sample() {
     ActionCard(
         icon = Icons.Default.NotificationAdd,
-        actionText = "Some Action"
+        actionText = "Some Action",
+        onAction = {}
     ) {
         Column {
             Text("Some Content. Some Content. Some Content. Some Content. ")

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsContract.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsContract.kt
@@ -16,7 +16,15 @@ interface PushSettingsContract {
             val selectedPushDistributor: String? = null,
             val defaultPushDistributor: String? = null,
             val pushDistributors: List<PushDistributorInfo> = emptyList()
-        ) : State
+        ) : State {
+            fun couldSelectDefaultDistributor(packageName: String): Boolean {
+                val unifiedPushDistributors = pushDistributors.filter {
+                    // Filter out FCM (Play Services) distributor embedded in our own app DAVx5
+                    it.packageName != packageName
+                }
+                return defaultPushDistributor == null && unifiedPushDistributors.size > 1
+            }
+        }
     }
 
     data class PushDistributorInfo(
@@ -28,5 +36,7 @@ interface PushSettingsContract {
     sealed interface Event {
         data class PushEnabled(val enabled: Boolean) : Event
         data class PushDistributorSelected(val packageName: String) : Event
+
+        class DefaultPushDistributorSelected : Event
     }
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsContract.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsContract.kt
@@ -37,6 +37,6 @@ interface PushSettingsContract {
         data class PushEnabled(val enabled: Boolean) : Event
         data class PushDistributorSelected(val packageName: String) : Event
 
-        class DefaultPushDistributorSelected : Event
+        data object DefaultPushDistributorSelected : Event
     }
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsModel.kt
@@ -13,6 +13,7 @@ import at.bitfire.davdroid.R
 import at.bitfire.davdroid.di.qualifier.ApplicationScope
 import at.bitfire.davdroid.di.qualifier.IoDispatcher
 import at.bitfire.davdroid.push.PushDistributorManager
+import at.bitfire.davdroid.push.PushRegistrationManager
 import at.bitfire.davdroid.ui.push.PushSettingsContract.Event
 import at.bitfire.davdroid.ui.push.PushSettingsContract.Event.PushDistributorSelected
 import at.bitfire.davdroid.ui.push.PushSettingsContract.Event.PushEnabled
@@ -35,7 +36,8 @@ class PushSettingsModel @Inject constructor(
     @param:ApplicationContext private val context: Context,
     @param:ApplicationScope private val applicationScope: CoroutineScope,
     @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
-    private val pushDistributorManager: PushDistributorManager
+    private val pushDistributorManager: PushDistributorManager,
+    private val pushRegistrationManager: PushRegistrationManager
 ) : ViewModel() {
     private val packageManager = context.packageManager
 
@@ -66,6 +68,7 @@ class PushSettingsModel @Inject constructor(
 
         applicationScope.launch(ioDispatcher) {
             pushDistributorManager.setPushEnabled(enabled)
+            pushRegistrationManager.update()
         }
     }
 
@@ -76,6 +79,7 @@ class PushSettingsModel @Inject constructor(
 
         applicationScope.launch(ioDispatcher) {
             pushDistributorManager.setPushDistributorAndEnablePush(packageName)
+            pushRegistrationManager.update()
         }
     }
 
@@ -94,6 +98,7 @@ class PushSettingsModel @Inject constructor(
         if (selectedDistributor == null) {
             applicationScope.launch(ioDispatcher) {
                 pushDistributorManager.setPushDistributorAndEnablePush(defaultDistributor)
+                pushRegistrationManager.update()
             }
         }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsModel.kt
@@ -18,8 +18,8 @@ import at.bitfire.davdroid.ui.push.PushSettingsContract.Event.PushDistributorSel
 import at.bitfire.davdroid.ui.push.PushSettingsContract.Event.PushEnabled
 import at.bitfire.davdroid.ui.push.PushSettingsContract.PushDistributorInfo
 import at.bitfire.davdroid.ui.push.PushSettingsContract.State
-import at.bitfire.davdroid.ui.push.PushSettingsContract.State.Loading
 import at.bitfire.davdroid.ui.push.PushSettingsContract.State.Content
+import at.bitfire.davdroid.ui.push.PushSettingsContract.State.Loading
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
@@ -52,6 +52,7 @@ class PushSettingsModel @Inject constructor(
         when (event) {
             is PushEnabled -> handlePushEnabled(event.enabled)
             is PushDistributorSelected -> handlePushDistributorSelected(event.packageName)
+            is Event.DefaultPushDistributorSelected -> handleDefaultPushDistributorSelected()
         }
     }
 
@@ -75,6 +76,26 @@ class PushSettingsModel @Inject constructor(
 
         applicationScope.launch(ioDispatcher) {
             pushDistributorManager.setPushDistributorAndEnablePush(packageName)
+        }
+    }
+
+    private fun handleDefaultPushDistributorSelected() {
+        // If there was no selection made in DAVx5 yet, the newly selected default distributor is also picked as selected distributor in DAVx5.
+        val defaultDistributor = pushDistributorManager.getDefaultDistributor() ?: return
+        // Update view
+        updateContent { content ->
+            content.copy(
+                selectedPushDistributor = defaultDistributor,
+                defaultPushDistributor = defaultDistributor
+            )
+        }
+
+        // If there was no selection made in DAVx5 yet, the newly selected default distributor is also picked as selected distributor in DAVx5.
+        val selectedDistributor = pushDistributorManager.getSelectedDistributor()
+        if (selectedDistributor == null) {
+            applicationScope.launch(ioDispatcher) {
+                pushDistributorManager.setPushDistributorAndEnablePush(defaultDistributor)
+            }
         }
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsModel.kt
@@ -80,23 +80,32 @@ class PushSettingsModel @Inject constructor(
     }
 
     private fun handleDefaultPushDistributorSelected() {
-        // If there was no selection made in DAVx5 yet, the newly selected default distributor is also picked as selected distributor in DAVx5.
-        val defaultDistributor = pushDistributorManager.getDefaultDistributor() ?: return
-        // Update view
-        updateContent { content ->
-            content.copy(
-                selectedPushDistributor = defaultDistributor,
-                defaultPushDistributor = defaultDistributor
-            )
-        }
-
-        // If there was no selection made in DAVx5 yet, the newly selected default distributor is also picked as selected distributor in DAVx5.
+        val defaultDistributor = pushDistributorManager.getDefaultDistributor()
         val selectedDistributor = pushDistributorManager.getSelectedDistributor()
+
+        // Return early if default distributor was not set for some reason (should not happen)
+        if (defaultDistributor == null)
+            return
+
+        // Our decision on UI behavior: If there was no selection made in DAVx5 yet, the newly
+        // selected default distributor is also picked as selected distributor in DAVx5.
+
+        // Update active distributor, if no selection made in DAVx5 yet
         if (selectedDistributor == null) {
             applicationScope.launch(ioDispatcher) {
                 pushDistributorManager.setPushDistributorAndEnablePush(defaultDistributor)
             }
         }
+
+        // Update view
+        updateContent { content ->
+            content.copy(
+                // Update active/selected distributor with default, if no selection made in DAVx5 yet (selectedDistributor is null)
+                selectedPushDistributor = selectedDistributor ?: defaultDistributor,
+                defaultPushDistributor = defaultDistributor
+            )
+        }
+
     }
 
     private fun loadSettings() {

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsModel.kt
@@ -105,7 +105,6 @@ class PushSettingsModel @Inject constructor(
                 defaultPushDistributor = defaultDistributor
             )
         }
-
     }
 
     private fun loadSettings() {

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsScreen.kt
@@ -270,7 +270,7 @@ private fun PushServicesList(content: Content, onEvent: (Event) -> Unit) {
                 onAction = {
                     if (activity != null) {
                         UnifiedPush.tryUseDefaultDistributor(activity) { success ->
-                            if (success) onEvent(DefaultPushDistributorSelected())
+                            if (success) onEvent(DefaultPushDistributorSelected)
                         }
                     }
                 },

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsScreen.kt
@@ -4,6 +4,7 @@
 
 package at.bitfire.davdroid.ui.push
 
+import androidx.activity.compose.LocalActivity
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -72,8 +73,10 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.ui.ExternalUris
 import at.bitfire.davdroid.ui.UiUtils.toAnnotatedString
+import at.bitfire.davdroid.ui.composable.ActionCard
 import at.bitfire.davdroid.ui.composable.AppTheme
 import at.bitfire.davdroid.ui.push.PushSettingsContract.Event
+import at.bitfire.davdroid.ui.push.PushSettingsContract.Event.DefaultPushDistributorSelected
 import at.bitfire.davdroid.ui.push.PushSettingsContract.Event.PushDistributorSelected
 import at.bitfire.davdroid.ui.push.PushSettingsContract.Event.PushEnabled
 import at.bitfire.davdroid.ui.push.PushSettingsContract.PushDistributorInfo
@@ -81,6 +84,7 @@ import at.bitfire.davdroid.ui.push.PushSettingsContract.State
 import at.bitfire.davdroid.ui.push.PushSettingsContract.State.Content
 import at.bitfire.davdroid.ui.push.PushSettingsContract.State.Loading
 import kotlinx.coroutines.time.delay
+import org.unifiedpush.android.connector.UnifiedPush
 import java.time.Duration
 
 private const val UNIFIED_PUSH_URL = "https://unifiedpush.org"
@@ -253,9 +257,29 @@ private fun NoPushServices() {
 
 @Composable
 private fun PushServicesList(content: Content, onEvent: (Event) -> Unit) {
-    Spacer(modifier = Modifier.height(32.dp))
+    val activity = LocalActivity.current
+    val context = LocalContext.current
+
+    Spacer(modifier = Modifier.height(16.dp))
 
     Column(modifier = Modifier.selectableGroup()) {
+        if (content.couldSelectDefaultDistributor(context.packageName)) {
+            ActionCard(
+                icon = null,
+                actionText = stringResource(R.string.app_settings_push_select_default_distributor_action),
+                onAction = {
+                    if (activity != null) {
+                        UnifiedPush.tryUseDefaultDistributor(activity) { success ->
+                            if (success) onEvent(DefaultPushDistributorSelected())
+                        }
+                    }
+                },
+                modifier = Modifier.padding(bottom = 16.dp)
+            ) {
+                Text(stringResource(R.string.app_settings_push_select_default_distributor_description))
+            }
+        }
+
         Text(
             text = stringResource(R.string.app_settings_push_push_services),
             style = MaterialTheme.typography.bodyLarge,
@@ -412,6 +436,40 @@ private fun PushSettingsScreenPreview_MultiplePushDistributors() {
             state = Content(
                 selectedPushDistributor = "sunup",
                 defaultPushDistributor = "ntfy",
+                pushDistributors = listOf(
+                    PushDistributorInfo(
+                        packageName = "ntfy",
+                        appName = "ntfy",
+                        appIcon = null
+                    ),
+                    PushDistributorInfo(
+                        packageName = "sunup",
+                        appName = "Sunup",
+                        appIcon = null
+                    ),
+                    PushDistributorInfo(
+                        packageName = context.packageName,
+                        appName = "FCM (Google Play)",
+                        appIcon = AppCompatResources.getDrawable(context, R.drawable.product_logomark_cloud_messaging_full_color)
+                    )
+                ),
+            ),
+            onEvent = {},
+            onNavUp = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PushSettingsScreenPreview_MultiplePushDistributors_NoDefault() {
+    AppTheme {
+        val context = LocalContext.current
+
+        PushSettingsContent(
+            state = Content(
+                selectedPushDistributor = "sunup",
+                defaultPushDistributor = null,
                 pushDistributors = listOf(
                     PushDistributorInfo(
                         packageName = "ntfy",

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -255,6 +255,8 @@
     <string name="app_settings_push_info_text"><![CDATA[Push messages are always encrypted. Learn more about WebDAV-Push from <a href=\"%s\">the manual</a>.]]></string>
     <string name="app_settings_push_push_services">Push Service</string>
     <string name="app_settings_push_default_distributor_text">(system default)</string>
+    <string name="app_settings_push_select_default_distributor_description">There are multiple UnifiedPush Distributor Apps installed. You can set a system-wide default here, so other UnifiedPush-enabled apps don\'t have to ask which one to use.</string>
+    <string name="app_settings_push_select_default_distributor_action">Set default</string>
 
     <!-- AccountScreen -->
     <string name="account_invalid_account">Account has been removed</string>


### PR DESCRIPTION
### Purpose

Provide possibility to set system-wide UnfiedPush default distributor in Push Settings


### Short description

* Add "Set unified push default distributor" action card above push services list
* Add `couldSelectDefaultDistributor` helper to check if default distributor can be set, which decides whether or not to show the action card
* Add `DefaultPushDistributorSelected` event and handler method
* Add preview for multiple push distributors without set default
* Add string resources for default distributor action button and description



### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

