### PR TITLE
Android 17 handle local network permission

### DIFF
--- a/app-ose/build.gradle.kts
+++ b/app-ose/build.gradle.kts
@@ -21,7 +21,7 @@ android {
 
     defaultConfig {
         minSdk = 24        // Android 7.0
-        targetSdk = 36     // Android 16
+        targetSdk = 37     // Android 17
 
         applicationId = "at.bitfire.davdroid"
 

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.READ_SYNC_SETTINGS"/>
     <uses-permission android:name="android.permission.READ_SYNC_STATS"/>

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/NetworkUtils.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/NetworkUtils.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.network
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.Build
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.net.Inet4Address
+import java.net.InetAddress
+import java.net.URL
+
+object NetworkUtils {
+    /**
+     * Parses a URL, resolves its IP address, and determines if it requires
+     * Android 17's ACCESS_LOCAL_NETWORK permission.
+     */
+    suspend fun requiresLocalNetworkPermission(urlString: String, context: Context): Boolean {
+        // If version is below Android 17, the permission does not exist and is not required.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.CINNAMON_BUN) {
+            return false
+        }
+
+        val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        if (isTrafficExemptedByVPN(connectivityManager)) {
+            // If traffic is routed through a VPN, it generally does not trigger the ACCESS_LOCAL_NETWORK check.
+            return false
+        }
+
+        return withContext(Dispatchers.IO) {
+            try {
+                val url = URL(urlString)
+                val host = url.host
+
+                // Note: This triggers a DNS lookup
+                val address = InetAddress.getByName(host)
+
+                isLocalNetworkAddress(address)
+            } catch (_: Exception) {
+                // Handle malformed URLs or failed DNS resolutions
+                false
+            }
+        }
+    }
+
+    private fun isTrafficExemptedByVPN(connectivityManager: ConnectivityManager): Boolean {
+        val activeNetwork = connectivityManager.activeNetwork ?: return false
+        val capabilities = connectivityManager.getNetworkCapabilities(activeNetwork) ?: return false
+
+        // If the active network is a VPN, traffic routed through it
+        // generally does not trigger the ACCESS_LOCAL_NETWORK check.
+        return capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)
+    }
+
+    /**
+     * Checks an InetAddress against Android's local network IP definitions.
+     */
+    private fun isLocalNetworkAddress(address: InetAddress): Boolean {
+        // 1. Loopback (127.0.0.1 / ::1) does NOT require the permission
+        if (address.isLoopbackAddress) {
+            return false
+        }
+
+        // 2. Standard local IP designations using built-in Java methods
+        if (address.isSiteLocalAddress ||  // Covers RFC 1918 (10.x.x.x, 172.16.x.x, 192.168.x.x)
+            address.isLinkLocalAddress ||  // Covers 169.254.x.x and fe80::/10
+            address.isMulticastAddress     // Covers 224.x.x.x and ff00::/8
+        ) {
+            return true
+        }
+
+        // 3. Android-specific or edge-case IPv4 designations not fully covered above
+        if (address is Inet4Address) {
+            val bytes = address.address
+            val b0 = bytes[0].toInt() and 0xFF
+            val b1 = bytes[1].toInt() and 0xFF
+            val b2 = bytes[2].toInt() and 0xFF
+            val b3 = bytes[3].toInt() and 0xFF
+
+            // Carrier-Grade NAT (CGNAT): 100.64.0.0/10 (100.64.0.0 to 100.127.255.255)
+            if (b0 == 100 && (b1 and 0xC0) == 64) {
+                return true
+            }
+
+            // IPv4 Global Broadcast: 255.255.255.255
+            if (b0 == 255 && b1 == 255 && b2 == 255 && b3 == 255) {
+                return true
+            }
+        }
+
+        return false
+    }
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncConditions.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncConditions.kt
@@ -9,7 +9,11 @@ import android.content.Intent
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.net.wifi.WifiManager
+import android.os.Build
 import androidx.core.content.getSystemService
+import at.bitfire.davdroid.db.Service
+import at.bitfire.davdroid.network.NetworkUtils
+import at.bitfire.davdroid.repository.DavServiceRepository
 import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.ui.NotificationRegistry
 import at.bitfire.davdroid.ui.account.WifiPermissionsActivity
@@ -28,7 +32,8 @@ class SyncConditions @AssistedInject constructor(
     @Assisted private val accountSettings: AccountSettings,
     @ApplicationContext private val context: Context,
     private val logger: Logger,
-    private val notificationRegistry: NotificationRegistry
+    private val notificationRegistry: NotificationRegistry,
+    private val serviceRepository: DavServiceRepository
 ) {
 
     @AssistedFactory
@@ -69,6 +74,30 @@ class SyncConditions @AssistedInject constructor(
             logger.fine("Connected to WiFi network ${info.ssid}")
         }
         return true
+    }
+
+    internal suspend fun accessToLan(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.CINNAMON_BUN)
+            return true
+
+        val isCalDavLan = serviceRepository.getByAccountAndType(accountSettings.account.name, Service.TYPE_CALDAV)
+            ?.principal
+            ?.let { principal ->
+                NetworkUtils.requiresLocalNetworkPermission(principal.toString(), context)
+            } ?: false
+        val isCardDavLan = serviceRepository.getByAccountAndType(accountSettings.account.name, Service.TYPE_CARDDAV)
+            ?.principal
+            ?.let { principal ->
+                NetworkUtils.requiresLocalNetworkPermission(principal.toString(), context)
+            } ?: false
+
+        if (isCalDavLan || isCardDavLan) {
+            logger.info("At least one service requires LAN access permission, checking...")
+            return PermissionUtils.lanAccessPermissionGranted(context)
+        } else {
+            logger.fine("No service requires LAN access permission, skipping check")
+            return true
+        }
     }
 
     /**

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
@@ -125,6 +125,12 @@ abstract class BaseSyncWorker(
                     logger.info("WiFi conditions not met. Won't run periodic sync.")
                     return Result.success()
                 }
+
+                // check LAN access permission
+                if (!syncConditions.accessToLan()) {
+                    logger.info("LAN access permission is not granted. Aborting sync.")
+                    return Result.success()
+                }
             }
 
             return doSyncWork(account, dataType)

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreen.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.ui.ExternalUris
 import at.bitfire.davdroid.ui.ExternalUris.withStatParams

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenModel.kt
@@ -12,10 +12,12 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import at.bitfire.davdroid.di.qualifier.DefaultDispatcher
+import at.bitfire.davdroid.network.NetworkUtils
 import at.bitfire.davdroid.repository.AccountRepository
 import at.bitfire.davdroid.servicedetection.DavResourceFinder
 import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.settings.SettingsManager
+import at.bitfire.davdroid.util.PermissionUtils
 import at.bitfire.vcard4android.GroupMethod
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -185,6 +187,7 @@ class LoginScreenModel @AssistedInject constructor(
         val foundNothing: Boolean = false,
         val encountered401: Boolean = false,
         val loginValidationFailed: Boolean = false,
+        val localNetworkPermissionRequired: Boolean = false,
         val logs: String? = null
     )
 
@@ -199,18 +202,31 @@ class LoginScreenModel @AssistedInject constructor(
         detectResourcesJob = viewModelScope.launch {
             // First, if we have a validator, validate the server
             val httpUrl = loginInfo.baseUri!!.toHttpUrlOrNull()
-            if (loginValidator.isPresent && httpUrl != null) {
-                val isValid = withContext(Dispatchers.IO) {
-                    runInterruptible {
-                        loginValidator.get().beforeLogin(httpUrl)
+            if (httpUrl != null) {
+                if (NetworkUtils.requiresLocalNetworkPermission(httpUrl.toString(), context)) {
+                    if (!PermissionUtils.lanAccessPermissionGranted(context)) {
+                        // If local network permission is required but not granted, we cannot proceed with detection. Show an error and return.
+                        // TODO: Show permission request UI
+                        detectResourcesUiState = detectResourcesUiState.copy(
+                            loading = false,
+                            localNetworkPermissionRequired = true
+                        )
+                        return@launch
                     }
                 }
-                if (!isValid) {
-                    detectResourcesUiState = detectResourcesUiState.copy(
-                        loading = false,
-                        loginValidationFailed = true
-                    )
-                    return@launch
+                if (loginValidator.isPresent) {
+                    val isValid = withContext(Dispatchers.IO) {
+                        runInterruptible {
+                            loginValidator.get().beforeLogin(httpUrl)
+                        }
+                    }
+                    if (!isValid) {
+                        detectResourcesUiState = detectResourcesUiState.copy(
+                            loading = false,
+                            loginValidationFailed = true
+                        )
+                        return@launch
+                    }
                 }
             }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/util/PermissionUtils.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/util/PermissionUtils.kt
@@ -55,6 +55,14 @@ object PermissionUtils {
                 arrayOf()
         }
 
+    val LAN_ACCESS_PERMISSIONS = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.CINNAMON_BUN) {
+        arrayOf(
+            Manifest.permission.ACCESS_LOCAL_NETWORK
+        )
+    } else {
+        emptyArray()
+    }
+
     /**
      * Checks whether all conditions to access the current WiFi's SSID are met:
      *
@@ -78,6 +86,18 @@ object PermissionUtils {
 
         return  havePermissions(context, WIFI_SSID_PERMISSIONS) &&
                 locationAvailable
+    }
+
+    /**
+     * Checks whether the LAN access permission is granted (Android 17+).
+     *
+     * For versions lower than Android 17, this permission doesn't exist and LAN access is always granted, so this method returns `true`.
+     */
+    fun lanAccessPermissionGranted(context: Context): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.CINNAMON_BUN)
+            return true
+
+        return havePermissions(context, LAN_ACCESS_PERMISSIONS)
     }
 
     /**


### PR DESCRIPTION
### Purpose

Handle the new `ACCESS_LOCAL_NETWORK` permission correctly.

### Short description

- Added a sync condition that checks this permission is granted in the required scenarios.
- Added a check when adding a new account that checks this permission is granted in the required scenarios.

TODO:
- Add the required UI message to acknowledge the user that the permission is required.
- Show a notification when sync is not possible because of missing permission so that the user can grant it. Maybe something like what happens when you install a new tasks app.

### Checklist

- [x] The PR has a proper title, description and label.
- [ ] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [ ] I have added documentation to complex functions and functions that can be used by other modules.
- [ ] I have added reasonable tests or consciously decided to not add tests.

