### PR TITLE
Implement DmfsTaskList CRUD operations

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskList.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskList.kt
@@ -53,11 +53,11 @@ class LocalTaskList (
     override fun countModified(): Int =
         dmfsTaskList.countTasks("${Tasks._DIRTY} AND NOT ${Tasks._DELETED}", null)
 
-    override fun findDeleted() = dmfsTaskList.findTasks(Tasks._DELETED, null)
+    override fun findDeleted() = dmfsTaskList.findDmfsTasks(Tasks._DELETED, null)
         .map { LocalTask(it) }
 
     override fun findDirty(): List<LocalTask> {
-        val dmfsTasks = dmfsTaskList.findTasks(Tasks._DIRTY, null)
+        val dmfsTasks = dmfsTaskList.findDmfsTasks(Tasks._DIRTY, null)
         for (localTask in dmfsTasks) {
             try {
                 val task = requireNotNull(localTask.task)
@@ -74,7 +74,7 @@ class LocalTaskList (
     }
 
     override fun findByName(name: String) =
-        dmfsTaskList.findTasks("${Tasks._SYNC_ID}=?", arrayOf(name))
+        dmfsTaskList.findDmfsTasks("${Tasks._SYNC_ID}=?", arrayOf(name))
             .firstOrNull()?.let {
                 LocalTask(it)
             }

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskBuilderTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskBuilderTest.kt
@@ -826,7 +826,7 @@ class DmfsTaskBuilderTest (
         val uri = DmfsTask(taskList!!, task, "9468a4cf-0d5b-4379-a704-12f1f84100ba", null, 0).add()
         Assert.assertNotNull(uri)
 
-        val testTask = taskList!!.getTask(ContentUris.parseId(uri))
+        val testTask = taskList!!.getDmfsTask(ContentUris.parseId(uri))
         try {
             // read again and verify result
             val task2 = testTask?.task!!

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
@@ -7,29 +7,35 @@ package at.bitfire.synctools.storage.tasks
 import android.accounts.Account
 import android.content.ContentUris
 import android.content.ContentValues
+import android.content.Entity
 import android.database.DatabaseUtils
+import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.DmfsStyleProvidersTaskTest
 import at.bitfire.ical4android.Task
 import at.bitfire.ical4android.TaskProvider
 import net.fortuna.ical4j.model.property.RelatedTo
 import org.dmfs.tasks.contract.TaskContract
+import org.dmfs.tasks.contract.TaskContract.Property
+import org.dmfs.tasks.contract.TaskContract.TaskLists
+import org.dmfs.tasks.contract.TaskContract.Tasks
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class DmfsTaskListTest(providerName: TaskProvider.ProviderName):
+class DmfsTaskListTest(providerName: TaskProvider.ProviderName) :
     DmfsStyleProvidersTaskTest(providerName) {
 
     private val testAccount = Account(javaClass.name, TaskContract.LOCAL_ACCOUNT_TYPE)
 
     private fun createTaskList(): DmfsTaskList {
         val info = ContentValues()
-        info.put(TaskContract.TaskLists.LIST_NAME, "Test Task List")
-        info.put(TaskContract.TaskLists.LIST_COLOR, 0xffff0000)
-        info.put(TaskContract.TaskLists.OWNER, "test@example.com")
-        info.put(TaskContract.TaskLists.SYNC_ENABLED, 1)
-        info.put(TaskContract.TaskLists.VISIBLE, 1)
+        info.put(TaskLists.LIST_NAME, "Test Task List")
+        info.put(TaskLists.LIST_COLOR, 0xffff0000)
+        info.put(TaskLists.OWNER, "test@example.com")
+        info.put(TaskLists.SYNC_ENABLED, 1)
+        info.put(TaskLists.VISIBLE, 1)
 
         val dmfsTaskListProvider = DmfsTaskListProvider(testAccount, provider.client, providerName)
         val id = dmfsTaskListProvider.createTaskList(info)
@@ -67,7 +73,7 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName):
             DmfsTask(taskList, task2, "sync-id-2", null, 0).add()
 
             // Test counting with UID filter
-            val filteredCount = taskList.countTasks("${TaskContract.Tasks._UID}=?", arrayOf("filter-uid-1"))
+            val filteredCount = taskList.countTasks("${Tasks._UID}=?", arrayOf("filter-uid-1"))
             assertEquals(1, filteredCount)
         } finally {
             taskList.delete()
@@ -130,9 +136,11 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName):
             val parentId = ContentUris.parseId(parentContentUri)
 
             // OpenTasks should provide the correct relation
-            taskList.provider.client.query(taskList.tasksPropertiesUri(), null,
+            taskList.provider.client.query(
+                taskList.tasksPropertiesUri(), null,
                 "${TaskContract.Properties.TASK_ID}=?", arrayOf(childId.toString()),
-                null, null)!!.use { cursor ->
+                null, null
+            )!!.use { cursor ->
                 assertEquals(1, cursor.count)
                 cursor.moveToNext()
 
@@ -140,20 +148,20 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName):
                 DatabaseUtils.cursorRowToContentValues(cursor, row)
 
                 assertEquals(
-                    TaskContract.Property.Relation.CONTENT_ITEM_TYPE,
+                    Property.Relation.CONTENT_ITEM_TYPE,
                     row.getAsString(TaskContract.Properties.MIMETYPE)
                 )
                 assertEquals(
                     parentId,
-                    row.getAsLong(TaskContract.Property.Relation.RELATED_ID)
+                    row.getAsLong(Property.Relation.RELATED_ID)
                 )
                 assertEquals(
                     parent.uid,
-                    row.getAsString(TaskContract.Property.Relation.RELATED_UID)
+                    row.getAsString(Property.Relation.RELATED_UID)
                 )
                 assertEquals(
-                    TaskContract.Property.Relation.RELTYPE_PARENT,
-                    row.getAsInteger(TaskContract.Property.Relation.RELATED_TYPE)
+                    Property.Relation.RELTYPE_PARENT,
+                    row.getAsInteger(Property.Relation.RELATED_TYPE)
                 )
             }
 
@@ -161,8 +169,10 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName):
             taskList.touchRelations()
 
             // now parent_id should bet set
-            taskList.provider.client.query(childContentUri, arrayOf(TaskContract.Tasks.PARENT_ID),
-                null, null, null)!!.use { cursor ->
+            taskList.provider.client.query(
+                childContentUri, arrayOf(Tasks.PARENT_ID),
+                null, null, null
+            )!!.use { cursor ->
                 assertTrue(cursor.moveToNext())
                 assertEquals(parentId, cursor.getLong(0))
             }
@@ -174,6 +184,268 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName):
 
     // test tasks CRUD
 
-    // TODO: add tests for addTask, etc. here
+    @Test
+    fun testAddTask_and_GetTask() {
+        val taskList = createTaskList()
+        try {
+            val entity = Entity(
+                contentValuesOf(
+                    Tasks.LIST_ID to taskList.id,
+                    Tasks.TITLE to "Test Task",
+                    Tasks.DESCRIPTION to "Test Description"
+                )
+            )
+
+            val id = taskList.addTask(entity)
+
+            // verify that task has been inserted
+            val result = taskList.getTask(id)!!
+            assertEquals("Test Task", result.entityValues.getAsString(Tasks.TITLE))
+            assertEquals("Test Description", result.entityValues.getAsString(Tasks.DESCRIPTION))
+        } finally {
+            taskList.delete()
+        }
+    }
+
+    @Test
+    fun testAddTask_toBatch() {
+        val taskList = createTaskList()
+        try {
+            val batch = TasksBatchOperation(taskList.client)
+
+            val entity = Entity(
+                contentValuesOf(
+                    Tasks.LIST_ID to taskList.id,
+                    Tasks.TITLE to "Batch Task"
+                )
+            )
+
+            val backRefIdx = taskList.addTask(entity, batch)
+            batch.commit()
+
+            // Get the result URI and parse the ID
+            val resultUri = batch.getResult(backRefIdx)?.uri
+            assertNotNull(resultUri)
+            val id = ContentUris.parseId(resultUri!!)
+
+            // Verify task was inserted
+            val result = taskList.getTask(id)
+            assertNotNull(result)
+            assertEquals("Batch Task", result?.entityValues?.getAsString(Tasks.TITLE))
+        } finally {
+            taskList.delete()
+        }
+    }
+
+    @Test
+    fun testFindTaskRow() {
+        val taskList = createTaskList()
+        try {
+            val entity = Entity(
+                contentValuesOf(
+                    Tasks.LIST_ID to taskList.id,
+                    Tasks.TITLE to "Find Test Task"
+                )
+            )
+            taskList.addTask(entity)
+
+            val result = taskList.findTaskRow(
+                arrayOf(Tasks.TITLE),
+                "${Tasks.TITLE}=?",
+                arrayOf("Find Test Task")
+            )
+            assertNotNull(result)
+            assertEquals("Find Test Task", result!!.getAsString(Tasks.TITLE))
+        } finally {
+            taskList.delete()
+        }
+    }
+
+    @Test
+    fun testFindTasks() {
+        val taskList = createTaskList()
+        try {
+            val entity1 = Entity(
+                contentValuesOf(
+                    Tasks.LIST_ID to taskList.id,
+                    Tasks.TITLE to "Task 1"
+                )
+            )
+            val entity2 = Entity(
+                contentValuesOf(
+                    Tasks.LIST_ID to taskList.id,
+                    Tasks.TITLE to "Task 2"
+                )
+            )
+
+            taskList.addTask(entity1)
+            taskList.addTask(entity2)
+
+            val tasks = taskList.findTasks()
+            assertEquals(2, tasks.size)
+
+            val titles = tasks.map { it.entityValues.getAsString(Tasks.TITLE) }.toSet()
+            assertEquals(setOf("Task 1", "Task 2"), titles)
+        } finally {
+            taskList.delete()
+        }
+    }
+
+    @Test
+    fun testGetTask() {
+        val taskList = createTaskList()
+        try {
+            val entity = Entity(
+                contentValuesOf(
+                    Tasks.LIST_ID to taskList.id,
+                    Tasks.TITLE to "Get Test Task"
+                )
+            )
+
+            val id = taskList.addTask(entity)
+
+            val result = taskList.getTask(id)
+            assertNotNull(result)
+            assertEquals("Get Test Task", result?.entityValues?.getAsString(Tasks.TITLE))
+        } finally {
+            taskList.delete()
+        }
+    }
+
+    @Test
+    fun testIterateTaskRows() {
+        val taskList = createTaskList()
+        try {
+            val entity1 = Entity(
+                contentValuesOf(
+                    Tasks.LIST_ID to taskList.id,
+                    Tasks.TITLE to "Iterate Task 1"
+                )
+            )
+            val entity2 = Entity(
+                contentValuesOf(
+                    Tasks.LIST_ID to taskList.id,
+                    Tasks.TITLE to "Iterate Task 2"
+                )
+            )
+
+            val id1 = taskList.addTask(entity1)
+            val id2 = taskList.addTask(entity2)
+
+            val result = mutableListOf<ContentValues>()
+            taskList.iterateTaskRows(null, null, null) { row ->
+                result += row
+            }
+
+            assertEquals(2, result.size)
+            val titles = result.map { it.getAsString(Tasks.TITLE) }.toSet()
+            assertEquals(setOf("Iterate Task 1", "Iterate Task 2"), titles)
+        } finally {
+            taskList.delete()
+        }
+    }
+
+    @Test
+    fun testUpdateTaskRow() {
+        val taskList = createTaskList()
+        try {
+            val entity = Entity(
+                contentValuesOf(
+                    Tasks.LIST_ID to taskList.id,
+                    Tasks.TITLE to "Original Title"
+                )
+            )
+
+            val id = taskList.addTask(entity)
+
+            taskList.updateTaskRow(id, contentValuesOf(Tasks.TITLE to "Updated Title"))
+
+            val result = taskList.getTask(id)
+            assertNotNull(result)
+            assertEquals("Updated Title", result?.entityValues?.getAsString(Tasks.TITLE))
+        } finally {
+            taskList.delete()
+        }
+    }
+
+    @Test
+    fun testUpdateTask() {
+        val taskList = createTaskList()
+        try {
+            val entity = Entity(
+                contentValuesOf(
+                    Tasks.LIST_ID to taskList.id,
+                    Tasks.TITLE to "Update Test Task"
+                )
+            ).apply {
+                // Use base properties URI for sub-values, MIMETYPE goes in ContentValues
+                addSubValue(
+                    taskList.tasksPropertiesUri(),
+                    contentValuesOf(
+                        TaskContract.Properties.MIMETYPE to Property.Category.CONTENT_ITEM_TYPE,
+                        Property.Category.CATEGORY_NAME to "Work"
+                    )
+                )
+            }
+
+            val id = taskList.addTask(entity)
+
+            // Update with new entity
+            val updatedEntity = Entity(
+                contentValuesOf(
+                    Tasks.TITLE to "Updated Task Title"
+                )
+            ).apply {
+                // Use base properties URI for sub-values, MIMETYPE goes in ContentValues
+                addSubValue(
+                    taskList.tasksPropertiesUri(),
+                    contentValuesOf(
+                        TaskContract.Properties.MIMETYPE to Property.Category.CONTENT_ITEM_TYPE,
+                        Property.Category.CATEGORY_NAME to "Personal"
+                    )
+                )
+            }
+
+            taskList.updateTask(id, updatedEntity)
+
+            val result = taskList.getTask(id)
+            assertNotNull(result)
+            assertEquals("Updated Task Title", result?.entityValues?.getAsString(Tasks.TITLE))
+
+            // Check property was updated
+            val categoryProperty = result?.subValues?.find {
+                it.values.getAsString(TaskContract.Properties.MIMETYPE) == Property.Category.CONTENT_ITEM_TYPE
+            }
+            assertNotNull(categoryProperty)
+            assertEquals(
+                "Personal",
+                categoryProperty?.values?.getAsString(Property.Category.CATEGORY_NAME)
+            )
+        } finally {
+            taskList.delete()
+        }
+    }
+
+    @Test
+    fun testDeleteTask() {
+        val taskList = createTaskList()
+        try {
+            val entity = Entity(
+                contentValuesOf(
+                    Tasks.LIST_ID to taskList.id,
+                    Tasks.TITLE to "Delete Test Task"
+                )
+            )
+
+            val id = taskList.addTask(entity)
+            assertNotNull(taskList.getTask(id))
+
+            taskList.deleteTask(id)
+
+            assertNull(taskList.getTask(id))
+        } finally {
+            taskList.delete()
+        }
+    }
 
 }

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
@@ -400,7 +400,7 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName) :
                     taskList.tasksPropertiesUri(),
                     contentValuesOf(
                         TaskContract.Properties.MIMETYPE to Property.Category.CONTENT_ITEM_TYPE,
-                        Property.Category.CATEGORY_NAME to "Personal"
+                        Property.Category.CATEGORY_NAME to "Work"
                     )
                 )
             }
@@ -412,13 +412,13 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName) :
             assertEquals("Updated Task Title", result?.entityValues?.getAsString(Tasks.TITLE))
 
             // Check property was updated
