### PR TITLE
Unify copyright notice in synctools

### DIFF
--- a/synctools/src/androidTest/kotlin/at/bitfire/ical4android/AospTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/ical4android/AospTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android

--- a/synctools/src/androidTest/kotlin/at/bitfire/ical4android/DmfsStyleProvidersTaskTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/ical4android/DmfsStyleProvidersTaskTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android

--- a/synctools/src/androidTest/kotlin/at/bitfire/ical4android/DmfsTaskTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/ical4android/DmfsTaskTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android

--- a/synctools/src/androidTest/kotlin/at/bitfire/ical4android/JtxCollectionTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/ical4android/JtxCollectionTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android

--- a/synctools/src/androidTest/kotlin/at/bitfire/ical4android/JtxICalObjectTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/ical4android/JtxICalObjectTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android

--- a/synctools/src/androidTest/kotlin/at/bitfire/ical4android/impl/Constants.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/ical4android/impl/Constants.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android.impl

--- a/synctools/src/androidTest/kotlin/at/bitfire/ical4android/impl/TestJtxCollection.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/ical4android/impl/TestJtxCollection.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android.impl

--- a/synctools/src/androidTest/kotlin/at/bitfire/ical4android/impl/TestJtxIcalObject.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/ical4android/impl/TestJtxIcalObject.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android.impl

--- a/synctools/src/androidTest/kotlin/at/bitfire/ical4android/impl/TestTaskList.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/ical4android/impl/TestTaskList.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android.impl

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/LoggingTestRunner.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/LoggingTestRunner.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/MockkCompat.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/MockkCompat.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/icalendar/AndroidTimeZonesTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/icalendar/AndroidTimeZonesTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.icalendar

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/mapping/contacts/TestUtils.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/mapping/contacts/TestUtils.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/mapping/contacts/builder/GroupMembershipBuilderTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/mapping/contacts/builder/GroupMembershipBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/mapping/contacts/builder/PhotoBuilderTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/mapping/contacts/builder/PhotoBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/mapping/contacts/handler/CachedGroupMembershipHandlerTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/mapping/contacts/handler/CachedGroupMembershipHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/mapping/contacts/handler/GroupMembershipHandlerTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/mapping/contacts/handler/GroupMembershipHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/mapping/contacts/handler/PhotoHandlerTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/mapping/contacts/handler/PhotoHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskBuilderTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskProcessorTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskProcessorTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/BatchOperationTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/BatchOperationTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/JtxBatchOperationTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/JtxBatchOperationTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/TasksBatchOperationTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/TasksBatchOperationTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendarProviderBehaviorTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendarProviderBehaviorTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.calendar

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendarProviderTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendarProviderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.calendar

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendarTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendarTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.calendar

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/calendar/AndroidRecurringCalendarTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/calendar/AndroidRecurringCalendarTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.calendar

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/calendar/CalendarBatchOperationTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/calendar/CalendarBatchOperationTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.calendar

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/calendar/TestCalendar.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/calendar/TestCalendar.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.calendar

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBookTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBookTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.contacts

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/contacts/AndroidContactTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/contacts/AndroidContactTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.contacts

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/contacts/AndroidGroupTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/contacts/AndroidGroupTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.contacts

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/contacts/Constants.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/contacts/Constants.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.contacts

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/contacts/TestAddressBook.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/contacts/TestAddressBook.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.contacts

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxCollectionProviderTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxCollectionProviderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.jtx

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxCollectionTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxCollectionTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.jtx

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxRecurringCollectionTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxRecurringCollectionTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.jtx

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/ContactsBatchOperationTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/ContactsBatchOperationTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.tasks

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.tasks

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/util/UtilsTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/util/UtilsTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.util

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/vcard/LocaleNonWesternDigitsTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/vcard/LocaleNonWesternDigitsTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.vcard

--- a/synctools/src/main/kotlin/at/bitfire/ical4android/DmfsTask.kt
+++ b/synctools/src/main/kotlin/at/bitfire/ical4android/DmfsTask.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android

--- a/synctools/src/main/kotlin/at/bitfire/ical4android/ICalendar.kt
+++ b/synctools/src/main/kotlin/at/bitfire/ical4android/ICalendar.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android

