### PR TITLE
DmfsTask: Migrate descriptive field builders to `VToDo`

### DIFF
--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/ColorBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/ColorBuilder.kt
@@ -7,10 +7,10 @@ package at.bitfire.synctools.mapping.tasks.builder
 import android.content.Entity
 import at.bitfire.ical4android.Task
 import at.bitfire.synctools.icalendar.Css3Color
-import at.bitfire.synctools.icalendar.plusAssign
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.property.Color
 import org.dmfs.tasks.contract.TaskContract.Tasks
+import kotlin.jvm.optionals.getOrNull
 
 class ColorBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
@@ -18,8 +18,9 @@ class ColorBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
         to.entityValues.put(Tasks.TASK_COLOR, from.color)
     }
 
-    override fun build(from: Task, to: VToDo) {
-        to += Color(null, from.color?.let { Css3Color.nearestMatch(it).name })
+    override fun build(from: VToDo, to: Entity) {
+        val color = from.getProperty<Color>(Color.PROPERTY_NAME).getOrNull()
+        to.entityValues.put(Tasks.TASK_COLOR, color?.value?.let(Css3Color::colorFromString))
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/ColorBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/ColorBuilder.kt
@@ -4,13 +4,19 @@
 
 package at.bitfire.synctools.mapping.tasks.builder
 
+import android.content.Entity
 import at.bitfire.ical4android.Task
 import at.bitfire.synctools.icalendar.Css3Color
 import at.bitfire.synctools.icalendar.plusAssign
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.property.Color
+import org.dmfs.tasks.contract.TaskContract.Tasks
 
-class ColorBuilder : DmfsTaskFieldBuilderVToDo {
+class ColorBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
+
+    override fun build(from: Task, to: Entity) {
+        to.entityValues.put(Tasks.TASK_COLOR, from.color)
+    }
 
     override fun build(from: Task, to: VToDo) {
         to += Color(null, from.color?.let { Css3Color.nearestMatch(it).name })

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/ColorBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/ColorBuilder.kt
@@ -4,14 +4,16 @@
 
 package at.bitfire.synctools.mapping.tasks.builder
 
-import android.content.Entity
 import at.bitfire.ical4android.Task
-import org.dmfs.tasks.contract.TaskContract.Tasks
+import at.bitfire.synctools.icalendar.Css3Color
+import at.bitfire.synctools.icalendar.plusAssign
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Color
 
-class ColorBuilder : DmfsTaskFieldBuilder {
+class ColorBuilder : DmfsTaskFieldBuilderVToDo {
 
-    override fun build(from: Task, to: Entity) {
-        to.entityValues.put(Tasks.TASK_COLOR, from.color)
+    override fun build(from: Task, to: VToDo) {
+        to += Color(null, from.color?.let { Css3Color.nearestMatch(it).name })
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DescriptionBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DescriptionBuilder.kt
@@ -4,11 +4,17 @@
 
 package at.bitfire.synctools.mapping.tasks.builder
 
+import android.content.Entity
 import at.bitfire.ical4android.Task
 import at.bitfire.synctools.util.trimToNull
 import net.fortuna.ical4j.model.component.VToDo
+import org.dmfs.tasks.contract.TaskContract.Tasks
 
-class DescriptionBuilder : DmfsTaskFieldBuilderVToDo {
+class DescriptionBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
+
+    override fun build(from: Task, to: Entity) {
+        to.entityValues.put(Tasks.DESCRIPTION, from.description.trimToNull())
+    }
 
     override fun build(from: Task, to: VToDo) {
         to.description.value = from.description.trimToNull()

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DescriptionBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DescriptionBuilder.kt
@@ -6,8 +6,10 @@ package at.bitfire.synctools.mapping.tasks.builder
 
 import android.content.Entity
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.icalendar.plusAssign
 import at.bitfire.synctools.util.trimToNull
 import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Description
 import org.dmfs.tasks.contract.TaskContract.Tasks
 
 class DescriptionBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
@@ -17,7 +19,7 @@ class DescriptionBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
     }
 
     override fun build(from: Task, to: VToDo) {
-        to.description.value = from.description.trimToNull()
+        to += Description(null, from.description.trimToNull())
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DescriptionBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DescriptionBuilder.kt
@@ -4,15 +4,14 @@
 
 package at.bitfire.synctools.mapping.tasks.builder
 
-import android.content.Entity
 import at.bitfire.ical4android.Task
 import at.bitfire.synctools.util.trimToNull
-import org.dmfs.tasks.contract.TaskContract.Tasks
+import net.fortuna.ical4j.model.component.VToDo
 
-class DescriptionBuilder : DmfsTaskFieldBuilder {
+class DescriptionBuilder : DmfsTaskFieldBuilderVToDo {
 
-    override fun build(from: Task, to: Entity) {
-        to.entityValues.put(Tasks.DESCRIPTION, from.description.trimToNull())
+    override fun build(from: Task, to: VToDo) {
+        to.description.value = from.description.trimToNull()
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DescriptionBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DescriptionBuilder.kt
@@ -6,11 +6,11 @@ package at.bitfire.synctools.mapping.tasks.builder
 
 import android.content.Entity
 import at.bitfire.ical4android.Task
-import at.bitfire.synctools.icalendar.plusAssign
 import at.bitfire.synctools.util.trimToNull
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.property.Description
 import org.dmfs.tasks.contract.TaskContract.Tasks
+import kotlin.jvm.optionals.getOrNull
 
 class DescriptionBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
@@ -18,8 +18,9 @@ class DescriptionBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
         to.entityValues.put(Tasks.DESCRIPTION, from.description.trimToNull())
     }
 
-    override fun build(from: Task, to: VToDo) {
-        to += Description(null, from.description.trimToNull())
+    override fun build(from: VToDo, to: Entity) {
+        val description = from.getProperty<Description>(Description.DESCRIPTION).getOrNull()
+        to.entityValues.put(Tasks.DESCRIPTION, description?.value.trimToNull())
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DmfsTaskFieldBuilderVToDo.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DmfsTaskFieldBuilderVToDo.kt
@@ -11,14 +11,14 @@ import net.fortuna.ical4j.model.component.VToDo
 interface DmfsTaskFieldBuilderVToDo {
 
     /**
-     * Maps a specific part of the given task into the provided [VToDo].
+     * Maps a specific part of the given [VToDo] into the provided [Entity].
      *
      * Note: The result of the mapping is used to either create or update the task row in the
      * content provider. For updates, explicit `null` values are required for fields that should
      * be `null` (otherwise the value wouldn't be updated to `null` in case of a task update).
      *
      * @param from  task to map
-     * @param to    destination [VToDo] where built values are stored (set `null` values, see note)
+     * @param to    destination [Entity] where built values are stored (set `null` values, see note)
      */
     fun build(from: VToDo, to: Entity)
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DmfsTaskFieldBuilderVToDo.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DmfsTaskFieldBuilderVToDo.kt
@@ -4,7 +4,7 @@
 
 package at.bitfire.synctools.mapping.tasks.builder
 
-import at.bitfire.ical4android.Task
+import android.content.Entity
 import net.fortuna.ical4j.model.component.VToDo
 
 // TODO: Once all super-classes of DmfsTaskFieldBuilder are migrated to DmfsTaskFieldBuilderVToDo, we can remove the old DmfsTaskFieldBuilder and rename this interface to DmfsTaskFieldBuilder
@@ -20,6 +20,6 @@ interface DmfsTaskFieldBuilderVToDo {
      * @param from  task to map
      * @param to    destination [VToDo] where built values are stored (set `null` values, see note)
      */
-    fun build(from: Task, to: VToDo)
+    fun build(from: VToDo, to: Entity)
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DmfsTaskFieldBuilderVToDo.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DmfsTaskFieldBuilderVToDo.kt
@@ -4,22 +4,22 @@
 
 package at.bitfire.synctools.mapping.tasks.builder
 
-import android.content.Entity
 import at.bitfire.ical4android.Task
+import net.fortuna.ical4j.model.component.VToDo
 
-@Deprecated("DmfsTaskFieldBuilderVToDo should be used instead")
-interface DmfsTaskFieldBuilder {
+// TODO: Once all super-classes of DmfsTaskFieldBuilder are migrated to DmfsTaskFieldBuilderVToDo, we can remove the old DmfsTaskFieldBuilder and rename this interface to DmfsTaskFieldBuilder
+interface DmfsTaskFieldBuilderVToDo {
 
     /**
-     * Maps a specific part of the given task into the provided [Entity].
+     * Maps a specific part of the given task into the provided [VToDo].
      *
      * Note: The result of the mapping is used to either create or update the task row in the
      * content provider. For updates, explicit `null` values are required for fields that should
      * be `null` (otherwise the value wouldn't be updated to `null` in case of a task update).
      *
      * @param from  task to map
-     * @param to    destination [Entity] where built values are stored (set `null` values, see note)
+     * @param to    destination [VToDo] where built values are stored (set `null` values, see note)
      */
-    fun build(from: Task, to: Entity)
+    fun build(from: Task, to: VToDo)
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/GeoBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/GeoBuilder.kt
@@ -6,10 +6,10 @@ package at.bitfire.synctools.mapping.tasks.builder
 
 import android.content.Entity
 import at.bitfire.ical4android.Task
-import at.bitfire.synctools.icalendar.plusAssign
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.property.Geo
 import org.dmfs.tasks.contract.TaskContract.Tasks
+import kotlin.jvm.optionals.getOrNull
 
 class GeoBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
@@ -17,8 +17,9 @@ class GeoBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
         to.entityValues.put(Tasks.GEO, from.geoPosition?.let { "${it.longitude},${it.latitude}" })
     }
 
-    override fun build(from: Task, to: VToDo) {
-        to += Geo(null, from.geoPosition?.latitude, from.geoPosition?.longitude)
+    override fun build(from: VToDo, to: Entity) {
+        val geo = from.getProperty<Geo>(Geo.GEO).getOrNull()
+        to.entityValues.put(Tasks.GEO, geo?.let { "${it.longitude},${it.latitude}" })
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/GeoBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/GeoBuilder.kt
@@ -4,10 +4,16 @@
 
 package at.bitfire.synctools.mapping.tasks.builder
 
+import android.content.Entity
 import at.bitfire.ical4android.Task
 import net.fortuna.ical4j.model.component.VToDo
+import org.dmfs.tasks.contract.TaskContract.Tasks
 
-class GeoBuilder : DmfsTaskFieldBuilderVToDo {
+class GeoBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
+
+    override fun build(from: Task, to: Entity) {
+        to.entityValues.put(Tasks.GEO, from.geoPosition?.let { "${it.longitude},${it.latitude}" })
+    }
 
     override fun build(from: Task, to: VToDo) {
         val position = from.geoPosition ?: return

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/GeoBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/GeoBuilder.kt
@@ -4,14 +4,15 @@
 
 package at.bitfire.synctools.mapping.tasks.builder
 
-import android.content.Entity
 import at.bitfire.ical4android.Task
-import org.dmfs.tasks.contract.TaskContract.Tasks
+import net.fortuna.ical4j.model.component.VToDo
 
-class GeoBuilder : DmfsTaskFieldBuilder {
+class GeoBuilder : DmfsTaskFieldBuilderVToDo {
 
-    override fun build(from: Task, to: Entity) {
-        to.entityValues.put(Tasks.GEO, from.geoPosition?.let { "${it.longitude},${it.latitude}" })
+    override fun build(from: Task, to: VToDo) {
+        val position = from.geoPosition ?: return
+        to.geographicPos.latitude = position.latitude
+        to.geographicPos.longitude = position.longitude
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/GeoBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/GeoBuilder.kt
@@ -6,7 +6,9 @@ package at.bitfire.synctools.mapping.tasks.builder
 
 import android.content.Entity
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.icalendar.plusAssign
 import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Geo
 import org.dmfs.tasks.contract.TaskContract.Tasks
 
 class GeoBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
@@ -16,9 +18,7 @@ class GeoBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
     }
 
     override fun build(from: Task, to: VToDo) {
-        val position = from.geoPosition ?: return
-        to.geographicPos.latitude = position.latitude
-        to.geographicPos.longitude = position.longitude
+        to += Geo(null, from.geoPosition?.latitude, from.geoPosition?.longitude)
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/LocationBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/LocationBuilder.kt
@@ -6,11 +6,11 @@ package at.bitfire.synctools.mapping.tasks.builder
 
 import android.content.Entity
 import at.bitfire.ical4android.Task
-import at.bitfire.synctools.icalendar.plusAssign
 import at.bitfire.synctools.util.trimToNull
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.property.Location
 import org.dmfs.tasks.contract.TaskContract.Tasks
+import kotlin.jvm.optionals.getOrNull
 
 class LocationBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
@@ -18,8 +18,9 @@ class LocationBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
         to.entityValues.put(Tasks.LOCATION, from.location.trimToNull())
     }
 
-    override fun build(from: Task, to: VToDo) {
-        to += Location(null, from.location.trimToNull())
+    override fun build(from: VToDo, to: Entity) {
+        val location = from.getProperty<Location>(Location.LOCATION).getOrNull()
+        to.entityValues.put(Tasks.LOCATION, location?.value.trimToNull())
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/LocationBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/LocationBuilder.kt
@@ -4,15 +4,14 @@
 
 package at.bitfire.synctools.mapping.tasks.builder
 
-import android.content.Entity
 import at.bitfire.ical4android.Task
 import at.bitfire.synctools.util.trimToNull
-import org.dmfs.tasks.contract.TaskContract.Tasks
+import net.fortuna.ical4j.model.component.VToDo
 
-class LocationBuilder : DmfsTaskFieldBuilder {
+class LocationBuilder : DmfsTaskFieldBuilderVToDo {
 
-    override fun build(from: Task, to: Entity) {
-        to.entityValues.put(Tasks.LOCATION, from.location.trimToNull())
+    override fun build(from: Task, to: VToDo) {
+        to.location.value = from.location.trimToNull()
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/LocationBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/LocationBuilder.kt
@@ -6,8 +6,10 @@ package at.bitfire.synctools.mapping.tasks.builder
 
 import android.content.Entity
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.icalendar.plusAssign
 import at.bitfire.synctools.util.trimToNull
 import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Location
 import org.dmfs.tasks.contract.TaskContract.Tasks
 
 class LocationBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
@@ -17,7 +19,7 @@ class LocationBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
     }
 
     override fun build(from: Task, to: VToDo) {
-        to.location.value = from.location.trimToNull()
+        to += Location(null, from.location.trimToNull())
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/LocationBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/LocationBuilder.kt
@@ -4,11 +4,17 @@
 
 package at.bitfire.synctools.mapping.tasks.builder
 
+import android.content.Entity
 import at.bitfire.ical4android.Task
 import at.bitfire.synctools.util.trimToNull
 import net.fortuna.ical4j.model.component.VToDo
+import org.dmfs.tasks.contract.TaskContract.Tasks
 
-class LocationBuilder : DmfsTaskFieldBuilderVToDo {
+class LocationBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
+
+    override fun build(from: Task, to: Entity) {
+        to.entityValues.put(Tasks.LOCATION, from.location.trimToNull())
+    }
 
     override fun build(from: Task, to: VToDo) {
         to.location.value = from.location.trimToNull()

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/OrganizerBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/OrganizerBuilder.kt
@@ -4,18 +4,41 @@
 
 package at.bitfire.synctools.mapping.tasks.builder
 
+import android.content.Entity
 import at.bitfire.ical4android.Task
 import net.fortuna.ical4j.model.Parameter
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.parameter.Email
+import org.dmfs.tasks.contract.TaskContract.Tasks
 import java.util.logging.Level
 import java.util.logging.Logger
 import kotlin.jvm.optionals.getOrNull
 
-class OrganizerBuilder : DmfsTaskFieldBuilderVToDo {
+class OrganizerBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
     private val logger
         get() = Logger.getLogger(javaClass.name)
+
+    override fun build(from: Task, to: Entity) {
+        val organizer = from.organizer
+        if (organizer == null) {
+            to.entityValues.putNull(Tasks.ORGANIZER)
+            return
+        }
+
+        val uri = organizer.calAddress
+        val email = if (uri.scheme.equals("mailto", true))
+            uri.schemeSpecificPart
+        else
+            organizer.getParameter<Email>(Parameter.EMAIL).getOrNull()?.value
+
+        if (email != null)
+            to.entityValues.put(Tasks.ORGANIZER, email)
+        else {
+            logger.log(Level.WARNING, "Ignoring ORGANIZER without email address (not supported by Android)", organizer)
+            to.entityValues.putNull(Tasks.ORGANIZER)
+        }
+    }
 
     override fun build(from: Task, to: VToDo) {
         val organizer = from.organizer

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/OrganizerBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/OrganizerBuilder.kt
@@ -4,24 +4,23 @@
 
 package at.bitfire.synctools.mapping.tasks.builder
 
-import android.content.Entity
 import at.bitfire.ical4android.Task
 import net.fortuna.ical4j.model.Parameter
+import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.parameter.Email
-import org.dmfs.tasks.contract.TaskContract.Tasks
 import java.util.logging.Level
 import java.util.logging.Logger
 import kotlin.jvm.optionals.getOrNull
 
-class OrganizerBuilder : DmfsTaskFieldBuilder {
+class OrganizerBuilder : DmfsTaskFieldBuilderVToDo {
 
     private val logger
         get() = Logger.getLogger(javaClass.name)
 
-    override fun build(from: Task, to: Entity) {
+    override fun build(from: Task, to: VToDo) {
         val organizer = from.organizer
         if (organizer == null) {
-            to.entityValues.putNull(Tasks.ORGANIZER)
+            to.organizer.value = null
             return
         }
 
@@ -32,10 +31,10 @@ class OrganizerBuilder : DmfsTaskFieldBuilder {
             organizer.getParameter<Email>(Parameter.EMAIL).getOrNull()?.value
 
         if (email != null)
-            to.entityValues.put(Tasks.ORGANIZER, email)
+            to.organizer.value = email
         else {
             logger.log(Level.WARNING, "Ignoring ORGANIZER without email address (not supported by Android)", organizer)
-            to.entityValues.putNull(Tasks.ORGANIZER)
+            to.organizer.value = null
         }
     }
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/OrganizerBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/OrganizerBuilder.kt
@@ -6,9 +6,11 @@ package at.bitfire.synctools.mapping.tasks.builder
 
 import android.content.Entity
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.icalendar.plusAssign
 import net.fortuna.ical4j.model.Parameter
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.parameter.Email
+import net.fortuna.ical4j.model.property.Organizer
 import org.dmfs.tasks.contract.TaskContract.Tasks
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -43,7 +45,7 @@ class OrganizerBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
     override fun build(from: Task, to: VToDo) {
         val organizer = from.organizer
         if (organizer == null) {
-            to.organizer.value = null
+            to += Organizer(null, "")
             return
         }
 
@@ -54,10 +56,10 @@ class OrganizerBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
             organizer.getParameter<Email>(Parameter.EMAIL).getOrNull()?.value
 
         if (email != null)
-            to.organizer.value = email
+            to += Organizer(null, email)
         else {
             logger.log(Level.WARNING, "Ignoring ORGANIZER without email address (not supported by Android)", organizer)
-            to.organizer.value = null
+            to += Organizer(null, "")
         }
     }
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/OrganizerBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/OrganizerBuilder.kt
@@ -6,7 +6,6 @@ package at.bitfire.synctools.mapping.tasks.builder
 
 import android.content.Entity
 import at.bitfire.ical4android.Task
-import at.bitfire.synctools.icalendar.plusAssign
 import net.fortuna.ical4j.model.Parameter
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.parameter.Email
@@ -42,10 +41,10 @@ class OrganizerBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
         }
     }
 
-    override fun build(from: Task, to: VToDo) {
-        val organizer = from.organizer
+    override fun build(from: VToDo, to: Entity) {
+        val organizer = from.getProperty<Organizer>(Organizer.ORGANIZER).getOrNull()
         if (organizer == null) {
-            to += Organizer(null, "")
+            to.entityValues.putNull(Tasks.ORGANIZER)
             return
         }
 
@@ -56,10 +55,10 @@ class OrganizerBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
             organizer.getParameter<Email>(Parameter.EMAIL).getOrNull()?.value
 
         if (email != null)
-            to += Organizer(null, email)
+            to.entityValues.put(Tasks.ORGANIZER, email)
         else {
             logger.log(Level.WARNING, "Ignoring ORGANIZER without email address (not supported by Android)", organizer)
-            to += Organizer(null, "")
+            to.entityValues.putNull(Tasks.ORGANIZER)
         }
     }
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/TitleBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/TitleBuilder.kt
@@ -6,11 +6,11 @@ package at.bitfire.synctools.mapping.tasks.builder
 
 import android.content.Entity
 import at.bitfire.ical4android.Task
-import at.bitfire.synctools.icalendar.plusAssign
 import at.bitfire.synctools.util.trimToNull
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.property.Summary
 import org.dmfs.tasks.contract.TaskContract.Tasks
+import kotlin.jvm.optionals.getOrNull
 
 class TitleBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
@@ -18,8 +18,9 @@ class TitleBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
         to.entityValues.put(Tasks.TITLE, from.summary.trimToNull())
     }
 
-    override fun build(from: Task, to: VToDo) {
-        to += Summary(null, from.summary.trimToNull())
+    override fun build(from: VToDo, to: Entity) {
+        val summary = from.getProperty<Summary>(Summary.SUMMARY).getOrNull()
+        to.entityValues.put(Tasks.TITLE, summary?.value.trimToNull())
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/TitleBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/TitleBuilder.kt
@@ -6,8 +6,10 @@ package at.bitfire.synctools.mapping.tasks.builder
 
 import android.content.Entity
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.icalendar.plusAssign
 import at.bitfire.synctools.util.trimToNull
 import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Summary
 import org.dmfs.tasks.contract.TaskContract.Tasks
 
 class TitleBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
@@ -17,7 +19,7 @@ class TitleBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
     }
 
     override fun build(from: Task, to: VToDo) {
-        to.summary.value = from.summary.trimToNull()
+        to += Summary(null, from.summary.trimToNull())
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/TitleBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/TitleBuilder.kt
@@ -7,12 +7,17 @@ package at.bitfire.synctools.mapping.tasks.builder
 import android.content.Entity
 import at.bitfire.ical4android.Task
 import at.bitfire.synctools.util.trimToNull
+import net.fortuna.ical4j.model.component.VToDo
 import org.dmfs.tasks.contract.TaskContract.Tasks
 
-class TitleBuilder : DmfsTaskFieldBuilder {
+class TitleBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
     override fun build(from: Task, to: Entity) {
         to.entityValues.put(Tasks.TITLE, from.summary.trimToNull())
+    }
+
+    override fun build(from: Task, to: VToDo) {
+        to.summary.value = from.summary.trimToNull()
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/UrlBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/UrlBuilder.kt
@@ -6,10 +6,10 @@ package at.bitfire.synctools.mapping.tasks.builder
 
 import android.content.Entity
 import at.bitfire.ical4android.Task
-import at.bitfire.synctools.icalendar.plusAssign
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.property.Url
 import org.dmfs.tasks.contract.TaskContract.Tasks
+import kotlin.jvm.optionals.getOrNull
 
 class UrlBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
@@ -17,8 +17,9 @@ class UrlBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
         to.entityValues.put(Tasks.URL, from.url)
     }
 
-    override fun build(from: Task, to: VToDo) {
-        to += Url(null, from.url.orEmpty())
+    override fun build(from: VToDo, to: Entity) {
+        val url = from.getProperty<Url>(Url.URL).getOrNull()
+        to.entityValues.put(Tasks.URL, url?.value)
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/UrlBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/UrlBuilder.kt
@@ -6,7 +6,9 @@ package at.bitfire.synctools.mapping.tasks.builder
 
 import android.content.Entity
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.icalendar.plusAssign
 import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Url
 import org.dmfs.tasks.contract.TaskContract.Tasks
 
 class UrlBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
@@ -16,7 +18,7 @@ class UrlBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
     }
 
     override fun build(from: Task, to: VToDo) {
-        to.url.value = from.url
+        to += Url(null, from.url.orEmpty())
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/UrlBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/UrlBuilder.kt
@@ -4,14 +4,13 @@
 
 package at.bitfire.synctools.mapping.tasks.builder
 
-import android.content.Entity
 import at.bitfire.ical4android.Task
-import org.dmfs.tasks.contract.TaskContract.Tasks
+import net.fortuna.ical4j.model.component.VToDo
 
-class UrlBuilder : DmfsTaskFieldBuilder {
+class UrlBuilder : DmfsTaskFieldBuilderVToDo {
 
-    override fun build(from: Task, to: Entity) {
-        to.entityValues.put(Tasks.URL, from.url)
+    override fun build(from: Task, to: VToDo) {
+        to.url.value = from.url
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/UrlBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/UrlBuilder.kt
@@ -4,10 +4,16 @@
 
 package at.bitfire.synctools.mapping.tasks.builder
 
+import android.content.Entity
 import at.bitfire.ical4android.Task
 import net.fortuna.ical4j.model.component.VToDo
+import org.dmfs.tasks.contract.TaskContract.Tasks
 
-class UrlBuilder : DmfsTaskFieldBuilderVToDo {
+class UrlBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
+
+    override fun build(from: Task, to: Entity) {
+        to.entityValues.put(Tasks.URL, from.url)
+    }
 
     override fun build(from: Task, to: VToDo) {
         to.url.value = from.url

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/VToDoUtil.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/VToDoUtil.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.synctools.mapping.tasks
+
+import net.fortuna.ical4j.model.Property
+import net.fortuna.ical4j.model.PropertyList
+import net.fortuna.ical4j.model.component.VToDo
+
+object VToDoUtil {
+    fun build(vararg properties: Property): VToDo {
+        return VToDo(PropertyList(listOf(*properties)))
+    }
+}

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/ColorBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/ColorBuilderTest.kt
@@ -60,7 +60,7 @@ class ColorBuilderTest {
     }
 
     @Test
-    fun `COLOR is set`() {
+    fun `COLOR is set - css name`() {
         val result = Entity(ContentValues())
         builder.build(
             from = build(Color(null, Css3Color.nearestMatch(0xFF112233.toInt()).name)),
@@ -68,6 +68,18 @@ class ColorBuilderTest {
         )
         assertContentValuesEqual(contentValuesOf(
             Tasks.TASK_COLOR to Css3Color.nearestMatch(0xFF112233.toInt()).argb
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `COLOR is set - hex`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = build(Color(null, "#FF112233")),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.TASK_COLOR to 0xFF112233.toInt()
         ), result.entityValues)
     }
 

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/ColorBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/ColorBuilderTest.kt
@@ -9,13 +9,11 @@ import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
 import at.bitfire.synctools.icalendar.Css3Color
+import at.bitfire.synctools.mapping.tasks.VToDoUtil.build
 import at.bitfire.synctools.test.assertContentValuesEqual
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.property.Color
 import org.dmfs.tasks.contract.TaskContract.Tasks
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -51,27 +49,26 @@ class ColorBuilderTest {
 
     @Test
     fun `No COLOR`() {
-        val result = VToDo()
+        val result = Entity(ContentValues())
         builder.build(
-            from = Task(),
+            from = VToDo(),
             to = result
         )
-        val color = result.getProperty<Color>(Color.PROPERTY_NAME)
-        assertTrue(color.isPresent)
-        assertNull(color.get().value)
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.TASK_COLOR to null
+        ), result.entityValues)
     }
 
     @Test
     fun `COLOR is set`() {
-        val result = VToDo()
+        val result = Entity(ContentValues())
         builder.build(
-            from = Task(color = 0xFF112233.toInt()),
+            from = build(Color(null, Css3Color.nearestMatch(0xFF112233.toInt()).name)),
             to = result
         )
-        assertEquals(
-            Css3Color.nearestMatch(0xFF112233.toInt()).name,
-            result.getRequiredProperty<Color>(Color.PROPERTY_NAME).value
-        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.TASK_COLOR to Css3Color.nearestMatch(0xFF112233.toInt()).argb
+        ), result.entityValues)
     }
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/ColorBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/ColorBuilderTest.kt
@@ -8,8 +8,14 @@ import android.content.ContentValues
 import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.icalendar.Css3Color
 import at.bitfire.synctools.test.assertContentValuesEqual
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Color
 import org.dmfs.tasks.contract.TaskContract.Tasks
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -20,7 +26,7 @@ class ColorBuilderTest {
     private val builder = ColorBuilder()
 
     @Test
-    fun `No COLOR`() {
+    fun `old No COLOR`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(),
@@ -32,7 +38,7 @@ class ColorBuilderTest {
     }
 
     @Test
-    fun `COLOR is set`() {
+    fun `old COLOR is set`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(color = 0xFF112233.toInt()),
@@ -41,6 +47,31 @@ class ColorBuilderTest {
         assertContentValuesEqual(contentValuesOf(
             Tasks.TASK_COLOR to 0xFF112233.toInt()
         ), result.entityValues)
+    }
+
+    @Test
+    fun `No COLOR`() {
+        val result = VToDo()
+        builder.build(
+            from = Task(),
+            to = result
+        )
+        val color = result.getProperty<Color>(Color.PROPERTY_NAME)
+        assertTrue(color.isPresent)
+        assertNull(color.get().value)
+    }
+
+    @Test
+    fun `COLOR is set`() {
+        val result = VToDo()
+        builder.build(
+            from = Task(color = 0xFF112233.toInt()),
+            to = result
+        )
+        assertEquals(
+            Css3Color.nearestMatch(0xFF112233.toInt()).name,
+            result.getRequiredProperty<Color>(Color.PROPERTY_NAME).value
+        )
     }
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/DescriptionBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/DescriptionBuilderTest.kt
@@ -7,6 +7,8 @@ package at.bitfire.synctools.mapping.tasks.builder
 import android.content.ContentValues
 import android.content.Entity
 import at.bitfire.ical4android.Task
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Description
 import org.dmfs.tasks.contract.TaskContract.Tasks
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -21,7 +23,7 @@ class DescriptionBuilderTest {
     private val builder = DescriptionBuilder()
 
     @Test
-    fun `No DESCRIPTION`() {
+    fun `old No DESCRIPTION`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(),
@@ -32,7 +34,7 @@ class DescriptionBuilderTest {
     }
 
     @Test
-    fun `DESCRIPTION is blank`() {
+    fun `old DESCRIPTION is blank`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(description = ""),
@@ -43,13 +45,47 @@ class DescriptionBuilderTest {
     }
 
     @Test
-    fun `DESCRIPTION is text`() {
+    fun `old DESCRIPTION is text`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(description = "Task Details"),
             to = result
         )
         assertEquals("Task Details", result.entityValues.getAsString(Tasks.DESCRIPTION))
+    }
+
+    @Test
+    fun `No DESCRIPTION`() {
+        val result = VToDo()
+        builder.build(
+            from = Task(),
+            to = result
+        )
+        val description = result.getProperty<Description>(Description.DESCRIPTION)
+        assertTrue(description.isPresent)
+        assertNull(description.get().value)
+    }
+
+    @Test
+    fun `DESCRIPTION is blank`() {
+        val result = VToDo()
+        builder.build(
+            from = Task(description = ""),
+            to = result
+        )
+        val description = result.getProperty<Description>(Description.DESCRIPTION)
+        assertTrue(description.isPresent)
+        assertNull(description.get().value)
+    }
+
+    @Test
+    fun `DESCRIPTION is text`() {
+        val result = VToDo()
+        builder.build(
+            from = Task(description = "Task Details"),
+            to = result
+        )
+        assertEquals("Task Details", result.description.value)
     }
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/DescriptionBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/DescriptionBuilderTest.kt
@@ -7,6 +7,7 @@ package at.bitfire.synctools.mapping.tasks.builder
 import android.content.ContentValues
 import android.content.Entity
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.mapping.tasks.VToDoUtil.build
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.property.Description
 import org.dmfs.tasks.contract.TaskContract.Tasks
@@ -56,36 +57,34 @@ class DescriptionBuilderTest {
 
     @Test
     fun `No DESCRIPTION`() {
-        val result = VToDo()
+        val result = Entity(ContentValues())
         builder.build(
-            from = Task(),
+            from = VToDo(),
             to = result
         )
-        val description = result.getProperty<Description>(Description.DESCRIPTION)
-        assertTrue(description.isPresent)
-        assertNull(description.get().value)
+        assertTrue(result.entityValues.containsKey(Tasks.DESCRIPTION))
+        assertNull(result.entityValues.get(Tasks.DESCRIPTION))
     }
 
     @Test
     fun `DESCRIPTION is blank`() {
-        val result = VToDo()
+        val result = Entity(ContentValues())
         builder.build(
-            from = Task(description = ""),
+            from = build(Description("")),
             to = result
         )
-        val description = result.getProperty<Description>(Description.DESCRIPTION)
-        assertTrue(description.isPresent)
-        assertNull(description.get().value)
+        assertTrue(result.entityValues.containsKey(Tasks.DESCRIPTION))
+        assertNull(result.entityValues.get(Tasks.DESCRIPTION))
     }
 
     @Test
     fun `DESCRIPTION is text`() {
-        val result = VToDo()
+        val result = Entity(ContentValues())
         builder.build(
-            from = Task(description = "Task Details"),
+            from = build(Description("Task Details")),
             to = result
         )
-        assertEquals("Task Details", result.description.value)
+        assertEquals("Task Details", result.entityValues.getAsString(Tasks.DESCRIPTION))
     }
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/GeoBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/GeoBuilderTest.kt
@@ -7,6 +7,7 @@ package at.bitfire.synctools.mapping.tasks.builder
 import android.content.ContentValues
 import android.content.Entity
 import at.bitfire.ical4android.Task
+import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.property.Geo
 import org.dmfs.tasks.contract.TaskContract.Tasks
 import org.junit.Assert.assertEquals
@@ -22,7 +23,7 @@ class GeoBuilderTest {
     private val builder = GeoBuilder()
 
     @Test
-    fun `No GEO`() {
+    fun `old No GEO`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(),
@@ -33,13 +34,38 @@ class GeoBuilderTest {
     }
 
     @Test
-    fun `GEO is set`() {
+    fun `old GEO is set`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(geoPosition = Geo(48.2.toBigDecimal(), 16.3.toBigDecimal())),
             to = result
         )
         assertEquals("16.3,48.2", result.entityValues.getAsString(Tasks.GEO))
+    }
+
+
+    @Test
+    fun `No GEO`() {
+        val result = VToDo()
+        builder.build(
+            from = Task(),
+            to = result
+        )
+        val geo = result.getProperty<Geo>(Geo.LOCATION)
+        assertTrue(geo.isPresent)
+        assertNull(geo.get().latitude)
+        assertNull(geo.get().longitude)
+    }
+
+    @Test
+    fun `GEO is set`() {
+        val result = VToDo()
+        builder.build(
+            from = Task(geoPosition = Geo(48.2.toBigDecimal(), 16.3.toBigDecimal())),
+            to = result
+        )
+        assertEquals(48.2.toBigDecimal(), result.geographicPos.latitude)
+        assertEquals(16.3.toBigDecimal(), result.geographicPos.longitude)
     }
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/GeoBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/GeoBuilderTest.kt
@@ -7,6 +7,7 @@ package at.bitfire.synctools.mapping.tasks.builder
 import android.content.ContentValues
 import android.content.Entity
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.mapping.tasks.VToDoUtil
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.property.Geo
 import org.dmfs.tasks.contract.TaskContract.Tasks
@@ -46,26 +47,23 @@ class GeoBuilderTest {
 
     @Test
     fun `No GEO`() {
-        val result = VToDo()
+        val result = Entity(ContentValues())
         builder.build(
-            from = Task(),
+            from = VToDo(),
             to = result
         )
-        val geo = result.getProperty<Geo>(Geo.LOCATION)
-        assertTrue(geo.isPresent)
-        assertNull(geo.get().latitude)
-        assertNull(geo.get().longitude)
+        assertTrue(result.entityValues.containsKey(Tasks.GEO))
+        assertNull(result.entityValues.get(Tasks.GEO))
     }
 
     @Test
     fun `GEO is set`() {
-        val result = VToDo()
+        val result = Entity(ContentValues())
         builder.build(
-            from = Task(geoPosition = Geo(48.2.toBigDecimal(), 16.3.toBigDecimal())),
+            from = VToDoUtil.build(Geo(48.2.toBigDecimal(), 16.3.toBigDecimal())),
             to = result
         )
-        assertEquals(48.2.toBigDecimal(), result.geographicPos.latitude)
-        assertEquals(16.3.toBigDecimal(), result.geographicPos.longitude)
+        assertEquals("16.3,48.2", result.entityValues.getAsString(Tasks.GEO))
     }
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/LocationBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/LocationBuilderTest.kt
@@ -7,6 +7,7 @@ package at.bitfire.synctools.mapping.tasks.builder
 import android.content.ContentValues
 import android.content.Entity
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.mapping.tasks.VToDoUtil
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.property.Location
 import org.dmfs.tasks.contract.TaskContract.Tasks
@@ -56,36 +57,34 @@ class LocationBuilderTest {
 
     @Test
     fun `No LOCATION`() {
-        val result = VToDo()
+        val result = Entity(ContentValues())
         builder.build(
-            from = Task(),
+            from = VToDo(),
             to = result
         )
-        val location = result.getProperty<Location>(Location.LOCATION)
-        assertTrue(location.isPresent)
-        assertNull(location.get().value)
+        assertTrue(result.entityValues.containsKey(Tasks.LOCATION))
+        assertNull(result.entityValues.get(Tasks.LOCATION))
     }
 
     @Test
     fun `LOCATION is blank`() {
-        val result = VToDo()
+        val result = Entity(ContentValues())
         builder.build(
-            from = Task(location = ""),
+            from = VToDoUtil.build(Location("")),
             to = result
         )
-        val location = result.getProperty<Location>(Location.LOCATION)
-        assertTrue(location.isPresent)
-        assertNull(location.get().value)
+        assertTrue(result.entityValues.containsKey(Tasks.LOCATION))
+        assertNull(result.entityValues.get(Tasks.LOCATION))
     }
 
     @Test
     fun `LOCATION is text`() {
-        val result = VToDo()
+        val result = Entity(ContentValues())
         builder.build(
-            from = Task(location = "Task Location"),
+            from = VToDoUtil.build(Location("Task Location")),
             to = result
         )
-        assertEquals("Task Location", result.location.value)
+        assertEquals("Task Location", result.entityValues.getAsString(Tasks.LOCATION))
     }
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/LocationBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/LocationBuilderTest.kt
@@ -7,6 +7,8 @@ package at.bitfire.synctools.mapping.tasks.builder
 import android.content.ContentValues
 import android.content.Entity
 import at.bitfire.ical4android.Task
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Location
 import org.dmfs.tasks.contract.TaskContract.Tasks
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -21,7 +23,7 @@ class LocationBuilderTest {
     private val builder = LocationBuilder()
 
     @Test
-    fun `No LOCATION`() {
+    fun `old No LOCATION`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(),
@@ -32,7 +34,7 @@ class LocationBuilderTest {
     }
 
     @Test
-    fun `LOCATION is blank`() {
+    fun `old LOCATION is blank`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(location = ""),
@@ -43,13 +45,47 @@ class LocationBuilderTest {
     }
 
     @Test
-    fun `LOCATION is text`() {
+    fun `old LOCATION is text`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(location = "Task Location"),
             to = result
         )
         assertEquals("Task Location", result.entityValues.getAsString(Tasks.LOCATION))
+    }
+
+    @Test
+    fun `No LOCATION`() {
+        val result = VToDo()
+        builder.build(
+            from = Task(),
+            to = result
+        )
+        val location = result.getProperty<Location>(Location.LOCATION)
+        assertTrue(location.isPresent)
+        assertNull(location.get().value)
+    }
+
+    @Test
+    fun `LOCATION is blank`() {
+        val result = VToDo()
+        builder.build(
+            from = Task(location = ""),
+            to = result
+        )
+        val location = result.getProperty<Location>(Location.LOCATION)
+        assertTrue(location.isPresent)
+        assertNull(location.get().value)
+    }
+
+    @Test
+    fun `LOCATION is text`() {
+        val result = VToDo()
+        builder.build(
+            from = Task(location = "Task Location"),
+            to = result
+        )
+        assertEquals("Task Location", result.location.value)
     }
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/OrganizerBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/OrganizerBuilderTest.kt
@@ -9,9 +9,14 @@ import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
 import at.bitfire.synctools.test.assertContentValuesEqual
+import at.bitfire.synctools.util.trimToNull
+import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.parameter.Email
 import net.fortuna.ical4j.model.property.Organizer
 import org.dmfs.tasks.contract.TaskContract.Tasks
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -22,7 +27,7 @@ class OrganizerBuilderTest {
     private val builder = OrganizerBuilder()
 
     @Test
-    fun `No ORGANIZER`() {
+    fun `old No ORGANIZER`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(),
@@ -34,7 +39,7 @@ class OrganizerBuilderTest {
     }
 
     @Test
-    fun `ORGANIZER is email address`() {
+    fun `old ORGANIZER is email address`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(organizer = Organizer("mailto:organizer@example.com")),
@@ -46,7 +51,7 @@ class OrganizerBuilderTest {
     }
 
     @Test
-    fun `ORGANIZER is custom URI without email`() {
+    fun `old ORGANIZER is custom URI without email`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(organizer = Organizer("local-id:user")),
@@ -59,7 +64,7 @@ class OrganizerBuilderTest {
     }
 
     @Test
-    fun `ORGANIZER is custom URI with email parameter`() {
+    fun `old ORGANIZER is custom URI with email parameter`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(organizer = Organizer("local-id:user").add(Email("organizer@example.com"))),
@@ -68,6 +73,55 @@ class OrganizerBuilderTest {
         assertContentValuesEqual(contentValuesOf(
             Tasks.ORGANIZER to "organizer@example.com"
         ), result.entityValues)
+    }
+
+    @Test
+    fun `No ORGANIZER`() {
+        val result = VToDo()
+        builder.build(
+            from = Task(),
+            to = result
+        )
+        val organizer = result.getProperty<Organizer>(Organizer.ORGANIZER)
+        assertTrue(organizer.isPresent)
+        assertNull(organizer.get().value.trimToNull())
+    }
+
+    @Test
+    fun `ORGANIZER is email address`() {
+        val result = VToDo()
+        builder.build(
+            from = Task(organizer = Organizer("mailto:organizer@example.com")),
+            to = result
+        )
+        val organizer = result.getProperty<Organizer>(Organizer.ORGANIZER)
+        assertTrue(organizer.isPresent)
+        assertEquals("organizer@example.com", organizer.get().value)
+    }
+
+    @Test
+    fun `ORGANIZER is custom URI without email`() {
+        val result = VToDo()
+        builder.build(
+            from = Task(organizer = Organizer("local-id:user")),
+            to = result
+        )
+        // Custom URI without email → null (tasks have no ownerAccount fallback)
+        val organizer = result.getProperty<Organizer>(Organizer.ORGANIZER)
+        assertTrue(organizer.isPresent)
+        assertNull(organizer.get().value.trimToNull())
+    }
+
+    @Test
+    fun `ORGANIZER is custom URI with email parameter`() {
+        val result = VToDo()
+        builder.build(
+            from = Task(organizer = Organizer("local-id:user").add(Email("organizer@example.com"))),
+            to = result
+        )
+        val organizer = result.getProperty<Organizer>(Organizer.ORGANIZER)
+        assertTrue(organizer.isPresent)
+        assertEquals("organizer@example.com", organizer.get().value)
     }
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/OrganizerBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/OrganizerBuilderTest.kt
@@ -8,15 +8,12 @@ import android.content.ContentValues
 import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.mapping.tasks.VToDoUtil
 import at.bitfire.synctools.test.assertContentValuesEqual
-import at.bitfire.synctools.util.trimToNull
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.parameter.Email
 import net.fortuna.ical4j.model.property.Organizer
 import org.dmfs.tasks.contract.TaskContract.Tasks
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -77,51 +74,51 @@ class OrganizerBuilderTest {
 
     @Test
     fun `No ORGANIZER`() {
-        val result = VToDo()
+        val result = Entity(ContentValues())
         builder.build(
-            from = Task(),
+            from = VToDo(),
             to = result
         )
-        val organizer = result.getProperty<Organizer>(Organizer.ORGANIZER)
-        assertTrue(organizer.isPresent)
-        assertNull(organizer.get().value.trimToNull())
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.ORGANIZER to null
+        ), result.entityValues)
     }
 
     @Test
     fun `ORGANIZER is email address`() {
-        val result = VToDo()
+        val result = Entity(ContentValues())
         builder.build(
-            from = Task(organizer = Organizer("mailto:organizer@example.com")),
+            from = VToDoUtil.build(Organizer("mailto:organizer@example.com")),
             to = result
         )
-        val organizer = result.getProperty<Organizer>(Organizer.ORGANIZER)
-        assertTrue(organizer.isPresent)
-        assertEquals("organizer@example.com", organizer.get().value)
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.ORGANIZER to "organizer@example.com"
+        ), result.entityValues)
     }
 
     @Test
     fun `ORGANIZER is custom URI without email`() {
-        val result = VToDo()
+        val result = Entity(ContentValues())
         builder.build(
-            from = Task(organizer = Organizer("local-id:user")),
+            from = VToDoUtil.build(Organizer("local-id:user")),
             to = result
         )
         // Custom URI without email → null (tasks have no ownerAccount fallback)
-        val organizer = result.getProperty<Organizer>(Organizer.ORGANIZER)
-        assertTrue(organizer.isPresent)
-        assertNull(organizer.get().value.trimToNull())
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.ORGANIZER to null
+        ), result.entityValues)
     }
 
     @Test
     fun `ORGANIZER is custom URI with email parameter`() {
-        val result = VToDo()
+        val result = Entity(ContentValues())
         builder.build(
-            from = Task(organizer = Organizer("local-id:user").add(Email("organizer@example.com"))),
+            from = VToDoUtil.build(Organizer("local-id:user").add(Email("organizer@example.com"))),
             to = result
         )
-        val organizer = result.getProperty<Organizer>(Organizer.ORGANIZER)
-        assertTrue(organizer.isPresent)
-        assertEquals("organizer@example.com", organizer.get().value)
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.ORGANIZER to "organizer@example.com"
+        ), result.entityValues)
     }
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/TitleBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/TitleBuilderTest.kt
@@ -7,8 +7,11 @@ package at.bitfire.synctools.mapping.tasks.builder
 import android.content.ContentValues
 import android.content.Entity
 import at.bitfire.ical4android.Task
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Summary
 import org.dmfs.tasks.contract.TaskContract.Tasks
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -21,7 +24,7 @@ class TitleBuilderTest {
     private val builder = TitleBuilder()
 
     @Test
-    fun `No SUMMARY`() {
+    fun `old No SUMMARY`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(),
@@ -32,7 +35,7 @@ class TitleBuilderTest {
     }
 
     @Test
-    fun `SUMMARY is blank`() {
+    fun `old SUMMARY is blank`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(summary = ""),
@@ -43,13 +46,47 @@ class TitleBuilderTest {
     }
 
     @Test
-    fun `SUMMARY is text`() {
+    fun `old SUMMARY is text`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(summary = "Task Summary"),
             to = result
         )
         assertEquals("Task Summary", result.entityValues.getAsString(Tasks.TITLE))
+    }
+
+    @Test
+    fun `No SUMMARY`() {
+        val result = VToDo()
+        builder.build(
+            from = Task(),
+            to = result
+        )
+        val summary = result.getProperty<Summary>(Summary.SUMMARY)
+        assertFalse(summary.isEmpty)
+        assertNull(summary.get().value)
+    }
+
+    @Test
+    fun `SUMMARY is blank`() {
+        val result = VToDo()
+        builder.build(
+            from = Task(summary = ""),
+            to = result
+        )
+        val summary = result.getProperty<Summary>(Summary.SUMMARY)
+        assertFalse(summary.isEmpty)
+        assertNull(summary.get().value)
+    }
+
+    @Test
+    fun `SUMMARY is text`() {
+        val result = VToDo()
+        builder.build(
+            from = Task(summary = "Task Summary"),
+            to = result
+        )
+        assertEquals("Task Summary", result.summary.value)
     }
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/TitleBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/TitleBuilderTest.kt
@@ -7,11 +7,11 @@ package at.bitfire.synctools.mapping.tasks.builder
 import android.content.ContentValues
 import android.content.Entity
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.mapping.tasks.VToDoUtil
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.property.Summary
 import org.dmfs.tasks.contract.TaskContract.Tasks
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -57,36 +57,34 @@ class TitleBuilderTest {
 
     @Test
     fun `No SUMMARY`() {
-        val result = VToDo()
+        val result = Entity(ContentValues())
         builder.build(
-            from = Task(),
+            from = VToDo(),
             to = result
         )
-        val summary = result.getProperty<Summary>(Summary.SUMMARY)
-        assertFalse(summary.isEmpty)
-        assertNull(summary.get().value)
+        assertTrue(result.entityValues.containsKey(Tasks.TITLE))
+        assertNull(result.entityValues.get(Tasks.TITLE))
     }
 
     @Test
     fun `SUMMARY is blank`() {
-        val result = VToDo()
+        val result = Entity(ContentValues())
         builder.build(
-            from = Task(summary = ""),
+            from = VToDoUtil.build(Summary("")),
             to = result
         )
-        val summary = result.getProperty<Summary>(Summary.SUMMARY)
-        assertFalse(summary.isEmpty)
-        assertNull(summary.get().value)
+        assertTrue(result.entityValues.containsKey(Tasks.TITLE))
+        assertNull(result.entityValues.get(Tasks.TITLE))
     }
 
     @Test
     fun `SUMMARY is text`() {
-        val result = VToDo()
+        val result = Entity(ContentValues())
         builder.build(
-            from = Task(summary = "Task Summary"),
+            from = VToDoUtil.build(Summary("Task Summary")),
             to = result
         )
-        assertEquals("Task Summary", result.summary.value)
+        assertEquals("Task Summary", result.entityValues.getAsString(Tasks.TITLE))
     }
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/UrlBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/UrlBuilderTest.kt
@@ -8,14 +8,11 @@ import android.content.ContentValues
 import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.mapping.tasks.VToDoUtil
 import at.bitfire.synctools.test.assertContentValuesEqual
-import at.bitfire.synctools.util.trimToNull
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.property.Url
 import org.dmfs.tasks.contract.TaskContract.Tasks
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -52,24 +49,26 @@ class UrlBuilderTest {
 
     @Test
     fun `No URL`() {
-        val result = VToDo()
+        val result = Entity(ContentValues())
         builder.build(
-            from = Task(),
+            from = VToDo(),
             to = result
         )
-        val url = result.getProperty<Url>(Url.URL)
-        assertTrue(url.isPresent)
-        assertNull(url.get().value.trimToNull())
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.URL to null
+        ), result.entityValues)
     }
 
     @Test
     fun `URL is set`() {
-        val result = VToDo()
+        val result = Entity(ContentValues())
         builder.build(
-            from = Task(url = "https://example.com"),
+            from = VToDoUtil.build(Url(null, "https://example.com")),
             to = result
         )
-        assertEquals("https://example.com", result.url.value)
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.URL to "https://example.com"
+        ), result.entityValues)
     }
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/UrlBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/UrlBuilderTest.kt
@@ -9,7 +9,13 @@ import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
 import at.bitfire.synctools.test.assertContentValuesEqual
+import at.bitfire.synctools.util.trimToNull
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Url
 import org.dmfs.tasks.contract.TaskContract.Tasks
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -20,7 +26,7 @@ class UrlBuilderTest {
     private val builder = UrlBuilder()
 
     @Test
-    fun `No URL`() {
+    fun `old No URL`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(),
@@ -32,7 +38,7 @@ class UrlBuilderTest {
     }
 
     @Test
-    fun `URL is set`() {
+    fun `old URL is set`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(url = "https://example.com"),
@@ -41,6 +47,29 @@ class UrlBuilderTest {
         assertContentValuesEqual(contentValuesOf(
             Tasks.URL to "https://example.com"
         ), result.entityValues)
+    }
+
+
+    @Test
+    fun `No URL`() {
+        val result = VToDo()
+        builder.build(
+            from = Task(),
+            to = result
+        )
+        val url = result.getProperty<Url>(Url.URL)
+        assertTrue(url.isPresent)
+        assertNull(url.get().value.trimToNull())
+    }
+
+    @Test
+    fun `URL is set`() {
+        val result = VToDo()
+        builder.build(
+            from = Task(url = "https://example.com"),
+            to = result
+        )
+        assertEquals("https://example.com", result.url.value)
     }
 
 }


### PR DESCRIPTION
### Purpose

See #2284 and #2290

### Short description

- [x] Add `DmfsTaskFieldBuilder`
- [x] Migrate title
- [x] Migrate description
- [x] Migrate geo
- [x] Migrate location
- [x] Migrate organizer
- [x] Migrate url
- [x] Migrate color
- [x] Tests

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

