### PR TITLE
DmfsTask: Migrate sub field builders to VToDo

### DIFF
--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/AlarmsBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/AlarmsBuilder.kt
@@ -7,19 +7,23 @@ package at.bitfire.synctools.mapping.tasks.builder
 import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.icalendar.dtStart
+import at.bitfire.synctools.icalendar.due
 import at.bitfire.synctools.storage.tasks.DmfsTaskList
 import at.bitfire.synctools.util.AlarmTriggerCalculator
 import net.fortuna.ical4j.model.Property
+import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.parameter.Related
 import net.fortuna.ical4j.model.property.Action
 import net.fortuna.ical4j.model.property.immutable.ImmutableAction
 import org.dmfs.tasks.contract.TaskContract.Property.Alarm
+import java.time.temporal.Temporal
 import java.util.Locale
 import kotlin.jvm.optionals.getOrNull
 
 class AlarmsBuilder(
     private val taskList: DmfsTaskList
-) : DmfsTaskFieldBuilder {
+) : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
     override fun build(from: Task, to: Entity) {
         for (alarm in from.alarms) {
@@ -27,6 +31,44 @@ class AlarmsBuilder(
                 alarm = alarm,
                 refStart = from.dtStart,
                 refEnd = from.end,
+                allowRelEnd = true
+            ) ?: continue
+
+            val ref = when (alarmRef) {
+                Related.END ->
+                    Alarm.ALARM_REFERENCE_DUE_DATE
+                else /* Related.START is the default value */ ->
+                    Alarm.ALARM_REFERENCE_START_DATE
+            }
+
+            val alarmType = when (
+                alarm.getProperty<Action>(Property.ACTION).getOrNull()?.value?.uppercase(Locale.ROOT)
+            ) {
+                ImmutableAction.VALUE_AUDIO   -> Alarm.ALARM_TYPE_SOUND
+                ImmutableAction.VALUE_DISPLAY -> Alarm.ALARM_TYPE_MESSAGE
+                ImmutableAction.VALUE_EMAIL   -> Alarm.ALARM_TYPE_EMAIL
+                else                          -> Alarm.ALARM_TYPE_NOTHING
+            }
+
+            to.addSubValue(
+                taskList.tasksPropertiesUri(),
+                contentValuesOf(
+                    Alarm.MIMETYPE to Alarm.CONTENT_ITEM_TYPE,
+                    Alarm.MINUTES_BEFORE to minutes,
+                    Alarm.REFERENCE to ref,
+                    Alarm.MESSAGE to (alarm.description?.value ?: alarm.summary),
+                    Alarm.ALARM_TYPE to alarmType
+                )
+            )
+        }
+    }
+
+    override fun build(from: VToDo, to: Entity) {
+        for (alarm in from.alarms) {
+            val (alarmRef, minutes) = AlarmTriggerCalculator.alarmTriggerToMinutes(
+                alarm = alarm,
+                refStart = from.dtStart<Temporal>(),
+                refEnd = from.due<Temporal>(),
                 allowRelEnd = true
             ) ?: continue
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/CategoriesBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/CategoriesBuilder.kt
@@ -8,11 +8,14 @@ import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
 import at.bitfire.synctools.storage.tasks.DmfsTaskList
+import net.fortuna.ical4j.model.Property
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Categories
 import org.dmfs.tasks.contract.TaskContract.Property.Category
 
 class CategoriesBuilder(
     private val taskList: DmfsTaskList
-) : DmfsTaskFieldBuilder {
+) : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
     override fun build(from: Task, to: Entity) {
         for (category in from.categories) {
@@ -23,6 +26,20 @@ class CategoriesBuilder(
                     Category.CATEGORY_NAME to category
                 )
             )
+        }
+    }
+
+    override fun build(from: VToDo, to: Entity) {
+        for (categoriesProp in from.getProperties<Categories>(Property.CATEGORIES)) {
+            for (category in categoriesProp.categories.texts) {
+                to.addSubValue(
+                    taskList.tasksPropertiesUri(),
+                    contentValuesOf(
+                        Category.MIMETYPE to Category.CONTENT_ITEM_TYPE,
+                        Category.CATEGORY_NAME to category
+                    )
+                )
+            }
         }
     }
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/CommentsBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/CommentsBuilder.kt
@@ -8,19 +8,34 @@ import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
 import at.bitfire.synctools.storage.tasks.DmfsTaskList
-import org.dmfs.tasks.contract.TaskContract.Property.Comment
+import net.fortuna.ical4j.model.Property
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Comment
+import org.dmfs.tasks.contract.TaskContract.Property.Comment as DmfsComment
+import kotlin.jvm.optionals.getOrNull
 
 class CommentsBuilder(
     private val taskList: DmfsTaskList
-) : DmfsTaskFieldBuilder {
+) : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
     override fun build(from: Task, to: Entity) {
         val comment = from.comment ?: return
         to.addSubValue(
             taskList.tasksPropertiesUri(),
             contentValuesOf(
-                Comment.MIMETYPE to Comment.CONTENT_ITEM_TYPE,
-                Comment.COMMENT to comment
+                DmfsComment.MIMETYPE to DmfsComment.CONTENT_ITEM_TYPE,
+                DmfsComment.COMMENT to comment
+            )
+        )
+    }
+
+    override fun build(from: VToDo, to: Entity) {
+        val comment = from.getProperty<Comment>(Property.COMMENT).getOrNull()?.value ?: return
+        to.addSubValue(
+            taskList.tasksPropertiesUri(),
+            contentValuesOf(
+                DmfsComment.MIMETYPE to DmfsComment.CONTENT_ITEM_TYPE,
+                DmfsComment.COMMENT to comment
             )
         )
     }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/CommentsBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/CommentsBuilder.kt
@@ -12,7 +12,6 @@ import net.fortuna.ical4j.model.Property
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.property.Comment
 import org.dmfs.tasks.contract.TaskContract.Property.Comment as DmfsComment
-import kotlin.jvm.optionals.getOrNull
 
 class CommentsBuilder(
     private val taskList: DmfsTaskList
@@ -30,14 +29,15 @@ class CommentsBuilder(
     }
 
     override fun build(from: VToDo, to: Entity) {
-        val comment = from.getProperty<Comment>(Property.COMMENT).getOrNull()?.value ?: return
-        to.addSubValue(
-            taskList.tasksPropertiesUri(),
-            contentValuesOf(
-                DmfsComment.MIMETYPE to DmfsComment.CONTENT_ITEM_TYPE,
-                DmfsComment.COMMENT to comment
+        for (comment in from.getProperties<Comment>(Property.COMMENT)) {
+            to.addSubValue(
+                taskList.tasksPropertiesUri(),
+                contentValuesOf(
+                    DmfsComment.MIMETYPE to DmfsComment.CONTENT_ITEM_TYPE,
+                    DmfsComment.COMMENT to comment.value
+                )
             )
-        )
+        }
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/ListIdBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/ListIdBuilder.kt
@@ -6,13 +6,18 @@ package at.bitfire.synctools.mapping.tasks.builder
 
 import android.content.Entity
 import at.bitfire.ical4android.Task
+import net.fortuna.ical4j.model.component.VToDo
 import org.dmfs.tasks.contract.TaskContract.Tasks
 
 class ListIdBuilder(
     private val listId: Long
-) : DmfsTaskFieldBuilder {
+) : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
     override fun build(from: Task, to: Entity) {
+        to.entityValues.put(Tasks.LIST_ID, listId)
+    }
+
+    override fun build(from: VToDo, to: Entity) {
         to.entityValues.put(Tasks.LIST_ID, listId)
     }
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/RelationsBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/RelationsBuilder.kt
@@ -9,7 +9,10 @@ import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
 import at.bitfire.synctools.storage.tasks.DmfsTaskList
 import net.fortuna.ical4j.model.Parameter
+import net.fortuna.ical4j.model.Property
+import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.parameter.RelType
+import net.fortuna.ical4j.model.property.RelatedTo
 import org.dmfs.tasks.contract.TaskContract.Property.Relation
 import org.dmfs.tasks.contract.TaskContract.Tasks
 import kotlin.jvm.optionals.getOrNull
@@ -19,13 +22,34 @@ import kotlin.jvm.optionals.getOrNull
  */
 class RelationsBuilder(
     private val taskList: DmfsTaskList
-) : DmfsTaskFieldBuilder {
+) : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
     override fun build(from: Task, to: Entity) {
         // parent_id will be re-calculated when the relation row is inserted (if there is any)
         to.entityValues.put(Tasks.PARENT_ID, null as Long?)
 
         for (relatedTo in from.relatedTo) {
+            val relType = when (relatedTo.getParameter<RelType>(Parameter.RELTYPE).getOrNull()) {
+                RelType.CHILD   -> Relation.RELTYPE_CHILD
+                RelType.SIBLING -> Relation.RELTYPE_SIBLING
+                else /* RelType.PARENT, default value */ -> Relation.RELTYPE_PARENT
+            }
+            to.addSubValue(
+                taskList.tasksPropertiesUri(),
+                contentValuesOf(
+                    Relation.MIMETYPE to Relation.CONTENT_ITEM_TYPE,
+                    Relation.RELATED_UID to relatedTo.value,
+                    Relation.RELATED_TYPE to relType
+                )
+            )
+        }
+    }
+
+    override fun build(from: VToDo, to: Entity) {
+        // parent_id will be re-calculated when the relation row is inserted (if there is any)
+        to.entityValues.put(Tasks.PARENT_ID, null as Long?)
+
+        for (relatedTo in from.getProperties<RelatedTo>(Property.RELATED_TO)) {
             val relType = when (relatedTo.getParameter<RelType>(Parameter.RELTYPE).getOrNull()) {
                 RelType.CHILD   -> Relation.RELTYPE_CHILD
                 RelType.SIBLING -> Relation.RELTYPE_SIBLING

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/UnknownPropertiesBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/UnknownPropertiesBuilder.kt
@@ -67,7 +67,7 @@ class UnknownPropertiesBuilder(
         }
     }
 
-    internal fun unknownProperties(from: VToDo): List<Property> =
+    private fun unknownProperties(from: VToDo): List<Property> =
         from.propertyList.all.filterNot {
             KNOWN_PROPERTY_NAMES.contains(it.name.uppercase())
         }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/UnknownPropertiesBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/UnknownPropertiesBuilder.kt
@@ -98,7 +98,8 @@ class UnknownPropertiesBuilder(
             Property.PERCENT_COMPLETE,  // PercentCompleteBuilder
             Property.RRULE,             // RecurrenceFieldsBuilder
             Property.RDATE,             // RecurrenceFieldsBuilder
-            Property.EXRULE,            // RecurrenceFieldsBuilder
+            // Note: EXRULE is intentionally absent – it's not mapped by RecurrenceFieldsBuilder
+            // (the dmfs tasks contract has no EXRULE field), so it must be preserved here.
             Property.EXDATE,            // RecurrenceFieldsBuilder
             Property.CATEGORIES,        // CategoriesBuilder
             Property.COMMENT,           // CommentsBuilder

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/UnknownPropertiesBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/UnknownPropertiesBuilder.kt
@@ -10,12 +10,15 @@ import at.bitfire.ical4android.Task
 import at.bitfire.ical4android.UnknownProperty
 import at.bitfire.synctools.storage.tasks.DmfsTask.Companion.UNKNOWN_PROPERTY_DATA
 import at.bitfire.synctools.storage.tasks.DmfsTaskList
+import net.fortuna.ical4j.model.Property
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Color
 import org.dmfs.tasks.contract.TaskContract.Properties
 import java.util.logging.Logger
 
 class UnknownPropertiesBuilder(
     private val taskList: DmfsTaskList
-) : DmfsTaskFieldBuilder {
+) : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
     private val logger
         get() = Logger.getLogger(javaClass.name)
@@ -40,6 +43,72 @@ class UnknownPropertiesBuilder(
                 )
             )
         }
+    }
+
+    override fun build(from: VToDo, to: Entity) {
+        for (property in unknownProperties(from)) {
+            val value = property.value
+            if (value == null) {
+                logger.warning("Ignoring unknown property with null value")
+                continue
+            }
+            if (value.length > UnknownProperty.MAX_UNKNOWN_PROPERTY_SIZE) {
+                logger.warning("Ignoring unknown property with ${value.length} octets (too long)")
+                continue
+            }
+
+            to.addSubValue(
+                taskList.tasksPropertiesUri(),
+                contentValuesOf(
+                    Properties.MIMETYPE to UnknownProperty.CONTENT_ITEM_TYPE,
+                    UNKNOWN_PROPERTY_DATA to UnknownProperty.toJsonString(property)
+                )
+            )
+        }
+    }
+
+    internal fun unknownProperties(from: VToDo): List<Property> =
+        from.propertyList.all.filterNot {
+            KNOWN_PROPERTY_NAMES.contains(it.name.uppercase())
+        }
+
+    companion object {
+
+        val KNOWN_PROPERTY_NAMES = arrayOf(
+            // These properties are processed by their respective builders,
+            // so we don't touch them in this builder.
+            Property.UID,               // UidBuilder
+            Property.SEQUENCE,          // SequenceBuilder
+            Property.CREATED,           // CreatedBuilder
+            Property.LAST_MODIFIED,     // LastModifiedBuilder
+            Property.SUMMARY,           // TitleBuilder
+            Property.LOCATION,          // LocationBuilder
+            Property.GEO,               // GeoBuilder
+            Property.DESCRIPTION,       // DescriptionBuilder
+            Color.PROPERTY_NAME,        // ColorBuilder
+            Property.URL,               // UrlBuilder
+            Property.ORGANIZER,         // OrganizerBuilder
+            Property.PRIORITY,          // PriorityBuilder
+            Property.CLASS,             // ClassificationBuilder
+            Property.STATUS,            // StatusBuilder
+            Property.DUE,               // DueBuilder
+            Property.DURATION,          // DurationBuilder
+            Property.DTSTART,           // StartTimeBuilder / AllDayBuilder
+            Property.COMPLETED,         // CompletedBuilder
+            Property.PERCENT_COMPLETE,  // PercentCompleteBuilder
+            Property.RRULE,             // RecurrenceFieldsBuilder
+            Property.RDATE,             // RecurrenceFieldsBuilder
+            Property.EXRULE,            // RecurrenceFieldsBuilder
+            Property.EXDATE,            // RecurrenceFieldsBuilder
+            Property.CATEGORIES,        // CategoriesBuilder
+            Property.COMMENT,           // CommentsBuilder
+            Property.RELATED_TO,        // RelationsBuilder
+
+            // These properties can be ignored and shall not be saved as unknown properties.
+            Property.PRODID,
+            Property.DTSTAMP,
+        )
+
     }
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/VToDoUtil.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/VToDoUtil.kt
@@ -4,12 +4,18 @@
 
 package at.bitfire.synctools.mapping.tasks
 
+import net.fortuna.ical4j.model.ComponentList
 import net.fortuna.ical4j.model.Property
 import net.fortuna.ical4j.model.PropertyList
+import net.fortuna.ical4j.model.component.VAlarm
 import net.fortuna.ical4j.model.component.VToDo
 
 object VToDoUtil {
     fun build(vararg properties: Property): VToDo {
         return VToDo(PropertyList(listOf(*properties)))
+    }
+
+    fun build(properties: List<Property>, alarms: List<VAlarm>): VToDo {
+        return VToDo(PropertyList(properties), ComponentList(alarms))
     }
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/AlarmsBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/AlarmsBuilderTest.kt
@@ -9,6 +9,7 @@ import android.content.Entity
 import android.net.Uri
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.mapping.tasks.VToDoUtil
 import at.bitfire.synctools.storage.tasks.DmfsTaskList
 import at.bitfire.synctools.test.assertContentValuesEqual
 import io.mockk.every
@@ -38,7 +39,7 @@ class AlarmsBuilderTest {
     private val builder = AlarmsBuilder(taskList)
 
     @Test
-    fun `No alarms`() {
+    fun `old No alarms`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(),
@@ -48,7 +49,7 @@ class AlarmsBuilderTest {
     }
 
     @Test
-    fun `Audio alarm relative to start`() {
+    fun `old Audio alarm relative to start`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(
@@ -74,7 +75,7 @@ class AlarmsBuilderTest {
     }
 
     @Test
-    fun `Display alarm`() {
+    fun `old Display alarm`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(
@@ -85,6 +86,66 @@ class AlarmsBuilderTest {
                     alarm.add<VAlarm>(Trigger(Duration.ofMinutes(-30)))
                 }
             },
+            to = result
+        )
+        assertEquals(1, result.subValues.size)
+        assertContentValuesEqual(contentValuesOf(
+            Alarm.MIMETYPE to Alarm.CONTENT_ITEM_TYPE,
+            Alarm.MINUTES_BEFORE to 30,
+            Alarm.REFERENCE to Alarm.ALARM_REFERENCE_START_DATE,
+            Alarm.MESSAGE to null,
+            Alarm.ALARM_TYPE to Alarm.ALARM_TYPE_MESSAGE
+        ), result.subValues.first().values)
+    }
+
+    @Test
+    fun `No alarms`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(),
+            to = result
+        )
+        assertTrue(result.subValues.isEmpty())
+    }
+
+    @Test
+    fun `Audio alarm relative to start`() {
+        val result = Entity(ContentValues())
+        val alarm = VAlarm().also {
+            it.add<VAlarm>(Action(ImmutableAction.VALUE_AUDIO))
+            it.add<VAlarm>(Trigger(Duration.ofMinutes(-15)))
+        }
+        builder.build(
+            from = VToDoUtil.build(
+                properties = listOf(DtStart(ZonedDateTime.of(2025, 1, 15, 10, 0, 0, 0, ZoneOffset.UTC))),
+                alarms = listOf(alarm)
+            ),
+            to = result
+        )
+        assertEquals(1, result.subValues.size)
+        val values = result.subValues.first().values
+        assertContentValuesEqual(contentValuesOf(
+            Alarm.MIMETYPE to Alarm.CONTENT_ITEM_TYPE,
+            Alarm.MINUTES_BEFORE to 15,
+            Alarm.REFERENCE to Alarm.ALARM_REFERENCE_START_DATE,
+            Alarm.MESSAGE to null,
+            Alarm.ALARM_TYPE to Alarm.ALARM_TYPE_SOUND
+        ), values)
+        assertEquals(propertiesUri, result.subValues.first().uri)
+    }
+
+    @Test
+    fun `Display alarm`() {
+        val result = Entity(ContentValues())
+        val alarm = VAlarm().also {
+            it.add<VAlarm>(Action(ImmutableAction.VALUE_DISPLAY))
+            it.add<VAlarm>(Trigger(Duration.ofMinutes(-30)))
+        }
+        builder.build(
+            from = VToDoUtil.build(
+                properties = listOf(DtStart(ZonedDateTime.of(2025, 1, 15, 10, 0, 0, 0, ZoneOffset.UTC))),
+                alarms = listOf(alarm)
+            ),
             to = result
         )
         assertEquals(1, result.subValues.size)

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/CategoriesBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/CategoriesBuilderTest.kt
@@ -9,10 +9,13 @@ import android.content.Entity
 import android.net.Uri
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.mapping.tasks.VToDoUtil
 import at.bitfire.synctools.storage.tasks.DmfsTaskList
 import at.bitfire.synctools.test.assertContentValuesEqual
 import io.mockk.every
 import io.mockk.mockk
+import net.fortuna.ical4j.model.TextList
+import net.fortuna.ical4j.model.property.Categories
 import org.dmfs.tasks.contract.TaskContract.Property.Category
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -30,7 +33,7 @@ class CategoriesBuilderTest {
     private val builder = CategoriesBuilder(taskList)
 
     @Test
-    fun `No categories`() {
+    fun `old No categories`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(),
@@ -40,7 +43,7 @@ class CategoriesBuilderTest {
     }
 
     @Test
-    fun `One category`() {
+    fun `old One category`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task().also { it.categories += "Work" },
@@ -55,13 +58,58 @@ class CategoriesBuilderTest {
     }
 
     @Test
-    fun `Multiple categories`() {
+    fun `old Multiple categories`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task().also {
                 it.categories += "Work"
                 it.categories += "Personal"
             },
+            to = result
+        )
+        assertEquals(2, result.subValues.size)
+    }
+
+    @Test
+    fun `No categories`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(),
+            to = result
+        )
+        assertTrue(result.subValues.isEmpty())
+    }
+
+    @Test
+    fun `One category`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(Categories(TextList("Work"))),
+            to = result
+        )
+        assertEquals(1, result.subValues.size)
+        assertContentValuesEqual(contentValuesOf(
+            Category.MIMETYPE to Category.CONTENT_ITEM_TYPE,
+            Category.CATEGORY_NAME to "Work"
+        ), result.subValues.first().values)
+        assertEquals(propertiesUri, result.subValues.first().uri)
+    }
+
+    @Test
+    fun `Multiple categories in one property`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(Categories(TextList("Work", "Personal"))),
+            to = result
+        )
+        assertEquals(2, result.subValues.size)
+    }
+
+    @Test
+    fun `Multiple categories in separate properties`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(Categories(TextList("Work")), Categories(TextList("Personal"))),
             to = result
         )
         assertEquals(2, result.subValues.size)

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/CommentsBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/CommentsBuilderTest.kt
@@ -9,11 +9,13 @@ import android.content.Entity
 import android.net.Uri
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.mapping.tasks.VToDoUtil
 import at.bitfire.synctools.storage.tasks.DmfsTaskList
 import at.bitfire.synctools.test.assertContentValuesEqual
 import io.mockk.every
 import io.mockk.mockk
-import org.dmfs.tasks.contract.TaskContract.Property.Comment
+import net.fortuna.ical4j.model.property.Comment
+import org.dmfs.tasks.contract.TaskContract.Property.Comment as DmfsComment
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -30,7 +32,7 @@ class CommentsBuilderTest {
     private val builder = CommentsBuilder(taskList)
 
     @Test
-    fun `No comment`() {
+    fun `old No comment`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(),
@@ -40,7 +42,7 @@ class CommentsBuilderTest {
     }
 
     @Test
-    fun `Comment is set`() {
+    fun `old Comment is set`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(comment = "This is a comment"),
@@ -48,8 +50,33 @@ class CommentsBuilderTest {
         )
         assertEquals(1, result.subValues.size)
         assertContentValuesEqual(contentValuesOf(
-            Comment.MIMETYPE to Comment.CONTENT_ITEM_TYPE,
-            Comment.COMMENT to "This is a comment"
+            DmfsComment.MIMETYPE to DmfsComment.CONTENT_ITEM_TYPE,
+            DmfsComment.COMMENT to "This is a comment"
+        ), result.subValues.first().values)
+        assertEquals(propertiesUri, result.subValues.first().uri)
+    }
+
+    @Test
+    fun `No comment`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(),
+            to = result
+        )
+        assertTrue(result.subValues.isEmpty())
+    }
+
+    @Test
+    fun `Comment is set`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(Comment("This is a comment")),
+            to = result
+        )
+        assertEquals(1, result.subValues.size)
+        assertContentValuesEqual(contentValuesOf(
+            DmfsComment.MIMETYPE to DmfsComment.CONTENT_ITEM_TYPE,
+            DmfsComment.COMMENT to "This is a comment"
         ), result.subValues.first().values)
         assertEquals(propertiesUri, result.subValues.first().uri)
     }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/CommentsBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/CommentsBuilderTest.kt
