### PR TITLE
Move `AccountSettings` access in `CollectionScreenViewModel` off main thread

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalDataStore.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalDataStore.kt
@@ -6,6 +6,7 @@ package at.bitfire.davdroid.resource
 
 import android.accounts.Account
 import android.content.ContentProviderClient
+import androidx.annotation.WorkerThread
 import at.bitfire.davdroid.db.Collection
 import javax.annotation.WillNotClose
 
@@ -66,6 +67,7 @@ interface LocalDataStore<T: LocalCollection<*>> {
      * @return The local collection with the specified DB collection ID, or `null` if not found.
      * @throws UnsupportedOperationException if the operation is not supported on this data store (jtx Board)
      */
+    @WorkerThread
     fun getByDbCollectionId(account: Account, client: ContentProviderClient, dbCollectionId: Long): T?
 
     /**

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionScreenViewModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionScreenViewModel.kt
@@ -50,6 +50,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -304,7 +305,7 @@ class CollectionScreenViewModel @AssistedInject constructor(
         awaitClose {
             context.contentResolver.unregisterContentObserver(observer)
         }
-    }
+    }.flowOn(ioDispatcher)      // localDataStore access should not be done on main thread
 
     private fun getProviderAppName(authority: String): String {
         val packageManager = context.packageManager


### PR DESCRIPTION
### Purpose

Fixes crash that is caused by main-thread `AccountSettings` access.

### Short description

- Annotated `getByDbCollectionId` with `@WorkerThread` to enforce off-main-thread usage.
- Changed local data store access to avoid blocking the main thread.