### PR TITLE
Fix mishandling of exceptions in UTC

### DIFF
--- a/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/ICalendarGenerator.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/ICalendarGenerator.kt
@@ -5,6 +5,7 @@
 package at.bitfire.synctools.icalendar
 
 import androidx.annotation.VisibleForTesting
+import at.bitfire.synctools.util.AndroidTimeUtils.toInstant
 import at.bitfire.synctools.util.Utils.trimToNull
 import net.fortuna.ical4j.data.CalendarOutputter
 import net.fortuna.ical4j.model.Calendar
@@ -13,7 +14,6 @@ import net.fortuna.ical4j.model.ComponentList
 import net.fortuna.ical4j.model.Parameter
 import net.fortuna.ical4j.model.PropertyContainer
 import net.fortuna.ical4j.model.PropertyList
-import net.fortuna.ical4j.model.TemporalAdapter
 import net.fortuna.ical4j.model.TimeZoneRegistryFactory
 import net.fortuna.ical4j.model.component.VEvent
 import net.fortuna.ical4j.model.component.VTimeZone
@@ -66,7 +66,10 @@ class ICalendarGenerator {
             ical += exception
 
             exception.dtStart<Temporal>()?.date?.let { start ->
-                if (earliestStart == null || TemporalAdapter.isBefore(start, earliestStart))
+                // Convert both Temporals to Instants for comparison, because they may be in different time zones. If conversion fails, ignore the start date of this exception.
+                val startInstant = runCatching { start.toInstant() }.getOrNull() ?: return@let
+                val earliestInstant = earliestStart?.let { runCatching { it.toInstant() }.getOrNull() }
+                if (earliestInstant == null || startInstant < earliestInstant)
                     earliestStart = start
             }
             usedTimezoneIds += timeZonesOf(exception)

--- a/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/ICalendarGenerator.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/ICalendarGenerator.kt
@@ -66,10 +66,10 @@ class ICalendarGenerator {
             ical += exception
 
             exception.dtStart<Temporal>()?.date?.let { start ->
-                // Convert both Temporals to Instants for comparison, because they may be in different time zones. If conversion fails, ignore the start date of this exception.
-                val startInstant = runCatching { start.toInstant() }.getOrNull() ?: return@let
-                val earliestInstant = earliestStart?.let { runCatching { it.toInstant() }.getOrNull() }
-                if (earliestInstant == null || startInstant < earliestInstant)
+                // Convert both Temporals to Instants for comparison because they may be in different time zones. If conversion fails, UnsupportedTemporalTypeException is thrown.
+                val startInstant = start.toInstant()
+                val earliestInstant = start.toInstant()
+                if (startInstant < earliestInstant)
                     earliestStart = start
             }
             usedTimezoneIds += timeZonesOf(exception)

--- a/synctools/src/test/kotlin/at/bitfire/synctools/icalendar/ICalendarGeneratorTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/icalendar/ICalendarGeneratorTest.kt
@@ -246,4 +246,27 @@ class ICalendarGeneratorTest {
         assertTrue(result.isEmpty())
     }
 
+    @Test
+    fun `Write event with UTC Instant exception DTSTART does not throw`() {
+        val iCal = StringWriter()
+        writer.write(AssociatedEvents(
+            main = VEvent(propertyListOf(
+                Uid("UTCTEST"),
+                DtStart(ZonedDateTime.of(LocalDateTime.parse("2025-08-22T05:30:00"), tzBerlin)),
+                DtStamp("20250822T000000Z"),
+                RRule<Temporal>("FREQ=DAILY;COUNT=3")
+            )),
+            exceptions = listOf(
+                VEvent(propertyListOf(
+                    Uid("UTCTEST"),
+                    RecurrenceId(Instant.parse("2025-08-22T03:30:00Z")),
+                    DtStart(Instant.parse("2025-08-22T03:30:00Z")),
+                    DtStamp("20250822T000000Z")
+                ))
+            ),
+            prodId = userAgent
+        ), iCal)
+        assertTrue(iCal.toString().contains("BEGIN:VCALENDAR"))
+    }
+
 }


### PR DESCRIPTION
### Purpose

Closes https://github.com/bitfireAT/davx5/issues/898

The TemporalAdapter.isBefore call in ICalendarGenerator.write crashed when comparing a UTC Instant (for example 2025-08-22T03:30:00Z from an exception's DTSTART) against a ZonedDateTime (from the main event's DTSTART), because ical4j internally tries ZonedDateTime.from(Instant) which always throws DateTimeException.

### Short description

Added a failing test that showcases the issue, and a fix for it.

Copy of https://github.com/bitfireAT/synctools/pull/442

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