-            val categoryProperty = result?.subValues?.find {
+            val commentProperty = result?.subValues?.find {
                 it.values.getAsString(TaskContract.Properties.MIMETYPE) == Property.Category.CONTENT_ITEM_TYPE
             }
-            assertNotNull(categoryProperty)
+            assertNotNull(commentProperty)
             assertEquals(
-                "Personal",
-                categoryProperty?.values?.getAsString(Property.Category.CATEGORY_NAME)
+                "Work",
+                commentProperty?.values?.getAsString(Property.Category.CATEGORY_NAME)
             )
         } finally {
             taskList.delete()

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
@@ -309,8 +309,11 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName) :
 
             val result = taskList.getTask(id)
             assertNotNull(result)
-            assertEquals("Get Test Task", result?.entityValues?.getAsString(Tasks.TITLE))
-            assertEquals("Some Comment", result?.subValues?.firstOrNull()?.values?.getAsString(Property.Comment.COMMENT))
+            assertEquals("Get Test Task", result!!.entityValues?.getAsString(Tasks.TITLE))
+
+            val subvalue = result.subValues.first()
+            assertEquals(TaskContract.Properties.getContentUri(taskList.providerName.authority), subvalue.uri)
+            assertEquals("Some Comment", subvalue.values?.getAsString(Property.Comment.COMMENT))
         } finally {
             taskList.delete()
         }

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
@@ -387,7 +387,6 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName) :
                     )
                 )
             }
