### PR TITLE
Push Settings: Add push capability info card

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/db/CollectionDao.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/CollectionDao.kt
@@ -48,11 +48,14 @@ interface CollectionDao {
     @Query("SELECT COUNT(*) FROM collection WHERE serviceId=:serviceId AND type=:type")
     suspend fun anyOfType(serviceId: Long, @CollectionType type: String): Boolean
 
-    @Query("SELECT COUNT(*) FROM collection")
-    suspend fun countTotal(): Int
-
     @Query("SELECT COUNT(*) FROM collection WHERE supportsWebPush AND pushTopic IS NOT NULL")
-    suspend fun countPushCapable(): Int
+    suspend fun anyPushCapable(): Boolean
+
+    @Query("SELECT COUNT(*) FROM collection WHERE sync")
+    suspend fun countSyncEnabled(): Int
+    
+    @Query("SELECT COUNT(*) FROM collection WHERE supportsWebPush AND pushTopic IS NOT NULL and sync")
+    suspend fun countSyncEnabledPushCapable(): Int
 
     /**
      * Returns collections which

--- a/core/src/main/kotlin/at/bitfire/davdroid/db/CollectionDao.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/CollectionDao.kt
@@ -48,8 +48,11 @@ interface CollectionDao {
     @Query("SELECT COUNT(*) FROM collection WHERE serviceId=:serviceId AND type=:type")
     suspend fun anyOfType(serviceId: Long, @CollectionType type: String): Boolean
 
+    @Query("SELECT COUNT(*) FROM collection")
+    suspend fun countTotal(): Int
+
     @Query("SELECT COUNT(*) FROM collection WHERE supportsWebPush AND pushTopic IS NOT NULL")
-    suspend fun anyPushCapable(): Boolean
+    suspend fun countPushCapable(): Int
 
     /**
      * Returns collections which

--- a/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
@@ -61,7 +61,7 @@ class DavCollectionRepository @Inject constructor(
     private val dao = db.collectionDao()
 
     /**
-     * Returns the number of collections that are registered for push.
+     * Returns the number of collections that are push capable.
      */
     suspend fun countPushCapable() =  dao.countPushCapable()
 
@@ -93,7 +93,7 @@ class DavCollectionRepository @Inject constructor(
     }
 
     /**
-     * Whether there are any collections that are registered for push.
+     * Whether there are any collections that are push capable.
      */
     suspend fun anyPushCapable(): Boolean = dao.countPushCapable() > 0
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
@@ -95,7 +95,7 @@ class DavCollectionRepository @Inject constructor(
     /**
      * Whether there are any collections that are registered for push.
      */
-    suspend fun anyPushCapable(): Boolean = getAmountPushCapable() != PushCollectionsAmount.None
+    suspend fun anyPushCapable(): Boolean = dao.countPushCapable() > 0
 
     /**
      * Creates address book collection on server and locally

--- a/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
@@ -61,9 +61,41 @@ class DavCollectionRepository @Inject constructor(
     private val dao = db.collectionDao()
 
     /**
+     * Returns the number of collections that are registered for push.
+     */
+    suspend fun countPushCapable() =  dao.countPushCapable()
+
+    /**
+     * Returns the total number of collections across all accounts.
+     */
+    suspend fun countTotal() = dao.countTotal()
+
+    /**
+     * Determines the amount of push capable collections in all accounts combined.
+     * @return
+     *  - [PushCollectionsAmount.All] if all collections in all accounts are push-capable
+     *  - [PushCollectionsAmount.Some] if some (but not all) collections are push-capable
+     *  - [PushCollectionsAmount.None] if no collections are push-capable
+     */
+    suspend fun getAmountPushCapable(): PushCollectionsAmount {
+        val totalCollections = countTotal()
+        if (totalCollections == 0) {
+            return PushCollectionsAmount.None
+        }
+
+        val pushCapableRatio = countPushCapable().toDouble() / totalCollections
+
+        return when (pushCapableRatio) {
+            0.0 -> PushCollectionsAmount.None
+            1.0 -> PushCollectionsAmount.All
+            else -> PushCollectionsAmount.Some
+        }
+    }
+
+    /**
      * Whether there are any collections that are registered for push.
      */
-    suspend fun anyPushCapable() = dao.anyPushCapable()
+    suspend fun anyPushCapable(): Boolean = getAmountPushCapable() != PushCollectionsAmount.None
 
     /**
      * Creates address book collection on server and locally
@@ -425,6 +457,12 @@ class DavCollectionRepository @Inject constructor(
     private fun getVTimeZone(tzId: String): VTimeZone? {
         val tzRegistry = TimeZoneRegistryFactory.getInstance().createRegistry()
         return tzRegistry.getTimeZone(tzId)?.vTimeZone
+    }
+
+    enum class PushCollectionsAmount {
+        All,     // All collections are push-capable
+        Some,    // Some collections are push-capable
+        None;    // Zero collections are push-capable
     }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
@@ -83,11 +83,11 @@ class DavCollectionRepository @Inject constructor(
             return PushCollectionsAmount.None
         }
 
-        val pushCapableRatio = countPushCapable().toDouble() / totalCollections
+        val pushCapableCollections = countPushCapable()
 
-        return when (pushCapableRatio) {
-            0.0 -> PushCollectionsAmount.None
-            1.0 -> PushCollectionsAmount.All
+        return when (pushCapableCollections) {
+            0 -> PushCollectionsAmount.None
+            totalCollections -> PushCollectionsAmount.All
             else -> PushCollectionsAmount.Some
         }
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
@@ -74,20 +74,17 @@ class DavCollectionRepository @Inject constructor(
      * Determines the amount of push capable collections in all accounts combined.
      * @return
      *  - [PushCollectionsAmount.All] if all collections in all accounts are push-capable
+     *  - [PushCollectionsAmount.All] if zero collections exist
      *  - [PushCollectionsAmount.Some] if some (but not all) collections are push-capable
      *  - [PushCollectionsAmount.None] if no collections are push-capable
      */
     suspend fun getAmountPushCapable(): PushCollectionsAmount {
         val totalCollections = countTotal()
-        if (totalCollections == 0) {
-            return PushCollectionsAmount.None
-        }
-
         val pushCapableCollections = countPushCapable()
 
         return when (pushCapableCollections) {
+            totalCollections -> PushCollectionsAmount.All // Also matches zero total collections
             0 -> PushCollectionsAmount.None
-            totalCollections -> PushCollectionsAmount.All
             else -> PushCollectionsAmount.Some
         }
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
@@ -63,27 +63,26 @@ class DavCollectionRepository @Inject constructor(
     /**
      * Returns the number of collections that are push capable.
      */
-    suspend fun countPushCapable() =  dao.countPushCapable()
+    suspend fun countSyncEnabledPushCapable() =  dao.countSyncEnabledPushCapable()
 
     /**
-     * Returns the total number of collections across all accounts.
+     * Returns the total number of collections in all accounts that are user enabled for synchronization.
      */
-    suspend fun countTotal() = dao.countTotal()
+    suspend fun countSyncEnabled() = dao.countSyncEnabled()
 
     /**
-     * Determines the amount of push capable collections in all accounts combined.
+     * Determines the amount of sync-enabled push capable collections in all accounts combined.
      * @return
-     *  - [PushCollectionsAmount.All] if all collections in all accounts are push-capable
-     *  - [PushCollectionsAmount.All] if zero collections exist
-     *  - [PushCollectionsAmount.Some] if some (but not all) collections are push-capable
-     *  - [PushCollectionsAmount.None] if no collections are push-capable
+     *  - [PushCollectionsAmount.All] if all the sync-enabled collections in all accounts are push-capable OR if zero sync-enabled collections exist
+     *  - [PushCollectionsAmount.Some] if some (but not all) sync-enabled collections are push-capable
+     *  - [PushCollectionsAmount.None] if no sync-enabled collections are push-capable
      */
     suspend fun getAmountPushCapable(): PushCollectionsAmount {
-        val totalCollections = countTotal()
-        val pushCapableCollections = countPushCapable()
+        val syncEnabled = countSyncEnabled()
+        val syncEnabledPushCapable = countSyncEnabledPushCapable()
 
-        return when (pushCapableCollections) {
-            totalCollections -> PushCollectionsAmount.All // Also matches zero total collections
+        return when (syncEnabledPushCapable) {
+            syncEnabled -> PushCollectionsAmount.All // Also matches zero sync-enabled collections
             0 -> PushCollectionsAmount.None
             else -> PushCollectionsAmount.Some
         }
@@ -92,7 +91,7 @@ class DavCollectionRepository @Inject constructor(
     /**
      * Whether there are any collections that are push capable.
      */
-    suspend fun anyPushCapable(): Boolean = dao.countPushCapable() > 0
+    suspend fun anyPushCapable(): Boolean = dao.anyPushCapable()
 
     /**
      * Creates address book collection on server and locally

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/composable/ActionCard.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/composable/ActionCard.kt
@@ -5,20 +5,14 @@
 package at.bitfire.davdroid.ui.composable
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.NotificationAdd
-import androidx.compose.material3.Card
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -64,68 +58,22 @@ private fun ActionCard(
     modifier: Modifier,
     icon: @Composable (RowScope.() -> Unit)?,
     content: @Composable (() -> Unit),
-    actionText: String?,
+    actionText: String,
     onAction: () -> Unit
 ) {
-    Card(
-        Modifier
-            .fillMaxWidth()
-            .then(modifier)
-    ) {
-        Column(
-            Modifier
-                .padding(8.dp)
-                .fillMaxWidth(),
-        ) {
-            ProvideTextStyle(MaterialTheme.typography.bodyLarge) {
-                if (icon != null) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        icon()
-                        content()
-                    }
-                } else {
-                    content()
-                }
+    BaseCard(
+        modifier = modifier,
+        icon = icon,
+        footer = {
+            OutlinedButton(
+                onClick = onAction,
+                modifier = Modifier.padding(top = 8.dp)
+            ) {
+                Text(actionText)
             }
-
-            if (actionText != null)
-                OutlinedButton(
-                    onClick = onAction,
-                    modifier = Modifier.padding(top = 8.dp)
-                ) {
-                    Text(actionText)
-                }
         }
-    }
-}
-
-@Composable
-private fun ImageVector.buildComposable(): @Composable (RowScope.() -> Unit) {
-    return {
-        Icon(
-            imageVector = this@buildComposable,
-            contentDescription = null,
-            modifier = Modifier
-                .align(Alignment.Top)
-                .padding(8.dp)
-        )
-    }
-}
-
-
-@Composable
-private fun Painter.buildComposable(): @Composable (RowScope.() -> Unit) {
-    return {
-        Icon(
-            painter = this@buildComposable,
-            contentDescription = null,
-            modifier = Modifier
-                .align(Alignment.Top)
-                .padding(8.dp)
-        )
+    ) {
+        content()
     }
 }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/composable/BaseCard.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/composable/BaseCard.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.ui.composable
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ProvideTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+
+/**
+ * Internal base card composable that provides shared layout for ActionCard and IconCard.
+ * Handles the Card wrapper, column layout, optional icon row, text styling, and optional footer.
+ */
+@Composable
+internal fun BaseCard(
+    modifier: Modifier = Modifier,
+    icon: @Composable (RowScope.() -> Unit)? = null,
+    footer: @Composable () -> Unit = {},
+    content: @Composable () -> Unit
+) {
+    Card(
+        Modifier
+            .fillMaxWidth()
+            .then(modifier)
+    ) {
+        Column(
+            Modifier
+                .padding(8.dp)
+                .fillMaxWidth(),
+        ) {
+            ProvideTextStyle(MaterialTheme.typography.bodyLarge) {
+                if (icon != null) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        icon()
+                        content()
+                    }
+                } else {
+                    content()
+                }
+            }
+
+            footer()
+        }
+    }
+}
+
+/**
+ * Extension function to convert an ImageVector into a composable icon for use in RowScope.
+ * Provides consistent icon styling (aligned to top, 8dp padding).
+ */
+@Composable
+internal fun ImageVector.buildComposable(): @Composable (RowScope.() -> Unit) {
+    return {
+        Icon(
+            imageVector = this@buildComposable,
+            contentDescription = null,
+            modifier = Modifier
+                .align(Alignment.Top)
+                .padding(8.dp)
+        )
+    }
+}
+
+/**
+ * Extension function to convert a Painter into a composable icon for use in RowScope.
+ * Provides consistent icon styling (aligned to top, 8dp padding).
+ */
+@Composable
+internal fun Painter.buildComposable(): @Composable (RowScope.() -> Unit) {
+    return {
+        Icon(
+            painter = this@buildComposable,
+            contentDescription = null,
+            modifier = Modifier
+                .align(Alignment.Top)
+                .padding(8.dp)
+        )
+    }
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/composable/IconCard.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/composable/IconCard.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.ui.composable
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Event
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ProvideTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun IconCard(
+    modifier: Modifier = Modifier,
+    icon: ImageVector? = null,
+    content: @Composable () -> Unit
+) {
+    IconCard(
+        modifier = modifier,
+        icon = icon?.buildComposable(), 
+        content = content
+    )
+}
+
+@Composable
+fun IconCard(
+    modifier: Modifier = Modifier,
+    painterIcon: Painter? = null,
+    content: @Composable () -> Unit
+) {
+    IconCard(
+        modifier = modifier,
+        icon = painterIcon?.buildComposable(),
+        content = content
+    )
+}
+
+@Composable
+private fun IconCard(
+    modifier: Modifier,
+    icon: @Composable (RowScope.() -> Unit)?,
+    content: @Composable (() -> Unit)
+) {
+    Card(
+        Modifier
+            .fillMaxWidth()
+            .then(modifier)
+    ) {
+        Column(
+            Modifier
+                .padding(8.dp)
+                .fillMaxWidth(),
+        ) {
+            ProvideTextStyle(MaterialTheme.typography.bodyLarge) {
+                if (icon != null) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        icon()
+                        content()
+                    }
+                } else {
+                    content()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ImageVector.buildComposable(): @Composable (RowScope.() -> Unit) {
+    return {
+        Icon(
+            imageVector = this@buildComposable,
+            contentDescription = null,
+            modifier = Modifier
+                .align(Alignment.Top)
+                .padding(8.dp)
+        )
+    }
+}
+
+
+@Composable
+private fun Painter.buildComposable(): @Composable (RowScope.() -> Unit) {
+    return {
+        Icon(
+            painter = this@buildComposable,
+            contentDescription = null,
+            modifier = Modifier
+                .align(Alignment.Top)
+                .padding(8.dp)
+        )
+    }
+}
+
+@Composable
+@Preview
+fun IconCard_Sample() {
+    IconCard(
+        icon = Icons.Default.Event
+    ) {
+        Column {
+            Text("Some Content. Some Content. Some Content. Some Content. ")
+            Text("Other Content. Other Content. Other Content. Other Content. Other Content. Other Content. Other Content. ", style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/composable/IconCard.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/composable/IconCard.kt
@@ -5,24 +5,16 @@
 package at.bitfire.davdroid.ui.composable
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Event
-import androidx.compose.material3.Card
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 
 @Composable
 fun IconCard(
@@ -56,57 +48,12 @@ private fun IconCard(
     icon: @Composable (RowScope.() -> Unit)?,
     content: @Composable (() -> Unit)
 ) {
-    Card(
-        Modifier
-            .fillMaxWidth()
-            .then(modifier)
+    BaseCard(
+        modifier = modifier,
+        icon = icon,
+        footer = {} // No footer for IconCard
     ) {
-        Column(
-            Modifier
-                .padding(8.dp)
-                .fillMaxWidth(),
-        ) {
-            ProvideTextStyle(MaterialTheme.typography.bodyLarge) {
-                if (icon != null) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        icon()
-                        content()
-                    }
-                } else {
-                    content()
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun ImageVector.buildComposable(): @Composable (RowScope.() -> Unit) {
-    return {
-        Icon(
-            imageVector = this@buildComposable,
-            contentDescription = null,
-            modifier = Modifier
-                .align(Alignment.Top)
-                .padding(8.dp)
-        )
-    }
-}
-
-
-@Composable
-private fun Painter.buildComposable(): @Composable (RowScope.() -> Unit) {
-    return {
-        Icon(
-            painter = this@buildComposable,
-            contentDescription = null,
-            modifier = Modifier
-                .align(Alignment.Top)
-                .padding(8.dp)
-        )
+        content()
     }
 }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsContract.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsContract.kt
@@ -5,7 +5,6 @@
 package at.bitfire.davdroid.ui.push
 
 import android.graphics.drawable.Drawable
-import at.bitfire.davdroid.repository.DavCollectionRepository.PushCollectionsAmount
 
 interface PushSettingsContract {
 
@@ -14,7 +13,7 @@ interface PushSettingsContract {
 
         data class Content(
             val isPushEnabled: Boolean = true,
-            val pushCollectionsAmount: PushCollectionsAmount = PushCollectionsAmount.Some,
+            val pushCapability: PushCapability = PushCapability.SomePushCapable,
             val selectedPushDistributor: String? = null,
             val defaultPushDistributor: String? = null,
             val pushDistributors: List<PushDistributorInfo> = emptyList()
@@ -27,6 +26,12 @@ interface PushSettingsContract {
                 return defaultPushDistributor == null && unifiedPushDistributors.size > 1
             }
         }
+    }
+
+    enum class PushCapability {
+        DoNotShow,
+        SomePushCapable,
+        NonePushCapable
     }
 
     data class PushDistributorInfo(

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsContract.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsContract.kt
@@ -5,6 +5,7 @@
 package at.bitfire.davdroid.ui.push
 
 import android.graphics.drawable.Drawable
+import at.bitfire.davdroid.repository.DavCollectionRepository.PushCollectionsAmount
 
 interface PushSettingsContract {
 
@@ -13,7 +14,7 @@ interface PushSettingsContract {
 
         data class Content(
             val isPushEnabled: Boolean = true,
-            val pushCollections: PushCollections = PushCollections.None,
+            val pushCollectionsAmount: PushCollectionsAmount = PushCollectionsAmount.Some,
             val selectedPushDistributor: String? = null,
             val defaultPushDistributor: String? = null,
             val pushDistributors: List<PushDistributorInfo> = emptyList()
@@ -41,9 +42,4 @@ interface PushSettingsContract {
         data object DefaultPushDistributorSelected : Event
     }
 
-    enum class PushCollections {
-        All,     // All collections are push-capable
-        Some,    // Some collections are push-capable
-        None;    // Zero collections are push-capable
-    }
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsContract.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsContract.kt
@@ -13,6 +13,7 @@ interface PushSettingsContract {
 
         data class Content(
             val isPushEnabled: Boolean = true,
+            val pushCollections: PushCollections = PushCollections.None,
             val selectedPushDistributor: String? = null,
             val defaultPushDistributor: String? = null,
             val pushDistributors: List<PushDistributorInfo> = emptyList()
@@ -38,5 +39,11 @@ interface PushSettingsContract {
         data class PushDistributorSelected(val packageName: String) : Event
 
         data object DefaultPushDistributorSelected : Event
+    }
+
+    enum class PushCollections {
+        All,     // All collections are push-capable
+        Some,    // Some collections are push-capable
+        None;    // Zero collections are push-capable
     }
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsModel.kt
@@ -14,6 +14,7 @@ import at.bitfire.davdroid.di.qualifier.ApplicationScope
 import at.bitfire.davdroid.di.qualifier.IoDispatcher
 import at.bitfire.davdroid.push.PushDistributorManager
 import at.bitfire.davdroid.push.PushRegistrationManager
+import at.bitfire.davdroid.repository.DavCollectionRepository
 import at.bitfire.davdroid.ui.push.PushSettingsContract.Event
 import at.bitfire.davdroid.ui.push.PushSettingsContract.Event.PushDistributorSelected
 import at.bitfire.davdroid.ui.push.PushSettingsContract.Event.PushEnabled
@@ -36,6 +37,7 @@ class PushSettingsModel @Inject constructor(
     @param:ApplicationContext private val context: Context,
     @param:ApplicationScope private val applicationScope: CoroutineScope,
     @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+    private val collectionRepository: DavCollectionRepository,
     private val pushDistributorManager: PushDistributorManager,
     private val pushRegistrationManager: PushRegistrationManager
 ) : ViewModel() {
@@ -112,10 +114,11 @@ class PushSettingsModel @Inject constructor(
         }
     }
 
-    private fun loadSettings() {
+    private suspend fun loadSettings() {
         val isPushEnabled = pushDistributorManager.isPushEnabled()
         val defaultDistributor = pushDistributorManager.getDefaultDistributor()
         val selectedDistributor = pushDistributorManager.getSelectedDistributor() ?: defaultDistributor
+        val pushCollectionsAmount = collectionRepository.getAmountPushCapable()
         val pushDistributors = pushDistributorManager.getDistributors()
             .mapNotNull { pushDistributor ->
                 if (pushDistributor == context.packageName) {
@@ -145,6 +148,7 @@ class PushSettingsModel @Inject constructor(
         updateContent { content ->
             content.copy(
                 isPushEnabled = isPushEnabled,
+                pushCollectionsAmount = pushCollectionsAmount,
                 selectedPushDistributor = selectedDistributor,
                 defaultPushDistributor = defaultDistributor,
                 pushDistributors = pushDistributors

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsModel.kt
@@ -15,9 +15,11 @@ import at.bitfire.davdroid.di.qualifier.IoDispatcher
 import at.bitfire.davdroid.push.PushDistributorManager
 import at.bitfire.davdroid.push.PushRegistrationManager
 import at.bitfire.davdroid.repository.DavCollectionRepository
+import at.bitfire.davdroid.repository.DavCollectionRepository.PushCollectionsAmount
 import at.bitfire.davdroid.ui.push.PushSettingsContract.Event
 import at.bitfire.davdroid.ui.push.PushSettingsContract.Event.PushDistributorSelected
 import at.bitfire.davdroid.ui.push.PushSettingsContract.Event.PushEnabled
+import at.bitfire.davdroid.ui.push.PushSettingsContract.PushCapability
 import at.bitfire.davdroid.ui.push.PushSettingsContract.PushDistributorInfo
 import at.bitfire.davdroid.ui.push.PushSettingsContract.State
 import at.bitfire.davdroid.ui.push.PushSettingsContract.State.Content
@@ -118,7 +120,7 @@ class PushSettingsModel @Inject constructor(
         val isPushEnabled = pushDistributorManager.isPushEnabled()
         val defaultDistributor = pushDistributorManager.getDefaultDistributor()
         val selectedDistributor = pushDistributorManager.getSelectedDistributor() ?: defaultDistributor
-        val pushCollectionsAmount = collectionRepository.getAmountPushCapable()
+        val pushCapability = getPushCapability()
         val pushDistributors = pushDistributorManager.getDistributors()
             .mapNotNull { pushDistributor ->
                 if (pushDistributor == context.packageName) {
@@ -148,11 +150,19 @@ class PushSettingsModel @Inject constructor(
         updateContent { content ->
             content.copy(
                 isPushEnabled = isPushEnabled,
-                pushCollectionsAmount = pushCollectionsAmount,
+                pushCapability = pushCapability,
                 selectedPushDistributor = selectedDistributor,
                 defaultPushDistributor = defaultDistributor,
                 pushDistributors = pushDistributors
             )
+        }
+    }
+
+    private suspend fun getPushCapability(): PushCapability {
+        return when (collectionRepository.getAmountPushCapable()) {
+            PushCollectionsAmount.All -> PushCapability.DoNotShow // No need to tell the user
+            PushCollectionsAmount.Some -> PushCapability.SomePushCapable
+            PushCollectionsAmount.None -> PushCapability.NonePushCapable
         }
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.Info
-import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -230,30 +229,24 @@ private fun PushServices(content: Content, onEvent: (Event) -> Unit) {
 private fun NoPushServices() {
     Spacer(modifier = Modifier.height(24.dp))
 
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Row(modifier = Modifier.padding(16.dp)) {
-            Icon(
-                Icons.Outlined.Info,
-                contentDescription = null,
-                modifier = Modifier.padding(end = 8.dp)
-            )
+    val infoText = HtmlCompat.fromHtml(
+        stringResource(
+            R.string.app_settings_push_no_push_services_found,
+            UNIFIED_PUSH_URL,
+            stringResource(R.string.app_settings_push_unified_push_url_text)
+        ),
+        HtmlCompat.FROM_HTML_MODE_COMPACT
+    ).toAnnotatedString()
 
-            val infoText = HtmlCompat.fromHtml(
-                stringResource(
-                    R.string.app_settings_push_no_push_services_found,
-                    UNIFIED_PUSH_URL,
-                    stringResource(R.string.app_settings_push_unified_push_url_text)
-                ),
-                HtmlCompat.FROM_HTML_MODE_COMPACT
-            ).toAnnotatedString()
-
-            Text(
-                text = infoText,
-                color = MaterialTheme.colorScheme.onSurface,
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.weight(1f)
-            )
-        }
+    IconCard(
+        modifier = Modifier.fillMaxWidth(),
+        icon = Icons.Outlined.Info
+    ) {
+        Text(
+            text = infoText,
+            color = MaterialTheme.colorScheme.onSurface,
+            style = MaterialTheme.typography.bodyMedium
+        )
     }
 }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsScreen.kt
@@ -75,10 +75,12 @@ import at.bitfire.davdroid.ui.ExternalUris
 import at.bitfire.davdroid.ui.UiUtils.toAnnotatedString
 import at.bitfire.davdroid.ui.composable.ActionCard
 import at.bitfire.davdroid.ui.composable.AppTheme
+import at.bitfire.davdroid.ui.composable.IconCard
 import at.bitfire.davdroid.ui.push.PushSettingsContract.Event
 import at.bitfire.davdroid.ui.push.PushSettingsContract.Event.DefaultPushDistributorSelected
 import at.bitfire.davdroid.ui.push.PushSettingsContract.Event.PushDistributorSelected
 import at.bitfire.davdroid.ui.push.PushSettingsContract.Event.PushEnabled
+import at.bitfire.davdroid.ui.push.PushSettingsContract.PushCollections
 import at.bitfire.davdroid.ui.push.PushSettingsContract.PushDistributorInfo
 import at.bitfire.davdroid.ui.push.PushSettingsContract.State
 import at.bitfire.davdroid.ui.push.PushSettingsContract.State.Content
@@ -257,28 +259,11 @@ private fun NoPushServices() {
 
 @Composable
 private fun PushServicesList(content: Content, onEvent: (Event) -> Unit) {
-    val activity = LocalActivity.current
-    val context = LocalContext.current
-
     Spacer(modifier = Modifier.height(16.dp))
 
     Column(modifier = Modifier.selectableGroup()) {
-        if (content.couldSelectDefaultDistributor(context.packageName)) {
-            ActionCard(
-                icon = null,
-                actionText = stringResource(R.string.app_settings_push_select_default_distributor_action),
-                onAction = {
-                    if (activity != null) {
-                        UnifiedPush.tryUseDefaultDistributor(activity) { success ->
-                            if (success) onEvent(DefaultPushDistributorSelected)
-                        }
-                    }
-                },
-                modifier = Modifier.padding(bottom = 16.dp)
-            ) {
-                Text(stringResource(R.string.app_settings_push_select_default_distributor_description))
-            }
-        }
+
+        InfoCards(content, onEvent)
 
         Text(
             text = stringResource(R.string.app_settings_push_push_services),
@@ -349,6 +334,44 @@ private fun PushServicesList(content: Content, onEvent: (Event) -> Unit) {
                     )
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun InfoCards(content: Content, onEvent: (Event) -> Unit) {
+    val activity = LocalActivity.current
+    val context = LocalContext.current
+
+    // Info on push capability of collections
+    when (content.pushCollections) {
+        PushCollections.None -> stringResource(R.string.app_settings_push_capability_none)
+        PushCollections.Some -> stringResource(R.string.app_settings_push_capability_some)
+        PushCollections.All -> null
+    }?.let { stringResource ->
+        IconCard(
+            icon = Icons.Outlined.Info,
+            modifier = Modifier.padding(bottom = 16.dp)
+        ) {
+            Text(stringResource)
+        }
+    }
+
+    // Select Default UnifiedPush Distributor card
+    if (content.couldSelectDefaultDistributor(context.packageName)) {
+        ActionCard(
+            icon = null,
+            actionText = stringResource(R.string.app_settings_push_select_default_distributor_action),
+            onAction = {
+                if (activity != null) {
+                    UnifiedPush.tryUseDefaultDistributor(activity) { success ->
+                        if (success) onEvent(DefaultPushDistributorSelected)
+                    }
+                }
+            },
+            modifier = Modifier.padding(bottom = 16.dp)
+        ) {
+            Text(stringResource(R.string.app_settings_push_select_default_distributor_description))
         }
     }
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsScreen.kt
@@ -71,6 +71,7 @@ import androidx.core.text.HtmlCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import at.bitfire.davdroid.R
+import at.bitfire.davdroid.repository.DavCollectionRepository.PushCollectionsAmount
 import at.bitfire.davdroid.ui.ExternalUris
 import at.bitfire.davdroid.ui.UiUtils.toAnnotatedString
 import at.bitfire.davdroid.ui.composable.ActionCard
@@ -80,7 +81,6 @@ import at.bitfire.davdroid.ui.push.PushSettingsContract.Event
 import at.bitfire.davdroid.ui.push.PushSettingsContract.Event.DefaultPushDistributorSelected
 import at.bitfire.davdroid.ui.push.PushSettingsContract.Event.PushDistributorSelected
 import at.bitfire.davdroid.ui.push.PushSettingsContract.Event.PushEnabled
-import at.bitfire.davdroid.ui.push.PushSettingsContract.PushCollections
 import at.bitfire.davdroid.ui.push.PushSettingsContract.PushDistributorInfo
 import at.bitfire.davdroid.ui.push.PushSettingsContract.State
 import at.bitfire.davdroid.ui.push.PushSettingsContract.State.Content
@@ -344,10 +344,10 @@ private fun InfoCards(content: Content, onEvent: (Event) -> Unit) {
     val context = LocalContext.current
 
     // Info on push capability of collections
-    when (content.pushCollections) {
-        PushCollections.None -> stringResource(R.string.app_settings_push_capability_none)
-        PushCollections.Some -> stringResource(R.string.app_settings_push_capability_some)
-        PushCollections.All -> null
+    when (content.pushCollectionsAmount) {
+        PushCollectionsAmount.All -> null // No need to tell the user
+        PushCollectionsAmount.Some -> stringResource(R.string.app_settings_push_capability_some)
+        PushCollectionsAmount.None -> stringResource(R.string.app_settings_push_capability_none)
     }?.let { stringResource ->
         IconCard(
             icon = Icons.Outlined.Info,

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsScreen.kt
@@ -70,7 +70,6 @@ import androidx.core.text.HtmlCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import at.bitfire.davdroid.R
-import at.bitfire.davdroid.repository.DavCollectionRepository.PushCollectionsAmount
 import at.bitfire.davdroid.ui.ExternalUris
 import at.bitfire.davdroid.ui.UiUtils.toAnnotatedString
 import at.bitfire.davdroid.ui.composable.ActionCard
@@ -80,6 +79,9 @@ import at.bitfire.davdroid.ui.push.PushSettingsContract.Event
 import at.bitfire.davdroid.ui.push.PushSettingsContract.Event.DefaultPushDistributorSelected
 import at.bitfire.davdroid.ui.push.PushSettingsContract.Event.PushDistributorSelected
 import at.bitfire.davdroid.ui.push.PushSettingsContract.Event.PushEnabled
+import at.bitfire.davdroid.ui.push.PushSettingsContract.PushCapability.DoNotShow
+import at.bitfire.davdroid.ui.push.PushSettingsContract.PushCapability.NonePushCapable
+import at.bitfire.davdroid.ui.push.PushSettingsContract.PushCapability.SomePushCapable
 import at.bitfire.davdroid.ui.push.PushSettingsContract.PushDistributorInfo
 import at.bitfire.davdroid.ui.push.PushSettingsContract.State
 import at.bitfire.davdroid.ui.push.PushSettingsContract.State.Content
@@ -337,17 +339,10 @@ private fun InfoCards(content: Content, onEvent: (Event) -> Unit) {
     val context = LocalContext.current
 
     // Info on push capability of collections
-    when (content.pushCollectionsAmount) {
-        PushCollectionsAmount.All -> null // No need to tell the user
-        PushCollectionsAmount.Some -> stringResource(R.string.app_settings_push_capability_some)
-        PushCollectionsAmount.None -> stringResource(R.string.app_settings_push_capability_none)
-    }?.let { message ->
-        IconCard(
-            icon = Icons.Outlined.Info,
-            modifier = Modifier.padding(bottom = 16.dp)
-        ) {
-            Text(message)
-        }
+    when (content.pushCapability) {
+        DoNotShow -> Unit
+        SomePushCapable -> PushCapabilityCard(stringResource(R.string.app_settings_push_capability_some))
+        NonePushCapable -> PushCapabilityCard(stringResource(R.string.app_settings_push_capability_none))
     }
 
     // Select Default UnifiedPush Distributor card
@@ -392,6 +387,15 @@ private fun InfoFooter() {
     )
 }
 
+@Composable
+private fun PushCapabilityCard(message: String) {
+    IconCard(
+        icon = Icons.Outlined.Info,
+        modifier = Modifier.padding(bottom = 16.dp)
+    ) {
+        Text(message)
+    }
+}
 
 @Preview
 @Composable

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/push/PushSettingsScreen.kt
@@ -348,12 +348,12 @@ private fun InfoCards(content: Content, onEvent: (Event) -> Unit) {
         PushCollectionsAmount.All -> null // No need to tell the user
         PushCollectionsAmount.Some -> stringResource(R.string.app_settings_push_capability_some)
         PushCollectionsAmount.None -> stringResource(R.string.app_settings_push_capability_none)
-    }?.let { stringResource ->
+    }?.let { message ->
         IconCard(
             icon = Icons.Outlined.Info,
             modifier = Modifier.padding(bottom = 16.dp)
         ) {
-            Text(stringResource)
+            Text(message)
         }
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/NextcloudLogin.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/NextcloudLogin.kt
@@ -12,7 +12,6 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardActions
@@ -20,7 +19,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.Warning
-import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -29,7 +27,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -48,6 +45,7 @@ import at.bitfire.davdroid.ui.ExternalUris
 import at.bitfire.davdroid.ui.ExternalUris.withStatParams
 import at.bitfire.davdroid.ui.UiUtils.haveCustomTabs
 import at.bitfire.davdroid.ui.composable.Assistant
+import at.bitfire.davdroid.ui.composable.IconCard
 import at.bitfire.davdroid.ui.composable.ProgressBar
 import io.ktor.http.HttpHeaders
 import kotlinx.coroutines.launch
@@ -199,21 +197,14 @@ fun NextcloudLoginScreen(
                 }
 
                 if (error != null)
-                    Card(Modifier.fillMaxWidth()) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier.padding(8.dp)
-                        ) {
-                            Icon(
-                                Icons.Default.Warning,
-                                contentDescription = null,
-                                modifier = Modifier.padding(end = 4.dp)
-                            )
-                            Text(
-                                error,
-                                style = MaterialTheme.typography.bodyLarge
-                            )
-                        }
+                    IconCard(
+                        modifier = Modifier.fillMaxWidth(),
+                        icon = Icons.Default.Warning
+                    ) {
+                        Text(
+                            error,
+                            style = MaterialTheme.typography.bodyLarge
+                        )
                     }
             }
         }

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -255,8 +255,8 @@
     <string name="app_settings_push_info_text"><![CDATA[Push messages are always encrypted. Learn more about WebDAV-Push from <a href=\"%s\">the manual</a>.]]></string>
     <string name="app_settings_push_push_services">Push Service</string>
     <string name="app_settings_push_default_distributor_text">(system default)</string>
-    <string name="app_settings_push_capability_none">None of your server collections currently support WebDAV-Push.</string>
-    <string name="app_settings_push_capability_some">Only some of your server collections currently support WebDAV-Push.</string>
+    <string name="app_settings_push_capability_none">None of your sync enabled server collections currently support WebDAV-Push.</string>
+    <string name="app_settings_push_capability_some">Only some of your sync enabled server collections currently support WebDAV-Push.</string>
     <string name="app_settings_push_select_default_distributor_description">There are multiple UnifiedPush Distributor Apps installed. You can set a system-wide default here, so other UnifiedPush-enabled apps don\'t have to ask which one to use.</string>
     <string name="app_settings_push_select_default_distributor_action">Set default</string>
 

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -255,6 +255,8 @@
     <string name="app_settings_push_info_text"><![CDATA[Push messages are always encrypted. Learn more about WebDAV-Push from <a href=\"%s\">the manual</a>.]]></string>
     <string name="app_settings_push_push_services">Push Service</string>
     <string name="app_settings_push_default_distributor_text">(system default)</string>
+    <string name="app_settings_push_capability_none">None of your server collections currently support WebDAV-Push.</string>
+    <string name="app_settings_push_capability_some">Only some of your server collections currently support WebDAV-Push.</string>
     <string name="app_settings_push_select_default_distributor_description">There are multiple UnifiedPush Distributor Apps installed. You can set a system-wide default here, so other UnifiedPush-enabled apps don\'t have to ask which one to use.</string>
     <string name="app_settings_push_select_default_distributor_action">Set default</string>
 


### PR DESCRIPTION
### Purpose

Show info card in Push Settings Screen to inform user, that only some or none of their collections are push capable.


### Short description

- add `PushCollectionsAmount` enum in `DavCollectionRepository`  to describe the amount of push capable collections
- add logic to collections DAO and repository for detecting amount of **push capable and sync enabled** collections
- Introduce a new `IconCard` based on new `BaseCard` which also serves as base for `ActionCard` now
- add card to push settings screen with some/none push capable collections text
- also use the IconCard where appropriate (i.e. NextcloudLogin)
- set card visibility and text based on amount of push capable collections 

Note: Could probably also replace action and info cards in `DetectResourcesPage` but is not really be in the scope of this PR anymore.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

