### PR TITLE
Update calendar color generation to use RGB format

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
@@ -394,7 +394,7 @@ class DavCollectionRepository @Inject constructor(
                         }
                         color?.let {
                             insertTag(CalDAV.CalendarColor) {
-                                text(DavUtils.ARGBtoCalDAVColor(it))
+                                text(DavUtils.argbToHexColor(it))
                             }
                         }
                         timezoneId?.let { id ->

--- a/core/src/main/kotlin/at/bitfire/davdroid/util/DavUtils.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/util/DavUtils.kt
@@ -37,11 +37,17 @@ object DavUtils {
         else
             MIME_TYPE_ACCEPT_ALL
 
-    @Suppress("FunctionName")
-    fun ARGBtoCalDAVColor(colorWithAlpha: Int): String {
-        val alpha = (colorWithAlpha shr 24) and 0xFF
+    /**
+     * Converts an Android (A)RGB color to a standard hex code color like it's used by CalDAV
+     * `calendar-color`.
+     *
+     * @param colorWithAlpha    color code, with or without alpha value (ARGB)
+     *
+     * @return hex color with prefix, like `#FAC308` (RGB)
+     */
+    fun argbToHexColor(colorWithAlpha: Int): String {
         val color = colorWithAlpha and 0xFFFFFF
-        return String.format(Locale.ROOT, "#%06X%02X", color, alpha)
+        return String.format(Locale.ROOT, "#%06X", color)
     }
 
     /**

--- a/core/src/test/kotlin/at/bitfire/davdroid/util/DavUtilsTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/util/DavUtilsTest.kt
@@ -20,10 +20,11 @@ class DavUtilsTest {
     }
 
     @Test
-    fun testARGBtoCalDAVColor() {
-        assertEquals("#00000000", DavUtils.ARGBtoCalDAVColor(0))
-        assertEquals("#123456FF", DavUtils.ARGBtoCalDAVColor(0xFF123456.toInt()))
-        assertEquals("#000000FF", DavUtils.ARGBtoCalDAVColor(0xFF000000.toInt()))
+    fun testArgbToHexColor() {
+        assertEquals("#000000", DavUtils.argbToHexColor(0))
+        assertEquals("#123456", DavUtils.argbToHexColor(0xFF123456.toInt()))
+        assertEquals("#123456", DavUtils.argbToHexColor(0x00123456))
+        assertEquals("#000000", DavUtils.argbToHexColor(0xFF000000.toInt()))
     }
 
     @Test


### PR DESCRIPTION
### Purpose

This PR updates the calendar creation process to generate colors in RGB format instead of ARGB.

There's no specification of the Apple-proprietary `calendar-color` element, but other clients use standard RGB hex values, too. Using ARGB recently caused problems (see #2209).

Creating a calendar on Fastmail works again with this PR.


### Short description

- Modified the color generation logic to output RGB values instead of ARGB during calendar creation.
- Ensures compatibility with existing systems expecting RGB format.