### PR TITLE
`LocalAddressBook`: take `groupMethod` as argument

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalTestAddressBook.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalTestAddressBook.kt
@@ -7,8 +7,6 @@ package at.bitfire.davdroid.resource
 import android.accounts.Account
 import android.content.ContentProviderClient
 import android.content.Context
-import at.bitfire.davdroid.repository.DavCollectionRepository
-import at.bitfire.davdroid.repository.DavServiceRepository
 import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.sync.adapter.SyncFrameworkIntegration
 import at.bitfire.vcard4android.GroupMethod
@@ -28,21 +26,18 @@ class LocalTestAddressBook @AssistedInject constructor(
     @Assisted provider: ContentProviderClient,
     @Assisted override val groupMethod: GroupMethod,
     accountSettingsFactory: AccountSettings.Factory,
-    collectionRepository: DavCollectionRepository,
     @ApplicationContext context: Context,
     logger: Logger,
-    serviceRepository: DavServiceRepository,
     syncFramework: SyncFrameworkIntegration
 ): LocalAddressBook(
     account = account,
     _addressBookAccount = addressBookAccount,
     provider = provider,
+    groupMethod = groupMethod,
     accountSettingsFactory = accountSettingsFactory,
-    collectionRepository = collectionRepository,
     context = context,
     dirtyVerifier = Optional.empty(),
     logger = logger,
-    serviceRepository = serviceRepository,
     syncFramework = syncFramework
 ) {
 

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration20Test.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration20Test.kt
@@ -19,6 +19,7 @@ import at.bitfire.davdroid.db.Service
 import at.bitfire.davdroid.resource.LocalAddressBook
 import at.bitfire.davdroid.resource.LocalCalendarStore
 import at.bitfire.davdroid.resource.LocalTestAddressBookProvider
+import at.bitfire.davdroid.sync.account.TestAccount
 import at.bitfire.davdroid.sync.account.setAndVerifyUserData
 import at.bitfire.ical4android.util.MiscUtils.asSyncAdapter
 import at.bitfire.vcard4android.GroupMethod
@@ -28,6 +29,7 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import io.mockk.junit4.MockKRule
 import io.mockk.mockk
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
@@ -64,18 +66,25 @@ class AccountSettingsMigration20Test {
         Manifest.permission.READ_CALENDAR, Manifest.permission.WRITE_CALENDAR
     )
 
-    val accountManager by lazy { AccountManager.get(context) }
+    private val accountManager by lazy { AccountManager.get(context) }
+    private lateinit var account: Account
 
     @Before
     fun setUp() {
         hiltRule.inject()
+
+        account = TestAccount.create(version = 19)
+    }
+
+    @After
+    fun cleanUp() {
+        TestAccount.remove(account)
     }
 
 
     @Test
     fun testMigrateAddressBooks_UrlMatchesCollection() {
         // set up legacy address-book with URL, but without collection ID
-        val account = Account("test", "test")
         val url = "https://example.com/"
 
         db.serviceDao().insertOrReplace(Service(id = 1, accountName = account.name, type = Service.TYPE_CARDDAV, principal = null))
@@ -105,7 +114,6 @@ class AccountSettingsMigration20Test {
     @Test
     fun testMigrateCalendars_UrlMatchesCollection() {
         // set up legacy calendar with URL, but without collection ID
-        val account = Account("test", CalendarContract.ACCOUNT_TYPE_LOCAL)
         val url = "https://example.com/"
 
         db.serviceDao().insertOrReplace(Service(id = 1, accountName = account.name, type = Service.TYPE_CALDAV, principal = null))

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -16,9 +16,6 @@ import android.provider.ContactsContract.Groups
 import android.provider.ContactsContract.RawContacts
 import androidx.annotation.OpenForTesting
 import androidx.core.content.contentValuesOf
-import at.bitfire.davdroid.R
-import at.bitfire.davdroid.repository.DavCollectionRepository
-import at.bitfire.davdroid.repository.DavServiceRepository
 import at.bitfire.davdroid.resource.LocalAddressBook.Companion.USER_DATA_READ_ONLY
 import at.bitfire.davdroid.resource.workaround.ContactDirtyVerifier
 import at.bitfire.davdroid.settings.AccountSettings
@@ -57,12 +54,11 @@ open class LocalAddressBook @AssistedInject constructor(
     @Assisted("account") val account: Account,
     @Assisted("addressBookAccount") _addressBookAccount: Account,
     @Assisted provider: ContentProviderClient,
+    @Assisted open val groupMethod: GroupMethod,
     private val accountSettingsFactory: AccountSettings.Factory,
-    private val collectionRepository: DavCollectionRepository,
     @ApplicationContext private val context: Context,
     internal val dirtyVerifier: Optional<ContactDirtyVerifier>,
     private val logger: Logger,
-    private val serviceRepository: DavServiceRepository,
     private val syncFramework: SyncFrameworkIntegration
 ): AndroidAddressBook<LocalContact, LocalGroup>(_addressBookAccount, provider, LocalContact.Factory, LocalGroup.Factory), LocalCollection<LocalAddress> {
 
@@ -71,7 +67,8 @@ open class LocalAddressBook @AssistedInject constructor(
         fun create(
             @Assisted("account") account: Account,
             @Assisted("addressBookAccount") addressBookAccount: Account,
-            provider: ContentProviderClient
+            provider: ContentProviderClient,
+            groupMethod: GroupMethod
         ): LocalAddressBook
     }
 
@@ -83,26 +80,6 @@ open class LocalAddressBook @AssistedInject constructor(
 
     private val accountManager by lazy { AccountManager.get(context) }
 
-    /**
-     * Whether contact groups ([LocalGroup]) are included in query results
-     * and are affected by updates/deletes on generic members.
-     *
-     * For instance, if groupMethod is GROUP_VCARDS, [findDirty] will find only dirty [LocalContact]s,
-     * but if it is enabled, [findDirty] will find dirty [LocalContact]s and [LocalGroup]s.
-     */
-    open val groupMethod: GroupMethod by lazy {
-        val account = accountManager.getUserData(addressBookAccount, USER_DATA_COLLECTION_ID)?.toLongOrNull()?.let { collectionId ->
-            collectionRepository.get(collectionId)?.let { collection ->
-                serviceRepository.getBlocking(collection.serviceId)?.let { service ->
-                    Account(service.accountName, context.getString(R.string.account_type))
-                }
-            }
-        }
-        if (account == null)
-            throw IllegalArgumentException("Collection of address book account $addressBookAccount does not have an account")
-        val accountSettings = accountSettingsFactory.create(account)
-        accountSettings.getGroupMethod()
-    }
     val includeGroups
         get() = groupMethod == GroupMethod.GROUP_VCARDS
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
@@ -18,6 +18,7 @@ import androidx.core.content.contentValuesOf
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.repository.DavServiceRepository
+import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.settings.Settings
 import at.bitfire.davdroid.settings.SettingsManager
 import at.bitfire.davdroid.sync.account.SystemAccountUtils
@@ -33,6 +34,7 @@ import java.util.logging.Logger
 import javax.inject.Inject
 
 class LocalAddressBookStore @Inject constructor(
+    private val accountSettingsFactory: AccountSettings.Factory,
     @ApplicationContext private val context: Context,
     private val localAddressBookFactory: LocalAddressBook.Factory,
     private val logger: Logger,
@@ -100,7 +102,8 @@ class LocalAddressBookStore @Inject constructor(
             id = fromCollection.id
         ) ?: return null
 
-        val addressBook = localAddressBookFactory.create(account, addressBookAccount, client)
+        val accountSettings = accountSettingsFactory.create(account)
+        val addressBook = localAddressBookFactory.create(account, addressBookAccount, client, accountSettings.getGroupMethod())
 
         // update settings
         addressBook.updateSyncFrameworkSettings()
@@ -127,10 +130,13 @@ class LocalAddressBookStore @Inject constructor(
         return addressBookAccount
     }
 
-    override fun getAll(account: Account, client: ContentProviderClient): List<LocalAddressBook> =
-        getAddressBookAccounts(account).map { addressBookAccount ->
-            localAddressBookFactory.create(account, addressBookAccount, client)
+    override fun getAll(account: Account, client: ContentProviderClient): List<LocalAddressBook> {
+        val accountSettings = accountSettingsFactory.create(account)
+        val groupMethod = accountSettings.getGroupMethod()
+        return getAddressBookAccounts(account).map { addressBookAccount ->
+            localAddressBookFactory.create(account, addressBookAccount, client, groupMethod)
         }
+    }
 
     override fun getByDbCollectionId(account: Account, client: ContentProviderClient, dbCollectionId: Long): LocalAddressBook? =
         getAll(account, client).firstOrNull { it.dbCollectionId == dbCollectionId }

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettings.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettings.kt
@@ -68,11 +68,7 @@ class AccountSettings @AssistedInject constructor(
 
     val accountManager: AccountManager = AccountManager.get(context)
     init {
-        val allowedAccountTypes = arrayOf(
-            context.getString(R.string.account_type),
-            "at.bitfire.davdroid.test"      // R.strings.account_type_test in androidTest
-        )
-        if (!allowedAccountTypes.contains(account.type))
+        if (account.type != context.getString(R.string.account_type))
             throw IllegalArgumentException("Invalid account type for AccountSettings(): ${account.type}")
 
         // synchronize because account migration must only be run one time

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration17.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration17.kt
@@ -69,7 +69,13 @@ class AccountSettingsMigration17 @Inject constructor(
                     // Old address books only have a URL, so use it to determine the collection ID
                     logger.info("Migrating address book ${oldAddressBookAccount.name}")
                     val oldAddressBook = localAddressBookFactory.create(account, oldAddressBookAccount, provider, groupMethod)
-                    val url = accountManager.getUserData(oldAddressBookAccount, LOCAL_ADDRESS_BOOK_ACCOUNT_USER_DATA_URL)
+
+                    val url: String? = accountManager.getUserData(oldAddressBookAccount, LOCAL_ADDRESS_BOOK_ACCOUNT_USER_DATA_URL)
+                    if (url == null) {
+                        logger.warning("Address book ${oldAddressBookAccount.name} doesn't have an assigned URL, can't migrate")
+                        continue
+                    }
+
                     collectionRepository.getByServiceAndUrl(service.id, url)?.let { collection ->
                         // Set collection ID and rename the account
                         localAddressBookStore.update(provider, oldAddressBook, collection)

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration17.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration17.kt
@@ -12,9 +12,9 @@ import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.Service
 import at.bitfire.davdroid.repository.DavCollectionRepository
 import at.bitfire.davdroid.repository.DavServiceRepository
-import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.resource.LocalAddressBook
 import at.bitfire.davdroid.resource.LocalAddressBookStore
+import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.sync.account.setAndVerifyUserData
 import dagger.Binds
 import dagger.Module
@@ -62,11 +62,13 @@ class AccountSettingsMigration17 @Inject constructor(
                         account.name == accountManager.getUserData(addressBookAccount, "real_account_name")
                     }
 
+                val accountSettings = accountSettingsFactory.create(account)
+                val groupMethod = accountSettings.getGroupMethod()
+
                 for (oldAddressBookAccount in oldAddressBookAccounts) {
                     // Old address books only have a URL, so use it to determine the collection ID
                     logger.info("Migrating address book ${oldAddressBookAccount.name}")
-                    val accountSettings = accountSettingsFactory.create(account)
-                    val oldAddressBook = localAddressBookFactory.create(account, oldAddressBookAccount, provider, accountSettings.getGroupMethod())
+                    val oldAddressBook = localAddressBookFactory.create(account, oldAddressBookAccount, provider, groupMethod)
                     val url = accountManager.getUserData(oldAddressBookAccount, LOCAL_ADDRESS_BOOK_ACCOUNT_USER_DATA_URL)
                     collectionRepository.getByServiceAndUrl(service.id, url)?.let { collection ->
                         // Set collection ID and rename the account

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration17.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration17.kt
@@ -12,6 +12,7 @@ import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.Service
 import at.bitfire.davdroid.repository.DavCollectionRepository
 import at.bitfire.davdroid.repository.DavServiceRepository
+import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.resource.LocalAddressBook
 import at.bitfire.davdroid.resource.LocalAddressBookStore
 import at.bitfire.davdroid.sync.account.setAndVerifyUserData
@@ -32,6 +33,7 @@ import javax.inject.Inject
  * identifier. We need to update the address book account names.
  */
 class AccountSettingsMigration17 @Inject constructor(
+    private val accountSettingsFactory: AccountSettings.Factory,
     private val collectionRepository: DavCollectionRepository,
     @ApplicationContext private val context: Context,
     private val localAddressBookFactory: LocalAddressBook.Factory,
@@ -63,7 +65,8 @@ class AccountSettingsMigration17 @Inject constructor(
                 for (oldAddressBookAccount in oldAddressBookAccounts) {
                     // Old address books only have a URL, so use it to determine the collection ID
                     logger.info("Migrating address book ${oldAddressBookAccount.name}")
-                    val oldAddressBook = localAddressBookFactory.create(account, oldAddressBookAccount, provider)
+                    val accountSettings = accountSettingsFactory.create(account)
+                    val oldAddressBook = localAddressBookFactory.create(account, oldAddressBookAccount, provider, accountSettings.getGroupMethod())
                     val url = accountManager.getUserData(oldAddressBookAccount, LOCAL_ADDRESS_BOOK_ACCOUNT_USER_DATA_URL)
                     collectionRepository.getByServiceAndUrl(service.id, url)?.let { collection ->
                         // Set collection ID and rename the account


### PR DESCRIPTION
### Purpose

Refactor `LocalAddressBook` to receive `groupMethod` as a parameter instead of actively fetching it from DB for better isolation.

Preparation for bitfireAT/synctools#118.

### Short description

- Modified `LocalAddressBook` factory to accept `groupMethod` as an argument.
- ⚠️ Changed AccountSettings to remove check for `at.bitfire.davdroid.test` because that doesn't exist anymore – not related to the scope but changed "on the go" because it's a refactoring/cleanup PR anyway
- Changed migration code to use `TestAccount` properly to fix failing tests

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.