@@ -15,12 +15,12 @@ import at.bitfire.synctools.test.assertContentValuesEqual
 import io.mockk.every
 import io.mockk.mockk
 import net.fortuna.ical4j.model.property.Comment
-import org.dmfs.tasks.contract.TaskContract.Property.Comment as DmfsComment
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.dmfs.tasks.contract.TaskContract.Property.Comment as DmfsComment
 
 @RunWith(RobolectricTestRunner::class)
 class CommentsBuilderTest {
@@ -79,6 +79,24 @@ class CommentsBuilderTest {
             DmfsComment.COMMENT to "This is a comment"
         ), result.subValues.first().values)
         assertEquals(propertiesUri, result.subValues.first().uri)
+    }
+
+    @Test
+    fun `Multiple comments`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(Comment("First comment"), Comment("Second comment")),
+            to = result
+        )
+        assertEquals(2, result.subValues.size)
+        assertContentValuesEqual(contentValuesOf(
+            DmfsComment.MIMETYPE to DmfsComment.CONTENT_ITEM_TYPE,
+            DmfsComment.COMMENT to "First comment"
+        ), result.subValues[0].values)
+        assertContentValuesEqual(contentValuesOf(
+            DmfsComment.MIMETYPE to DmfsComment.CONTENT_ITEM_TYPE,
+            DmfsComment.COMMENT to "Second comment"
+        ), result.subValues[1].values)
     }
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/ListIdBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/ListIdBuilderTest.kt
@@ -9,6 +9,7 @@ import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
 import at.bitfire.synctools.test.assertContentValuesEqual
