### PR TITLE
Update compile SDK to 37 and AGP 9.x compatibility

### DIFF
--- a/app-ose/build.gradle.kts
+++ b/app-ose/build.gradle.kts
@@ -10,8 +10,14 @@ plugins {
     alias(libs.plugins.mikepenz.aboutLibraries.android)
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
 android {
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 24        // Android 7.0
@@ -53,12 +59,6 @@ android {
         resValue("string", "authority_debug_provider", debugInfoAuthority)
 
         // Currently no instrumentation tests for app-ose, so no testInstrumentationRunner
-    }
-
-    java {
-        toolchain {
-            languageVersion = JavaLanguageVersion.of(21)
-        }
     }
 
     compileOptions {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -11,9 +11,14 @@ plugins {
     alias(libs.plugins.mikepenz.aboutLibraries.android)
 }
 
-// Android configuration
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
 android {
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 24        // Android 7.0
@@ -22,12 +27,6 @@ android {
 
         // include these rules in the app that uses the core library
         consumerProguardFile("core-proguard-rules.pro")
-    }
-
-    java {
-        toolchain {
-            languageVersion = JavaLanguageVersion.of(21)
-        }
     }
 
     compileOptions {

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,9 +10,6 @@ org.gradle.parallel=true
 # Android
 android.useAndroidX=true
 
-# Compatibility with AGP 9.0.0
-android.newDsl=false
-
 # It's recommended to add these settings to your $GRADLE_USER_HOME/gradle.properties:
 
 # org.gradle.configuration-cache=true


### PR DESCRIPTION
### Purpose

Update the compile SDK and ensure compatibility with Android Gradle Plugin (AGP) 9.0 `androidDsl`.

Part of #2014.

### Short description

- Updated the compile SDK version.
- Made necessary adjustments to ensure compatibility with AGP 9.0 `androidDsl`.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.