### PR TITLE
Switch Kotlin annotation default target to `param-property` for core, too

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -20,7 +20,7 @@ java {
 kotlin {
     compilerOptions {
         // use new defaulting rule for qualifiers to avoid `@param:` prefix for DI annotations
-        freeCompilerArgs.add("-Xannotation-default-target=first-only")
+        freeCompilerArgs.add("-Xannotation-default-target=param-property")
     }
 }
 


### PR DESCRIPTION
Amendment to #2203