--- a/synctools/src/main/kotlin/at/bitfire/ical4android/JtxCollection.kt
+++ b/synctools/src/main/kotlin/at/bitfire/ical4android/JtxCollection.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android

--- a/synctools/src/main/kotlin/at/bitfire/ical4android/JtxCollectionFactory.kt
+++ b/synctools/src/main/kotlin/at/bitfire/ical4android/JtxCollectionFactory.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android

--- a/synctools/src/main/kotlin/at/bitfire/ical4android/JtxICalObject.kt
+++ b/synctools/src/main/kotlin/at/bitfire/ical4android/JtxICalObject.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android

--- a/synctools/src/main/kotlin/at/bitfire/ical4android/JtxICalObjectFactory.kt
+++ b/synctools/src/main/kotlin/at/bitfire/ical4android/JtxICalObjectFactory.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android

--- a/synctools/src/main/kotlin/at/bitfire/ical4android/Task.kt
+++ b/synctools/src/main/kotlin/at/bitfire/ical4android/Task.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android

--- a/synctools/src/main/kotlin/at/bitfire/ical4android/TaskProvider.kt
+++ b/synctools/src/main/kotlin/at/bitfire/ical4android/TaskProvider.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android

--- a/synctools/src/main/kotlin/at/bitfire/ical4android/TaskReader.kt
+++ b/synctools/src/main/kotlin/at/bitfire/ical4android/TaskReader.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android

--- a/synctools/src/main/kotlin/at/bitfire/ical4android/TaskWriter.kt
+++ b/synctools/src/main/kotlin/at/bitfire/ical4android/TaskWriter.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android

--- a/synctools/src/main/kotlin/at/bitfire/ical4android/UnknownProperty.kt
+++ b/synctools/src/main/kotlin/at/bitfire/ical4android/UnknownProperty.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android

--- a/synctools/src/main/kotlin/at/bitfire/ical4android/util/DateUtils.kt
+++ b/synctools/src/main/kotlin/at/bitfire/ical4android/util/DateUtils.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android.util

--- a/synctools/src/main/kotlin/at/bitfire/ical4android/util/MiscUtils.kt
+++ b/synctools/src/main/kotlin/at/bitfire/ical4android/util/MiscUtils.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android.util

--- a/synctools/src/main/kotlin/at/bitfire/ical4android/util/TimeApiExtensions.kt
+++ b/synctools/src/main/kotlin/at/bitfire/ical4android/util/TimeApiExtensions.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android.util

--- a/synctools/src/main/kotlin/at/bitfire/synctools/exception/InvalidICalendarException.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/exception/InvalidICalendarException.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.exception

--- a/synctools/src/main/kotlin/at/bitfire/synctools/exception/InvalidLocalResourceException.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/exception/InvalidLocalResourceException.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.exception

--- a/synctools/src/main/kotlin/at/bitfire/synctools/exception/InvalidResourceException.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/exception/InvalidResourceException.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.exception

--- a/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/AssociatedComponents.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/AssociatedComponents.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.icalendar

--- a/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/CalendarUidSplitter.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/CalendarUidSplitter.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.icalendar

--- a/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/Css3Color.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/Css3Color.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.icalendar

--- a/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/DatePropertyTzMapper.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/DatePropertyTzMapper.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.icalendar

--- a/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/ICalendarGenerator.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/ICalendarGenerator.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.icalendar

--- a/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/ICalendarParser.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/ICalendarParser.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.icalendar

--- a/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/Ical4jHelpers.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/Ical4jHelpers.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.icalendar

--- a/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/VTimeZoneMinifier.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/VTimeZoneMinifier.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.icalendar

--- a/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/validation/FixInvalidDayOffsetPreprocessor.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/validation/FixInvalidDayOffsetPreprocessor.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.icalendar.validation

--- a/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/validation/FixInvalidUtcOffsetPreprocessor.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/validation/FixInvalidUtcOffsetPreprocessor.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.icalendar.validation

--- a/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/validation/ICalPreprocessor.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/validation/ICalPreprocessor.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.icalendar.validation

