### PR TITLE
Migrate recurrence field builders to VToDo

### DIFF
--- a/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/Ical4jHelpers.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/Ical4jHelpers.kt
@@ -4,6 +4,7 @@
 
 package at.bitfire.synctools.icalendar
 
+import at.bitfire.ical4android.util.DateUtils
 import at.bitfire.synctools.BuildConfig
 import at.bitfire.synctools.exception.InvalidICalendarException
 import net.fortuna.ical4j.model.Component
@@ -15,6 +16,7 @@ import net.fortuna.ical4j.model.PropertyContainer
 import net.fortuna.ical4j.model.PropertyList
 import net.fortuna.ical4j.model.component.CalendarComponent
 import net.fortuna.ical4j.model.component.VEvent
+import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.property.DtEnd
 import net.fortuna.ical4j.model.property.DtStart
 import net.fortuna.ical4j.model.property.Due
@@ -62,6 +64,19 @@ fun <T: Temporal> CalendarComponent.due(): Due<T>? {
 
 fun <T: Temporal> VEvent.requireDtStart(): DtStart<T> =
     getProperty<DtStart<T>>(Property.DTSTART).getOrNull() ?: throw InvalidICalendarException("Missing DTSTART in VEVENT")
+
+/**
+ * Whether this VTODO represents an all-day task.
+ *
+ * All-day tasks use DATE values (not DATE-TIME). Returns `true` if:
+ * - DTSTART is a DATE value, or
+ * - DTSTART is absent and DUE is a DATE value, or
+ * - both DTSTART and DUE are absent.
+ */
+fun VToDo.isAllDay(): Boolean =
+    dtStart<Temporal>()?.let { DateUtils.isDate(it) }
+        ?: due<Temporal>()?.let { DateUtils.isDate(it) }
+        ?: true
 
 operator fun PropertyContainer.plusAssign(property: Property) {
     add<PropertyContainer>(property)

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/AllDayBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/AllDayBuilder.kt
@@ -6,21 +6,40 @@ package at.bitfire.synctools.mapping.tasks.builder
 
 import android.content.Entity
 import at.bitfire.ical4android.Task
+import at.bitfire.ical4android.util.DateUtils
 import net.fortuna.ical4j.model.Parameter
 import net.fortuna.ical4j.model.TimeZone
 import net.fortuna.ical4j.model.TimeZoneRegistryFactory
+import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.parameter.TzId
+import net.fortuna.ical4j.model.property.DtStart
+import net.fortuna.ical4j.model.property.Due
 import net.fortuna.ical4j.util.TimeZones
 import org.dmfs.tasks.contract.TaskContract.Tasks
 import java.time.ZoneId
 import kotlin.jvm.optionals.getOrNull
 
-class AllDayBuilder : DmfsTaskFieldBuilder {
+class AllDayBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
     private val tzRegistry by lazy { TimeZoneRegistryFactory.getInstance().createRegistry() }
 
     override fun build(from: Task, to: Entity) {
         val allDay = from.isAllDay()
+        if (allDay) {
+            to.entityValues.put(Tasks.IS_ALLDAY, 1)
+            to.entityValues.putNull(Tasks.TZ)
+        } else {
+            to.entityValues.put(Tasks.IS_ALLDAY, 0)
+            to.entityValues.put(Tasks.TZ, getTimeZone(from).id)
+        }
+    }
+
+    override fun build(from: VToDo, to: Entity) {
+        val dtStart = from.getProperty<DtStart<*>>(DtStart.DTSTART).getOrNull()
+        val due = from.getProperty<Due<*>>(Due.DUE).getOrNull()
+        val allDay = dtStart?.let { DateUtils.isDate(it) }
+            ?: due?.let { DateUtils.isDate(it) }
+            ?: true
         if (allDay) {
             to.entityValues.put(Tasks.IS_ALLDAY, 1)
             to.entityValues.putNull(Tasks.TZ)
@@ -42,6 +61,30 @@ class AllDayBuilder : DmfsTaskFieldBuilder {
                 TimeZones.UTC_ID
             else
                 due.getParameter<TzId>(Parameter.TZID).getOrNull()?.value
+        } ?:
+        ZoneId.systemDefault().id
+
+        // 'Z' is not a valid timezone id, replace it by the UTC definition
+        if (tzId == "Z") tzId = TimeZones.UTC_ID
+
+        val timeZone: TimeZone? = tzRegistry.getTimeZone(tzId)
+        return timeZone ?: throw NullPointerException("Could not find timezone '$tzId' in registry.")
+    }
+
+    fun getTimeZone(vtodo: VToDo): TimeZone {
+        val dtStart = vtodo.getProperty<DtStart<*>>(DtStart.DTSTART).getOrNull()
+        val due = vtodo.getProperty<Due<*>>(Due.DUE).getOrNull()
+        var tzId = dtStart?.let { ds ->
+            if (ds.isUtc)
+                TimeZones.UTC_ID
+            else
+                ds.getParameter<TzId>(Parameter.TZID).getOrNull()?.value
+        } ?:
+        due?.let { d ->
+            if (d.isUtc)
+                TimeZones.UTC_ID
+            else
+                d.getParameter<TzId>(Parameter.TZID).getOrNull()?.value
         } ?:
         ZoneId.systemDefault().id
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/AllDayBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/AllDayBuilder.kt
@@ -6,7 +6,7 @@ package at.bitfire.synctools.mapping.tasks.builder
 
 import android.content.Entity
 import at.bitfire.ical4android.Task
-import at.bitfire.ical4android.util.DateUtils
+import at.bitfire.synctools.icalendar.isAllDay
 import net.fortuna.ical4j.model.Parameter
 import net.fortuna.ical4j.model.TimeZone
 import net.fortuna.ical4j.model.TimeZoneRegistryFactory
@@ -35,11 +35,7 @@ class AllDayBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
     }
 
     override fun build(from: VToDo, to: Entity) {
-        val dtStart = from.getProperty<DtStart<*>>(DtStart.DTSTART).getOrNull()
-        val due = from.getProperty<Due<*>>(Due.DUE).getOrNull()
-        val allDay = dtStart?.let { DateUtils.isDate(it) }
-            ?: due?.let { DateUtils.isDate(it) }
-            ?: true
+        val allDay = from.isAllDay()
         if (allDay) {
             to.entityValues.put(Tasks.IS_ALLDAY, 1)
             to.entityValues.putNull(Tasks.TZ)

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DueBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DueBuilder.kt
@@ -8,12 +8,20 @@ import android.content.Entity
 import at.bitfire.ical4android.Task
 import at.bitfire.synctools.icalendar.DatePropertyTzMapper.normalizedDate
 import at.bitfire.synctools.util.AndroidTimeUtils.toTimestamp
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Due
 import org.dmfs.tasks.contract.TaskContract.Tasks
+import kotlin.jvm.optionals.getOrNull
 
-class DueBuilder : DmfsTaskFieldBuilder {
+class DueBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
     override fun build(from: Task, to: Entity) {
         to.entityValues.put(Tasks.DUE, from.due?.normalizedDate()?.toTimestamp())
+    }
+
+    override fun build(from: VToDo, to: Entity) {
+        val due = from.getProperty<Due<*>>(Due.DUE).getOrNull()
+        to.entityValues.put(Tasks.DUE, due?.normalizedDate()?.toTimestamp())
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DurationBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DurationBuilder.kt
@@ -6,12 +6,20 @@ package at.bitfire.synctools.mapping.tasks.builder
 
 import android.content.Entity
 import at.bitfire.ical4android.Task
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Duration
 import org.dmfs.tasks.contract.TaskContract.Tasks
+import kotlin.jvm.optionals.getOrNull
 
-class DurationBuilder : DmfsTaskFieldBuilder {
+class DurationBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
     override fun build(from: Task, to: Entity) {
         to.entityValues.put(Tasks.DURATION, from.duration?.value)
+    }
+
+    override fun build(from: VToDo, to: Entity) {
+        val duration = from.getProperty<Duration>(Duration.DURATION).getOrNull()
+        to.entityValues.put(Tasks.DURATION, duration?.value)
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/RecurrenceFieldsBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/RecurrenceFieldsBuilder.kt
@@ -6,10 +6,18 @@ package at.bitfire.synctools.mapping.tasks.builder
 
 import android.content.Entity
 import at.bitfire.ical4android.Task
+import at.bitfire.ical4android.util.DateUtils
 import at.bitfire.synctools.util.AndroidTimeUtils
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.DtStart
+import net.fortuna.ical4j.model.property.Due
+import net.fortuna.ical4j.model.property.ExDate
+import net.fortuna.ical4j.model.property.RDate
+import net.fortuna.ical4j.model.property.RRule
 import org.dmfs.tasks.contract.TaskContract.Tasks
+import kotlin.jvm.optionals.getOrNull
 
-class RecurrenceFieldsBuilder : DmfsTaskFieldBuilder {
+class RecurrenceFieldsBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
     private val allDayBuilder = AllDayBuilder()
 
@@ -31,6 +39,34 @@ class RecurrenceFieldsBuilder : DmfsTaskFieldBuilder {
                 null
             else
                 AndroidTimeUtils.recurrenceSetsToOpenTasksString(from.exDates, tz)
+        )
+    }
+
+    override fun build(from: VToDo, to: Entity) {
+        val dtStart = from.getProperty<DtStart<*>>(DtStart.DTSTART).getOrNull()
+        val due = from.getProperty<Due<*>>(Due.DUE).getOrNull()
+        val allDay = dtStart?.let { DateUtils.isDate(it) }
+            ?: due?.let { DateUtils.isDate(it) }
+            ?: true
+        val tz = if (allDay) null else allDayBuilder.getTimeZone(from)
+
+        val rRule = from.getProperty<RRule<*>>(RRule.RRULE).getOrNull()
+        to.entityValues.put(Tasks.RRULE, rRule?.value)
+
+        val rDates = from.getProperties<RDate<*>>(RDate.RDATE)
+        to.entityValues.put(Tasks.RDATE,
+            if (rDates.isEmpty())
+                null
+            else
+                AndroidTimeUtils.recurrenceSetsToOpenTasksString(rDates, tz)
+        )
+
+        val exDates = from.getProperties<ExDate<*>>(ExDate.EXDATE)
+        to.entityValues.put(Tasks.EXDATE,
+            if (exDates.isEmpty())
+                null
+            else
+                AndroidTimeUtils.recurrenceSetsToOpenTasksString(exDates, tz)
         )
     }
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/RecurrenceFieldsBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/RecurrenceFieldsBuilder.kt
@@ -6,11 +6,9 @@ package at.bitfire.synctools.mapping.tasks.builder
 
 import android.content.Entity
 import at.bitfire.ical4android.Task
-import at.bitfire.ical4android.util.DateUtils
+import at.bitfire.synctools.icalendar.isAllDay
 import at.bitfire.synctools.util.AndroidTimeUtils
 import net.fortuna.ical4j.model.component.VToDo
-import net.fortuna.ical4j.model.property.DtStart
-import net.fortuna.ical4j.model.property.Due
 import net.fortuna.ical4j.model.property.ExDate
 import net.fortuna.ical4j.model.property.RDate
 import net.fortuna.ical4j.model.property.RRule
@@ -43,11 +41,7 @@ class RecurrenceFieldsBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo 
     }
 
     override fun build(from: VToDo, to: Entity) {
-        val dtStart = from.getProperty<DtStart<*>>(DtStart.DTSTART).getOrNull()
-        val due = from.getProperty<Due<*>>(Due.DUE).getOrNull()
-        val allDay = dtStart?.let { DateUtils.isDate(it) }
-            ?: due?.let { DateUtils.isDate(it) }
-            ?: true
+        val allDay = from.isAllDay()
         val tz = if (allDay) null else allDayBuilder.getTimeZone(from)
 
         val rRule = from.getProperty<RRule<*>>(RRule.RRULE).getOrNull()

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/StartTimeBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/StartTimeBuilder.kt
@@ -8,12 +8,20 @@ import android.content.Entity
 import at.bitfire.ical4android.Task
 import at.bitfire.synctools.icalendar.DatePropertyTzMapper.normalizedDate
 import at.bitfire.synctools.util.AndroidTimeUtils.toTimestamp
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.DtStart
 import org.dmfs.tasks.contract.TaskContract.Tasks
+import kotlin.jvm.optionals.getOrNull
 
-class StartTimeBuilder : DmfsTaskFieldBuilder {
+class StartTimeBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
     override fun build(from: Task, to: Entity) {
         to.entityValues.put(Tasks.DTSTART, from.dtStart?.normalizedDate()?.toTimestamp())
+    }
+
+    override fun build(from: VToDo, to: Entity) {
+        val dtStart = from.getProperty<DtStart<*>>(DtStart.DTSTART).getOrNull()
+        to.entityValues.put(Tasks.DTSTART, dtStart?.normalizedDate()?.toTimestamp())
     }
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/AllDayBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/AllDayBuilderTest.kt
@@ -9,6 +9,7 @@ import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.DefaultTimezoneRule
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.mapping.tasks.VToDoUtil
 import at.bitfire.synctools.test.assertContentValuesEqual
 import net.fortuna.ical4j.model.property.DtStart
 import net.fortuna.ical4j.model.property.Due
@@ -31,7 +32,7 @@ class AllDayBuilderTest {
     private val builder = AllDayBuilder()
 
     @Test
-    fun `No DTSTART and no DUE - treated as all-day`() {
+    fun `old No DTSTART and no DUE - treated as all-day`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(),
@@ -44,7 +45,7 @@ class AllDayBuilderTest {
     }
 
     @Test
-    fun `DTSTART is DATE - all-day`() {
+    fun `old DTSTART is DATE - all-day`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(dtStart = DtStart(LocalDate.of(2025, 1, 15))),
@@ -57,7 +58,7 @@ class AllDayBuilderTest {
     }
 
     @Test
-    fun `DTSTART is DATE-TIME - not all-day`() {
+    fun `old DTSTART is DATE-TIME - not all-day`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(dtStart = DtStart(ZonedDateTime.of(2025, 1, 15, 10, 0, 0, 0, ZoneOffset.UTC))),
@@ -70,7 +71,7 @@ class AllDayBuilderTest {
     }
 
     @Test
-    fun `DUE is DATE - all-day`() {
+    fun `old DUE is DATE - all-day`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(due = Due(LocalDate.of(2025, 1, 15))),
@@ -83,7 +84,7 @@ class AllDayBuilderTest {
     }
 
     @Test
-    fun `DUE is DATE-TIME - not all-day`() {
+    fun `old DUE is DATE-TIME - not all-day`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(due = Due(ZonedDateTime.of(2025, 1, 15, 10, 0, 0, 0, ZoneOffset.UTC))),
@@ -96,7 +97,7 @@ class AllDayBuilderTest {
     }
 
     @Test
-    fun `DTSTART is DATE-TIME with named timezone - not all-day`() {
+    fun `old DTSTART is DATE-TIME with named timezone - not all-day`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(dtStart = DtStart(ZonedDateTime.of(2025, 1, 15, 10, 0, 0, 0, defaultTimezone.defaultZoneId))),
@@ -109,7 +110,7 @@ class AllDayBuilderTest {
     }
 
     @Test
-    fun `DTSTART is floating DATE-TIME - not all-day, uses system default timezone`() {
+    fun `old DTSTART is floating DATE-TIME - not all-day, uses system default timezone`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(dtStart = DtStart(LocalDateTime.of(2025, 1, 15, 10, 0, 0))),
@@ -122,7 +123,7 @@ class AllDayBuilderTest {
     }
 
     @Test
-    fun `DUE is DATE-TIME with named timezone (no DTSTART) - not all-day`() {
+    fun `old DUE is DATE-TIME with named timezone (no DTSTART) - not all-day`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(due = Due(ZonedDateTime.of(2025, 1, 15, 10, 0, 0, 0, defaultTimezone.defaultZoneId))),
@@ -135,10 +136,127 @@ class AllDayBuilderTest {
     }
 
     @Test
-    fun `DUE is floating DATE-TIME (no DTSTART) - not all-day, uses system default timezone`() {
+    fun `old DUE is floating DATE-TIME (no DTSTART) - not all-day, uses system default timezone`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(due = Due(LocalDateTime.of(2025, 1, 15, 10, 0, 0))),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.IS_ALLDAY to 0,
+            Tasks.TZ to defaultTimezone.defaultZoneId.id
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `No DTSTART and no DUE - treated as all-day`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.IS_ALLDAY to 1,
+            Tasks.TZ to null
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `DTSTART is DATE - all-day`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(DtStart(LocalDate.of(2025, 1, 15))),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.IS_ALLDAY to 1,
+            Tasks.TZ to null
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `DTSTART is DATE-TIME - not all-day`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(DtStart(ZonedDateTime.of(2025, 1, 15, 10, 0, 0, 0, ZoneOffset.UTC))),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.IS_ALLDAY to 0,
+            Tasks.TZ to "Etc/UTC"
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `DUE is DATE - all-day`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(Due(LocalDate.of(2025, 1, 15))),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.IS_ALLDAY to 1,
+            Tasks.TZ to null
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `DUE is DATE-TIME - not all-day`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(Due(ZonedDateTime.of(2025, 1, 15, 10, 0, 0, 0, ZoneOffset.UTC))),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.IS_ALLDAY to 0,
+            Tasks.TZ to "Etc/UTC"
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `DTSTART is DATE-TIME with named timezone - not all-day`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(DtStart(ZonedDateTime.of(2025, 1, 15, 10, 0, 0, 0, defaultTimezone.defaultZoneId))),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.IS_ALLDAY to 0,
+            Tasks.TZ to defaultTimezone.defaultZoneId.id
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `DTSTART is floating DATE-TIME - not all-day, uses system default timezone`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(DtStart(LocalDateTime.of(2025, 1, 15, 10, 0, 0))),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.IS_ALLDAY to 0,
+            Tasks.TZ to defaultTimezone.defaultZoneId.id
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `DUE is DATE-TIME with named timezone (no DTSTART) - not all-day`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(Due(ZonedDateTime.of(2025, 1, 15, 10, 0, 0, 0, defaultTimezone.defaultZoneId))),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.IS_ALLDAY to 0,
+            Tasks.TZ to defaultTimezone.defaultZoneId.id
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `DUE is floating DATE-TIME (no DTSTART) - not all-day, uses system default timezone`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(Due(LocalDateTime.of(2025, 1, 15, 10, 0, 0))),
             to = result
         )
         assertContentValuesEqual(contentValuesOf(

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/DueBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/DueBuilderTest.kt
@@ -8,6 +8,7 @@ import android.content.ContentValues
 import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.mapping.tasks.VToDoUtil
 import at.bitfire.synctools.test.assertContentValuesEqual
 import net.fortuna.ical4j.model.property.Due
 import org.dmfs.tasks.contract.TaskContract.Tasks
@@ -24,7 +25,7 @@ class DueBuilderTest {
     private val builder = DueBuilder()
 
     @Test
-    fun `No DUE`() {
+    fun `old No DUE`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(),
@@ -36,10 +37,47 @@ class DueBuilderTest {
     }
 
     @Test
-    fun `DUE is DATE`() {
+    fun `old DUE is DATE`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(due = Due(LocalDate.of(2025, 1, 15))),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.DUE to 1736899200000L   // 2025-01-15 00:00:00 UTC
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `old DUE is DATE-TIME (UTC)`() {
+        val result = Entity(ContentValues())
+        val ts = ZonedDateTime.of(2025, 1, 15, 10, 0, 0, 0, ZoneOffset.UTC)
+        builder.build(
+            from = Task(due = Due(ts)),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.DUE to ts.toInstant().toEpochMilli()
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `No DUE`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.DUE to null
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `DUE is DATE`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(Due(LocalDate.of(2025, 1, 15))),
             to = result
         )
         assertContentValuesEqual(contentValuesOf(
@@ -52,7 +90,7 @@ class DueBuilderTest {
         val result = Entity(ContentValues())
         val ts = ZonedDateTime.of(2025, 1, 15, 10, 0, 0, 0, ZoneOffset.UTC)
         builder.build(
-            from = Task(due = Due(ts)),
+            from = VToDoUtil.build(Due(ts)),
             to = result
         )
         assertContentValuesEqual(contentValuesOf(

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/DurationBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/DurationBuilderTest.kt
@@ -8,6 +8,7 @@ import android.content.ContentValues
 import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.mapping.tasks.VToDoUtil
 import at.bitfire.synctools.test.assertContentValuesEqual
 import net.fortuna.ical4j.model.property.Duration
 import org.dmfs.tasks.contract.TaskContract.Tasks
@@ -21,7 +22,7 @@ class DurationBuilderTest {
     private val builder = DurationBuilder()
 
     @Test
-    fun `No DURATION`() {
+    fun `old No DURATION`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(),
@@ -33,10 +34,34 @@ class DurationBuilderTest {
     }
 
     @Test
-    fun `DURATION is set`() {
+    fun `old DURATION is set`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(duration = Duration(null, "PT2H")),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.DURATION to "PT2H"
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `No DURATION`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.DURATION to null
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `DURATION is set`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(Duration(null, "PT2H")),
             to = result
         )
         assertContentValuesEqual(contentValuesOf(

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/RecurrenceFieldsBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/RecurrenceFieldsBuilderTest.kt
@@ -8,6 +8,7 @@ import android.content.ContentValues
 import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.mapping.tasks.VToDoUtil
 import at.bitfire.synctools.test.assertContentValuesEqual
 import net.fortuna.ical4j.model.DateList
 import net.fortuna.ical4j.model.property.DtStart
@@ -15,6 +16,7 @@ import net.fortuna.ical4j.model.property.ExDate
 import net.fortuna.ical4j.model.property.RDate
 import net.fortuna.ical4j.model.property.RRule
 import org.dmfs.tasks.contract.TaskContract.Tasks
+import org.junit.Assert.assertNotNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -29,7 +31,7 @@ class RecurrenceFieldsBuilderTest {
     private val builder = RecurrenceFieldsBuilder()
 
     @Test
-    fun `No recurrence fields`() {
+    fun `old No recurrence fields`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(),
@@ -43,7 +45,7 @@ class RecurrenceFieldsBuilderTest {
     }
 
     @Test
-    fun `RRULE is set`() {
+    fun `old RRULE is set`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task().also {
@@ -59,7 +61,7 @@ class RecurrenceFieldsBuilderTest {
     }
 
     @Test
-    fun `RDATE all-day dates`() {
+    fun `old RDATE all-day dates`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task().also {
@@ -73,7 +75,7 @@ class RecurrenceFieldsBuilderTest {
     }
 
     @Test
-    fun `EXDATE all-day dates`() {
+    fun `old EXDATE all-day dates`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task().also {
@@ -84,6 +86,84 @@ class RecurrenceFieldsBuilderTest {
         )
         val exdate = result.entityValues.getAsString(Tasks.EXDATE)
         assert(exdate != null) { "EXDATE should be set" }
+    }
+
+    @Test
+    fun `No recurrence fields`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.RRULE to null,
+            Tasks.RDATE to null,
+            Tasks.EXDATE to null
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `RRULE is set`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(
+                DtStart(LocalDate.of(2025, 1, 15)),
+                RRule<Temporal>("FREQ=DAILY;COUNT=10")
+            ),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.RRULE to "FREQ=DAILY;COUNT=10",
+            Tasks.RDATE to null,
+            Tasks.EXDATE to null
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `RDATE all-day dates`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(
+                DtStart(LocalDate.of(2025, 1, 10)),
+                RDate(DateList(LocalDate.of(2025, 1, 15)))
+            ),
+            to = result
+        )
+        val rdate = result.entityValues.getAsString(Tasks.RDATE)
+        assertNotNull("RDATE should be set", rdate)
+    }
+
+    @Test
+    fun `EXDATE all-day dates`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(
+                DtStart(LocalDate.of(2025, 1, 10)),
+                RRule<Temporal>("FREQ=DAILY;COUNT=10"),
+                ExDate(DateList(LocalDate.of(2025, 1, 15)))
+            ),
+            to = result
+        )
+        val exdate = result.entityValues.getAsString(Tasks.EXDATE)
+        assertNotNull("EXDATE should be set", exdate)
+    }
+
+    @Test
+    fun `RRULE with DATE-TIME DTSTART`() {
+        val result = Entity(ContentValues())
+        val ts = ZonedDateTime.of(2025, 1, 15, 10, 0, 0, 0, ZoneOffset.UTC)
+        builder.build(
+            from = VToDoUtil.build(
+                DtStart(ts),
+                RRule<Temporal>("FREQ=DAILY;COUNT=5")
+            ),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.RRULE to "FREQ=DAILY;COUNT=5",
+            Tasks.RDATE to null,
+            Tasks.EXDATE to null
+        ), result.entityValues)
     }
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/StartTimeBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/StartTimeBuilderTest.kt
@@ -8,6 +8,7 @@ import android.content.ContentValues
 import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.mapping.tasks.VToDoUtil
 import at.bitfire.synctools.test.assertContentValuesEqual
 import net.fortuna.ical4j.model.property.DtStart
 import org.dmfs.tasks.contract.TaskContract.Tasks
@@ -24,7 +25,7 @@ class StartTimeBuilderTest {
     private val builder = StartTimeBuilder()
 
     @Test
-    fun `No DTSTART`() {
+    fun `old No DTSTART`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(),
@@ -36,10 +37,47 @@ class StartTimeBuilderTest {
     }
 
     @Test
-    fun `DTSTART is DATE`() {
+    fun `old DTSTART is DATE`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(dtStart = DtStart(LocalDate.of(2025, 1, 15))),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.DTSTART to 1736899200000L   // 2025-01-15 00:00:00 UTC
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `old DTSTART is DATE-TIME (UTC)`() {
+        val result = Entity(ContentValues())
+        val ts = ZonedDateTime.of(2025, 1, 15, 10, 0, 0, 0, ZoneOffset.UTC)
+        builder.build(
+            from = Task(dtStart = DtStart(ts)),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.DTSTART to ts.toInstant().toEpochMilli()
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `No DTSTART`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.DTSTART to null
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `DTSTART is DATE`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(DtStart(LocalDate.of(2025, 1, 15))),
             to = result
         )
         assertContentValuesEqual(contentValuesOf(
@@ -52,7 +90,7 @@ class StartTimeBuilderTest {
         val result = Entity(ContentValues())
         val ts = ZonedDateTime.of(2025, 1, 15, 10, 0, 0, 0, ZoneOffset.UTC)
         builder.build(
-            from = Task(dtStart = DtStart(ts)),
+            from = VToDoUtil.build(DtStart(ts)),
             to = result
         )
         assertContentValuesEqual(contentValuesOf(


### PR DESCRIPTION
### Purpose

Describe the purpose of this PR and its benefits.

Example: 

> Adds support for AAA in BBB, as requested by several people in issue #XX.


### Short description

Add `DmfsTaskFieldBuilderVToDo` interface and `build(VToDo, Entity)` methods to `AllDayBuilder`, `StartTimeBuilder`, `DueBuilder`, `DurationBuilder`, and `RecurrenceFieldsBuilder` so they can read directly from `VToDo` (ical4j) instead of the deprecated `Task` data class.

`AllDayBuilder` also gains `a getTimeZone(VToDo)` overload used by `RecurrenceFieldsBuilder` for the `VToDo` path.

Existing `Task`-based tests renamed with 'old' prefix; `VToDo`-based equivalents added for all five builders.


### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

