### PR TITLE
Change debug info/WebDAV authority names to work around Google Play bug

### DIFF
--- a/app-ose/build.gradle.kts
+++ b/app-ose/build.gradle.kts
@@ -49,8 +49,8 @@ android {
         Google Play just shows a generic "Can't install DAVx5" message. So we derive the authority names
         from the package ID, so that the build variants (and clones) have their own authority names and
         can be installed beside DAVx5. */
-        val webdavAuthority = "${applicationId}.webdav"
-        val debugInfoAuthority = "${applicationId}.debug"
+        val webdavAuthority = "${applicationId}.provider.webdav"
+        val debugInfoAuthority = "${applicationId}.provider.debuginfo"
         manifestPlaceholders["webdavAuthority"] = webdavAuthority
         manifestPlaceholders["debugInfoAuthority"] = debugInfoAuthority
         /* Override the default string values from the core library (core/src/main/res/values/strings.xml)


### PR DESCRIPTION
### Purpose

Updates authority names to include `provider` path segment.

A change to the authority names is necessary because of a Google Play bug that currently prevents us from submitting updates for the app, see bitfireAT/davx5#877.

> [!NOTE]
> This breaks existing WebDAV integration in file managers. However users would just have to connect the WebDAV mount in the file manager again.

**If possible (= if Google fixes the upload bug), the resulting commit in the main branch should be reverted before releasing the final version.** Otherwise, we must live with the inconvenience mentioned in the note above in order to be able to release versions again.


### Short description

- Modified authority name construction to append `/provider` segment for compatibility with the referenced issue.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.