-
             val id = taskList.addTask(entity)
 
             // Update with new entity

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
@@ -62,10 +62,10 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName):
                 uid = "filter-uid-2"
                 summary = "Filter Test 2"
             }
-            
+
             DmfsTask(taskList, task1, "sync-id-1", null, 0).add()
             DmfsTask(taskList, task2, "sync-id-2", null, 0).add()
-            
+
             // Test counting with UID filter
             val filteredCount = taskList.countTasks("${TaskContract.Tasks._UID}=?", arrayOf("filter-uid-1"))
             assertEquals(1, filteredCount)
@@ -131,8 +131,8 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName):
 
             // OpenTasks should provide the correct relation
             taskList.provider.client.query(taskList.tasksPropertiesUri(), null,
-                    "${TaskContract.Properties.TASK_ID}=?", arrayOf(childId.toString()),
-                    null, null)!!.use { cursor ->
+                "${TaskContract.Properties.TASK_ID}=?", arrayOf(childId.toString()),
+                null, null)!!.use { cursor ->
                 assertEquals(1, cursor.count)
                 cursor.moveToNext()
 
@@ -162,7 +162,7 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName):
 
             // now parent_id should bet set
             taskList.provider.client.query(childContentUri, arrayOf(TaskContract.Tasks.PARENT_ID),
-                    null, null, null)!!.use { cursor ->
+                null, null, null)!!.use { cursor ->
                 assertTrue(cursor.moveToNext())
                 assertEquals(parentId, cursor.getLong(0))
             }
@@ -170,5 +170,10 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName):
             taskList.delete()
         }
     }
+
+
+    // test tasks CRUD
+
+    // TODO: add tests for addTask, etc. here
 
 }

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
@@ -185,7 +185,7 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName) :
     // test tasks CRUD
 
     @Test
