### PR TITLE
Avoid NullPointerException when VTIMEZONE is missing STANDARD/DAYLIGHT

### DIFF
--- a/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/TimeZoneRegistryFactoryWorkaround.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/TimeZoneRegistryFactoryWorkaround.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.synctools.icalendar
+
+import net.fortuna.ical4j.model.DefaultTimeZoneRegistryFactory
+import net.fortuna.ical4j.model.TimeZone
+import net.fortuna.ical4j.model.TimeZoneRegistry
+import net.fortuna.ical4j.model.TimeZoneRegistryFactory
+import net.fortuna.ical4j.model.component.Observance
+import java.util.logging.Logger
+
+class TimeZoneRegistryFactoryWorkaround : TimeZoneRegistryFactory() {
+    override fun createRegistry(): TimeZoneRegistry {
+        return TimeZoneRegistryWorkaround()
+    }
+}
+
+/**
+ * Work around https://github.com/bitfireAT/davx5-ose/issues/2248
+ */
+class TimeZoneRegistryWorkaround(
+    private val timeZoneRegistry: TimeZoneRegistry = DefaultTimeZoneRegistryFactory().createRegistry()
+) : TimeZoneRegistry by timeZoneRegistry {
+
+    private val logger = Logger.getLogger(javaClass.name)
+
+    override fun register(timeZone: TimeZone) {
+        register(timeZone, update = false)
+    }
+
+    override fun register(timeZone: TimeZone, update: Boolean) {
+        val vTimeZone = timeZone.vTimeZone
+
+        val standardObservances = vTimeZone.getComponents<Observance>(Observance.STANDARD)
+        val daylightObservances = vTimeZone.getComponents<Observance>(Observance.DAYLIGHT)
+
+        if (standardObservances.isEmpty() && daylightObservances.isEmpty()) {
+            logger.info("Ignoring invalid VTIMEZONE with TZID: ${timeZone.id}")
+        } else {
+            timeZoneRegistry.register(timeZone, update)
+        }
+    }
+}

--- a/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/TimeZoneRegistryFactoryWorkaround.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/TimeZoneRegistryFactoryWorkaround.kt
@@ -24,7 +24,8 @@ class TimeZoneRegistryWorkaround(
     private val timeZoneRegistry: TimeZoneRegistry = DefaultTimeZoneRegistryFactory().createRegistry()
 ) : TimeZoneRegistry by timeZoneRegistry {
 
-    private val logger = Logger.getLogger(javaClass.name)
+    private val logger: Logger
+        get() = Logger.getLogger(javaClass.name)
 
     override fun register(timeZone: TimeZone) {
         register(timeZone, update = false)

--- a/synctools/src/main/resources/ical4j.properties
+++ b/synctools/src/main/resources/ical4j.properties
@@ -1,3 +1,4 @@
+net.fortuna.ical4j.timezone.registry=at.bitfire.synctools.icalendar.TimeZoneRegistryFactoryWorkaround
 net.fortuna.ical4j.timezone.cache.impl=net.fortuna.ical4j.util.MapTimeZoneCache
 net.fortuna.ical4j.timezone.offset.negative_dst_supported=true
 net.fortuna.ical4j.timezone.update.enabled=false

--- a/synctools/src/test/kotlin/at/bitfire/synctools/icalendar/Ical4jTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/icalendar/Ical4jTest.kt
@@ -8,6 +8,7 @@ import at.bitfire.dateTimeValue
 import at.bitfire.synctools.icalendar.validation.ICalPreprocessor
 import net.fortuna.ical4j.data.CalendarBuilder
 import net.fortuna.ical4j.data.CalendarOutputter
+import net.fortuna.ical4j.data.ParserException
 import net.fortuna.ical4j.model.Calendar
 import net.fortuna.ical4j.model.Component
 import net.fortuna.ical4j.model.Parameter
@@ -16,6 +17,7 @@ import net.fortuna.ical4j.model.Property
 import net.fortuna.ical4j.model.TemporalAmountAdapter
 import net.fortuna.ical4j.model.TemporalComparator
 import net.fortuna.ical4j.model.TimeZoneRegistryFactory
+import net.fortuna.ical4j.model.TimeZoneRegistryImpl
 import net.fortuna.ical4j.model.component.VEvent
 import net.fortuna.ical4j.model.component.VTimeZone
 import net.fortuna.ical4j.model.parameter.Email
@@ -356,6 +358,35 @@ class Ical4jTest {
         )
 
         assertTrue(calendar.getComponent<VTimeZone>(Component.VTIMEZONE).isPresent)
+    }
+
+    @Test
+    fun `VTIMEZONE without STANDARD and DAYLIGHT sub-components`() {
+        // https://github.com/ical4j/ical4j/issues/531
+        val defaultTimeZoneRegistry = TimeZoneRegistryImpl()
+        val reader = StringReader(
+            """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Example Corp.//CalDAV Client//EN
+            BEGIN:VTIMEZONE
+            TZID:UTC
+            END:VTIMEZONE
+            BEGIN:VEVENT
+            DTSTAMP:20260529T095200Z
+            UID:bc295665-5b3b-11f1-9a52-d843aea66ff2
+            DTSTART;TZID=UTC:20260528T120000
+            END:VEVENT
+            END:VCALENDAR
+            """.trimIndent()
+        )
+
+        try {
+            CalendarBuilder(defaultTimeZoneRegistry).build(reader)
+            fail("TimeZoneRegistryFactoryWorkaround can be removed")
+        } catch (e: ParserException) {
+            assertTrue(e.cause is NullPointerException)
+        }
     }
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/icalendar/TimeZoneRegistryFactoryWorkaroundTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/icalendar/TimeZoneRegistryFactoryWorkaroundTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.synctools.icalendar
+
+import net.fortuna.ical4j.data.CalendarBuilder
+import net.fortuna.ical4j.model.TimeZoneRegistryFactory
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.StringReader
+
+class TimeZoneRegistryFactoryWorkaroundTest {
+
+    @Test
+    fun `VTIMEZONE without STANDARD and DAYLIGHT sub-components`() {
+        assertTrue(TimeZoneRegistryFactory.getInstance() is TimeZoneRegistryFactoryWorkaround)
+
+        val reader = StringReader(
+            """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//Example Corp.//CalDAV Client//EN
+            BEGIN:VTIMEZONE
+            TZID:UTC
+            END:VTIMEZONE
+            BEGIN:VEVENT
+            DTSTAMP:20260529T095200Z
+            UID:bc295665-5b3b-11f1-9a52-d843aea66ff2
+            DTSTART;TZID=UTC:20260528T120000
+            END:VEVENT
+            END:VCALENDAR
+            """.trimIndent()
+        )
+
+        val calendar = CalendarBuilder().build(reader)
+
+        assertNotNull(calendar)
+    }
+}


### PR DESCRIPTION
ical4j 3.x didn't throw an exception when encountering `VTIMEZONE` components that were missing both `STANDARD` and `DAYLIGHT` sub-components. We should continue to do so and ignore such invalid `VTIMEZONE` components.

ical4j issue: https://github.com/ical4j/ical4j/issues/531