### PR TITLE
Remove Room deprecation

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/db/AppDatabase.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/AppDatabase.kt
@@ -83,7 +83,7 @@ abstract class AppDatabase: RoomDatabase() {
                 for (spec in autoMigrations)
                     addAutoMigrationSpec(spec)
             }
-            .fallbackToDestructiveMigration()   // as a last fallback, recreate database instead of crashing
+            .fallbackToDestructiveMigration(dropAllTables = true)   // as a last fallback, recreate database instead of crashing
             .addCallback(object: Callback() {
                 override fun onDestructiveMigration(db: SupportSQLiteDatabase) {
                     notificationRegistry.notifyIfPossible(NotificationRegistry.NOTIFY_DATABASE_CORRUPTED) {

--- a/core/src/main/kotlin/at/bitfire/davdroid/db/Collection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/Collection.kt
@@ -79,7 +79,7 @@ data class Collection(
     /**
      * Type of service. CalDAV or CardDAV
      */
-    @CollectionType
+    @param:CollectionType
     val type: String,
 
     /**


### PR DESCRIPTION
### Purpose

Remove a Room warning

Example: 

```
> Task :core:compileDebugKotlin
w: file:///home/runner/work/davx5-ose/davx5-ose/core/src/main/kotlin/at/bitfire/davdroid/db/AppDatabase.kt:86:14 'fun fallbackToDestructiveMigration(): RoomDatabase.Builder<AppDatabase>' is deprecated. Replace by overloaded version with parameter to indicate if all tables should be dropped or not.
w: file:///home/runner/work/davx5-ose/davx5-ose/core/src/main/kotlin/at/bitfire/davdroid/db/Collection.kt:82:5 This annotation is currently applied to the value parameter only, but in the future it will also be applied to property.
```

found here https://github.com/bitfireAT/davx5-ose/actions/runs/25539906645/job/74963421605?pr=2195

### Short description

It's just to reduce warnings during build

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [ ] I have added documentation to complex functions and functions that can be used by other modules.
- [ ] I have added reasonable tests or consciously decided to not add tests.

