### PR TITLE
[DmfsTask] Create `DmfsTaskFieldHandler2` interface

### DIFF
--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/DmfsTaskFieldHandler2.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/DmfsTaskFieldHandler2.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.synctools.mapping.tasks.handler
+
+import android.content.Entity
+import at.bitfire.synctools.exception.InvalidLocalResourceException
+import net.fortuna.ical4j.model.component.VToDo
+
+interface DmfsTaskFieldHandler2 {
+
+    /**
+     * Takes specific data from a task (= task row + data rows, taken from the content provider)
+     * and maps it into the given [VToDo].
+     *
+     * If [from] references the same object as [main], this method is called for a main task (not an exception).
+     * If [from] references another object as [main], this method is called for an exception (not a main task).
+     *
+     * @param from task from the content provider
+     * @param main main task from the content provider
+     * @param to destination object where the mapped data is stored
+     *
+     * @throws InvalidLocalResourceException on missing or invalid required fields
+     */
+    fun process(from: Entity, main: Entity, to: VToDo)
+}


### PR DESCRIPTION
Adds a `DmfsTaskFieldHandler2` interface that will eventually replace `DmfsTaskFieldHandler` (#2303) and then be renamed to `DmfsTaskFieldHandler` (#2305).