### PR TITLE
Fix various compile warnings

### DIFF
--- a/app-ose/src/ose/kotlin/com/davx5/ose/DebugInfoCrashHandler.kt
+++ b/app-ose/src/ose/kotlin/com/davx5/ose/DebugInfoCrashHandler.kt
@@ -34,7 +34,8 @@ class DebugInfoCrashHandler @Inject constructor(
 
 
     override fun uncaughtException(t: Thread, e: Throwable) {
-        logger.log(Level.SEVERE, "Unhandled exception in thread ${t.threadId}!", e)
+        @Suppress("DEPRECATION")
+        logger.log(Level.SEVERE, "Unhandled exception in thread ${t.id}!", e)
 
         // start debug info activity with exception (will be started in a new process)
         val intent = DebugInfoActivity.IntentBuilder(context)

--- a/app-ose/src/ose/kotlin/com/davx5/ose/DebugInfoCrashHandler.kt
+++ b/app-ose/src/ose/kotlin/com/davx5/ose/DebugInfoCrashHandler.kt
@@ -34,7 +34,7 @@ class DebugInfoCrashHandler @Inject constructor(
 
 
     override fun uncaughtException(t: Thread, e: Throwable) {
-        logger.log(Level.SEVERE, "Unhandled exception in thread ${t.id}!", e)
+        logger.log(Level.SEVERE, "Unhandled exception in thread ${t.threadId}!", e)
 
         // start debug info activity with exception (will be started in a new process)
         val intent = DebugInfoActivity.IntentBuilder(context)

--- a/core/src/main/kotlin/at/bitfire/davdroid/db/AppDatabase.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/AppDatabase.kt
@@ -83,7 +83,7 @@ abstract class AppDatabase: RoomDatabase() {
                 for (spec in autoMigrations)
                     addAutoMigrationSpec(spec)
             }
-            .fallbackToDestructiveMigration()   // as a last fallback, recreate database instead of crashing
+            .fallbackToDestructiveMigration(dropAllTables = true)   // as a last fallback, recreate database instead of crashing
             .addCallback(object: Callback() {
                 override fun onDestructiveMigration(db: SupportSQLiteDatabase) {
                     notificationRegistry.notifyIfPossible(NotificationRegistry.NOTIFY_DATABASE_CORRUPTED) {

--- a/core/src/main/kotlin/at/bitfire/davdroid/db/WebDavDocument.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/WebDavDocument.kt
@@ -8,7 +8,7 @@ import android.annotation.SuppressLint
 import android.os.Bundle
 import android.provider.DocumentsContract.Document
 import android.webkit.MimeTypeMap
-import androidx.core.os.bundleOf
+
 import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
@@ -76,10 +76,10 @@ data class WebDavDocument(
         if (parent?.isDirectory == false)
             throw IllegalArgumentException("Parent must be a directory")
 
-        val bundle = bundleOf(
-            Document.COLUMN_DOCUMENT_ID to id.toString(),
-            Document.COLUMN_DISPLAY_NAME to name
-        )
+        val bundle = Bundle().apply {
+            putString(Document.COLUMN_DOCUMENT_ID, id.toString())
+            putString(Document.COLUMN_DISPLAY_NAME, name)
+        }
 
         displayName?.let { bundle.putString(Document.COLUMN_SUMMARY, it) }
         size?.let { bundle.putLong(Document.COLUMN_SIZE, it) }

--- a/core/src/main/kotlin/at/bitfire/davdroid/db/WebDavDocument.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/WebDavDocument.kt
@@ -8,7 +8,6 @@ import android.annotation.SuppressLint
 import android.os.Bundle
 import android.provider.DocumentsContract.Document
 import android.webkit.MimeTypeMap
-
 import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index

--- a/core/src/main/kotlin/at/bitfire/davdroid/di/CoroutineScopesModule.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/di/CoroutineScopesModule.kt
@@ -13,7 +13,6 @@ import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
-import javax.inject.Qualifier
 import javax.inject.Singleton
 
 @Module

--- a/core/src/main/kotlin/at/bitfire/davdroid/di/StartupPluginsModule.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/di/StartupPluginsModule.kt
@@ -8,7 +8,6 @@ import at.bitfire.davdroid.startup.CrashHandlerSetup
 import at.bitfire.davdroid.startup.StartupPlugin
 import at.bitfire.davdroid.startup.TasksAppWatcher
 import dagger.Binds
-import dagger.BindsOptionalOf
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/MemoryCookieStore.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/MemoryCookieStore.kt
@@ -4,7 +4,6 @@
 
 package at.bitfire.davdroid.network
 
-import androidx.annotation.VisibleForTesting
 import okhttp3.Cookie
 import okhttp3.CookieJar
 import okhttp3.HttpUrl

--- a/core/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
@@ -171,7 +171,7 @@ class PushRegistrationManager @Inject constructor(
      *
      * Uses the subscription to subscribe to syncable collections, and then unsubscribes from non-syncable collections.
      */
-    suspend fun processSubscription(serviceId: Long, endpoint: PushEndpoint) = mutex.withLock {
+    suspend fun processSubscription(serviceId: Long, endpoint: PushEndpoint): Unit = mutex.withLock {
         val service = serviceRepository.get(serviceId) ?: return
 
         try {
@@ -235,7 +235,7 @@ class PushRegistrationManager @Inject constructor(
      *
      * Unsubscribes from all subscribed collections.
      */
-    suspend fun removeSubscription(serviceId: Long) = mutex.withLock {
+    suspend fun removeSubscription(serviceId: Long): Unit = mutex.withLock {
         val service = serviceRepository.get(serviceId) ?: return
         unsubscribeAll(service)
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
@@ -33,7 +33,6 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.runInterruptible
 import net.fortuna.ical4j.model.Calendar
 import net.fortuna.ical4j.model.Component
-import net.fortuna.ical4j.model.ComponentList
 import net.fortuna.ical4j.model.TimeZoneRegistryFactory
 import net.fortuna.ical4j.model.component.VTimeZone
 import net.fortuna.ical4j.model.property.ProdId

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
@@ -9,12 +9,12 @@ import android.accounts.AccountManager
 import android.accounts.OnAccountsUpdateListener
 import android.content.ContentProviderClient
 import android.content.Context
+import android.os.Bundle
 import android.provider.ContactsContract
 import androidx.annotation.OpenForTesting
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.WorkerThread
 import androidx.core.content.contentValuesOf
-
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.repository.DavServiceRepository

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
@@ -14,7 +14,7 @@ import androidx.annotation.OpenForTesting
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.WorkerThread
 import androidx.core.content.contentValuesOf
-import androidx.core.os.bundleOf
+
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.repository.DavServiceRepository
@@ -114,11 +114,11 @@ class LocalAddressBookStore @Inject constructor(
     internal fun createAddressBookAccount(account: Account, name: String, id: Long): Account? {
         // create address book account with reference to account, collection ID and URL
         val addressBookAccount = Account(name, context.getString(R.string.account_type_address_book))
-        val userData = bundleOf(
-            LocalAddressBook.USER_DATA_ACCOUNT_NAME to account.name,
-            LocalAddressBook.USER_DATA_ACCOUNT_TYPE to account.type,
-            LocalAddressBook.USER_DATA_COLLECTION_ID to id.toString()
-        )
+        val userData = Bundle().apply {
+            putString(LocalAddressBook.USER_DATA_ACCOUNT_NAME, account.name)
+            putString(LocalAddressBook.USER_DATA_ACCOUNT_TYPE, account.type)
+            putString(LocalAddressBook.USER_DATA_COLLECTION_ID, id.toString())
+        }
         if (!SystemAccountUtils.createAccount(context, addressBookAccount, userData)) {
             logger.warning("Couldn't create address book account: $addressBookAccount")
             return null

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskList.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskList.kt
@@ -24,9 +24,9 @@ class LocalTaskList (
     private val logger = Logger.getGlobal()
 
     override val readOnly
-        get() = dmfsTaskList.accessLevel?.let {
+        get() = dmfsTaskList.accessLevel.let {
             it != TaskListColumns.ACCESS_LEVEL_UNDEFINED && it <= TaskListColumns.ACCESS_LEVEL_READ
-        } ?: false
+        }
 
     override val dbCollectionId: Long?
         get() = dmfsTaskList.syncId?.toLongOrNull()

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettings.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettings.kt
@@ -9,7 +9,6 @@ import android.content.Context
 import android.os.Bundle
 import android.os.Looper
 import androidx.annotation.WorkerThread
-
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.settings.AccountSettings.Companion.CREDENTIALS_LOCK
 import at.bitfire.davdroid.settings.AccountSettings.Companion.CREDENTIALS_LOCK_AT_LOGIN_AND_SETTINGS

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettings.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettings.kt
@@ -9,7 +9,7 @@ import android.content.Context
 import android.os.Bundle
 import android.os.Looper
 import androidx.annotation.WorkerThread
-import androidx.core.os.bundleOf
+
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.settings.AccountSettings.Companion.CREDENTIALS_LOCK
 import at.bitfire.davdroid.settings.AccountSettings.Companion.CREDENTIALS_LOCK_AT_LOGIN_AND_SETTINGS
@@ -429,7 +429,9 @@ class AccountSettings @AssistedInject constructor(
         val currentlyUpdating = Collections.synchronizedSet(mutableSetOf<Account>())
 
         fun initialUserData(credentials: Credentials?, preconfigurationUrl: String?): Bundle {
-            val bundle = bundleOf(KEY_SETTINGS_VERSION to CURRENT_VERSION.toString())
+            val bundle = Bundle().apply {
+                putString(KEY_SETTINGS_VERSION, CURRENT_VERSION.toString())
+            }
 
             if (credentials != null) {
                 if (credentials.username != null)

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/SettingsManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/SettingsManager.kt
@@ -7,7 +7,6 @@ package at.bitfire.davdroid.settings
 import android.util.NoSuchPropertyException
 import androidx.annotation.AnyThread
 import androidx.annotation.VisibleForTesting
-import at.bitfire.davdroid.settings.SettingsManager.OnChangeListener
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/SharedPreferencesProvider.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/SharedPreferencesProvider.kt
@@ -10,13 +10,7 @@ import android.content.SharedPreferences
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 import at.bitfire.davdroid.util.TextTable
-import dagger.Binds
-import dagger.Module
-import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
-import dagger.hilt.components.SingletonComponent
-import dagger.multibindings.IntKey
-import dagger.multibindings.IntoMap
 import java.io.Writer
 import java.util.logging.Logger
 import javax.inject.Inject

--- a/core/src/main/kotlin/at/bitfire/davdroid/startup/CrashHandlerSetup.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/startup/CrashHandlerSetup.kt
@@ -10,13 +10,7 @@ import android.os.StrictMode
 import at.bitfire.davdroid.BuildConfig
 import at.bitfire.davdroid.startup.StartupPlugin.Companion.PRIORITY_DEFAULT
 import at.bitfire.davdroid.startup.StartupPlugin.Companion.PRIORITY_HIGHEST
-import dagger.Binds
-import dagger.BindsOptionalOf
-import dagger.Module
-import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
-import dagger.hilt.components.SingletonComponent
-import dagger.multibindings.IntoSet
 import java.util.Optional
 import java.util.logging.Logger
 import javax.inject.Inject

--- a/core/src/main/kotlin/at/bitfire/davdroid/startup/TasksAppWatcher.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/startup/TasksAppWatcher.kt
@@ -9,12 +9,7 @@ import at.bitfire.davdroid.startup.StartupPlugin.Companion.PRIORITY_DEFAULT
 import at.bitfire.davdroid.sync.TasksAppManager
 import at.bitfire.davdroid.util.packageChangedFlow
 import at.bitfire.ical4android.TaskProvider
-import dagger.Binds
-import dagger.Module
-import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
-import dagger.hilt.components.SingletonComponent
-import dagger.multibindings.IntoSet
 import java.util.logging.Logger
 import javax.inject.Inject
 import javax.inject.Provider

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/account/AccountAuthenticatorService.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/account/AccountAuthenticatorService.kt
@@ -11,7 +11,6 @@ import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import androidx.core.os.bundleOf
 import at.bitfire.davdroid.R
 
 
@@ -35,11 +34,11 @@ class AccountAuthenticatorService: Service() {
     ): AbstractAccountAuthenticator(context) {
 
         override fun addAccount(response: AccountAuthenticatorResponse?, accountType: String?, authTokenType: String?, requiredFeatures: Array<String>?, options: Bundle?) =
-            bundleOf(
-                AccountManager.KEY_ACCOUNT_AUTHENTICATOR_RESPONSE to response,
-                AccountManager.KEY_ERROR_CODE to AccountManager.ERROR_CODE_UNSUPPORTED_OPERATION,
-                AccountManager.KEY_ERROR_MESSAGE to context.getString(R.string.account_prefs_use_app)
-            )
+            Bundle().apply {
+                putParcelable(AccountManager.KEY_ACCOUNT_AUTHENTICATOR_RESPONSE, response)
+                putInt(AccountManager.KEY_ERROR_CODE, AccountManager.ERROR_CODE_UNSUPPORTED_OPERATION)
+                putString(AccountManager.KEY_ERROR_MESSAGE, context.getString(R.string.account_prefs_use_app))
+            }
 
         override fun editProperties(response: AccountAuthenticatorResponse?, accountType: String?) = null
         override fun getAuthTokenLabel(p0: String?) = null

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/account/AddressBookAuthenticatorService.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/account/AddressBookAuthenticatorService.kt
@@ -11,7 +11,7 @@ import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import androidx.core.os.bundleOf
+
 import at.bitfire.davdroid.R
 
 class AddressBookAuthenticatorService: Service() {
@@ -30,11 +30,12 @@ class AddressBookAuthenticatorService: Service() {
         val context: Context
     ): AbstractAccountAuthenticator(context) {
 
-        override fun addAccount(response: AccountAuthenticatorResponse?, accountType: String?, authTokenType: String?, requiredFeatures: Array<String>?, options: Bundle?) = bundleOf(
-            AccountManager.KEY_ACCOUNT_AUTHENTICATOR_RESPONSE to response,
-            AccountManager.KEY_ERROR_CODE to AccountManager.ERROR_CODE_UNSUPPORTED_OPERATION,
-            AccountManager.KEY_ERROR_MESSAGE to context.getString(R.string.account_prefs_use_app)
-        )
+        override fun addAccount(response: AccountAuthenticatorResponse?, accountType: String?, authTokenType: String?, requiredFeatures: Array<String>?, options: Bundle?) =
+            Bundle().apply {
+                putParcelable(AccountManager.KEY_ACCOUNT_AUTHENTICATOR_RESPONSE, response)
+                putInt(AccountManager.KEY_ERROR_CODE, AccountManager.ERROR_CODE_UNSUPPORTED_OPERATION)
+                putString(AccountManager.KEY_ERROR_MESSAGE, context.getString(R.string.account_prefs_use_app))
+            }
 
         override fun editProperties(response: AccountAuthenticatorResponse?, accountType: String?) = null
         override fun getAuthTokenLabel(p0: String?) = null

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/account/SystemAccountUtils.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/account/SystemAccountUtils.kt
@@ -29,7 +29,8 @@ object SystemAccountUtils {
     fun createAccount(context: Context, account: Account, userData: Bundle, password: SensitiveString? = null): Boolean {
         // validate user data
         for (key in userData.keySet()) {
-            userData.get(key)?.let { entry ->
+            @Suppress("DEPRECATION")
+            userData[key]?.let { entry ->
                 if (entry !is String)
                     throw IllegalArgumentException("userData[$key] is ${entry::class.java} (expected: String)")
             }

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncAdapterImpl.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncAdapterImpl.kt
@@ -26,8 +26,8 @@ import at.bitfire.davdroid.sync.SyncDataType
 import at.bitfire.davdroid.sync.account.InvalidAccountException
 import at.bitfire.davdroid.sync.worker.BaseSyncWorker
 import at.bitfire.davdroid.sync.worker.SyncWorkerManager
-import dagger.Lazy
 import dagger.Binds
+import dagger.Lazy
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
@@ -69,7 +69,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.ui.account.AccountProgress

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsScreen.kt
@@ -48,11 +48,15 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.toBitmap
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.settings.Settings
+import at.bitfire.davdroid.ui.PushSummary.PushDisabled
+import at.bitfire.davdroid.ui.PushSummary.PushEnabled
+import at.bitfire.davdroid.ui.PushSummary.PushLoading
 import at.bitfire.davdroid.ui.composable.AppTheme
 import at.bitfire.davdroid.ui.composable.EditTextInputDialog
 import at.bitfire.davdroid.ui.composable.MultipleChoiceInputDialog
@@ -60,10 +64,6 @@ import at.bitfire.davdroid.ui.composable.Setting
 import at.bitfire.davdroid.ui.composable.SettingsHeader
 import at.bitfire.davdroid.ui.composable.SwitchSetting
 import kotlinx.coroutines.launch
-import androidx.core.content.ContextCompat
-import at.bitfire.davdroid.ui.PushSummary.PushDisabled
-import at.bitfire.davdroid.ui.PushSummary.PushEnabled
-import at.bitfire.davdroid.ui.PushSummary.PushLoading
 
 @Composable
 fun AppSettingsScreen(

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoScreen.kt
@@ -42,7 +42,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import at.bitfire.dav4jvm.okhttp.exception.DavException
 import at.bitfire.dav4jvm.okhttp.exception.HttpException
 import at.bitfire.davdroid.R

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/about/AboutActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/about/AboutActivity.kt
@@ -22,9 +22,9 @@ import androidx.compose.material.icons.filled.Home
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
-import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -45,11 +45,7 @@ import com.mikepenz.aboutlibraries.Libs
 import com.mikepenz.aboutlibraries.ui.compose.LibraryDefaults
 import com.mikepenz.aboutlibraries.ui.compose.m3.LibrariesContainer
 import com.mikepenz.aboutlibraries.util.withContext
-import dagger.BindsOptionalOf
-import dagger.Module
-import dagger.hilt.InstallIn
 import dagger.hilt.android.AndroidEntryPoint
-import dagger.hilt.android.components.ActivityComponent
 import kotlinx.coroutines.launch
 import java.util.Optional
 import javax.inject.Inject

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/about/AboutActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/about/AboutActivity.kt
@@ -24,7 +24,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
+import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -108,7 +108,7 @@ class AboutActivity: AppCompatActivity() {
                         val scope = rememberCoroutineScope()
                         val state = rememberPagerState(pageCount = { 3 })
 
-                        TabRow(state.currentPage) {
+                        PrimaryTabRow(state.currentPage) {
                             Tab(state.currentPage == 0, onClick = {
                                 scope.launch { state.scrollToPage(0) }
                             }) {

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreen.kt
@@ -76,7 +76,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsScreen.kt
@@ -55,7 +55,7 @@ import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.settings.AccountSettings.Companion.SYNC_INTERVAL_MANUALLY
 import at.bitfire.davdroid.settings.Credentials

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionActivity.kt
@@ -21,7 +21,9 @@ class CollectionActivity: AppCompatActivity() {
         const val EXTRA_COLLECTION_ID = "collection_id"
     }
 
-    val account by lazy { IntentCompat.getParcelableExtra(intent, EXTRA_ACCOUNT, Account::class.java)!! }
+    val account by lazy {
+        IntentCompat.getParcelableExtra(intent, EXTRA_ACCOUNT, Account::class.java) ?: throw IllegalArgumentException("EXTRA_ACCOUNT must be set")
+    }
     val collectionId by lazy { intent.getLongExtra(EXTRA_COLLECTION_ID, -1) }
 
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionActivity.kt
@@ -7,10 +7,10 @@ package at.bitfire.davdroid.ui.account
 import android.accounts.Account
 import android.content.Intent
 import android.os.Bundle
-import androidx.core.content.IntentCompat
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.TaskStackBuilder
+import androidx.core.content.IntentCompat
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionActivity.kt
@@ -7,6 +7,7 @@ package at.bitfire.davdroid.ui.account
 import android.accounts.Account
 import android.content.Intent
 import android.os.Bundle
+import androidx.core.content.IntentCompat
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.TaskStackBuilder
@@ -20,7 +21,7 @@ class CollectionActivity: AppCompatActivity() {
         const val EXTRA_COLLECTION_ID = "collection_id"
     }
 
-    val account by lazy { intent.getParcelableExtra<Account>(EXTRA_ACCOUNT)!! }
+    val account by lazy { IntentCompat.getParcelableExtra(intent, EXTRA_ACCOUNT, Account::class.java)!! }
     val collectionId by lazy { intent.getLongExtra(EXTRA_COLLECTION_ID, -1) }
 
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionScreen.kt
@@ -52,7 +52,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.repository.DavSyncStatsRepository

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateAddressBookActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateAddressBookActivity.kt
@@ -7,6 +7,7 @@ package at.bitfire.davdroid.ui.account
 import android.accounts.Account
 import android.content.Intent
 import android.os.Bundle
+import androidx.core.content.IntentCompat
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.TaskStackBuilder
@@ -20,7 +21,7 @@ class CreateAddressBookActivity: AppCompatActivity() {
     }
 
     val account by lazy {
-        intent.getParcelableExtra<Account>(EXTRA_ACCOUNT) ?: throw IllegalArgumentException("EXTRA_ACCOUNT must be set")
+        IntentCompat.getParcelableExtra(intent, EXTRA_ACCOUNT, Account::class.java) ?: throw IllegalArgumentException("EXTRA_ACCOUNT must be set")
     }
 
     

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateAddressBookActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateAddressBookActivity.kt
@@ -7,10 +7,10 @@ package at.bitfire.davdroid.ui.account
 import android.accounts.Account
 import android.content.Intent
 import android.os.Bundle
-import androidx.core.content.IntentCompat
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.TaskStackBuilder
+import androidx.core.content.IntentCompat
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateAddressBookScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateAddressBookScreen.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.HomeSet

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateCalendarActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateCalendarActivity.kt
@@ -7,6 +7,7 @@ package at.bitfire.davdroid.ui.account
 import android.accounts.Account
 import android.content.Intent
 import android.os.Bundle
+import androidx.core.content.IntentCompat
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.TaskStackBuilder
@@ -21,7 +22,7 @@ class CreateCalendarActivity: AppCompatActivity() {
     }
 
     val account by lazy {
-        intent.getParcelableExtra<Account>(EXTRA_ACCOUNT) ?: throw IllegalArgumentException("EXTRA_ACCOUNT must be set")
+        IntentCompat.getParcelableExtra(intent, EXTRA_ACCOUNT, Account::class.java) ?: throw IllegalArgumentException("EXTRA_ACCOUNT must be set")
     }
 
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateCalendarActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateCalendarActivity.kt
@@ -7,10 +7,10 @@ package at.bitfire.davdroid.ui.account
 import android.accounts.Account
 import android.content.Intent
 import android.os.Bundle
-import androidx.core.content.IntentCompat
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.TaskStackBuilder
+import androidx.core.content.IntentCompat
 import at.bitfire.davdroid.ui.composable.AppTheme
 import dagger.hilt.android.AndroidEntryPoint
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateCalendarScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateCalendarScreen.kt
@@ -26,12 +26,12 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -55,7 +55,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.HomeSet
@@ -256,7 +256,7 @@ fun CreateCalendarScreen(
                             readOnly = true,
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                                .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
                         )
 
                         ExposedDropdownMenu(

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/HomeSetSelection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/HomeSetSelection.kt
@@ -9,10 +9,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/HomeSetSelection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/HomeSetSelection.kt
@@ -12,7 +12,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -62,7 +62,7 @@ fun HomeSetSelection(
                 },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                    .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
             )
 
             ExposedDropdownMenu(

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/WifiPermissionsActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/WifiPermissionsActivity.kt
@@ -8,6 +8,7 @@ import android.accounts.Account
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import androidx.core.content.IntentCompat
 import android.provider.Settings
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
@@ -23,7 +24,7 @@ class WifiPermissionsActivity: AppCompatActivity() {
         const val EXTRA_ACCOUNT = "account"
     }
 
-    private val account by lazy { intent.getParcelableExtra<Account>(EXTRA_ACCOUNT) ?: throw IllegalArgumentException("EXTRA_ACCOUNT must be set") }
+    private val account by lazy { IntentCompat.getParcelableExtra(intent, EXTRA_ACCOUNT, Account::class.java) ?: throw IllegalArgumentException("EXTRA_ACCOUNT must be set") }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/WifiPermissionsActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/WifiPermissionsActivity.kt
@@ -8,12 +8,12 @@ import android.accounts.Account
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
-import androidx.core.content.IntentCompat
 import android.provider.Settings
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.ui.res.stringResource
 import androidx.core.app.TaskStackBuilder
+import androidx.core.content.IntentCompat
 import at.bitfire.davdroid.R
 import dagger.hilt.android.AndroidEntryPoint
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/composable/PasswordTextField.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/composable/PasswordTextField.kt
@@ -8,7 +8,6 @@ import android.net.Uri
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.KeyboardActionHandler
 import androidx.compose.foundation.text.input.TextFieldState

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/composable/Settings.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/composable/Settings.kt
@@ -13,7 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Folder
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
@@ -32,7 +32,7 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun SettingsHeader(divider: Boolean = false, content: @Composable () -> Unit) {
     if (divider)
-        Divider(Modifier.padding(vertical = 8.dp))
+        HorizontalDivider(Modifier.padding(vertical = 8.dp))
 
     Row(
         Modifier

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/intro/PermissionsIntroPage.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/intro/PermissionsIntroPage.kt
@@ -6,8 +6,8 @@ package at.bitfire.davdroid.ui.intro
 
 import android.content.Context
 import androidx.compose.runtime.Composable
-import at.bitfire.davdroid.ui.PermissionsViewModel
 import at.bitfire.davdroid.ui.PermissionsScreen
+import at.bitfire.davdroid.ui.PermissionsViewModel
 import at.bitfire.davdroid.util.PermissionUtils
 import at.bitfire.davdroid.util.PermissionUtils.CALENDAR_PERMISSIONS
 import at.bitfire.davdroid.util.PermissionUtils.CONTACT_PERMISSIONS

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/AccountDetailsPage.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/AccountDetailsPage.kt
@@ -18,11 +18,11 @@ import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.SnackbarHostState

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/AccountDetailsPage.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/AccountDetailsPage.kt
@@ -22,7 +22,7 @@ import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.SnackbarHostState
@@ -125,7 +125,7 @@ fun AccountDetailsPageContent(
                         { ExposedDropdownMenuDefaults.TrailingIcon(expanded) }
                     } else null,
                     modifier = Modifier
-                        .menuAnchor(MenuAnchorType.PrimaryEditable)
+                        .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryEditable)
                         .fillMaxWidth()
                 )
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/AdvancedLogin.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/AdvancedLogin.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.text.HtmlCompat
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.ui.ExternalUris
 import at.bitfire.davdroid.ui.UiUtils.toAnnotatedString

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/EmailLogin.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/EmailLogin.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.text.HtmlCompat
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.ui.ExternalUris
 import at.bitfire.davdroid.ui.UiUtils.toAnnotatedString

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/FastmailLogin.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/FastmailLogin.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.ui.ExternalUris
 import at.bitfire.davdroid.ui.ExternalUris.withStatParams

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/GoogleLogin.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/GoogleLogin.kt
@@ -40,7 +40,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.text.HtmlCompat
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.ui.ExternalUris
 import at.bitfire.davdroid.ui.ExternalUris.withStatParams

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreen.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.ui.ExternalUris
 import at.bitfire.davdroid.ui.ExternalUris.withStatParams

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/NextcloudLogin.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/NextcloudLogin.kt
@@ -38,8 +38,8 @@ import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
-import androidx.core.os.bundleOf
-import androidx.hilt.navigation.compose.hiltViewModel
+import android.os.Bundle
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.ui.ExternalUris
 import at.bitfire.davdroid.ui.ExternalUris.withStatParams
@@ -93,7 +93,9 @@ object NextcloudLogin : LoginType {
                     browser.intent.data = loginUri
                     browser.intent.putExtra(
                         Browser.EXTRA_HEADERS,
-                        bundleOf(HttpHeaders.AcceptLanguage to Locale.current.toLanguageTag())
+                        Bundle().apply {
+                            putString(HttpHeaders.AcceptLanguage, Locale.current.toLanguageTag())
+                        }
                     )
                     checkResultCallback.launch(browser.intent)
                 } else {

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/NextcloudLogin.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/NextcloudLogin.kt
@@ -7,6 +7,7 @@ package at.bitfire.davdroid.ui.setup
 import android.annotation.SuppressLint
 import android.content.Intent
 import android.net.Uri
+import android.os.Bundle
 import android.provider.Browser
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -38,7 +39,6 @@ import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
-import android.os.Bundle
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.ui.ExternalUris

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/UrlLogin.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/UrlLogin.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.text.HtmlCompat
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.ui.ExternalUris
 import at.bitfire.davdroid.ui.UiUtils.toAnnotatedString

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/DocumentsCursor.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/DocumentsCursor.kt
@@ -31,7 +31,8 @@ class DocumentsCursor(columns: Array<out String>): MatrixCursor(columns) {
     fun addRow(bundle: Bundle) {
         newRow().also { row ->
             for (entry in bundle.keySet()) {
-                val value = bundle.get(entry)
+                @Suppress("DEPRECATION")
+                val value = bundle[entry]
                 row.add(entry, value)
             }
         }


### PR DESCRIPTION
- Fix deprecated RoomDatabase fallbackToDestructiveMigration()
- Replace deprecated bundleOf() with Bundle().apply { ... }
- Update deprecated Android APIs: DnsResolver, getInstallerPackageName, Bundle.get, Intent.getParcelableExtra
- Update deprecated Compose APIs: TabRow, Divider, MenuAnchorType, hiltViewModel package
- Fix KTLC-288: add explicit return types
- Remove unnecessary safe call on non-null receiver
- Suppress warning for deprecated Thread.id
- Add @Suppress(DEPRECATION) for Bundle generic access where typed getters not feasible

Closes #2196
Closes #2198

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [ ] I have added documentation to complex functions and functions that can be used by other modules.
- [ ] I have added reasonable tests or consciously decided to not add tests.