--- a/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/validation/StreamPreprocessor.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/validation/StreamPreprocessor.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.icalendar.validation

--- a/synctools/src/main/kotlin/at/bitfire/synctools/log/ClassNameUtils.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/log/ClassNameUtils.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.log

--- a/synctools/src/main/kotlin/at/bitfire/synctools/log/LogcatHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/log/LogcatHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.log

--- a/synctools/src/main/kotlin/at/bitfire/synctools/log/PlainTextFormatter.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/log/PlainTextFormatter.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.log

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/AndroidEventBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/AndroidEventBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/AndroidEventHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/AndroidEventHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/AttendeeMappings.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/AttendeeMappings.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/ProdIdGenerator.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/ProdIdGenerator.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/SequenceUpdater.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/SequenceUpdater.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/AccessLevelBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/AccessLevelBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/AllDayBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/AllDayBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/AndroidEntityBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/AndroidEntityBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/AndroidRecurrenceMapper.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/AndroidRecurrenceMapper.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/AttendeesBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/AttendeesBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/AvailabilityBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/AvailabilityBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/CalendarIdBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/CalendarIdBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/CategoriesBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/CategoriesBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/ColorBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/ColorBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/DescriptionBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/DescriptionBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/DirtyAndDeletedBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/DirtyAndDeletedBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/DurationBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/DurationBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/ETagBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/ETagBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/EndTimeBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/EndTimeBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/LocationBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/LocationBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/OrganizerBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/OrganizerBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/OriginalInstanceTimeBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/OriginalInstanceTimeBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/RecurrenceFieldsBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/RecurrenceFieldsBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/RemindersBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/RemindersBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/SequenceBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/SequenceBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/StartTimeBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/StartTimeBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/StatusBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/StatusBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/SyncFlagsBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/SyncFlagsBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/SyncIdBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/SyncIdBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/TitleBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/TitleBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/UidBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/UidBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/UnknownPropertiesBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/UnknownPropertiesBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/UrlBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/UrlBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/AccessLevelHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/AccessLevelHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/AndroidEventFieldHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/AndroidEventFieldHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/AndroidTimeField.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/AndroidTimeField.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/AttendeesHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/AttendeesHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/AvailabilityHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/AvailabilityHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/CategoriesHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/CategoriesHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/ColorHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/ColorHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/DescriptionHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/DescriptionHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/DurationHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/DurationHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/EndTimeHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/EndTimeHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/LocationHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/LocationHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/OrganizerHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/OrganizerHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/OriginalInstanceTimeHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/OriginalInstanceTimeHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/RecurrenceFieldsHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/RecurrenceFieldsHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/RemindersHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/RemindersHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/SequenceHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/SequenceHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/StartTimeHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/StartTimeHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/StatusHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/StatusHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/TitleHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/TitleHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/UidGenerator.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/UidGenerator.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/UidHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/UidHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/UnknownPropertiesHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/UnknownPropertiesHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/UrlHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/UrlHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/Contact.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/Contact.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/ContactReader.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/ContactReader.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/ContactWriter.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/ContactWriter.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/LabeledProperty.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/LabeledProperty.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/RawContactBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/RawContactBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/RawContactHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/RawContactHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/DataRowBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/DataRowBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/EmailBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/EmailBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/EventBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/EventBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/GroupMembershipBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/GroupMembershipBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/ImBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/ImBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/NicknameBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/NicknameBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/NoteBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/NoteBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/OrganizationBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/OrganizationBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/PhoneBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/PhoneBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/PhotoBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/PhotoBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/RelationBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/RelationBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/SipAddressBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/SipAddressBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/StructuredNameBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/StructuredNameBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/StructuredPostalBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/StructuredPostalBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/UnknownPropertiesBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/UnknownPropertiesBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/WebsiteBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/WebsiteBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/CachedGroupMembershipHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/CachedGroupMembershipHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/DataRowHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/DataRowHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/EmailHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/EmailHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/EventHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/EventHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/GroupMembershipHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/GroupMembershipHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/ImHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/ImHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/NicknameHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/NicknameHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/NoteHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/NoteHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/OrganizationHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/OrganizationHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/PhoneHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/PhoneHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/PhotoHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/PhotoHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/RelationHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/RelationHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/SipAddressHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/SipAddressHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/StructuredNameHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/StructuredNameHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/StructuredPostalHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/StructuredPostalHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/UnknownPropertiesHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/UnknownPropertiesHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/WebsiteHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/handler/WebsiteHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/JtxObjectBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/JtxObjectBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/JtxObjectHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/JtxObjectHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/CategoriesBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/CategoriesBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/CollectionIdBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/CollectionIdBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/CommentsBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/CommentsBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/DescriptionBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/DescriptionBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/DirtyAndDeletedBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/DirtyAndDeletedBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/JtxEntityBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/JtxEntityBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/RecurrenceFieldsBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/RecurrenceFieldsBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/RemindersBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/RemindersBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/ResourcesBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/ResourcesBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/SyncPropertiesBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/SyncPropertiesBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/TimeFieldsBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/TimeFieldsBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/TimeZoneIdMapper.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/TimeZoneIdMapper.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/CategoriesHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/CategoriesHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/CommentsHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/CommentsHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/DescriptionHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/DescriptionHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/JtxFieldHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/JtxFieldHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskProcessor.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskProcessor.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/AlarmsBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/AlarmsBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/AllDayBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/AllDayBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/CategoriesBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/CategoriesBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/ClassificationBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/ClassificationBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/ColorBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/ColorBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/CommentsBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/CommentsBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/CompletedBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/CompletedBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/CreatedBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/CreatedBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DescriptionBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DescriptionBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DirtyBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DirtyBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DmfsTaskFieldBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DmfsTaskFieldBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DueBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DueBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DurationBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DurationBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/ETagBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/ETagBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/GeoBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/GeoBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/LastModifiedBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/LastModifiedBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/ListIdBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/ListIdBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/LocationBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/LocationBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/OrganizerBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/OrganizerBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/PercentCompleteBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/PercentCompleteBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/PriorityBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/PriorityBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/RecurrenceFieldsBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/RecurrenceFieldsBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/RelationsBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/RelationsBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/SequenceBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/SequenceBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/StartTimeBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/StartTimeBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/StatusBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/StatusBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/SyncFlagsBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/SyncFlagsBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/SyncIdBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/SyncIdBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/TitleBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/TitleBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/UidBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/UidBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/UnknownPropertiesBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/UnknownPropertiesBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/UrlBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/UrlBuilder.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/AlarmsHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/AlarmsHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/ClassificationHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/ClassificationHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/ColorHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/ColorHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/CompletedHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/CompletedHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/DescriptionHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/DescriptionHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/DmfsTaskFieldHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/DmfsTaskFieldHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/DmfsTaskPropertyHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/DmfsTaskPropertyHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/DueHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/DueHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/DurationHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/DurationHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/GeoHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/GeoHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/LocationHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/LocationHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/OrganizerHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/OrganizerHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/PercentCompleteHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/PercentCompleteHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/PriorityHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/PriorityHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/SequenceHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/SequenceHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/StartTimeHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/StartTimeHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/StatusHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/StatusHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/TaskTimeField.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/TaskTimeField.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/TitleHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/TitleHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/UidHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/UidHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/UrlHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/UrlHandler.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/BatchOperation.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/BatchOperation.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/ContactsBatchOperation.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/ContactsBatchOperation.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/ContentValuesHelpers.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/ContentValuesHelpers.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/JtxBatchOperation.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/JtxBatchOperation.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/LocalStorageException.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/LocalStorageException.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/MainItemAndExceptions.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/MainItemAndExceptions.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendar.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendar.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.calendar

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendarProvider.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendarProvider.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.calendar

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidRecurringCalendar.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidRecurringCalendar.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.calendar

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/CalendarBatchOperation.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/CalendarBatchOperation.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.calendar

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/EventAndExceptions.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/EventAndExceptions.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.calendar

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/EventsContract.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/EventsContract.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.calendar

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.contacts

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidContact.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidContact.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.contacts

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidContactFactory.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidContactFactory.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.contacts

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidGroup.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidGroup.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.contacts

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidGroupFactory.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidGroupFactory.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.contacts

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/CachedGroupMembershipContract.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/CachedGroupMembershipContract.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.contacts

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/ContactsBatchOperation.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/ContactsBatchOperation.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.contacts

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/UnknownPropertyContract.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/UnknownPropertyContract.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.contacts

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollection.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollection.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.jtx

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollectionProvider.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollectionProvider.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.jtx

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxObjectAndExceptions.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxObjectAndExceptions.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.jtx

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxRecurringCollection.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxRecurringCollection.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.jtx

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTask.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTask.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.tasks

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.tasks

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListProvider.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListProvider.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.tasks

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/TasksBatchOperation.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/TasksBatchOperation.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage.tasks

