### PR TITLE
DmfsTask: Migrate status field builders to VToDo

### DIFF
--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/ClassificationBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/ClassificationBuilder.kt
@@ -6,13 +6,26 @@ package at.bitfire.synctools.mapping.tasks.builder
 
 import android.content.Entity
 import at.bitfire.ical4android.Task
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Clazz
 import net.fortuna.ical4j.model.property.immutable.ImmutableClazz
 import org.dmfs.tasks.contract.TaskContract.Tasks
+import kotlin.jvm.optionals.getOrNull
 
-class ClassificationBuilder : DmfsTaskFieldBuilder {
+class ClassificationBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
     override fun build(from: Task, to: Entity) {
         to.entityValues.put(Tasks.CLASSIFICATION, when (from.classification?.value?.uppercase()) {
+            ImmutableClazz.VALUE_PUBLIC       -> Tasks.CLASSIFICATION_PUBLIC
+            ImmutableClazz.VALUE_CONFIDENTIAL -> Tasks.CLASSIFICATION_CONFIDENTIAL
+            null                              -> Tasks.CLASSIFICATION_DEFAULT
+            else                              -> Tasks.CLASSIFICATION_PRIVATE    // all unknown classifications MUST be treated as PRIVATE
+        })
+    }
+
+    override fun build(from: VToDo, to: Entity) {
+        val clazz = from.getProperty<Clazz>(Clazz.CLASS).getOrNull()
+        to.entityValues.put(Tasks.CLASSIFICATION, when (clazz?.value?.uppercase()) {
             ImmutableClazz.VALUE_PUBLIC       -> Tasks.CLASSIFICATION_PUBLIC
             ImmutableClazz.VALUE_CONFIDENTIAL -> Tasks.CLASSIFICATION_CONFIDENTIAL
             null                              -> Tasks.CLASSIFICATION_DEFAULT

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/CompletedBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/CompletedBuilder.kt
@@ -8,13 +8,23 @@ import android.content.Entity
 import at.bitfire.ical4android.Task
 import at.bitfire.synctools.icalendar.DatePropertyTzMapper.normalizedDate
 import at.bitfire.synctools.util.AndroidTimeUtils.toTimestamp
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Completed
 import org.dmfs.tasks.contract.TaskContract.Tasks
+import kotlin.jvm.optionals.getOrNull
 
-class CompletedBuilder : DmfsTaskFieldBuilder {
+class CompletedBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
     override fun build(from: Task, to: Entity) {
         // COMPLETED must always be a DATE-TIME
         to.entityValues.put(Tasks.COMPLETED, from.completedAt?.normalizedDate()?.toTimestamp())
+        to.entityValues.put(Tasks.COMPLETED_IS_ALLDAY, 0)
+    }
+
+    override fun build(from: VToDo, to: Entity) {
+        val completed = from.getProperty<Completed>(Completed.COMPLETED).getOrNull()
+        // COMPLETED must always be a DATE-TIME
+        to.entityValues.put(Tasks.COMPLETED, completed?.normalizedDate()?.toTimestamp())
         to.entityValues.put(Tasks.COMPLETED_IS_ALLDAY, 0)
     }
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/PercentCompleteBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/PercentCompleteBuilder.kt
@@ -6,12 +6,20 @@ package at.bitfire.synctools.mapping.tasks.builder
 
 import android.content.Entity
 import at.bitfire.ical4android.Task
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.PercentComplete
 import org.dmfs.tasks.contract.TaskContract.Tasks
+import kotlin.jvm.optionals.getOrNull
 
-class PercentCompleteBuilder : DmfsTaskFieldBuilder {
+class PercentCompleteBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
     override fun build(from: Task, to: Entity) {
         to.entityValues.put(Tasks.PERCENT_COMPLETE, from.percentComplete)
+    }
+
+    override fun build(from: VToDo, to: Entity) {
+        val percentComplete = from.getProperty<PercentComplete>(PercentComplete.PERCENT_COMPLETE).getOrNull()
+        to.entityValues.put(Tasks.PERCENT_COMPLETE, percentComplete?.percentage)
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/PriorityBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/PriorityBuilder.kt
@@ -6,12 +6,20 @@ package at.bitfire.synctools.mapping.tasks.builder
 
 import android.content.Entity
 import at.bitfire.ical4android.Task
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Priority
 import org.dmfs.tasks.contract.TaskContract.Tasks
+import kotlin.jvm.optionals.getOrNull
 
-class PriorityBuilder : DmfsTaskFieldBuilder {
+class PriorityBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
     override fun build(from: Task, to: Entity) {
         to.entityValues.put(Tasks.PRIORITY, from.priority)
+    }
+
+    override fun build(from: VToDo, to: Entity) {
+        val priority = from.getProperty<Priority>(Priority.PRIORITY).getOrNull()
+        to.entityValues.put(Tasks.PRIORITY, priority?.level ?: Priority.VALUE_UNDEFINED)
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/StatusBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/StatusBuilder.kt
@@ -6,13 +6,26 @@ package at.bitfire.synctools.mapping.tasks.builder
 
 import android.content.Entity
 import at.bitfire.ical4android.Task
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Status
 import net.fortuna.ical4j.model.property.immutable.ImmutableStatus
 import org.dmfs.tasks.contract.TaskContract.Tasks
+import kotlin.jvm.optionals.getOrNull
 
-class StatusBuilder : DmfsTaskFieldBuilder {
+class StatusBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
     override fun build(from: Task, to: Entity) {
         to.entityValues.put(Tasks.STATUS, when (from.status?.value) {
+            ImmutableStatus.VALUE_IN_PROCESS -> Tasks.STATUS_IN_PROCESS
+            ImmutableStatus.VALUE_COMPLETED  -> Tasks.STATUS_COMPLETED
+            ImmutableStatus.VALUE_CANCELLED  -> Tasks.STATUS_CANCELLED
+            else                             -> Tasks.STATUS_DEFAULT    // == Tasks.STATUS_NEEDS_ACTION
+        })
+    }
+
+    override fun build(from: VToDo, to: Entity) {
+        val status = from.getProperty<Status>(Status.STATUS).getOrNull()
+        to.entityValues.put(Tasks.STATUS, when (status?.value) {
             ImmutableStatus.VALUE_IN_PROCESS -> Tasks.STATUS_IN_PROCESS
             ImmutableStatus.VALUE_COMPLETED  -> Tasks.STATUS_COMPLETED
             ImmutableStatus.VALUE_CANCELLED  -> Tasks.STATUS_CANCELLED

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/ClassificationBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/ClassificationBuilderTest.kt
@@ -8,6 +8,7 @@ import android.content.ContentValues
 import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.mapping.tasks.VToDoUtil
 import at.bitfire.synctools.test.assertContentValuesEqual
 import net.fortuna.ical4j.model.property.Clazz
 import net.fortuna.ical4j.model.property.immutable.ImmutableClazz
@@ -22,7 +23,7 @@ class ClassificationBuilderTest {
     private val builder = ClassificationBuilder()
 
     @Test
-    fun `No CLASS defaults to DEFAULT`() {
+    fun `old No CLASS defaults to DEFAULT`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(),
@@ -34,7 +35,7 @@ class ClassificationBuilderTest {
     }
 
     @Test
-    fun `CLASS is PUBLIC`() {
+    fun `old CLASS is PUBLIC`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(classification = Clazz(ImmutableClazz.VALUE_PUBLIC)),
@@ -46,7 +47,7 @@ class ClassificationBuilderTest {
     }
 
     @Test
-    fun `CLASS is PRIVATE`() {
+    fun `old CLASS is PRIVATE`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(classification = Clazz(ImmutableClazz.VALUE_PRIVATE)),
@@ -58,7 +59,7 @@ class ClassificationBuilderTest {
     }
 
     @Test
-    fun `CLASS is CONFIDENTIAL`() {
+    fun `old CLASS is CONFIDENTIAL`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(classification = Clazz(ImmutableClazz.VALUE_CONFIDENTIAL)),
@@ -70,10 +71,70 @@ class ClassificationBuilderTest {
     }
 
     @Test
-    fun `Unknown CLASS maps to PRIVATE`() {
+    fun `old Unknown CLASS maps to PRIVATE`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(classification = Clazz("X-CUSTOM")),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.CLASSIFICATION to Tasks.CLASSIFICATION_PRIVATE
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `No CLASS defaults to DEFAULT`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.CLASSIFICATION to Tasks.CLASSIFICATION_DEFAULT
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `CLASS is PUBLIC`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(Clazz(ImmutableClazz.VALUE_PUBLIC)),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.CLASSIFICATION to Tasks.CLASSIFICATION_PUBLIC
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `CLASS is PRIVATE`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(Clazz(ImmutableClazz.VALUE_PRIVATE)),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.CLASSIFICATION to Tasks.CLASSIFICATION_PRIVATE
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `CLASS is CONFIDENTIAL`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(Clazz(ImmutableClazz.VALUE_CONFIDENTIAL)),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.CLASSIFICATION to Tasks.CLASSIFICATION_CONFIDENTIAL
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `Unknown CLASS maps to PRIVATE`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(Clazz("X-CUSTOM")),
             to = result
         )
         assertContentValuesEqual(contentValuesOf(

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/CompletedBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/CompletedBuilderTest.kt
@@ -9,6 +9,7 @@ import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.DefaultTimezoneRule
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.mapping.tasks.VToDoUtil
 import at.bitfire.synctools.test.assertContentValuesEqual
 import at.bitfire.synctools.util.AndroidTimeUtils.toTimestamp
 import net.fortuna.ical4j.model.property.Completed
@@ -30,10 +31,55 @@ class CompletedBuilderTest {
     private val builder = CompletedBuilder()
 
     @Test
-    fun `No COMPLETED`() {
+    fun `old No COMPLETED`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.COMPLETED to null,
+            Tasks.COMPLETED_IS_ALLDAY to 0
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `old COMPLETED is set`() {
+        val instant = Instant.ofEpochMilli(1_000_000L)
+        val result = Entity(ContentValues())
+        builder.build(
+            from = Task(completedAt = Completed(instant)),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.COMPLETED to 1_000_000L,
+            Tasks.COMPLETED_IS_ALLDAY to 0
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `old COMPLETED is floating LocalDateTime`() {
+        // COMPLETED without timezone (floating) must not crash with ClassCastException
+        // A floating COMPLETED is represented as a string without 'Z' (e.g. "20240601T120000")
+        val result = Entity(ContentValues())
+        builder.build(
+            from = Task(completedAt = Completed("20240601T120000")),
+            to = result
+        )
+        // floating date-time is interpreted in system default timezone
+        val expectedTimestamp = LocalDateTime.of(2024, 6, 1, 12, 0, 0)
+            .atZone(ZoneId.systemDefault()).toInstant().toTimestamp()
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.COMPLETED to expectedTimestamp,
+            Tasks.COMPLETED_IS_ALLDAY to 0
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `No COMPLETED`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(),
             to = result
         )
         assertContentValuesEqual(contentValuesOf(
@@ -47,7 +93,7 @@ class CompletedBuilderTest {
         val instant = Instant.ofEpochMilli(1_000_000L)
         val result = Entity(ContentValues())
         builder.build(
-            from = Task(completedAt = Completed(instant)),
+            from = VToDoUtil.build(Completed(instant)),
             to = result
         )
         assertContentValuesEqual(contentValuesOf(
@@ -62,7 +108,7 @@ class CompletedBuilderTest {
         // A floating COMPLETED is represented as a string without 'Z' (e.g. "20240601T120000")
         val result = Entity(ContentValues())
         builder.build(
-            from = Task(completedAt = Completed("20240601T120000")),
+            from = VToDoUtil.build(Completed("20240601T120000")),
             to = result
         )
         // floating date-time is interpreted in system default timezone

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/PercentCompleteBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/PercentCompleteBuilderTest.kt
@@ -8,7 +8,9 @@ import android.content.ContentValues
 import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.mapping.tasks.VToDoUtil
 import at.bitfire.synctools.test.assertContentValuesEqual
+import net.fortuna.ical4j.model.property.PercentComplete
 import org.dmfs.tasks.contract.TaskContract.Tasks
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -20,7 +22,7 @@ class PercentCompleteBuilderTest {
     private val builder = PercentCompleteBuilder()
 
     @Test
-    fun `No PERCENT-COMPLETE`() {
+    fun `old No PERCENT-COMPLETE`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(),
@@ -32,7 +34,7 @@ class PercentCompleteBuilderTest {
     }
 
     @Test
-    fun `PERCENT-COMPLETE is 50`() {
+    fun `old PERCENT-COMPLETE is 50`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(percentComplete = 50),
@@ -44,10 +46,46 @@ class PercentCompleteBuilderTest {
     }
 
     @Test
-    fun `PERCENT-COMPLETE is 100`() {
+    fun `old PERCENT-COMPLETE is 100`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(percentComplete = 100),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.PERCENT_COMPLETE to 100
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `No PERCENT-COMPLETE`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.PERCENT_COMPLETE to null
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `PERCENT-COMPLETE is 50`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(PercentComplete(50)),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.PERCENT_COMPLETE to 50
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `PERCENT-COMPLETE is 100`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(PercentComplete(100)),
             to = result
         )
         assertContentValuesEqual(contentValuesOf(

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/PriorityBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/PriorityBuilderTest.kt
@@ -8,7 +8,9 @@ import android.content.ContentValues
 import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.mapping.tasks.VToDoUtil
 import at.bitfire.synctools.test.assertContentValuesEqual
+import net.fortuna.ical4j.model.property.Priority
 import org.dmfs.tasks.contract.TaskContract.Tasks
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -20,7 +22,7 @@ class PriorityBuilderTest {
     private val builder = PriorityBuilder()
 
     @Test
-    fun `No PRIORITY`() {
+    fun `old No PRIORITY`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(),
@@ -32,10 +34,34 @@ class PriorityBuilderTest {
     }
 
     @Test
-    fun `PRIORITY is 5`() {
+    fun `old PRIORITY is 5`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(priority = 5),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.PRIORITY to 5
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `No PRIORITY`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.PRIORITY to Priority.VALUE_UNDEFINED
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `PRIORITY is 5`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(Priority(5)),
             to = result
         )
         assertContentValuesEqual(contentValuesOf(

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/StatusBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/StatusBuilderTest.kt
@@ -8,6 +8,7 @@ import android.content.ContentValues
 import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.mapping.tasks.VToDoUtil
 import at.bitfire.synctools.test.assertContentValuesEqual
 import net.fortuna.ical4j.model.property.Status
 import net.fortuna.ical4j.model.property.immutable.ImmutableStatus
@@ -22,7 +23,7 @@ class StatusBuilderTest {
     private val builder = StatusBuilder()
 
     @Test
-    fun `No STATUS defaults to STATUS_DEFAULT`() {
+    fun `old No STATUS defaults to STATUS_DEFAULT`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(),
@@ -34,7 +35,7 @@ class StatusBuilderTest {
     }
 
     @Test
-    fun `STATUS is NEEDS-ACTION`() {
+    fun `old STATUS is NEEDS-ACTION`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(status = Status(ImmutableStatus.VALUE_NEEDS_ACTION)),
@@ -46,7 +47,7 @@ class StatusBuilderTest {
     }
 
     @Test
-    fun `STATUS is IN-PROCESS`() {
+    fun `old STATUS is IN-PROCESS`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(status = Status(ImmutableStatus.VALUE_IN_PROCESS)),
@@ -58,7 +59,7 @@ class StatusBuilderTest {
     }
 
     @Test
-    fun `STATUS is COMPLETED`() {
+    fun `old STATUS is COMPLETED`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(status = Status(ImmutableStatus.VALUE_COMPLETED)),
@@ -70,10 +71,70 @@ class StatusBuilderTest {
     }
 
     @Test
-    fun `STATUS is CANCELLED`() {
+    fun `old STATUS is CANCELLED`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(status = Status(ImmutableStatus.VALUE_CANCELLED)),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.STATUS to Tasks.STATUS_CANCELLED
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `No STATUS defaults to STATUS_DEFAULT`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.STATUS to Tasks.STATUS_DEFAULT
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `STATUS is NEEDS-ACTION`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(Status(ImmutableStatus.VALUE_NEEDS_ACTION)),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.STATUS to Tasks.STATUS_NEEDS_ACTION
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `STATUS is IN-PROCESS`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(Status(ImmutableStatus.VALUE_IN_PROCESS)),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.STATUS to Tasks.STATUS_IN_PROCESS
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `STATUS is COMPLETED`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(Status(ImmutableStatus.VALUE_COMPLETED)),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.STATUS to Tasks.STATUS_COMPLETED
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `STATUS is CANCELLED`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(Status(ImmutableStatus.VALUE_CANCELLED)),
             to = result
         )
         assertContentValuesEqual(contentValuesOf(


### PR DESCRIPTION
### Purpose

Migrate more status field builders to map from `VToDo` to `Entity` instead of `Task`.

### Short description

Migrate
-  `PriorityBuilder`
- `ClassificationBuilder`
- `StatusBuilder`
- `CompletedBuilder`
- `PercentCompleteBuilder` 

... to also implement `DmfsTaskFieldBuilderVToDo` with a `build(VToDo, Entity)` method.


### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