+import net.fortuna.ical4j.model.component.VToDo
 import org.dmfs.tasks.contract.TaskContract.Tasks
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -18,10 +19,22 @@ import org.robolectric.RobolectricTestRunner
 class ListIdBuilderTest {
 
     @Test
-    fun `ListId sets LIST_ID`() {
+    fun `old ListId sets LIST_ID`() {
         val result = Entity(ContentValues())
         ListIdBuilder(42L).build(
             from = Task(),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.LIST_ID to 42L
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `ListId sets LIST_ID`() {
+        val result = Entity(ContentValues())
+        ListIdBuilder(42L).build(
+            from = VToDo(),
             to = result
         )
         assertContentValuesEqual(contentValuesOf(

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/RelationsBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/RelationsBuilderTest.kt
@@ -9,6 +9,7 @@ import android.content.Entity
 import android.net.Uri
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.mapping.tasks.VToDoUtil
 import at.bitfire.synctools.storage.tasks.DmfsTaskList
 import at.bitfire.synctools.test.assertContentValuesEqual
 import io.mockk.every
@@ -34,7 +35,7 @@ class RelationsBuilderTest {
     private val builder = RelationsBuilder(taskList)
 
     @Test
-    fun `No relations - PARENT_ID reset to null`() {
+    fun `old No relations - PARENT_ID reset to null`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(),
@@ -46,7 +47,7 @@ class RelationsBuilderTest {
     }
 
     @Test
-    fun `RELATED-TO with PARENT type`() {
+    fun `old RELATED-TO with PARENT type`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task().also {
@@ -64,7 +65,7 @@ class RelationsBuilderTest {
     }
 
     @Test
-    fun `RELATED-TO with CHILD type`() {
+    fun `old RELATED-TO with CHILD type`() {
         val result = Entity(ContentValues())
         val related = RelatedTo("child-uid").add<RelatedTo>(RelType.CHILD)
         builder.build(
@@ -80,11 +81,71 @@ class RelationsBuilderTest {
     }
 
     @Test
-    fun `RELATED-TO with SIBLING type`() {
+    fun `old RELATED-TO with SIBLING type`() {
         val result = Entity(ContentValues())
         val related = RelatedTo("sibling-uid").add<RelatedTo>(RelType.SIBLING)
         builder.build(
             from = Task().also { it.relatedTo += related },
+            to = result
+        )
+        assertEquals(1, result.subValues.size)
+        assertContentValuesEqual(contentValuesOf(
+            Relation.MIMETYPE to Relation.CONTENT_ITEM_TYPE,
+            Relation.RELATED_UID to "sibling-uid",
+            Relation.RELATED_TYPE to Relation.RELTYPE_SIBLING
+        ), result.subValues.first().values)
+    }
+
+    @Test
+    fun `No relations - PARENT_ID reset to null`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(),
+            to = result
+        )
+        assertTrue(result.entityValues.containsKey(Tasks.PARENT_ID))
+        assertNull(result.entityValues.get(Tasks.PARENT_ID))
+        assertTrue(result.subValues.isEmpty())
+    }
+
+    @Test
+    fun `RELATED-TO with PARENT type`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(RelatedTo("parent-uid")),
+            to = result
+        )
+        assertEquals(1, result.subValues.size)
+        assertContentValuesEqual(contentValuesOf(
+            Relation.MIMETYPE to Relation.CONTENT_ITEM_TYPE,
+            Relation.RELATED_UID to "parent-uid",
+            Relation.RELATED_TYPE to Relation.RELTYPE_PARENT
+        ), result.subValues.first().values)
+        assertEquals(propertiesUri, result.subValues.first().uri)
+    }
+
+    @Test
+    fun `RELATED-TO with CHILD type`() {
+        val result = Entity(ContentValues())
+        val related = RelatedTo("child-uid").add<RelatedTo>(RelType.CHILD)
+        builder.build(
+            from = VToDoUtil.build(related),
+            to = result
+        )
+        assertEquals(1, result.subValues.size)
+        assertContentValuesEqual(contentValuesOf(
+            Relation.MIMETYPE to Relation.CONTENT_ITEM_TYPE,
+            Relation.RELATED_UID to "child-uid",
+            Relation.RELATED_TYPE to Relation.RELTYPE_CHILD
+        ), result.subValues.first().values)
+    }
+
+    @Test
+    fun `RELATED-TO with SIBLING type`() {
+        val result = Entity(ContentValues())
+        val related = RelatedTo("sibling-uid").add<RelatedTo>(RelType.SIBLING)
+        builder.build(
+            from = VToDoUtil.build(related),
             to = result
         )
         assertEquals(1, result.subValues.size)

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/UnknownPropertiesBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/UnknownPropertiesBuilderTest.kt
@@ -16,7 +16,9 @@ import at.bitfire.synctools.storage.tasks.DmfsTaskList
 import at.bitfire.synctools.test.assertContentValuesEqual
 import io.mockk.every
 import io.mockk.mockk
+import net.fortuna.ical4j.model.ParameterList
 import net.fortuna.ical4j.model.parameter.XParameter
+import net.fortuna.ical4j.model.property.ExRule
 import net.fortuna.ical4j.model.property.XProperty
 import org.dmfs.tasks.contract.TaskContract.Properties
 import org.junit.Assert.assertEquals
@@ -24,6 +26,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.time.temporal.Temporal
 
 @RunWith(RobolectricTestRunner::class)
 class UnknownPropertiesBuilderTest {
@@ -113,6 +116,20 @@ class UnknownPropertiesBuilderTest {
             to = result
         )
         assertTrue(result.subValues.isEmpty())
+    }
+
+    @Test
+    fun `EXRULE is preserved as unknown property`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(ExRule<Temporal>(ParameterList(), "FREQ=WEEKLY")),
+            to = result
+        )
+        assertEquals(1, result.subValues.size)
+        assertContentValuesEqual(contentValuesOf(
+            Properties.MIMETYPE to UnknownProperty.CONTENT_ITEM_TYPE,
+            UNKNOWN_PROPERTY_DATA to "[\"EXRULE\",\"FREQ=WEEKLY\"]"
+        ), result.subValues.first().values)
     }
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/UnknownPropertiesBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/UnknownPropertiesBuilderTest.kt
@@ -10,6 +10,7 @@ import android.net.Uri
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
 import at.bitfire.ical4android.UnknownProperty
+import at.bitfire.synctools.mapping.tasks.VToDoUtil
 import at.bitfire.synctools.storage.tasks.DmfsTask.Companion.UNKNOWN_PROPERTY_DATA
 import at.bitfire.synctools.storage.tasks.DmfsTaskList
 import at.bitfire.synctools.test.assertContentValuesEqual
@@ -34,7 +35,7 @@ class UnknownPropertiesBuilderTest {
     private val builder = UnknownPropertiesBuilder(taskList)
 
     @Test
-    fun `No unknown properties`() {
+    fun `old No unknown properties`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(),
@@ -44,7 +45,7 @@ class UnknownPropertiesBuilderTest {
     }
 
     @Test
-    fun `Unknown property with value and parameters`() {
+    fun `old Unknown property with value and parameters`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task().also {
@@ -63,13 +64,52 @@ class UnknownPropertiesBuilderTest {
     }
 
     @Test
-    fun `Unknown property exceeding size limit is ignored`() {
+    fun `old Unknown property exceeding size limit is ignored`() {
         val result = Entity(ContentValues())
         val longValue = "x".repeat(UnknownProperty.MAX_UNKNOWN_PROPERTY_SIZE + 1)
         builder.build(
             from = Task().also {
                 it.unknownProperties += XProperty("X-Huge-Property", longValue)
             },
+            to = result
+        )
+        assertTrue(result.subValues.isEmpty())
+    }
+
+    @Test
+    fun `No unknown properties`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(),
+            to = result
+        )
+        assertTrue(result.subValues.isEmpty())
+    }
+
+    @Test
+    fun `Unknown property with value and parameters`() {
+        val result = Entity(ContentValues())
+        val prop = XProperty("X-Some-Property", "Some Value")
+            .add<XProperty>(XParameter("Param1", "Value1"))
+            .add<XProperty>(XParameter("Param2", "Value2"))
+        builder.build(
+            from = VToDoUtil.build(prop),
+            to = result
+        )
+        assertEquals(1, result.subValues.size)
+        assertContentValuesEqual(contentValuesOf(
+            Properties.MIMETYPE to UnknownProperty.CONTENT_ITEM_TYPE,
+            UNKNOWN_PROPERTY_DATA to "[\"X-Some-Property\",\"Some Value\",{\"Param1\":\"Value1\",\"Param2\":\"Value2\"}]"
+        ), result.subValues.first().values)
+        assertEquals(propertiesUri, result.subValues.first().uri)
+    }
+
+    @Test
+    fun `Unknown property exceeding size limit is ignored`() {
+        val result = Entity(ContentValues())
+        val longValue = "x".repeat(UnknownProperty.MAX_UNKNOWN_PROPERTY_SIZE + 1)
+        builder.build(
+            from = VToDoUtil.build(XProperty("X-Huge-Property", longValue)),
             to = result
         )
         assertTrue(result.subValues.isEmpty())


### PR DESCRIPTION
### Purpose

Migrate sub field builders to map from `VToDo` instead of from legacy `Task`.


### Short description

Implement `DmfsTaskFieldBuilderVToDo` for the sub-field builders:
- `ListIdBuilder`
- `AlarmsBuilder`
- `CategoriesBuilder`
- `CommentsBuilder` also add support for multiple comments like jtx does already
- `RelationsBuilder`
- `UnknownPropertiesBuilder`

Each builder now implements both `DmfsTaskFieldBuilder` (old) and `DmfsTaskFieldBuilderVToDo` (new), keeping the old `build(Task, Entity)` unchanged while adding `build(VToDo, Entity)` that reads directly from the ical4j `VToDo` component.

Also extends `VToDoUtil` test helper with alarm sub-component support. Old tests are prefixed with 'old ' and new `VToDo`-based tests added.


### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