--- a/synctools/src/main/kotlin/at/bitfire/synctools/test/AssertHelpers.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/test/AssertHelpers.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.test

--- a/synctools/src/main/kotlin/at/bitfire/synctools/test/GrantPermissionOrSkipRule.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/test/GrantPermissionOrSkipRule.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.test

--- a/synctools/src/main/kotlin/at/bitfire/synctools/util/AccountManagerExtensions.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/util/AccountManagerExtensions.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.util

--- a/synctools/src/main/kotlin/at/bitfire/synctools/util/AlarmTriggerCalculator.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/util/AlarmTriggerCalculator.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.util

--- a/synctools/src/main/kotlin/at/bitfire/synctools/util/AndroidAccountUtils.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/util/AndroidAccountUtils.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.util

--- a/synctools/src/main/kotlin/at/bitfire/synctools/util/AndroidTimeUtils.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/util/AndroidTimeUtils.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.util

--- a/synctools/src/main/kotlin/at/bitfire/synctools/util/SensitiveString.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/util/SensitiveString.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.util

--- a/synctools/src/main/kotlin/at/bitfire/synctools/util/Utils.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/util/Utils.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.util

--- a/synctools/src/main/kotlin/at/bitfire/synctools/vcard/GroupMethod.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/vcard/GroupMethod.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.vcard