-    fun testAddTask_and_GetTask() {
+    fun testAddTask() {
         val taskList = createTaskList()
         try {
             val entity = Entity(
@@ -195,7 +195,6 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName) :
                     Tasks.DESCRIPTION to "Test Description"
                 )
             )
-
             val id = taskList.addTask(entity)
 
             // verify that task has been inserted
@@ -212,25 +211,21 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName) :
         val taskList = createTaskList()
         try {
             val batch = TasksBatchOperation(taskList.client)
-
             val entity = Entity(
                 contentValuesOf(
                     Tasks.LIST_ID to taskList.id,
                     Tasks.TITLE to "Batch Task"
                 )
             )
-
             val backRefIdx = taskList.addTask(entity, batch)
             batch.commit()
 
             // Get the result URI and parse the ID
             val resultUri = batch.getResult(backRefIdx)?.uri
-            assertNotNull(resultUri)
             val id = ContentUris.parseId(resultUri!!)
 
             // Verify task was inserted
             val result = taskList.getTask(id)
-            assertNotNull(result)
             assertEquals("Batch Task", result?.entityValues?.getAsString(Tasks.TITLE))
         } finally {
             taskList.delete()
@@ -254,8 +249,7 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName) :
                 "${Tasks.TITLE}=?",
                 arrayOf("Find Test Task")
             )
-            assertNotNull(result)
-            assertEquals("Find Test Task", result!!.getAsString(Tasks.TITLE))
+            assertEquals("Find Test Task", result?.getAsString(Tasks.TITLE))
         } finally {
             taskList.delete()
         }
@@ -265,21 +259,22 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName) :
     fun testFindTasks() {
         val taskList = createTaskList()
         try {
-            val entity1 = Entity(
+            taskList.addTask(
+                Entity(
                 contentValuesOf(
                     Tasks.LIST_ID to taskList.id,
                     Tasks.TITLE to "Task 1"
                 )
+                )
             )
-            val entity2 = Entity(
+            taskList.addTask(
+                Entity(
                 contentValuesOf(
                     Tasks.LIST_ID to taskList.id,
                     Tasks.TITLE to "Task 2"
                 )
+                )
             )
-
-            taskList.addTask(entity1)
-            taskList.addTask(entity2)
 
             val tasks = taskList.findTasks()
             assertEquals(2, tasks.size)
@@ -300,13 +295,22 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName) :
                     Tasks.LIST_ID to taskList.id,
                     Tasks.TITLE to "Get Test Task"
                 )
-            )
+            ).apply {
+                addSubValue(
+                    taskList.tasksPropertiesUri(),
+                    contentValuesOf(
+                        TaskContract.Properties.MIMETYPE to Property.Comment.CONTENT_ITEM_TYPE,
+                        Property.Comment.COMMENT to "Some Comment"
+                    )
+                )
+            }
 
             val id = taskList.addTask(entity)
 
             val result = taskList.getTask(id)
             assertNotNull(result)
             assertEquals("Get Test Task", result?.entityValues?.getAsString(Tasks.TITLE))
+            assertEquals("Some Comment", result?.subValues?.firstOrNull()?.values?.getAsString(Property.Comment.COMMENT))
         } finally {
             taskList.delete()
         }
