### PR TITLE
Add VALUE=DATE for RECURRENCE-ID in all-day jtx Board items

### DIFF
--- a/synctools/src/main/kotlin/at/bitfire/ical4android/JtxICalObject.kt
+++ b/synctools/src/main/kotlin/at/bitfire/ical4android/JtxICalObject.kt
@@ -54,6 +54,7 @@ import net.fortuna.ical4j.model.parameter.Role
 import net.fortuna.ical4j.model.parameter.Rsvp
 import net.fortuna.ical4j.model.parameter.SentBy
 import net.fortuna.ical4j.model.parameter.TzId
+import net.fortuna.ical4j.model.parameter.Value
 import net.fortuna.ical4j.model.parameter.XParameter
 import net.fortuna.ical4j.model.property.Action
 import net.fortuna.ical4j.model.property.Attach
@@ -998,11 +999,12 @@ open class JtxICalObject(
             props += RRule<Temporal>(rrule)
         }
         recurid?.let { recurid ->
-            props += if (recuridTimezone == TZ_ALLDAY || recuridTimezone.isNullOrEmpty()) {
-                RecurrenceId<Temporal>(recurid)
-            } else {
-                RecurrenceId<Temporal>(ParameterList(listOf(TzId(recuridTimezone))), recurid)
-            }
+            val parameterList = mutableListOf<Parameter>()
+            if (recuridTimezone == TZ_ALLDAY)
+                parameterList.add(Value.DATE)
+            else if (!recuridTimezone.isNullOrEmpty())
+                parameterList.add(TzId(recuridTimezone))
+            props += RecurrenceId<Temporal>(ParameterList(parameterList), recurid)
         }
 
         rdate?.let { rdateString ->


### PR DESCRIPTION
### Purpose

This PR adds support for `VALUE=DATE` in `RECURRENCE-ID` for all-day items in jtx Board, ensuring proper handling of recurring events with date-based exceptions.

### Short description

- Updated the jtx Board implementation to include `VALUE=DATE` for `RECURRENCE-ID` when processing all-day recurring items.
- Ensures compatibility with iCalendar (RFC 5545) standards for date-based recurrence exceptions.

Tests not added by intention. These will be added during #2265.