--- a/synctools/src/main/kotlin/at/bitfire/synctools/vcard/VCardGenerator.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/vcard/VCardGenerator.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.vcard

--- a/synctools/src/main/kotlin/at/bitfire/synctools/vcard/VCardParser.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/vcard/VCardParser.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.vcard

--- a/synctools/src/main/kotlin/at/bitfire/synctools/vcard/property/CustomScribes.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/vcard/property/CustomScribes.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.vcard.property

--- a/synctools/src/main/kotlin/at/bitfire/synctools/vcard/property/CustomType.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/vcard/property/CustomType.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.vcard.property

--- a/synctools/src/main/kotlin/at/bitfire/synctools/vcard/property/XAbDate.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/vcard/property/XAbDate.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.vcard.property

--- a/synctools/src/main/kotlin/at/bitfire/synctools/vcard/property/XAbLabel.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/vcard/property/XAbLabel.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.vcard.property

--- a/synctools/src/main/kotlin/at/bitfire/synctools/vcard/property/XAbRelatedNames.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/vcard/property/XAbRelatedNames.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.vcard.property

--- a/synctools/src/main/kotlin/at/bitfire/synctools/vcard/property/XAddressBookServerKind.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/vcard/property/XAddressBookServerKind.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.vcard.property

--- a/synctools/src/main/kotlin/at/bitfire/synctools/vcard/property/XAddressBookServerMember.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/vcard/property/XAddressBookServerMember.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.vcard.property

--- a/synctools/src/main/kotlin/at/bitfire/synctools/vcard/property/XPhoneticFirstName.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/vcard/property/XPhoneticFirstName.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.vcard.property

--- a/synctools/src/main/kotlin/at/bitfire/synctools/vcard/property/XPhoneticLastName.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/vcard/property/XPhoneticLastName.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.vcard.property

--- a/synctools/src/main/kotlin/at/bitfire/synctools/vcard/property/XPhoneticMiddleName.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/vcard/property/XPhoneticMiddleName.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.vcard.property