@@ -316,21 +320,22 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName) :
     fun testIterateTaskRows() {
         val taskList = createTaskList()
         try {
-            val entity1 = Entity(
+            taskList.addTask(
+                Entity(
                 contentValuesOf(
                     Tasks.LIST_ID to taskList.id,
                     Tasks.TITLE to "Iterate Task 1"
                 )
+                )
             )
-            val entity2 = Entity(
+            taskList.addTask(
+                Entity(
                 contentValuesOf(
                     Tasks.LIST_ID to taskList.id,
                     Tasks.TITLE to "Iterate Task 2"
                 )
+                )
             )
-
-            val id1 = taskList.addTask(entity1)
-            val id2 = taskList.addTask(entity2)
 
             val result = mutableListOf<ContentValues>()
             taskList.iterateTaskRows(null, null, null) { row ->
@@ -355,7 +360,6 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName) :
                     Tasks.TITLE to "Original Title"
                 )
             )
-
             val id = taskList.addTask(entity)
 
             taskList.updateTaskRow(id, contentValuesOf(Tasks.TITLE to "Updated Title"))
@@ -378,7 +382,6 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName) :
                     Tasks.TITLE to "Update Test Task"
                 )
             ).apply {
-                // Use base properties URI for sub-values, MIMETYPE goes in ContentValues
                 addSubValue(
                     taskList.tasksPropertiesUri(),
                     contentValuesOf(

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskTest.kt
@@ -117,7 +117,7 @@ class DmfsTaskTest(
         assertNotNull("Couldn't add task", uri)
 
         // read and parse event from calendar provider
-        val testTask = taskList!!.getTask(ContentUris.parseId(uri))
+        val testTask = taskList!!.getDmfsTask(ContentUris.parseId(uri))
         try {
             assertNotNull("Inserted task is not here", testTask)
             val task2 = testTask?.task
@@ -160,7 +160,7 @@ class DmfsTaskTest(
             task.alarms += VAlarm(java.time.Duration.ofMinutes(i.toLong()))
 
         val uri = DmfsTask(taskList!!, task, "9468a4cf-0d5b-4379-a704-12f1f84100ba", null, 0).add()
-        val task2 = taskList!!.getTask(ContentUris.parseId(uri))
+        val task2 = taskList!!.getDmfsTask(ContentUris.parseId(uri))
         assertEquals(1050, task2?.task?.alarms?.size)
     }
 
@@ -181,7 +181,7 @@ class DmfsTaskTest(
         val uri = DmfsTask(taskList!!, task, "9468a4cf-0d5b-4379-a704-12f1f84100ba", null, 0).add()
         assertNotNull(uri)
 
-        val testTask = taskList!!.getTask(ContentUris.parseId(uri))
+        val testTask = taskList!!.getDmfsTask(ContentUris.parseId(uri))
         try {
             // update test event in calendar
             val task2 = testTask?.task!!
@@ -191,7 +191,7 @@ class DmfsTaskTest(
             testTask.update(task2)
 
             // read again and verify result
-            val updatedTask = taskList!!.getTask(ContentUris.parseId(uri))?.task!!
+            val updatedTask = taskList!!.getDmfsTask(ContentUris.parseId(uri))?.task!!
             assertEquals(task2.summary, updatedTask.summary)
             assertEquals(task2.location, updatedTask.location)
             assertEquals(task2.dtStart, updatedTask.dtStart)

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTask.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTask.kt
@@ -148,6 +148,7 @@ class DmfsTask(
      * @throws at.bitfire.synctools.storage.LocalStorageException when the tasks provider doesn't return a result row
      * @throws android.os.RemoteException on tasks provider errors
      */
+    @Deprecated("Use DmfsTaskList.add() instead")
     fun add(): Uri {
         val batch = TasksBatchOperation(taskList.provider.client)
 
@@ -172,6 +173,7 @@ class DmfsTask(
      * @throws LocalStorageException when the tasks provider doesn't return a result row
      * @throws android.os.RemoteException on tasks provider errors
      */
+    @Deprecated("Use DmfsTaskList.update() instead")
     fun update(task: Task): Uri {
         this.task = task
         val existingId = requireNotNull(id)
@@ -192,6 +194,7 @@ class DmfsTask(
     }
 
     fun update(values: ContentValues) {
+        // TODO update shortcut to use taskList.updateTask()
         taskList.provider.client.update(taskSyncURI(), values, null, null)
     }
 
@@ -203,6 +206,7 @@ class DmfsTask(
      * @throws android.os.RemoteException on tasks provider errors
      */
     fun delete(): Int {
+        // TODO update shortcut to use taskList.deleteTask()
         return taskList.provider.client.delete(taskSyncURI(), null, null)
     }
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTask.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTask.kt
@@ -148,7 +148,7 @@ class DmfsTask(
      * @throws at.bitfire.synctools.storage.LocalStorageException when the tasks provider doesn't return a result row
      * @throws android.os.RemoteException on tasks provider errors
      */
-    @Deprecated("Use DmfsTaskList.add() instead")
+    @Deprecated("Use DmfsTaskList.addTask() instead")
     fun add(): Uri {
         val batch = TasksBatchOperation(taskList.provider.client)
 
@@ -173,7 +173,7 @@ class DmfsTask(
      * @throws LocalStorageException when the tasks provider doesn't return a result row
      * @throws android.os.RemoteException on tasks provider errors
      */
-    @Deprecated("Use DmfsTaskList.update() instead")
+    @Deprecated("Use DmfsTaskList.updateTask() or DmfsTaskList.updateTaskRow() instead")
     fun update(task: Task): Uri {
         this.task = task
         val existingId = requireNotNull(id)
@@ -193,22 +193,17 @@ class DmfsTask(
         return ContentUris.withAppendedId(TaskContract.Tasks.getContentUri(taskList.providerName.authority), existingId)
     }
 
+    /**
+     * Shortcut for [DmfsTaskList.updateTaskRow] with [id].
+     */
     fun update(values: ContentValues) {
-        // TODO update shortcut to use taskList.updateTask()
-        taskList.provider.client.update(taskSyncURI(), values, null, null)
+        taskList.update(values)
     }
 
     /**
-     * Deletes an existing task from the tasks provider storage.
-     *
-     * @return number of affected rows
-     *
-     * @throws android.os.RemoteException on tasks provider errors
+     * Shortcut for [DmfsTaskList.deleteTask] with [id].
      */
-    fun delete(): Int {
-        // TODO update shortcut to use taskList.deleteTask()
-        return taskList.provider.client.delete(taskSyncURI(), null, null)
-    }
+    fun delete(): Int = taskList.deleteTask(id!!)
 
     private fun taskSyncURI(loadProperties: Boolean = false): Uri {
         val id = requireNotNull(id)

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTask.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTask.kt
@@ -197,7 +197,7 @@ class DmfsTask(
      * Shortcut for [DmfsTaskList.updateTaskRow] with [id].
      */
     fun update(values: ContentValues) {
-        taskList.update(values)
+        taskList.updateTaskRow(id!!, values)
     }
 
     /**

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
@@ -174,7 +174,10 @@ class DmfsTaskList(
                         null
                     )?.use { propertiesCursor ->
                         while (propertiesCursor.moveToNext())
-                            entity.addSubValue(tasksPropertiesUri(), propertiesCursor.toContentValues())
+                            entity.addSubValue(
+                                tasksPropertiesUri(asSyncAdapter = false),
+                                propertiesCursor.toContentValues()
+                            )
                     }
                     return entity
                 }
@@ -375,7 +378,7 @@ class DmfsTaskList(
                         val cv = cursor.toContentValues()
                         // Use base properties URI for all sub-values so that Entity can be used
                         // for both reading and writing. MIMETYPE is stored in ContentValues.
-                        entity.addSubValue(tasksPropertiesUri(), cv)
+                        entity.addSubValue(tasksPropertiesUri(asSyncAdapter = false), cv)
                     }
                     return entity
                 }
@@ -460,8 +463,13 @@ class DmfsTaskList(
     fun taskUri(id: Long, loadProperties: Boolean = false): Uri =
         ContentUris.withAppendedId(tasksUri(loadProperties), id)
 
-    fun tasksPropertiesUri(): Uri =
-        TaskContract.Properties.getContentUri(providerName.authority).asSyncAdapter(account)
+    fun tasksPropertiesUri(asSyncAdapter: Boolean = false): Uri {
+        val uri = TaskContract.Properties.getContentUri(providerName.authority)
+        return if (asSyncAdapter)
+            uri.asSyncAdapter(account)
+        else
+            uri
+    }
 
     /**
      * Restricts a given selection/where clause to this task list ID.

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
@@ -94,7 +94,7 @@ class DmfsTaskList(
         // insert property rows (with reference to task row ID)
         for (row in entity.subValues) {
             batch += BatchOperation.CpoBuilder
-                .newInsert(row.uri)
+                .newInsert(tasksPropertiesUri())
                 .withValues(row.values)
                 .withValueBackReference(TaskContract.Properties.TASK_ID, taskRowIdx)
         }
@@ -267,7 +267,7 @@ class DmfsTaskList(
         // insert new property rows (with reference to task ID)
         for (row in entity.subValues) {
             batch += BatchOperation.CpoBuilder
-                .newInsert(row.uri)
+                .newInsert(tasksPropertiesUri())
                 .withValues(ContentValues(row.values).apply {
                     remove(TaskContract.Properties.PROPERTY_ID) // don't reuse property IDs
                     put(TaskContract.Properties.TASK_ID, id)

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
@@ -14,6 +14,7 @@ import at.bitfire.ical4android.util.MiscUtils.asSyncAdapter
 import at.bitfire.synctools.storage.BatchOperation
 import at.bitfire.synctools.storage.LocalStorageException
 import at.bitfire.synctools.storage.toContentValues
+import net.fortuna.ical4j.model.Content
 import org.dmfs.tasks.contract.TaskContract
 import java.util.LinkedList
 import java.util.logging.Logger
@@ -29,8 +30,10 @@ class DmfsTaskList(
     val providerName: TaskProvider.ProviderName
 ) {
 
+    // task list properties
+
     private val logger
-        get() = Logger.getLogger(DmfsTaskList::class.java.name)
+        get() = Logger.getLogger(javaClass.name)
 
     /** see [TaskContract.TaskLists._ID] **/
     val id: Long = values.getAsLong(TaskContract.TaskLists._ID)
@@ -47,6 +50,45 @@ class DmfsTaskList(
     /** see [TaskContract.TaskLists._SYNC_ID] **/
     val syncId: String?
         get() = values.getAsString(TaskContract.TaskLists._SYNC_ID)
+
+
+    // CRUD tasks
+
+    fun addTask(entity: Entity): Long {
+        TODO()
+    }
+
+    fun addTask(entity: Entity, batch: TasksBatchOperation): Long {
+        TODO()
+    }
+
+    fun findTaskRow(projection: Array<String>?, where: String?, whereArgs: Array<String>?): ContentValues? {
+        TODO()
+    }
+
+    fun findTasks(): List<Entity> {
+        TODO("use iterateTaskRows and call getTask for every row to build list")
+    }
+
+    fun getTask(id: Long): Entity? {
+        TODO("get main row, data rows and put together to Entity")
+    }
+
+    fun iterateTaskRows(projection: Array<String>?, where: String?, whereArgs: Array<String>?, body: (ContentValues) -> Unit) {
+        TODO()
+    }
+
+    fun updateTaskRow(id: Long, values: ContentValues) {
+        TODO("update Task row with new values")
+    }
+
+    fun updateTask(id: Long, entity: Entity) {
+        TODO("updateTask row and data rows with new values")
+    }
+
+    fun deleteTask(id: Long) {
+        TODO()
+    }
 
 
     // CRUD DmfsTask
@@ -82,7 +124,8 @@ class DmfsTaskList(
      *
      * @return tasks from this task list which match the selection
      */
-    fun findTasks(where: String? = null, whereArgs: Array<String>? = null): List<DmfsTask> {
+    @Deprecated("Use findTasks() instead")
+    fun findDmfsTasks(where: String? = null, whereArgs: Array<String>? = null): List<DmfsTask> {
         val tasks = LinkedList<DmfsTask>()
         try {
             val (protectedWhere, protectedWhereArgs) = whereWithTaskListId(where, whereArgs)
@@ -105,7 +148,8 @@ class DmfsTaskList(
      *
      * @return task from this task list which matches the selection
      */
-    fun getTask(id: Long): DmfsTask? {
+    @Deprecated("Use getTask() instead")
+    fun getDmfsTask(id: Long): DmfsTask? {
         val values = getTaskEntity(id) ?: return null
         return DmfsTask(this, values)
     }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
@@ -160,14 +160,19 @@ class DmfsTaskList(
      */
     fun getTask(id: Long): Entity? {
         try {
-            client.query(taskUri(id, true), null, null, null, null)?.use { cursor ->
+            client.query(taskUri(id), null, null, null, null)?.use { cursor ->
                 if (cursor.moveToFirst()) {
-                    // first row holds entity main values
                     val entity = Entity(cursor.toContentValues())
-                    // remaining rows hold entity subvalues (extended properties)
-                    while (cursor.moveToNext()) {
-                        val cv = cursor.toContentValues()   // MIMETYPE is stored in ContentValues
-                        entity.addSubValue(tasksPropertiesUri(), cv)
+                    client.query(
+                        tasksPropertiesUri(),
+                        null,
+                        "${TaskContract.Properties.TASK_ID}=?",
+                        arrayOf(id.toString()),
+                        null
+                    )?.use { propertiesCursor ->
+                        while (propertiesCursor.moveToNext()) {
+                            entity.addSubValue(tasksPropertiesUri(), propertiesCursor.toContentValues())
+                        }
                     }
                     return entity
                 }
@@ -455,7 +460,7 @@ class DmfsTaskList(
         ContentUris.withAppendedId(tasksUri(loadProperties), id)
 
     fun tasksPropertiesUri(): Uri =
-        TaskContract.Properties.getContentUri(providerName.authority)
+        TaskContract.Properties.getContentUri(providerName.authority).asSyncAdapter(account)
 
     /**
      * Restricts a given selection/where clause to this task list ID.

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
@@ -14,7 +14,6 @@ import at.bitfire.ical4android.util.MiscUtils.asSyncAdapter
 import at.bitfire.synctools.storage.BatchOperation
 import at.bitfire.synctools.storage.LocalStorageException
 import at.bitfire.synctools.storage.toContentValues
-import net.fortuna.ical4j.model.Content
 import org.dmfs.tasks.contract.TaskContract
 import java.util.LinkedList
 import java.util.logging.Logger
@@ -167,9 +166,7 @@ class DmfsTaskList(
                     val entity = Entity(cursor.toContentValues())
                     // remaining rows hold entity subvalues (extended properties)
                     while (cursor.moveToNext()) {
-                        val cv = cursor.toContentValues()
-                        // Use base properties URI for all sub-values so that Entity can be used
-                        // for both reading and writing. MIMETYPE is stored in ContentValues.
+                        val cv = cursor.toContentValues()   // MIMETYPE is stored in ContentValues
                         entity.addSubValue(tasksPropertiesUri(), cv)
                     }
                     return entity
@@ -457,11 +454,8 @@ class DmfsTaskList(
     fun taskUri(id: Long, loadProperties: Boolean = false): Uri =
         ContentUris.withAppendedId(tasksUri(loadProperties), id)
 
-    fun tasksPropertiesUri() =
-        TaskContract.Properties.getContentUri(providerName.authority).asSyncAdapter(account)
-
-    fun tasksPropertyUri(mimetype: String): Uri =
-        tasksPropertiesUri().buildUpon().appendPath(mimetype).build()!!
+    fun tasksPropertiesUri(): Uri =
+        TaskContract.Properties.getContentUri(providerName.authority)
 
     /**
      * Restricts a given selection/where clause to this task list ID.

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
@@ -103,9 +103,7 @@ class DmfsTaskList(
     }
 
     /**
-     * Gets the first task row that matches the given query.
-     *
-     * Adds a WHERE clause that restricts the query to [TaskContract.TaskColumns.LIST_ID] = [id].
+     * Gets the first task row in the task list that matches the given query.
      *
      * @param projection    requested fields
      * @param where         selection
@@ -130,6 +128,9 @@ class DmfsTaskList(
 
     /**
      * Queries all tasks from this task list.
+     *
+     * Should be used rarely because it has a potentially large memory footprint.
+     * Prefer [iterateTaskRows].
      *
      * @return list of task entities
      *
@@ -160,9 +161,11 @@ class DmfsTaskList(
      */
     fun getTask(id: Long): Entity? {
         try {
-            client.query(taskUri(id), null, null, null, null)?.use { cursor ->
+            // query tasks
+            client.query(taskUri(id, loadProperties = false), null, null, null, null)?.use { cursor ->
                 if (cursor.moveToFirst()) {
                     val entity = Entity(cursor.toContentValues())
+                    // explicitly load task properties into subrows
                     client.query(
                         tasksPropertiesUri(),
                         null,
@@ -170,9 +173,8 @@ class DmfsTaskList(
                         arrayOf(id.toString()),
                         null
                     )?.use { propertiesCursor ->
-                        while (propertiesCursor.moveToNext()) {
+                        while (propertiesCursor.moveToNext())
                             entity.addSubValue(tasksPropertiesUri(), propertiesCursor.toContentValues())
-                        }
                     }
                     return entity
                 }
@@ -186,8 +188,6 @@ class DmfsTaskList(
     /**
      * Iterates task rows from this task list.
      *
-     * Adds a WHERE clause that restricts the query to [TaskContract.TaskColumns.LIST_ID] = [id].
-     *
      * @param projection    requested fields
      * @param where         selection
      * @param whereArgs     arguments for selection
@@ -200,7 +200,8 @@ class DmfsTaskList(
             val (protectedWhere, protectedWhereArgs) = whereWithTaskListId(where, whereArgs)
             client.query(tasksUri(), projection, protectedWhere, protectedWhereArgs, null)?.use { cursor ->
                 while (cursor.moveToNext()) {
-                    body(cursor.toContentValues())
+                    val row = cursor.toContentValues()
+                    body(row)
                 }
             }
         } catch (e: RemoteException) {
@@ -281,15 +282,15 @@ class DmfsTaskList(
      *
      * @param id    ID of the task
      *
+     * @return number of affected rows
      * @throws LocalStorageException when the content provider returns an error
      */
-    fun deleteTask(id: Long) {
+    fun deleteTask(id: Long): Int =
         try {
             client.delete(taskUri(id), null, null)
         } catch (e: RemoteException) {
             throw LocalStorageException("Couldn't delete task $id", e)
         }
-    }
 
 
     // CRUD DmfsTask

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
@@ -54,40 +54,239 @@ class DmfsTaskList(
 
     // CRUD tasks
 
+    /**
+     * Inserts a task into the task provider.
+     *
+     * @param entity    task to insert (with main row values and sub-values)
+     *
+     * @return ID of the new task
+     *
+     * @throws LocalStorageException when the content provider returns an error
+     */
     fun addTask(entity: Entity): Long {
-        TODO()
+        try {
+            val batch = TasksBatchOperation(client)
+            val backRefIdx = addTask(entity, batch)
+            batch.commit()
+
+            val uri = batch.getResult(backRefIdx)?.uri
+                ?: throw LocalStorageException("Content provider returned null on insert")
+            return ContentUris.parseId(uri)
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't insert task", e)
+        }
     }
 
-    fun addTask(entity: Entity, batch: TasksBatchOperation): Long {
-        TODO()
+    /**
+     * Enqueues an insert operation for a task into a batch.
+     *
+     * @param entity    task to insert (with main row values and sub-values)
+     * @param batch     batch operation in which the insert is enqueued
+     *
+     * @return back-reference index of the main task row
+     */
+    fun addTask(entity: Entity, batch: TasksBatchOperation): Int {
+        // insert task row
+        val taskRowIdx = batch.nextBackrefIdx()
+        batch += BatchOperation.CpoBuilder
+            .newInsert(tasksUri())
+            .withValues(entity.entityValues)
+
+        // insert property rows (with reference to task row ID)
+        for (row in entity.subValues) {
+            batch += BatchOperation.CpoBuilder
+                .newInsert(row.uri)
+                .withValues(row.values)
+                .withValueBackReference(TaskContract.Properties.TASK_ID, taskRowIdx)
+        }
+
+        return taskRowIdx
     }
 
+    /**
+     * Gets the first task row that matches the given query.
+     *
+     * Adds a WHERE clause that restricts the query to [TaskContract.TaskColumns.LIST_ID] = [id].
+     *
+     * @param projection    requested fields
+     * @param where         selection
+     * @param whereArgs     arguments for selection
+     *
+     * @return first task row that matches the selection, or `null` if none found
+     *
+     * @throws LocalStorageException when the content provider returns an error
+     */
     fun findTaskRow(projection: Array<String>?, where: String?, whereArgs: Array<String>?): ContentValues? {
-        TODO()
+        try {
+            val (protectedWhere, protectedWhereArgs) = whereWithTaskListId(where, whereArgs)
+            client.query(tasksUri(), projection, protectedWhere, protectedWhereArgs, null)?.use { cursor ->
+                if (cursor.moveToNext())
+                    return cursor.toContentValues()
+            }
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't query task rows", e)
+        }
+        return null
     }
 
+    /**
+     * Queries all tasks from this task list.
+     *
+     * @return list of task entities
+     *
+     * @throws LocalStorageException when the content provider returns an error
+     */
     fun findTasks(): List<Entity> {
-        TODO("use iterateTaskRows and call getTask for every row to build list")
+        val entities = LinkedList<Entity>()
+        try {
+            iterateTaskRows(null, null, null) { row ->
+                val id = row.getAsLong(TaskContract.Tasks._ID) ?: return@iterateTaskRows
+                val entity = getTask(id) ?: return@iterateTaskRows
+                entities += entity
+            }
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't query tasks", e)
+        }
+        return entities
     }
 
+    /**
+     * Gets a specific task, identified by its ID, from this task list.
+     *
+     * @param id    task ID
+     *
+     * @return task entity (or `null` if not found)
+     *
+     * @throws LocalStorageException when the content provider returns an error
+     */
     fun getTask(id: Long): Entity? {
-        TODO("get main row, data rows and put together to Entity")
+        try {
+            client.query(taskUri(id, true), null, null, null, null)?.use { cursor ->
+                if (cursor.moveToFirst()) {
+                    // first row holds entity main values
+                    val entity = Entity(cursor.toContentValues())
+                    // remaining rows hold entity subvalues (extended properties)
+                    while (cursor.moveToNext()) {
+                        val cv = cursor.toContentValues()
+                        // Use base properties URI for all sub-values so that Entity can be used
+                        // for both reading and writing. MIMETYPE is stored in ContentValues.
+                        entity.addSubValue(tasksPropertiesUri(), cv)
+                    }
+                    return entity
+                }
+            }
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't query task entity", e)
+        }
+        return null
     }
 
+    /**
+     * Iterates task rows from this task list.
+     *
+     * Adds a WHERE clause that restricts the query to [TaskContract.TaskColumns.LIST_ID] = [id].
+     *
+     * @param projection    requested fields
+     * @param where         selection
+     * @param whereArgs     arguments for selection
+     * @param body          callback that is called for each main row
+     *
+     * @throws LocalStorageException when the content provider returns an error
+     */
     fun iterateTaskRows(projection: Array<String>?, where: String?, whereArgs: Array<String>?, body: (ContentValues) -> Unit) {
-        TODO()
+        try {
+            val (protectedWhere, protectedWhereArgs) = whereWithTaskListId(where, whereArgs)
+            client.query(tasksUri(), projection, protectedWhere, protectedWhereArgs, null)?.use { cursor ->
+                while (cursor.moveToNext()) {
+                    body(cursor.toContentValues())
+                }
+            }
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't iterate task rows", e)
+        }
     }
 
+    /**
+     * Updates a specific task's main row with the given values. Doesn't influence property rows.
+     *
+     * @param id        task ID
+     * @param values    new values
+     *
+     * @throws LocalStorageException when the content provider returns an error
+     */
     fun updateTaskRow(id: Long, values: ContentValues) {
-        TODO("update Task row with new values")
+        try {
+            client.update(taskUri(id), values, null, null)
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't update task row $id", e)
+        }
     }
 
+    /**
+     * Updates a specific task's main row and property rows with the values from the given entity.
+     *
+     * @param id        task ID
+     * @param entity    new values of the task (main row and sub-values)
+     *
+     * @throws LocalStorageException when the content provider returns an error
+     */
     fun updateTask(id: Long, entity: Entity) {
-        TODO("updateTask row and data rows with new values")
+        try {
+            val batch = TasksBatchOperation(client)
+            updateTask(id, entity, batch)
+            batch.commit()
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't update task $id", e)
+        }
     }
 
+    /**
+     * Enqueues an update of a task into a batch operation.
+     *
+     * @param id        task ID
+     * @param entity    new values of the task (main row and sub-values)
+     * @param batch     batch operation in which the update is enqueued
+     */
+    fun updateTask(id: Long, entity: Entity, batch: TasksBatchOperation) {
+        // delete existing property rows for this task
+        batch += BatchOperation.CpoBuilder
+            .newDelete(tasksPropertiesUri())
+            .withSelection("${TaskContract.Properties.TASK_ID}=?", arrayOf(id.toString()))
+
+        // update main row
+        val newValues = ContentValues(entity.entityValues).apply {
+            remove(TaskContract.Tasks._ID) // don't update task ID
+        }
+        batch += BatchOperation.CpoBuilder
+            .newUpdate(taskUri(id))
+            .withValues(newValues)
+
+        // insert new property rows (with reference to task ID)
+        for (row in entity.subValues) {
+            batch += BatchOperation.CpoBuilder
+                .newInsert(row.uri)
+                .withValues(ContentValues(row.values).apply {
+                    remove(TaskContract.Properties.PROPERTY_ID) // don't reuse property IDs
+                    put(TaskContract.Properties.TASK_ID, id)
+                })
+        }
+    }
+
+    /**
+     * Deletes a task row.
+     *
+     * The content provider automatically deletes associated property rows.
+     *
+     * @param id    ID of the task
+     *
+     * @throws LocalStorageException when the content provider returns an error
+     */
     fun deleteTask(id: Long) {
-        TODO()
+        try {
+            client.delete(taskUri(id), null, null)
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't delete task $id", e)
+        }
     }
 
 
@@ -171,8 +370,9 @@ class DmfsTaskList(
                     // remaining rows hold entity subvalues (extended properties)
                     while (cursor.moveToNext()) {
                         val cv = cursor.toContentValues()
-                        val mimetype = cv.getAsString(TaskContract.PropertyColumns.MIMETYPE) // CONTENT_ITEM_TYPE of extended property
-                        entity.addSubValue(tasksPropertyUri(mimetype), cv)
+                        // Use base properties URI for all sub-values so that Entity can be used
+                        // for both reading and writing. MIMETYPE is stored in ContentValues.
+                        entity.addSubValue(tasksPropertiesUri(), cv)
                     }
                     return entity
                 }


### PR DESCRIPTION
This PR implements CRUD operations for `DmfsTaskList` using `Entity` and `ContentValues`, following the design pattern from `AndroidCalendar.kt` for tasks.