### PR TITLE
Fix R8 build errors after updating to ical4j 4.x

### DIFF
--- a/core/core-proguard-rules.pro
+++ b/core/core-proguard-rules.pro
@@ -7,6 +7,11 @@
 # [https://developer.android.com/build/releases/past-releases/agp-7-0-0-release-notes#r8-missing-class-warning]
 -dontwarn org.xmlpull.**
 
+# synctools / ical4j
+-dontwarn com.github.benmanes.caffeine.**
+-dontwarn java.time.zone.ZoneRulesProvider
+-dontwarn org.joda.convert.ToString
+
 # dnsjava
 -dontwarn com.sun.jna.**
 -dontwarn lombok.**


### PR DESCRIPTION
Closes https://github.com/bitfireAT/synctools/issues/335

### Purpose

Fix R8 build errors after updating to ical4j 4.x.  

### Short description

This is assuming we don't want to use the optional caffeine caching library that ical4j uses for timezone caching.

I first tried to place the `-dontwarn` rules in synctools, which I would normally think to be the right place for library-specific shrink instructions. The release build still failed in DAVx5, however (tried with gradles `includeBuild` composite build).  I am not sure why, but an idea is that missing-class checks happen in the final app build (not synctools build) when R8 has the complete view on all depencies? Maybe it would work if included via jitpack, but I don't think so.

The unresolved references come from 
- `com.github.benmanes.caffeine.**` ical4j - Optional caching library. We have timezone cache configured to use `MapTimeZoneCache` in [ical4j.propterties](https://github.com/bitfireAT/synctools/blob/main/lib/src/main/resources/ical4j.properties) so safe to ignore.
- `org.joda.convert.ToString`: threeten-extra (`@ToString` annotation) - I assume that is safe to ignore.
- `java.time.zone.ZoneRulesProvider`: Runtime support for java.time is provided through desugaring which can lead to a different class path than R8 might expect during static analysis. I think ignoring is safe because DAVx5’s has desugaring enabled.

Please correct me if my understanding is wrong here.

### Checklist

- [X] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