--- a/synctools/src/main/kotlin/at/bitfire/synctools/vcard/property/XSip.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/vcard/property/XSip.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.vcard.property

--- a/synctools/src/test/kotlin/at/bitfire/DefaultTimezoneRule.kt
+++ b/synctools/src/test/kotlin/at/bitfire/DefaultTimezoneRule.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire

--- a/synctools/src/test/kotlin/at/bitfire/Ical4jHelper.kt
+++ b/synctools/src/test/kotlin/at/bitfire/Ical4jHelper.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire

--- a/synctools/src/test/kotlin/at/bitfire/ical4android/Css3ColorTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/ical4android/Css3ColorTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android

--- a/synctools/src/test/kotlin/at/bitfire/ical4android/ICalendarTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/ical4android/ICalendarTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android

--- a/synctools/src/test/kotlin/at/bitfire/ical4android/Ical4jServiceLoaderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/ical4android/Ical4jServiceLoaderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android

--- a/synctools/src/test/kotlin/at/bitfire/ical4android/Ical4jSettingsTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/ical4android/Ical4jSettingsTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android

--- a/synctools/src/test/kotlin/at/bitfire/ical4android/LocaleNonWesternDigitsTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/ical4android/LocaleNonWesternDigitsTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android

--- a/synctools/src/test/kotlin/at/bitfire/ical4android/TaskReaderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/ical4android/TaskReaderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android

--- a/synctools/src/test/kotlin/at/bitfire/ical4android/TaskTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/ical4android/TaskTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android

--- a/synctools/src/test/kotlin/at/bitfire/ical4android/TaskWriterTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/ical4android/TaskWriterTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android

--- a/synctools/src/test/kotlin/at/bitfire/ical4android/UnknownPropertyTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/ical4android/UnknownPropertyTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android

--- a/synctools/src/test/kotlin/at/bitfire/ical4android/util/DateUtilsTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/ical4android/util/DateUtilsTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android.util

--- a/synctools/src/test/kotlin/at/bitfire/ical4android/util/MiscUtilsTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/ical4android/util/MiscUtilsTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android.util

--- a/synctools/src/test/kotlin/at/bitfire/ical4android/util/TimeApiExtensionsTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/ical4android/util/TimeApiExtensionsTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.ical4android.util

--- a/synctools/src/test/kotlin/at/bitfire/synctools/icalendar/AssociatedComponentsTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/icalendar/AssociatedComponentsTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.icalendar

--- a/synctools/src/test/kotlin/at/bitfire/synctools/icalendar/CalendarUidSplitterTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/icalendar/CalendarUidSplitterTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.icalendar

--- a/synctools/src/test/kotlin/at/bitfire/synctools/icalendar/DatePropertyTzMapperTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/icalendar/DatePropertyTzMapperTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.icalendar

--- a/synctools/src/test/kotlin/at/bitfire/synctools/icalendar/ICalendarGeneratorTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/icalendar/ICalendarGeneratorTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.icalendar

--- a/synctools/src/test/kotlin/at/bitfire/synctools/icalendar/ICalendarParserTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/icalendar/ICalendarParserTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.icalendar

--- a/synctools/src/test/kotlin/at/bitfire/synctools/icalendar/Ical4jTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/icalendar/Ical4jTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.icalendar

--- a/synctools/src/test/kotlin/at/bitfire/synctools/icalendar/VTimeZoneMinifierTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/icalendar/VTimeZoneMinifierTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.icalendar

--- a/synctools/src/test/kotlin/at/bitfire/synctools/icalendar/validation/FixInvalidDayOffsetPreprocessorTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/icalendar/validation/FixInvalidDayOffsetPreprocessorTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.icalendar.validation

--- a/synctools/src/test/kotlin/at/bitfire/synctools/icalendar/validation/FixInvalidUtcOffsetPreprocessorTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/icalendar/validation/FixInvalidUtcOffsetPreprocessorTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.icalendar.validation

--- a/synctools/src/test/kotlin/at/bitfire/synctools/icalendar/validation/ICalPreprocessorTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/icalendar/validation/ICalPreprocessorTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.icalendar.validation

