### PR TITLE
Migrate WebDAV file access from OkHttp to Ktor

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
@@ -6,7 +6,6 @@ package at.bitfire.davdroid.network
 
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
-import io.ktor.client.engine.okhttp.OkHttpEngine
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.test.runTest
@@ -16,7 +15,6 @@ import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -58,11 +56,20 @@ class HttpClientBuilderTest {
     }
 
     @Test
-    fun testBuildKtor_SharesConnectionPoolAndDispatcher() {
+    fun testBuildKtor_SharesConnectionPool() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("ok"))
+
+        val sharedPool = HttpClientBuilder.sharedOkHttpClient.connectionPool
+        val countBefore = sharedPool.connectionCount()
+
         httpClientBuilder.get().buildKtor().use { client ->
-            val preconfigured = (client.engine as OkHttpEngine).config.preconfigured!!
-            assertSame(HttpClientBuilder.sharedOkHttpClient.connectionPool, preconfigured.connectionPool)
-            assertSame(HttpClientBuilder.sharedOkHttpClient.dispatcher, preconfigured.dispatcher)
+            client.get(server.url("/").toString())
+            // The Ktor engine builds its OkHttpClient from the shared pool via newBuilder(),
+            // so after a request the connection appears in the shared pool.
+            assertTrue(
+                "Ktor client should use the shared OkHttp connection pool",
+                sharedPool.connectionCount() > countBefore
+            )
         }
     }
 

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
@@ -6,6 +6,7 @@ package at.bitfire.davdroid.network
 
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import io.ktor.client.engine.okhttp.OkHttpEngine
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.test.runTest
@@ -15,6 +16,7 @@ import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -53,6 +55,15 @@ class HttpClientBuilderTest {
         val client2 = httpClientBuilder.get().build()
         assertEquals(client1.connectionPool, client2.connectionPool)
         assertEquals(client1.dispatcher, client2.dispatcher)
+    }
+
+    @Test
+    fun testBuildKtor_SharesConnectionPoolAndDispatcher() {
+        httpClientBuilder.get().buildKtor().use { client ->
+            val preconfigured = (client.engine as OkHttpEngine).config.preconfigured!!
+            assertSame(HttpClientBuilder.sharedOkHttpClient.connectionPool, preconfigured.connectionPool)
+            assertSame(HttpClientBuilder.sharedOkHttpClient.dispatcher, preconfigured.dispatcher)
+        }
     }
 
     @Test

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallbackTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallbackTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.webdav
+
+import android.content.Context
+import android.system.ErrnoException
+import android.system.OsConstants
+import at.bitfire.davdroid.di.qualifier.IoDispatcher
+import at.bitfire.davdroid.network.HttpClientBuilder
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import io.ktor.client.HttpClient
+import io.ktor.http.HttpHeaders
+import io.ktor.http.Url
+import java.util.logging.Logger
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import javax.inject.Inject
+
+@HiltAndroidTest
+class RandomAccessCallbackTest {
+
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+
+    @Inject
+    lateinit var httpClientBuilder: HttpClientBuilder
+
+    @Inject
+    @ApplicationContext
+    lateinit var context: Context
+
+    @Inject
+    @IoDispatcher
+    lateinit var ioDispatcher: CoroutineDispatcher
+
+    @Inject
+    lateinit var logger: Logger
+
+    private lateinit var server: MockWebServer
+    private lateinit var client: HttpClient
+    private lateinit var scope: CoroutineScope
+
+    /** File size = exactly one page so MockWebServer serves the full page in one request. */
+    private val fileSize = 64L
+    private val fileContent = ByteArray(fileSize.toInt()) { it.toByte() }
+
+    @Before
+    fun setUp() {
+        hiltRule.inject()
+
+        scope = CoroutineScope(ioDispatcher + SupervisorJob())
+
+        server = MockWebServer()
+        server.start()
+
+        client = httpClientBuilder.buildKtor()
+    }
+
+    @After
+    fun tearDown() {
+        client.close()
+        server.shutdown()
+        scope.cancel()
+    }
+
+    private fun url() = Url(server.url("/").toString())
+
+    private fun makeCallback() = RandomAccessCallback(
+        httpClient = client,
+        url = url(),
+        mimeType = null,
+        headResponse = HeadResponse(size = fileSize, eTag = "testETag"),
+        externalScope = scope,
+        context = context,
+        logger = logger
+    )
+
+    @Test
+    fun rangedRequestReturnsCorrectBytes() {
+        // Server responds with the full page (offset 0, size = fileSize)
+        server.enqueue(MockResponse()
+            .setResponseCode(206)
+            .setBody(okio.Buffer().write(fileContent))
+            .addHeader(HttpHeaders.ContentRange, "bytes 0-${fileSize - 1}/$fileSize"))
+
+        val data = ByteArray(32)
+        makeCallback().onRead(0, 32, data)
+
+        assertArrayEquals(fileContent.copyOf(32), data)
+    }
+
+    @Test
+    fun response200CausesErrnoExceptionWithEio() {
+        server.enqueue(MockResponse()
+            .setResponseCode(200)
+            .setBody("full body"))
+
+        try {
+            makeCallback().onRead(0, 32, ByteArray(32))
+            fail("Expected ErrnoException")
+        } catch (e: ErrnoException) {
+            // Guava LoadingCache wraps loader exceptions in ExecutionException,
+            // which doesn't match any specific branch → EIO
+            assertEquals(OsConstants.EIO, e.errno)
+        }
+    }
+
+}

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/webdav/StreamingFileDescriptorTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/webdav/StreamingFileDescriptorTest.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.webdav
+
+import android.os.ParcelFileDescriptor
+import at.bitfire.davdroid.di.qualifier.IoDispatcher
+import at.bitfire.davdroid.network.HttpClientBuilder
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import io.ktor.client.HttpClient
+import io.ktor.http.Url
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.logging.Logger
+import javax.inject.Inject
+
+@HiltAndroidTest
+class StreamingFileDescriptorTest {
+
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+
+    @Inject
+    lateinit var httpClientBuilder: HttpClientBuilder
+
+    @Inject
+    @IoDispatcher
+    lateinit var ioDispatcher: CoroutineDispatcher
+
+    @Inject
+    lateinit var logger: Logger
+
+    private lateinit var server: MockWebServer
+    private lateinit var client: HttpClient
+    private lateinit var scope: CoroutineScope
+
+    @Before
+    fun setUp() {
+        hiltRule.inject()
+
+        scope = CoroutineScope(ioDispatcher + SupervisorJob())
+
+        server = MockWebServer()
+        server.start()
+
+        client = httpClientBuilder.buildKtor()
+    }
+
+    @After
+    fun tearDown() {
+        client.close()
+        server.shutdown()
+        scope.cancel()
+    }
+
+    /** Creates a [StreamingFileDescriptor] pointing at the mock server's root URL. */
+    private fun create(onFinished: StreamingFileDescriptor.OnSuccessCallback): StreamingFileDescriptor {
+        val url = Url(server.url("/").toString())
+        return StreamingFileDescriptor(client, url, mimeType = null, scope, onFinished, logger)
+    }
+
+    @Test
+    fun downloadWritesServerBodyToPipe() {
+        val body = "Hello WebDAV"
+        server.enqueue(MockResponse()
+            .setResponseCode(200)
+            .setBody(body))
+
+        val latch = CountDownLatch(1)
+        var success = false
+        val readFd = create(onFinished = { _, s -> success = s; latch.countDown() }).download()
+
+        val received = ParcelFileDescriptor.AutoCloseInputStream(readFd).readBytes()
+        assertTrue("callback not called in time", latch.await(5, TimeUnit.SECONDS))
+
+        assertTrue(success)
+        assertArrayEquals(body.toByteArray(), received)
+    }
+
+    @Test
+    fun uploadSendsPipeContentToServer() {
+        server.enqueue(MockResponse()
+            .setResponseCode(201))
+        val body = "Uploaded content".toByteArray()
+
+        val latch = CountDownLatch(1)
+        val writeFd = create(onFinished = { _, _ -> latch.countDown() }).upload()
+        ParcelFileDescriptor.AutoCloseOutputStream(writeFd).use { it.write(body) }
+
+        assertTrue("callback not called in time", latch.await(5, TimeUnit.SECONDS))
+        val request = server.takeRequest(1, TimeUnit.SECONDS)
+        assertNotNull(request)
+        assertEquals("PUT", request!!.method)
+        assertArrayEquals(body, request.body.readByteArray())
+    }
+
+    @Test
+    fun downloadClosesPipeWithErrorOnHttpError() {
+        server.enqueue(MockResponse()
+            .setResponseCode(404))
+
+        val latch = CountDownLatch(1)
+        var success = true
+        val readFd = create(onFinished = { _, s -> success = s; latch.countDown() }).download()
+
+        try {
+            ParcelFileDescriptor.AutoCloseInputStream(readFd).readBytes()
+        } catch (_: Exception) { /* pipe may be closed with error */ }
+
+        assertTrue("callback not called in time", latch.await(5, TimeUnit.SECONDS))
+        assertFalse(success)
+    }
+
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
@@ -355,13 +355,11 @@ class HttpClientBuilder @Inject constructor(
             }
 
             engine {
-                // Use sharedOkHttpClient as the base so that the connection pool and
-                // dispatcher are shared with all other OkHttp clients in the app.
+                // Use sharedOkHttpClient as the base so that the connection pool is shared with
+                // all other OkHttp clients in the app. Includes timeout configuration.
                 preconfigured = sharedOkHttpClient
 
-                // Apply DAVdroid-specific configuration (interceptors, auth, …) on top.
-                // configureTimeouts() is not needed here because sharedOkHttpClient
-                // already carries the configured timeouts.
+                // Apply specific configuration (interceptors, auth, …) on top.
                 config {
                     configureOkHttp(this)
                 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
@@ -355,15 +355,14 @@ class HttpClientBuilder @Inject constructor(
             }
 
             engine {
-                // okhttp engine configuration here
+                // Use sharedOkHttpClient as the base so that the connection pool and
+                // dispatcher are shared with all other OkHttp clients in the app.
+                preconfigured = sharedOkHttpClient
 
+                // Apply DAVdroid-specific configuration (interceptors, auth, …) on top.
+                // configureTimeouts() is not needed here because sharedOkHttpClient
+                // already carries the configured timeouts.
                 config {
-                    // OkHttpClient.Builder configuration here
-
-                    // we don't use the sharedOkHttpClient, so we have to apply timeouts again
-                    configureTimeouts(this)
-
-                    // build most config on okhttp level
                     configureOkHttp(this)
                 }
             }

--- a/core/src/main/kotlin/at/bitfire/davdroid/util/DavUtils.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/util/DavUtils.kt
@@ -6,6 +6,9 @@ package at.bitfire.davdroid.util
 
 import at.bitfire.davdroid.util.DavUtils.generateUidIfNecessary
 import io.ktor.http.ContentType
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
+import io.ktor.http.headersOf
 import okhttp3.HttpUrl
 import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaType
@@ -32,11 +35,13 @@ object DavUtils {
      *
      * @return `media-range` for `Accept` header that accepts anything, but prefers [preferred] (if it was specified)
      */
-    fun acceptAnything(preferred: ContentType?): String =
-        if (preferred != null)
-            "$preferred, $MIME_TYPE_ACCEPT_ALL;q=0.8"
-        else
-            MIME_TYPE_ACCEPT_ALL
+    fun acceptAnything(preferred: ContentType?): Headers =
+        headersOf(HttpHeaders.Accept,
+            if (preferred != null)
+                "$preferred, $MIME_TYPE_ACCEPT_ALL;q=0.8"
+            else
+                MIME_TYPE_ACCEPT_ALL
+        )
 
     @Suppress("FunctionName")
     fun ARGBtoCalDAVColor(colorWithAlpha: Int): String {

--- a/core/src/main/kotlin/at/bitfire/davdroid/util/DavUtils.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/util/DavUtils.kt
@@ -5,6 +5,7 @@
 package at.bitfire.davdroid.util
 
 import at.bitfire.davdroid.util.DavUtils.generateUidIfNecessary
+import io.ktor.http.ContentType
 import okhttp3.HttpUrl
 import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaType
@@ -24,14 +25,14 @@ object DavUtils {
     val MEDIA_TYPE_VCARD = "text/vcard".toMediaType()
 
     /**
-     * Builds an HTTP `Accept` header that accepts anything (&#42;/&#42;), but optionally
+     * Builds an HTTP `Accept` header value that accepts anything (&#42;/&#42;), but optionally
      * specifies a preference.
      *
      * @param preferred  preferred MIME type (optional)
      *
      * @return `media-range` for `Accept` header that accepts anything, but prefers [preferred] (if it was specified)
      */
-    fun acceptAnything(preferred: MediaType?): String =
+    fun acceptAnything(preferred: ContentType?): String =
         if (preferred != null)
             "$preferred, $MIME_TYPE_ACCEPT_ALL;q=0.8"
         else

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/HeadResponse.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/HeadResponse.kt
@@ -4,16 +4,13 @@
 
 package at.bitfire.davdroid.webdav
 
-import androidx.annotation.WorkerThread
 import at.bitfire.dav4jvm.HttpUtils
-import at.bitfire.dav4jvm.ktor.DavResource as KtorDavResource
-import at.bitfire.dav4jvm.okhttp.DavResource
 import at.bitfire.dav4jvm.property.webdav.GetETag
 import io.ktor.client.HttpClient
+import io.ktor.http.HttpHeaders
 import io.ktor.http.Url
-import okhttp3.HttpUrl
-import okhttp3.OkHttpClient
 import java.time.Instant
+import at.bitfire.dav4jvm.ktor.DavResource as KtorDavResource
 
 /**
  * Represents the information that was retrieved via a HEAD request before
@@ -36,18 +33,18 @@ data class HeadResponse(
             var supportsPartial: Boolean? = null
 
             KtorDavResource(client, url).head { response ->
-                response.headers["ETag"]?.let {
+                response.headers[HttpHeaders.ETag]?.let {
                     val getETag = GetETag(it)
                     if (!getETag.weak)
                         eTag = getETag.eTag
                 }
-                response.headers["Last-Modified"]?.let {
+                response.headers[HttpHeaders.LastModified]?.let {
                     lastModified = HttpUtils.parseDate(it)
                 }
-                response.headers["Content-Length"]?.let {
+                response.headers[HttpHeaders.ContentLength]?.let {
                     size = it.toLong()
                 }
-                response.headers["Accept-Ranges"]?.let { acceptRangesStr ->
+                response.headers[HttpHeaders.AcceptRanges]?.let { acceptRangesStr ->
                     val acceptRanges = acceptRangesStr.split(',').map { it.trim().lowercase() }
                     when {
                         acceptRanges.contains("none") -> supportsPartial = false

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/HeadResponse.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/HeadResponse.kt
@@ -29,36 +29,6 @@ data class HeadResponse(
 
     companion object {
 
-        @WorkerThread
-        fun fromUrl(client: OkHttpClient, url: HttpUrl): HeadResponse {
-            var size: Long? = null
-            var eTag: String? = null
-            var lastModified: Instant? = null
-            var supportsPartial: Boolean? = null
-
-            DavResource(client, url).head { response ->
-                response.header("ETag", null)?.let {
-                    val getETag = GetETag(it)
-                    if (!getETag.weak)
-                        eTag = getETag.eTag
-                }
-                response.header("Last-Modified", null)?.let {
-                    lastModified = HttpUtils.parseDate(it)
-                }
-                response.headers["Content-Length"]?.let {
-                    size = it.toLong()
-                }
-                response.headers["Accept-Ranges"]?.let { acceptRangesStr ->
-                    val acceptRanges = acceptRangesStr.split(',').map { it.trim().lowercase() }
-                    when {
-                        acceptRanges.contains("none") -> supportsPartial = false
-                        acceptRanges.contains("bytes") -> supportsPartial = true
-                    }
-                }
-            }
-            return HeadResponse(size, eTag, lastModified, supportsPartial)
-        }
-
         suspend fun fromUrl(client: HttpClient, url: Url): HeadResponse {
             var size: Long? = null
             var eTag: String? = null

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/HeadResponse.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/HeadResponse.kt
@@ -6,8 +6,11 @@ package at.bitfire.davdroid.webdav
 
 import androidx.annotation.WorkerThread
 import at.bitfire.dav4jvm.HttpUtils
+import at.bitfire.dav4jvm.ktor.DavResource as KtorDavResource
 import at.bitfire.dav4jvm.okhttp.DavResource
 import at.bitfire.dav4jvm.property.webdav.GetETag
+import io.ktor.client.HttpClient
+import io.ktor.http.Url
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import java.time.Instant
@@ -40,6 +43,35 @@ data class HeadResponse(
                         eTag = getETag.eTag
                 }
                 response.header("Last-Modified", null)?.let {
+                    lastModified = HttpUtils.parseDate(it)
+                }
+                response.headers["Content-Length"]?.let {
+                    size = it.toLong()
+                }
+                response.headers["Accept-Ranges"]?.let { acceptRangesStr ->
+                    val acceptRanges = acceptRangesStr.split(',').map { it.trim().lowercase() }
+                    when {
+                        acceptRanges.contains("none") -> supportsPartial = false
+                        acceptRanges.contains("bytes") -> supportsPartial = true
+                    }
+                }
+            }
+            return HeadResponse(size, eTag, lastModified, supportsPartial)
+        }
+
+        suspend fun fromUrl(client: HttpClient, url: Url): HeadResponse {
+            var size: Long? = null
+            var eTag: String? = null
+            var lastModified: Instant? = null
+            var supportsPartial: Boolean? = null
+
+            KtorDavResource(client, url).head { response ->
+                response.headers["ETag"]?.let {
+                    val getETag = GetETag(it)
+                    if (!getETag.weak)
+                        eTag = getETag.eTag
+                }
+                response.headers["Last-Modified"]?.let {
                     lastModified = HttpUtils.parseDate(it)
                 }
                 response.headers["Content-Length"]?.let {

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallback.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallback.kt
@@ -18,6 +18,7 @@ import at.bitfire.dav4jvm.HttpUtils
 import at.bitfire.dav4jvm.ktor.DavResource as KtorDavResource
 import at.bitfire.dav4jvm.ktor.exception.DavException
 import at.bitfire.dav4jvm.ktor.exception.HttpException
+import at.bitfire.davdroid.util.DavUtils
 import com.google.common.cache.CacheBuilder
 import com.google.common.cache.CacheLoader
 import com.google.common.cache.LoadingCache
@@ -193,7 +194,7 @@ class RandomAccessCallback @AssistedInject constructor(
             logger.fine("Loading page $url $offset/$size")
 
             val additionalHeaders = Headers.build {
-                append(HttpHeaders.Accept, mimeType?.let { "$it, */*;q=0.8" } ?: "*/*")
+                append(HttpHeaders.Accept, DavUtils.acceptAnything(mimeType))
                 when {
                     documentState.eTag != null ->
                         append(HttpHeaders.IfMatch, "\"${documentState.eTag}\"")

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallback.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallback.kt
@@ -194,7 +194,7 @@ class RandomAccessCallback @AssistedInject constructor(
             logger.fine("Loading page $url $offset/$size")
 
             val additionalHeaders = Headers.build {
-                append(HttpHeaders.Accept, DavUtils.acceptAnything(mimeType))
+                appendAll(DavUtils.acceptAnything(preferred = mimeType))
                 when {
                     documentState.eTag != null ->
                         append(HttpHeaders.IfMatch, "\"${documentState.eTag}\"")

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallback.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallback.kt
@@ -15,10 +15,9 @@ import android.system.OsConstants
 import androidx.annotation.RequiresApi
 import androidx.core.content.getSystemService
 import at.bitfire.dav4jvm.HttpUtils
-import at.bitfire.dav4jvm.okhttp.DavResource
-import at.bitfire.dav4jvm.okhttp.exception.DavException
-import at.bitfire.dav4jvm.okhttp.exception.HttpException
-import at.bitfire.davdroid.util.DavUtils
+import at.bitfire.dav4jvm.ktor.DavResource as KtorDavResource
+import at.bitfire.dav4jvm.ktor.exception.DavException
+import at.bitfire.dav4jvm.ktor.exception.HttpException
 import com.google.common.cache.CacheBuilder
 import com.google.common.cache.CacheLoader
 import com.google.common.cache.LoadingCache
@@ -26,25 +25,27 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.qualifiers.ApplicationContext
+import io.ktor.client.HttpClient
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.http.ContentType
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
+import io.ktor.http.Url
+import io.ktor.utils.io.toByteArray
+import java.io.InterruptedIOException
+import java.util.logging.Logger
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.runInterruptible
-import okhttp3.Headers
-import okhttp3.HttpUrl
-import okhttp3.MediaType
-import okhttp3.OkHttpClient
-import java.io.InterruptedIOException
-import java.util.logging.Logger
 
 @RequiresApi(26)
 class RandomAccessCallback @AssistedInject constructor(
-    @Assisted private val httpClient: OkHttpClient,
-    @Assisted private val url: HttpUrl,
-    @Assisted private val mimeType: MediaType?,
+    @Assisted private val httpClient: HttpClient,
+    @Assisted private val url: Url,
+    @Assisted private val mimeType: ContentType?,
     @Assisted headResponse: HeadResponse,
     @Assisted private val externalScope: CoroutineScope,
     @ApplicationContext private val context: Context,
@@ -62,15 +63,13 @@ class RandomAccessCallback @AssistedInject constructor(
 
     @AssistedFactory
     interface Factory {
-        fun create(httpClient: OkHttpClient, url: HttpUrl, mimeType: MediaType?, headResponse: HeadResponse, externalScope: CoroutineScope): RandomAccessCallback
+        fun create(httpClient: HttpClient, url: Url, mimeType: ContentType?, headResponse: HeadResponse, externalScope: CoroutineScope): RandomAccessCallback
     }
 
     data class PageIdentifier(
         val offset: Long,
         val size: Int
     )
-
-    private val dav = DavResource(httpClient, url)
 
     private val fileSize = headResponse.size ?: throw IllegalArgumentException("Can only be used with given file size")
     private val documentState = headResponse.toDocumentState() ?: throw IllegalArgumentException("Can only be used with ETag/Last-Modified")
@@ -193,30 +192,25 @@ class RandomAccessCallback @AssistedInject constructor(
             val size = key.size
             logger.fine("Loading page $url $offset/$size")
 
-            val ifMatch: Headers =
-                documentState.eTag?.let { eTag ->
-                    Headers.headersOf("If-Match", "\"$eTag\"")
-                } ?: documentState.lastModified?.let { lastModified ->
-                    Headers.headersOf("If-Unmodified-Since", HttpUtils.formatDate(lastModified))
-                } ?: throw DavException("ETag/Last-Modified required for random access")
-
-            return runInterruptible {   // network I/O that should be cancelled by Thread interruption
-                var result: ByteArray? = null
-                dav.getRange(
-                    DavUtils.acceptAnything(preferred = mimeType),
-                    offset,
-                    size,
-                    ifMatch
-                ) { response ->
-                    if (response.code == 200)       // server doesn't support ranged requests
-                        throw PartialContentNotSupportedException()
-                    else if (response.code != 206)
-                        throw HttpException(response)
-
-                    result = response.body.bytes()
+            val additionalHeaders = Headers.build {
+                append(HttpHeaders.Accept, mimeType?.let { "$it, */*;q=0.8" } ?: "*/*")
+                when {
+                    documentState.eTag != null ->
+                        append(HttpHeaders.IfMatch, "\"${documentState.eTag}\"")
+                    documentState.lastModified != null ->
+                        append(HttpHeaders.IfUnmodifiedSince, HttpUtils.formatDate(documentState.lastModified!!))
+                    else ->
+                        throw DavException("ETag/Last-Modified required for random access")
                 }
-                result ?: throw DavException("No response body")
             }
+
+            var result: ByteArray? = null
+            KtorDavResource(httpClient, url).getRange(offset, size, additionalHeaders) { response ->
+                if (response.status.value == 200)       // server doesn't support ranged requests
+                    throw PartialContentNotSupportedException()
+                result = response.bodyAsChannel().toByteArray()
+            }
+            return result ?: throw DavException("No response body")
         }
 
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallbackWrapper.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallbackWrapper.kt
@@ -30,8 +30,8 @@ import kotlinx.coroutines.CoroutineScope
  * **All fields of objects of this class must be set to `null` when [onRelease] is called!**
  * Otherwise they will leak memory.
  *
- * @param httpClient    HTTP client; ownership is transferred to this class and it will be
- *                      closed when [onRelease] is called
+ * @param httpClient    HTTP client; this class is responsible for closing it when [onRelease]
+ *                      is called
  */
 @RequiresApi(26)
 class RandomAccessCallbackWrapper @AssistedInject constructor(

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallbackWrapper.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallbackWrapper.kt
@@ -14,6 +14,8 @@ import dagger.assisted.AssistedInject
 import io.ktor.client.HttpClient
 import io.ktor.http.ContentType
 import io.ktor.http.Url
+import javax.annotation.WillClose
+import javax.annotation.WillCloseWhenClosed
 import kotlinx.coroutines.CoroutineScope
 
 /**
@@ -28,11 +30,12 @@ import kotlinx.coroutines.CoroutineScope
  * **All fields of objects of this class must be set to `null` when [onRelease] is called!**
  * Otherwise they will leak memory.
  *
- * @param httpClient    HTTP client ([RandomAccessCallbackWrapper] is responsible to close it)
+ * @param httpClient    HTTP client; ownership is transferred to this class and it will be
+ *                      closed when [onRelease] is called
  */
 @RequiresApi(26)
 class RandomAccessCallbackWrapper @AssistedInject constructor(
-    @Assisted httpClient: HttpClient,
+    @WillClose @Assisted httpClient: HttpClient,
     @Assisted url: Url,
     @Assisted mimeType: ContentType?,
     @Assisted headResponse: HeadResponse,
@@ -54,6 +57,9 @@ class RandomAccessCallbackWrapper @AssistedInject constructor(
      */
     private var callbackRef: RandomAccessCallback? =
         callbackFactory.create(httpClient, url, mimeType, headResponse, externalScope)
+
+    @WillCloseWhenClosed
+    private var clientRef: HttpClient? = httpClient
 
     private fun requireCallback(functionName: String): RandomAccessCallback =
         callbackRef ?: throw ErrnoException(functionName, OsConstants.EBADF)
@@ -81,8 +87,10 @@ class RandomAccessCallbackWrapper @AssistedInject constructor(
     override fun onRelease() {
         requireCallback("onRelease").onRelease()
 
-        // remove reference to allow garbage collection
+        // remove references to allow garbage collection
         callbackRef = null
+        clientRef?.close()
+        clientRef = null
     }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallbackWrapper.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallbackWrapper.kt
@@ -11,10 +11,10 @@ import androidx.annotation.RequiresApi
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import io.ktor.client.HttpClient
+import io.ktor.http.ContentType
+import io.ktor.http.Url
 import kotlinx.coroutines.CoroutineScope
-import okhttp3.HttpUrl
-import okhttp3.MediaType
-import okhttp3.OkHttpClient
 
 /**
  * Use this wrapper to ensure that all memory is released as soon as [onRelease] is called.
@@ -32,9 +32,9 @@ import okhttp3.OkHttpClient
  */
 @RequiresApi(26)
 class RandomAccessCallbackWrapper @AssistedInject constructor(
-    @Assisted httpClient: OkHttpClient,
-    @Assisted url: HttpUrl,
-    @Assisted mimeType: MediaType?,
+    @Assisted httpClient: HttpClient,
+    @Assisted url: Url,
+    @Assisted mimeType: ContentType?,
     @Assisted headResponse: HeadResponse,
     @Assisted externalScope: CoroutineScope,
     callbackFactory: RandomAccessCallback.Factory
@@ -42,7 +42,7 @@ class RandomAccessCallbackWrapper @AssistedInject constructor(
 
     @AssistedFactory
     interface Factory {
-        fun create(httpClient: OkHttpClient, url: HttpUrl, mimeType: MediaType?, headResponse: HeadResponse, externalScope: CoroutineScope): RandomAccessCallbackWrapper
+        fun create(httpClient: HttpClient, url: Url, mimeType: ContentType?, headResponse: HeadResponse, externalScope: CoroutineScope): RandomAccessCallbackWrapper
     }
 
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/StreamingFileDescriptor.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/StreamingFileDescriptor.kt
@@ -18,14 +18,15 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.Url
 import io.ktor.http.content.OutgoingContent
 import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.copyTo
+import io.ktor.utils.io.jvm.javaio.copyTo
 import io.ktor.utils.io.jvm.javaio.toByteReadChannel
-import io.ktor.utils.io.jvm.javaio.toInputStream
-import java.io.FilterInputStream
 import java.io.IOException
 import java.util.logging.Level
 import java.util.logging.Logger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import okio.source
 
 /**
  * @param client    HTTP client to use
@@ -94,9 +95,7 @@ class StreamingFileDescriptor @AssistedInject constructor(
     private suspend fun downloadNow(writeFd: ParcelFileDescriptor) {
         dav.get(DavUtils.acceptAnything(preferred = mimeType)) { response ->
             ParcelFileDescriptor.AutoCloseOutputStream(writeFd).use { destination ->
-                response.bodyAsChannel().toInputStream().use { source ->
-                    transferred += source.copyTo(destination)
-                }
+                transferred += response.bodyAsChannel().copyTo(destination)
                 logger.fine("Downloaded $transferred byte(s) from $url")
             }
         }
@@ -110,18 +109,11 @@ class StreamingFileDescriptor @AssistedInject constructor(
     private suspend fun uploadNow(readFd: ParcelFileDescriptor) {
         val body = object : OutgoingContent.ReadChannelContent() {
             override val contentType = mimeType
-            override fun readFrom(): ByteReadChannel {
-                val source = object : FilterInputStream(ParcelFileDescriptor.AutoCloseInputStream(readFd)) {
-                    override fun read(b: ByteArray, off: Int, len: Int): Int =
-                        super.read(b, off, len).also { if (it > 0) transferred += it }
-                    override fun read(): Int =
-                        super.read().also { if (it >= 0) transferred++ }
-                }
-                return source.toByteReadChannel()
-            }
+            override fun readFrom(): ByteReadChannel =
+                ParcelFileDescriptor.AutoCloseInputStream(readFd).toByteReadChannel()
         }
         dav.put(body) {
-            logger.fine("Uploaded $transferred byte(s) to $url")
+            logger.fine("Uploaded to $url")
         }
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/StreamingFileDescriptor.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/StreamingFileDescriptor.kt
@@ -5,45 +5,45 @@
 package at.bitfire.davdroid.webdav
 
 import android.os.ParcelFileDescriptor
-import at.bitfire.dav4jvm.okhttp.DavResource
-import at.bitfire.dav4jvm.okhttp.exception.HttpException
-import at.bitfire.davdroid.di.qualifier.IoDispatcher
-import at.bitfire.davdroid.util.DavUtils
+import at.bitfire.dav4jvm.ktor.DavResource as KtorDavResource
+import at.bitfire.dav4jvm.ktor.exception.HttpException
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runInterruptible
-import okhttp3.HttpUrl
-import okhttp3.MediaType
-import okhttp3.OkHttpClient
-import okhttp3.RequestBody
-import okio.BufferedSink
+import io.ktor.client.HttpClient
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.Url
+import io.ktor.http.content.OutgoingContent
+import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.jvm.javaio.toByteReadChannel
+import io.ktor.utils.io.jvm.javaio.toInputStream
+import java.io.FilterInputStream
 import java.io.IOException
 import java.util.logging.Level
 import java.util.logging.Logger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 /**
  * @param client    HTTP client to use
  */
 class StreamingFileDescriptor @AssistedInject constructor(
-    @Assisted private val client: OkHttpClient,
-    @Assisted private val url: HttpUrl,
-    @Assisted private val mimeType: MediaType?,
+    @Assisted private val client: HttpClient,
+    @Assisted private val url: Url,
+    @Assisted private val mimeType: ContentType?,
     @Assisted private val externalScope: CoroutineScope,
     @Assisted private val finishedCallback: OnSuccessCallback,
-    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     private val logger: Logger
 ) {
 
     @AssistedFactory
     interface Factory {
-        fun create(client: OkHttpClient, url: HttpUrl, mimeType: MediaType?, externalScope: CoroutineScope, finishedCallback: OnSuccessCallback): StreamingFileDescriptor
+        fun create(client: HttpClient, url: Url, mimeType: ContentType?, externalScope: CoroutineScope, finishedCallback: OnSuccessCallback): StreamingFileDescriptor
     }
 
-    val dav = DavResource(client, url)
     var transferred: Long = 0
 
     fun download() = doStreaming(false)
@@ -89,19 +89,15 @@ class StreamingFileDescriptor @AssistedInject constructor(
      *
      * @param writeFd   destination file descriptor (could for instance represent a local file)
      */
-    private suspend fun downloadNow(writeFd: ParcelFileDescriptor) = runInterruptible(ioDispatcher) {
-        dav.get(DavUtils.acceptAnything(preferred = mimeType), null) { response ->
-            response.body.use { body ->
-                if (response.isSuccessful) {
-                    ParcelFileDescriptor.AutoCloseOutputStream(writeFd).use { destination ->
-                        body.byteStream().use { source ->
-                            transferred += source.copyTo(destination)
-                        }
-                        logger.fine("Downloaded $transferred byte(s) from $url")
-                    }
-
-                } else
-                    writeFd.closeWithError("${response.code} ${response.message}")
+    private suspend fun downloadNow(writeFd: ParcelFileDescriptor) {
+        val acceptStr = mimeType?.let { "$it, */*;q=0.8" } ?: "*/*"
+        val headers = headersOf(HttpHeaders.Accept, acceptStr)
+        KtorDavResource(client, url).get(headers) { response ->
+            ParcelFileDescriptor.AutoCloseOutputStream(writeFd).use { destination ->
+                response.bodyAsChannel().toInputStream().use { source ->
+                    transferred += source.copyTo(destination)
+                }
+                logger.fine("Downloaded $transferred byte(s) from $url")
             }
         }
     }
@@ -111,19 +107,21 @@ class StreamingFileDescriptor @AssistedInject constructor(
      *
      * @param readFd    source file descriptor (could for instance represent a local file)
      */
-    private suspend fun uploadNow(readFd: ParcelFileDescriptor) = runInterruptible(ioDispatcher) {
-        val body = object: RequestBody() {
-            override fun contentType(): MediaType? = mimeType
-            override fun isOneShot() = true
-            override fun writeTo(sink: BufferedSink) {
-                ParcelFileDescriptor.AutoCloseInputStream(readFd).use { input ->
-                    transferred += input.copyTo(sink.outputStream())
-                    logger.fine("Uploaded $transferred byte(s) to $url")
+    private suspend fun uploadNow(readFd: ParcelFileDescriptor) {
+        val body = object : OutgoingContent.ReadChannelContent() {
+            override val contentType = mimeType
+            override fun readFrom(): ByteReadChannel {
+                val source = object : FilterInputStream(ParcelFileDescriptor.AutoCloseInputStream(readFd)) {
+                    override fun read(b: ByteArray, off: Int, len: Int): Int =
+                        super.read(b, off, len).also { if (it > 0) transferred += it }
+                    override fun read(): Int =
+                        super.read().also { if (it >= 0) transferred++ }
                 }
+                return source.toByteReadChannel()
             }
         }
-        DavResource(client, url).put(body) {
-            // upload successful
+        KtorDavResource(client, url).put(body) {
+            logger.fine("Uploaded $transferred byte(s) to $url")
         }
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/StreamingFileDescriptor.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/StreamingFileDescriptor.kt
@@ -27,8 +27,8 @@ import java.util.logging.Logger
 import at.bitfire.dav4jvm.ktor.DavResource as KtorDavResource
 
 /**
- * @param client    HTTP client to use; ownership is transferred to this class and it will be
- *                  closed when the streaming transfer finishes
+ * @param client    HTTP client to use; this class is responsible for closing it when the
+ *                  streaming transfer finishes
  */
 class StreamingFileDescriptor @AssistedInject constructor(
     @WillClose @Assisted private val client: HttpClient,

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/StreamingFileDescriptor.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/StreamingFileDescriptor.kt
@@ -7,6 +7,7 @@ package at.bitfire.davdroid.webdav
 import android.os.ParcelFileDescriptor
 import at.bitfire.dav4jvm.ktor.DavResource as KtorDavResource
 import at.bitfire.dav4jvm.ktor.exception.HttpException
+import at.bitfire.davdroid.util.DavUtils
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -90,8 +91,7 @@ class StreamingFileDescriptor @AssistedInject constructor(
      * @param writeFd   destination file descriptor (could for instance represent a local file)
      */
     private suspend fun downloadNow(writeFd: ParcelFileDescriptor) {
-        val acceptStr = mimeType?.let { "$it, */*;q=0.8" } ?: "*/*"
-        val headers = headersOf(HttpHeaders.Accept, acceptStr)
+        val headers = headersOf(HttpHeaders.Accept, DavUtils.acceptAnything(mimeType))
         KtorDavResource(client, url).get(headers) { response ->
             ParcelFileDescriptor.AutoCloseOutputStream(writeFd).use { destination ->
                 response.bodyAsChannel().toInputStream().use { source ->

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/StreamingFileDescriptor.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/StreamingFileDescriptor.kt
@@ -46,6 +46,8 @@ class StreamingFileDescriptor @AssistedInject constructor(
 
     var transferred: Long = 0
 
+    private val dav = KtorDavResource(client, url)
+
     fun download() = doStreaming(false)
     fun upload() = doStreaming(true)
 
@@ -90,7 +92,7 @@ class StreamingFileDescriptor @AssistedInject constructor(
      * @param writeFd   destination file descriptor (could for instance represent a local file)
      */
     private suspend fun downloadNow(writeFd: ParcelFileDescriptor) {
-        KtorDavResource(client, url).get(DavUtils.acceptAnything(preferred = mimeType)) { response ->
+        dav.get(DavUtils.acceptAnything(preferred = mimeType)) { response ->
             ParcelFileDescriptor.AutoCloseOutputStream(writeFd).use { destination ->
                 response.bodyAsChannel().toInputStream().use { source ->
                     transferred += source.copyTo(destination)
@@ -118,7 +120,7 @@ class StreamingFileDescriptor @AssistedInject constructor(
                 return source.toByteReadChannel()
             }
         }
-        KtorDavResource(client, url).put(body) {
+        dav.put(body) {
             logger.fine("Uploaded $transferred byte(s) to $url")
         }
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/StreamingFileDescriptor.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/StreamingFileDescriptor.kt
@@ -5,7 +5,6 @@
 package at.bitfire.davdroid.webdav
 
 import android.os.ParcelFileDescriptor
-import at.bitfire.dav4jvm.ktor.DavResource as KtorDavResource
 import at.bitfire.dav4jvm.ktor.exception.HttpException
 import at.bitfire.davdroid.util.DavUtils
 import dagger.assisted.Assisted
@@ -14,25 +13,25 @@ import dagger.assisted.AssistedInject
 import io.ktor.client.HttpClient
 import io.ktor.client.statement.bodyAsChannel
 import io.ktor.http.ContentType
-import io.ktor.http.HttpHeaders
 import io.ktor.http.Url
 import io.ktor.http.content.OutgoingContent
 import io.ktor.utils.io.ByteReadChannel
-import io.ktor.utils.io.copyTo
 import io.ktor.utils.io.jvm.javaio.copyTo
 import io.ktor.utils.io.jvm.javaio.toByteReadChannel
+import javax.annotation.WillClose
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import java.io.IOException
 import java.util.logging.Level
 import java.util.logging.Logger
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
-import okio.source
+import at.bitfire.dav4jvm.ktor.DavResource as KtorDavResource
 
 /**
- * @param client    HTTP client to use
+ * @param client    HTTP client to use; ownership is transferred to this class and it will be
+ *                  closed when the streaming transfer finishes
  */
 class StreamingFileDescriptor @AssistedInject constructor(
-    @Assisted private val client: HttpClient,
+    @WillClose @Assisted private val client: HttpClient,
     @Assisted private val url: Url,
     @Assisted private val mimeType: ContentType?,
     @Assisted private val externalScope: CoroutineScope,
@@ -78,6 +77,7 @@ class StreamingFileDescriptor @AssistedInject constructor(
                 } catch (_: IOException) {}
 
                 finishedCallback.onFinished(transferred, success)
+                client.close()
             }
         }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/StreamingFileDescriptor.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/StreamingFileDescriptor.kt
@@ -17,7 +17,6 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.Url
 import io.ktor.http.content.OutgoingContent
-import io.ktor.http.headersOf
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.jvm.javaio.toByteReadChannel
 import io.ktor.utils.io.jvm.javaio.toInputStream
@@ -91,8 +90,7 @@ class StreamingFileDescriptor @AssistedInject constructor(
      * @param writeFd   destination file descriptor (could for instance represent a local file)
      */
     private suspend fun downloadNow(writeFd: ParcelFileDescriptor) {
-        val headers = headersOf(HttpHeaders.Accept, DavUtils.acceptAnything(mimeType))
-        KtorDavResource(client, url).get(headers) { response ->
+        KtorDavResource(client, url).get(DavUtils.acceptAnything(preferred = mimeType)) { response ->
             ParcelFileDescriptor.AutoCloseOutputStream(writeFd).use { destination ->
                 response.bodyAsChannel().toInputStream().use { source ->
                     transferred += source.copyTo(destination)

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/OpenDocumentOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/OpenDocumentOperation.kt
@@ -43,7 +43,7 @@ class OpenDocumentOperation @Inject constructor(
 
         val doc = documentDao.get(documentId.toLong()) ?: throw FileNotFoundException()
         val url = doc.toKtorUrl(db)
-        val mimeType = doc.mimeType?.toString()?.let { runCatching { ContentType.parse(it) }.getOrNull() }
+        val mimeType = doc.mimeType?.toString()?.let { ContentType.parse(it) }
         val client = httpClientBuilder.buildKtor(doc.mountId, logBody = false)
 
         val readOnlyMode = when (mode) {

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/OpenDocumentOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/OpenDocumentOperation.kt
@@ -9,22 +9,20 @@ import android.os.Build
 import android.os.CancellationSignal
 import android.os.ParcelFileDescriptor
 import at.bitfire.davdroid.db.AppDatabase
-import at.bitfire.davdroid.di.qualifier.IoDispatcher
 import at.bitfire.davdroid.webdav.DavHttpClientBuilder
 import at.bitfire.davdroid.webdav.DocumentProviderUtils
 import at.bitfire.davdroid.webdav.HeadResponse
 import at.bitfire.davdroid.webdav.RandomAccessCallbackWrapper
 import at.bitfire.davdroid.webdav.StreamingFileDescriptor
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.CoroutineDispatcher
+import io.ktor.client.HttpClient
+import io.ktor.http.ContentType
+import io.ktor.http.Url
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.runInterruptible
-import okhttp3.HttpUrl
-import okhttp3.OkHttpClient
 import java.io.FileNotFoundException
 import java.util.logging.Logger
 import javax.inject.Inject
@@ -33,7 +31,6 @@ class OpenDocumentOperation @Inject constructor(
     @ApplicationContext private val context: Context,
     private val db: AppDatabase,
     private val httpClientBuilder: DavHttpClientBuilder,
-    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     private val logger: Logger,
     private val randomAccessCallbackWrapperFactory: RandomAccessCallbackWrapper.Factory,
     private val streamingFileDescriptorFactory: StreamingFileDescriptor.Factory
@@ -45,8 +42,9 @@ class OpenDocumentOperation @Inject constructor(
         logger.fine("WebDAV openDocument $documentId $mode $signal")
 
         val doc = documentDao.get(documentId.toLong()) ?: throw FileNotFoundException()
-        val url = doc.toHttpUrl(db)
-        val client = httpClientBuilder.build(doc.mountId, logBody = false)
+        val url = doc.toKtorUrl(db)
+        val mimeType = doc.mimeType?.toString()?.let { runCatching { ContentType.parse(it) }.getOrNull() }
+        val client = httpClientBuilder.buildKtor(doc.mountId, logBody = false)
 
         val readOnlyMode = when (mode) {
             "r" -> true
@@ -65,7 +63,7 @@ class OpenDocumentOperation @Inject constructor(
         }.await()
         logger.fine("Received file info: $fileInfo")
 
-        // RandomAccessCallback.Wrapper / StreamingFileDescriptor are responsible for closing httpClient
+        // RandomAccessCallbackWrapper / StreamingFileDescriptor are responsible for closing httpClient
         return@runBlocking if (
             androidSupportsRandomAccess &&
             readOnlyMode &&                     // WebDAV doesn't support random write access (natively)
@@ -74,12 +72,12 @@ class OpenDocumentOperation @Inject constructor(
             fileInfo.supportsPartial == true    // WebDAV server must advertise random access
         ) {
             logger.fine("Creating RandomAccessCallback for $url")
-            val accessor = randomAccessCallbackWrapperFactory.create(client, url, doc.mimeType, fileInfo, accessScope)
+            val accessor = randomAccessCallbackWrapperFactory.create(client, url, mimeType, fileInfo, accessScope)
             accessor.fileDescriptor()
 
         } else {
             logger.fine("Creating StreamingFileDescriptor for $url")
-            val fd = streamingFileDescriptorFactory.create(client, url, doc.mimeType, accessScope) { transferred, success ->
+            val fd = streamingFileDescriptorFactory.create(client, url, mimeType, accessScope) { transferred, success ->
                 // called when transfer is finished
                 if (!success)
                     return@create
@@ -100,9 +98,8 @@ class OpenDocumentOperation @Inject constructor(
         }
     }
 
-    private suspend fun headRequest(client: OkHttpClient, url: HttpUrl): HeadResponse = runInterruptible(ioDispatcher) {
+    private suspend fun headRequest(client: HttpClient, url: Url): HeadResponse =
         HeadResponse.fromUrl(client, url)
-    }
 
 
     companion object {

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/OpenDocumentOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/OpenDocumentOperation.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.os.Build
 import android.os.CancellationSignal
 import android.os.ParcelFileDescriptor
+import at.bitfire.dav4jvm.ktor.toContentTypeOrNull
 import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.webdav.DavHttpClientBuilder
 import at.bitfire.davdroid.webdav.DocumentProviderUtils
@@ -16,7 +17,6 @@ import at.bitfire.davdroid.webdav.RandomAccessCallbackWrapper
 import at.bitfire.davdroid.webdav.StreamingFileDescriptor
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.ktor.client.HttpClient
-import io.ktor.http.ContentType
 import io.ktor.http.Url
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -43,7 +43,7 @@ class OpenDocumentOperation @Inject constructor(
 
         val doc = documentDao.get(documentId.toLong()) ?: throw FileNotFoundException()
         val url = doc.toKtorUrl(db)
-        val mimeType = doc.mimeType?.toString()?.let { ContentType.parse(it) }
+        val mimeType = doc.mimeType?.toString().toContentTypeOrNull()
         val client = httpClientBuilder.buildKtor(doc.mountId, logBody = false)
 
         val readOnlyMode = when (mode) {

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/OpenDocumentOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/OpenDocumentOperation.kt
@@ -63,7 +63,6 @@ class OpenDocumentOperation @Inject constructor(
         }.await()
         logger.fine("Received file info: $fileInfo")
 
-        // RandomAccessCallbackWrapper / StreamingFileDescriptor are responsible for closing httpClient
         return@runBlocking if (
             androidSupportsRandomAccess &&
             readOnlyMode &&                     // WebDAV doesn't support random write access (natively)

--- a/core/src/test/kotlin/at/bitfire/davdroid/util/DavUtilsTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/util/DavUtilsTest.kt
@@ -6,8 +6,8 @@ package at.bitfire.davdroid.util
 
 import at.bitfire.davdroid.util.DavUtils.lastSegment
 import at.bitfire.davdroid.util.DavUtils.parent
+import io.ktor.http.ContentType
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.MediaType.Companion.toMediaType
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -16,7 +16,7 @@ class DavUtilsTest {
     @Test
     fun testAcceptAnything() {
         assertEquals("*/*", DavUtils.acceptAnything(null))
-        assertEquals("some/thing;v=2.1, */*;q=0.8", DavUtils.acceptAnything("some/thing;v=2.1".toMediaType()))
+        assertEquals("some/thing;v=2.1, */*;q=0.8", DavUtils.acceptAnything(ContentType.parse("some/thing;v=2.1")))
     }
 
     @Test

--- a/core/src/test/kotlin/at/bitfire/davdroid/util/DavUtilsTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/util/DavUtilsTest.kt
@@ -7,6 +7,7 @@ package at.bitfire.davdroid.util
 import at.bitfire.davdroid.util.DavUtils.lastSegment
 import at.bitfire.davdroid.util.DavUtils.parent
 import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -15,8 +16,8 @@ class DavUtilsTest {
 
     @Test
     fun testAcceptAnything() {
-        assertEquals("*/*", DavUtils.acceptAnything(null))
-        assertEquals("some/thing;v=2.1, */*;q=0.8", DavUtils.acceptAnything(ContentType.parse("some/thing;v=2.1")))
+        assertEquals("*/*", DavUtils.acceptAnything(preferred = null)[HttpHeaders.Accept])
+        assertEquals("some/thing;v=2.1, */*;q=0.8", DavUtils.acceptAnything(preferred = ContentType.parse("some/thing;v=2.1"))[HttpHeaders.Accept])
     }
 
     @Test

--- a/core/src/test/kotlin/at/bitfire/davdroid/webdav/HeadResponseTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/webdav/HeadResponseTest.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.webdav
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.http.HttpHeaders
+import io.ktor.http.Url
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+class HeadResponseTest {
+
+    private val server = MockWebServer()
+    private val client = HttpClient(OkHttp)
+
+    @Before
+    fun setUp() {
+        server.start()
+    }
+
+    @After
+    fun tearDown() {
+        client.close()
+        server.shutdown()
+    }
+
+    private fun url() = Url(server.url("/").toString())
+
+    @Test
+    fun `strong ETag is parsed`() = runBlocking {
+        server.enqueue(MockResponse()
+            .setResponseCode(200)
+            .addHeader(HttpHeaders.ETag, "\"abc123\""))
+        assertEquals("abc123", HeadResponse.fromUrl(client, url()).eTag)
+    }
+
+    @Test
+    fun `weak ETag is ignored`() = runBlocking {
+        server.enqueue(MockResponse()
+            .setResponseCode(200)
+            .addHeader(HttpHeaders.ETag, "W/\"abc123\""))
+        assertNull(HeadResponse.fromUrl(client, url()).eTag)
+    }
+
+    @Test
+    fun `Last-Modified is parsed`() = runBlocking {
+        server.enqueue(MockResponse()
+            .setResponseCode(200)
+            .addHeader(HttpHeaders.LastModified, "Wed, 21 Oct 2015 07:28:00 GMT"))
+        assertNotNull(HeadResponse.fromUrl(client, url()).lastModified)
+    }
+
+    @Test
+    fun `Content-Length is parsed`() = runBlocking {
+        server.enqueue(MockResponse()
+            .setResponseCode(200)
+            .setHeader(HttpHeaders.ContentLength, "12345"))
+        assertEquals(12345L, HeadResponse.fromUrl(client, url()).size)
+    }
+
+    @Test
+    fun `Accept-Ranges bytes enables partial content`() = runBlocking {
+        server.enqueue(MockResponse()
+            .setResponseCode(200)
+            .addHeader(HttpHeaders.AcceptRanges, "bytes"))
+        assertEquals(true, HeadResponse.fromUrl(client, url()).supportsPartial)
+    }
+
+    @Test
+    fun `Accept-Ranges none disables partial content`() = runBlocking {
+        server.enqueue(MockResponse()
+            .setResponseCode(200)
+            .addHeader(HttpHeaders.AcceptRanges, "none"))
+        assertEquals(false, HeadResponse.fromUrl(client, url()).supportsPartial)
+    }
+
+}


### PR DESCRIPTION
### Purpose
Replace OkHttp with Ktor for WebDAV read/write operations.

### Short description
- Introduce `buildKtor()` with shared `OkHttpClient` for connection pooling
- Add suspendable `HeadResponse.fromUrl(HttpClient, Url)` overload
- Migrate `StreamingFileDescriptor` to Ktor + `dav4jvm.ktor.DavResource`:
  - Replace OkHttp types with Ktor equivalents (`HttpUrl` → `Url`, etc.)
  - Use `DavResource.get()`/`put()` with `bodyAsChannel()`
- Update `RandomAccessCallback` to use Ktor's `DavResource.getRange()`
- Remove `runInterruptible` (replaced by coroutine cancellation)
- Adapt `OpenDocumentOperation` to use new Ktor-typed factories

### Checklist
- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.