### PR TITLE
Fix `UnsupportedOperationException` when parsing inline attachment in JtxICalObject

### DIFF
--- a/synctools/src/androidTest/kotlin/at/bitfire/ical4android/JtxICalObjectTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/ical4android/JtxICalObjectTest.kt
@@ -857,6 +857,31 @@ class JtxICalObjectTest {
         assertEquals("America/New_York", iCalObjects.first().recuridTimezone)
     }
 
+    @Test
+    fun testFromReader_parses_inline_attachment() {
+        val attachmentData = "test data".toByteArray()
+        val base64Data = android.util.Base64.encodeToString(attachmentData, android.util.Base64.DEFAULT)
+
+        val icalString = "BEGIN:VCALENDAR\r\n" +
+                "VERSION:2.0\r\n" +
+                "PRODID:-//Test//Test//EN\r\n" +
+                "BEGIN:VTODO\r\n" +
+                "UID:test-attachment\r\n" +
+                "ATTACH;ENCODING=BASE64;VALUE=BINARY:$base64Data\r\n" +
+                "END:VTODO\r\n" +
+                "END:VCALENDAR\r\n"
+
+        val objects = at.bitfire.ical4android.JtxICalObject.fromReader(StringReader(icalString), collection!!)
+
+        assertEquals(1, objects.size)
+        assertEquals(1, objects[0].attachments.size)
+
+        val attachment = objects[0].attachments[0]
+        assertNotNull(attachment.binary)
+        val decoded = android.util.Base64.decode(attachment.binary, android.util.Base64.DEFAULT)
+        assertEquals(attachmentData.size, decoded.size)
+    }
+
 
     @Test
     fun getICalendarFormat_recurringVToDo_exceptionsMustHaveUidAndRecurrenceId() {
@@ -997,4 +1022,5 @@ class JtxICalObjectTest {
 
         return iCalOut
     }
+
 }

--- a/synctools/src/androidTest/kotlin/at/bitfire/ical4android/JtxICalObjectTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/ical4android/JtxICalObjectTest.kt
@@ -9,6 +9,7 @@ import android.content.ContentProviderClient
 import android.content.ContentValues
 import android.database.DatabaseUtils
 import android.os.ParcelFileDescriptor
+import android.util.Base64
 import androidx.core.content.pm.PackageInfoCompat
 import androidx.test.platform.app.InstrumentationRegistry
 import at.bitfire.ical4android.impl.TestJtxCollection
@@ -860,8 +861,7 @@ class JtxICalObjectTest {
     @Test
     fun testFromReader_parses_inline_attachment() {
         val attachmentData = "test data".toByteArray()
-        val base64Data = android.util.Base64.encodeToString(attachmentData, android.util.Base64.DEFAULT)
-
+        val base64Data = Base64.encodeToString(attachmentData, Base64.NO_WRAP)
         val icalString = "BEGIN:VCALENDAR\r\n" +
                 "VERSION:2.0\r\n" +
                 "PRODID:-//Test//Test//EN\r\n" +
@@ -878,8 +878,8 @@ class JtxICalObjectTest {
 
         val attachment = objects[0].attachments[0]
         assertNotNull(attachment.binary)
-        val decoded = android.util.Base64.decode(attachment.binary, android.util.Base64.DEFAULT)
-        assertEquals(attachmentData.size, decoded.size)
+        val decoded = Base64.decode(attachment.binary, Base64.DEFAULT)
+        assertEquals(attachmentData.contentToString(), decoded.contentToString())
     }
 
 

--- a/synctools/src/androidTest/kotlin/at/bitfire/ical4android/JtxICalObjectTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/ical4android/JtxICalObjectTest.kt
@@ -35,6 +35,7 @@ import net.fortuna.ical4j.model.property.Trigger
 import net.fortuna.ical4j.model.property.immutable.ImmutableAction
 import org.junit.After
 import org.junit.Assert
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assume
 import org.junit.Before
 import org.junit.Rule
@@ -879,7 +880,7 @@ class JtxICalObjectTest {
         val attachment = objects[0].attachments[0]
         assertNotNull(attachment.binary)
         val decoded = Base64.decode(attachment.binary, Base64.DEFAULT)
-        assertEquals(attachmentData.contentToString(), decoded.contentToString())
+        assertArrayEquals(attachmentData, decoded)
     }
 
 

--- a/synctools/src/main/kotlin/at/bitfire/ical4android/JtxICalObject.kt
+++ b/synctools/src/main/kotlin/at/bitfire/ical4android/JtxICalObject.kt
@@ -501,7 +501,7 @@ open class JtxICalObject(
                     is Attach -> {
                         val attachment = Attachment()
                         prop.uri?.let { attachment.uri = it.toString() }
-                        prop.binary?.array()?.let {
+                        prop.getBinaryData()?.let {
                             attachment.binary = Base64.encodeToString(it, Base64.DEFAULT)
                         }
                         prop.getParameter<FmtType>(Parameter.FMTTYPE)?.getOrNull()?.let {


### PR DESCRIPTION
### Purpose

Fixes the deprecated method usage in `JtxICalObject` for inline attachment parsing to ensure compatibility and reliability.

### Short description

- Replaced deprecated `binary.array()` with `getBinaryData()` for inline attachment parsing.
- Added a test to verify the correctness of the updated parsing logic.