--- a/synctools/src/test/kotlin/at/bitfire/synctools/log/PlainTextFormatterTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/log/PlainTextFormatterTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.log

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/AndroidEventHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/AndroidEventHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/AttendeeMappingsTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/AttendeeMappingsTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/SequenceUpdaterTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/SequenceUpdaterTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/AccessLevelBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/AccessLevelBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/AllDayBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/AllDayBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/AndroidRecurrenceMapperTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/AndroidRecurrenceMapperTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/AttendeesBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/AttendeesBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/AvailabilityBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/AvailabilityBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/CalendarIdBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/CalendarIdBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/CategoriesBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/CategoriesBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/ColorBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/ColorBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/DescriptionBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/DescriptionBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/DirtyAndDeletedBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/DirtyAndDeletedBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/DurationBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/DurationBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/ETagBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/ETagBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/EndTimeBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/EndTimeBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/LocationBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/LocationBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/OrganizerBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/OrganizerBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/OriginalInstanceTimeBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/OriginalInstanceTimeBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/RecurrenceFieldsBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/RecurrenceFieldsBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/RemindersBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/RemindersBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/SequenceBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/SequenceBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/StartTimeBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/StartTimeBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/StatusBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/StatusBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/SyncFlagsBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/SyncFlagsBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/SyncIdBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/SyncIdBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/TitleBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/TitleBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/UidBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/UidBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/UnknownPropertiesBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/UnknownPropertiesBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/UrlBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/builder/UrlBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/AccessLevelHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/AccessLevelHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/AndroidTimeFieldTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/AndroidTimeFieldTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/AttendeesHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/AttendeesHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/AvailabilityHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/AvailabilityHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/CategoriesHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/CategoriesHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/ColorHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/ColorHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/DescriptionHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/DescriptionHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/DurationHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/DurationHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/EndTimeHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/EndTimeHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/LocationHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/LocationHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/OrganizerHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/OrganizerHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/OriginalInstanceTimeHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/OriginalInstanceTimeHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/RecurrenceFieldHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/RecurrenceFieldHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/RemindersHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/RemindersHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/SequenceHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/SequenceHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/StartTimeHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/StartTimeHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/StatusHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/StatusHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/TitleHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/TitleHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/UidHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/UidHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/UnknownPropertiesHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/UnknownPropertiesHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/UrlHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/UrlHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.calendar.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/Constants.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/Constants.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/ContactReaderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/ContactReaderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/ContactTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/ContactTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/ContactWriterTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/ContactWriterTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/builder/DataRowBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/builder/DataRowBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/builder/EmailBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/builder/EmailBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/builder/EventBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/builder/EventBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/builder/ImBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/builder/ImBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/builder/NicknameBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/builder/NicknameBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/builder/NoteBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/builder/NoteBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/builder/OrganizationBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/builder/OrganizationBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/builder/PhoneBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/builder/PhoneBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/builder/RelationBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/builder/RelationBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/builder/SipAddressBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/builder/SipAddressBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/builder/StructuredNameBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/builder/StructuredNameBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/builder/StructuredPostalBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/builder/StructuredPostalBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/builder/UnknownPropertiesBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/builder/UnknownPropertiesBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/builder/WebsiteBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/builder/WebsiteBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/handler/EmailHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/handler/EmailHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/handler/EventHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/handler/EventHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/handler/ImHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/handler/ImHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/handler/NicknameHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/handler/NicknameHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/handler/NoteHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/handler/NoteHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/handler/OrganizationHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/handler/OrganizationHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/handler/PhoneHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/handler/PhoneHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/handler/RelationHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/handler/RelationHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/handler/SipAddressHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/handler/SipAddressHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/handler/StructuredNameHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/handler/StructuredNameHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/handler/StructuredPostalHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/handler/StructuredPostalHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/handler/UnknownPropertiesHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/handler/UnknownPropertiesHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/handler/WebsiteHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/handler/WebsiteHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.contacts.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/JtxObjectBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/JtxObjectBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/JtxObjectHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/JtxObjectHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/builder/CategoriesBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/builder/CategoriesBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/builder/CollectionIdBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/builder/CollectionIdBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/builder/CommentsBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/builder/CommentsBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/builder/DescriptionBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/builder/DescriptionBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/builder/DirtyAndDeletedBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/builder/DirtyAndDeletedBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/builder/RecurrenceFieldsBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/builder/RecurrenceFieldsBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/builder/RemindersBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/builder/RemindersBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/builder/ResourcesBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/builder/ResourcesBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/builder/SyncPropertiesBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/builder/SyncPropertiesBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/builder/TimeFieldsBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/builder/TimeFieldsBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/handler/CategoriesHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/handler/CategoriesHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/handler/CommentsHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/handler/CommentsHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/handler/DescriptionHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/handler/DescriptionHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.jtx.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/AlarmsBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/AlarmsBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/AllDayBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/AllDayBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/CategoriesBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/CategoriesBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/ClassificationBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/ClassificationBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/ColorBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/ColorBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/CommentsBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/CommentsBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/CompletedBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/CompletedBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/CreatedBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/CreatedBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/DescriptionBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/DescriptionBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/DirtyBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/DirtyBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/DueBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/DueBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/DurationBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/DurationBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/ETagBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/ETagBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/GeoBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/GeoBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/LastModifiedBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/LastModifiedBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/ListIdBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/ListIdBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/LocationBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/LocationBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/OrganizerBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/OrganizerBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/PercentCompleteBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/PercentCompleteBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/PriorityBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/PriorityBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/RecurrenceFieldsBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/RecurrenceFieldsBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/RelationsBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/RelationsBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/SequenceBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/SequenceBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/StartTimeBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/StartTimeBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/StatusBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/StatusBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/SyncFlagsBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/SyncFlagsBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/SyncIdBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/SyncIdBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/TitleBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/TitleBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/UidBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/UidBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/UnknownPropertiesBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/UnknownPropertiesBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/UrlBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/UrlBuilderTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.builder

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/AlarmsHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/AlarmsHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/ClassificationHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/ClassificationHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/ColorHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/ColorHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/CompletedHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/CompletedHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/DescriptionHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/DescriptionHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/DueHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/DueHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/DurationHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/DurationHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/GeoHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/GeoHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/LocationHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/LocationHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/OrganizerHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/OrganizerHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/PercentCompleteHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/PercentCompleteHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/PriorityHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/PriorityHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/SequenceHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/SequenceHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/StartTimeHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/StartTimeHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/StatusHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/StatusHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/TitleHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/TitleHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/UidHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/UidHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/UrlHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/UrlHandlerTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.mapping.tasks.handler

--- a/synctools/src/test/kotlin/at/bitfire/synctools/storage/ContentValuesHelpersTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/storage/ContentValuesHelpersTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.storage

--- a/synctools/src/test/kotlin/at/bitfire/synctools/util/AlarmTriggerCalculatorTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/util/AlarmTriggerCalculatorTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.util

--- a/synctools/src/test/kotlin/at/bitfire/synctools/util/AndroidAccountUtilsTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/util/AndroidAccountUtilsTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.util

--- a/synctools/src/test/kotlin/at/bitfire/synctools/util/AndroidTimeUtilsTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/util/AndroidTimeUtilsTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.util

--- a/synctools/src/test/kotlin/at/bitfire/synctools/util/SensitiveStringTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/util/SensitiveStringTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.util

--- a/synctools/src/test/kotlin/at/bitfire/synctools/vcard/EzVCardTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/vcard/EzVCardTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.vcard

--- a/synctools/src/test/kotlin/at/bitfire/synctools/vcard/VCardGeneratorTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/vcard/VCardGeneratorTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.vcard

--- a/synctools/src/test/kotlin/at/bitfire/synctools/vcard/VCardParserTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/vcard/VCardParserTest.kt
@@ -1,7 +1,5 @@
 /*
- * This file is part of bitfireAT/synctools which is released under GPLv3.
- * Copyright © All Contributors. See the LICENSE and AUTHOR files in the root directory for details.
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
 package at.bitfire.synctools.vcard


### PR DESCRIPTION
Use davx5-ose copyright notice for synctools, too.