### PR TITLE
DmfsTask: Migrate main field builders to `VToDo`

### DIFF
--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/CreatedBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/CreatedBuilder.kt
@@ -6,6 +6,8 @@ package at.bitfire.synctools.mapping.tasks.builder
 
 import android.content.Entity
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.icalendar.DatePropertyTzMapper.normalizedDate
+import at.bitfire.synctools.util.AndroidTimeUtils.toTimestamp
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.property.Created
 import org.dmfs.tasks.contract.TaskContract.Tasks
@@ -19,7 +21,7 @@ class CreatedBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
     override fun build(from: VToDo, to: Entity) {
         val createdAt = from.getProperty<Created>(Created.CREATED).getOrNull()
-        to.entityValues.put(Tasks.CREATED, createdAt?.date?.toEpochMilli())
+        to.entityValues.put(Tasks.CREATED, createdAt?.normalizedDate()?.toTimestamp())
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/CreatedBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/CreatedBuilder.kt
@@ -6,12 +6,20 @@ package at.bitfire.synctools.mapping.tasks.builder
 
 import android.content.Entity
 import at.bitfire.ical4android.Task
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Created
 import org.dmfs.tasks.contract.TaskContract.Tasks
+import kotlin.jvm.optionals.getOrNull
 
-class CreatedBuilder : DmfsTaskFieldBuilder {
+class CreatedBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
     override fun build(from: Task, to: Entity) {
         to.entityValues.put(Tasks.CREATED, from.createdAt)
+    }
+
+    override fun build(from: VToDo, to: Entity) {
+        val createdAt = from.getProperty<Created>(Created.CREATED).getOrNull()
+        to.entityValues.put(Tasks.CREATED, createdAt?.date?.toEpochMilli())
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DirtyBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DirtyBuilder.kt
@@ -6,11 +6,17 @@ package at.bitfire.synctools.mapping.tasks.builder
 
 import android.content.Entity
 import at.bitfire.ical4android.Task
+import net.fortuna.ical4j.model.component.VToDo
 import org.dmfs.tasks.contract.TaskContract.Tasks
 
-class DirtyBuilder : DmfsTaskFieldBuilder {
+class DirtyBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
     override fun build(from: Task, to: Entity) {
+        // DIRTY is always unset when we create or update a task row
+        to.entityValues.put(Tasks._DIRTY, 0)
+    }
+
+    override fun build(from: VToDo, to: Entity) {
         // DIRTY is always unset when we create or update a task row
         to.entityValues.put(Tasks._DIRTY, 0)
     }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/ETagBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/ETagBuilder.kt
@@ -7,12 +7,17 @@ package at.bitfire.synctools.mapping.tasks.builder
 import android.content.Entity
 import at.bitfire.ical4android.Task
 import at.bitfire.synctools.storage.tasks.DmfsTask.Companion.COLUMN_ETAG
+import net.fortuna.ical4j.model.component.VToDo
 
 class ETagBuilder(
     private val eTag: String?
-) : DmfsTaskFieldBuilder {
+) : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
     override fun build(from: Task, to: Entity) {
+        to.entityValues.put(COLUMN_ETAG, eTag)
+    }
+
+    override fun build(from: VToDo, to: Entity) {
         to.entityValues.put(COLUMN_ETAG, eTag)
     }
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/LastModifiedBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/LastModifiedBuilder.kt
@@ -6,6 +6,8 @@ package at.bitfire.synctools.mapping.tasks.builder
 
 import android.content.Entity
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.icalendar.DatePropertyTzMapper.normalizedDate
+import at.bitfire.synctools.util.AndroidTimeUtils.toTimestamp
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.property.LastModified
 import org.dmfs.tasks.contract.TaskContract.Tasks
@@ -19,7 +21,7 @@ class LastModifiedBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
     override fun build(from: VToDo, to: Entity) {
         val lastModified = from.getProperty<LastModified>(LastModified.LAST_MODIFIED).getOrNull()
-        to.entityValues.put(Tasks.LAST_MODIFIED, lastModified?.date?.toEpochMilli())
+        to.entityValues.put(Tasks.LAST_MODIFIED, lastModified?.normalizedDate()?.toTimestamp())
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/LastModifiedBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/LastModifiedBuilder.kt
@@ -6,12 +6,20 @@ package at.bitfire.synctools.mapping.tasks.builder
 
 import android.content.Entity
 import at.bitfire.ical4android.Task
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.LastModified
 import org.dmfs.tasks.contract.TaskContract.Tasks
+import kotlin.jvm.optionals.getOrNull
 
-class LastModifiedBuilder : DmfsTaskFieldBuilder {
+class LastModifiedBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
     override fun build(from: Task, to: Entity) {
         to.entityValues.put(Tasks.LAST_MODIFIED, from.lastModified)
+    }
+
+    override fun build(from: VToDo, to: Entity) {
+        val lastModified = from.getProperty<LastModified>(LastModified.LAST_MODIFIED).getOrNull()
+        to.entityValues.put(Tasks.LAST_MODIFIED, lastModified?.date?.toEpochMilli())
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/SequenceBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/SequenceBuilder.kt
@@ -6,14 +6,24 @@ package at.bitfire.synctools.mapping.tasks.builder
 
 import android.content.Entity
 import at.bitfire.ical4android.Task
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Sequence
 import org.dmfs.tasks.contract.TaskContract.Tasks
+import kotlin.jvm.optionals.getOrNull
 
-class SequenceBuilder : DmfsTaskFieldBuilder {
+class SequenceBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
     override fun build(from: Task, to: Entity) {
         /* When we build the SYNC_VERSION column from a real task, we set the sequence to 0 (not null), so that we
         can distinguish it from tasks which have been created locally and have never been uploaded yet. */
         to.entityValues.put(Tasks.SYNC_VERSION, from.sequence ?: 0)
+    }
+
+    override fun build(from: VToDo, to: Entity) {
+        /* When we build the SYNC_VERSION column from a real task, we set the sequence to 0 (not null), so that we
+        can distinguish it from tasks which have been created locally and have never been uploaded yet. */
+        val sequence = from.getProperty<Sequence>(Sequence.SEQUENCE).getOrNull()
+        to.entityValues.put(Tasks.SYNC_VERSION, sequence?.sequenceNo ?: 0)
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/SyncFlagsBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/SyncFlagsBuilder.kt
@@ -7,12 +7,17 @@ package at.bitfire.synctools.mapping.tasks.builder
 import android.content.Entity
 import at.bitfire.ical4android.Task
 import at.bitfire.synctools.storage.tasks.DmfsTask.Companion.COLUMN_FLAGS
+import net.fortuna.ical4j.model.component.VToDo
 
 class SyncFlagsBuilder(
     private val flags: Int
-) : DmfsTaskFieldBuilder {
+) : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
     override fun build(from: Task, to: Entity) {
+        to.entityValues.put(COLUMN_FLAGS, flags)
+    }
+
+    override fun build(from: VToDo, to: Entity) {
         to.entityValues.put(COLUMN_FLAGS, flags)
     }
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/SyncIdBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/SyncIdBuilder.kt
@@ -6,13 +6,18 @@ package at.bitfire.synctools.mapping.tasks.builder
 
 import android.content.Entity
 import at.bitfire.ical4android.Task
+import net.fortuna.ical4j.model.component.VToDo
 import org.dmfs.tasks.contract.TaskContract.Tasks
 
 class SyncIdBuilder(
     private val syncId: String?
-) : DmfsTaskFieldBuilder {
+) : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
     override fun build(from: Task, to: Entity) {
+        to.entityValues.put(Tasks._SYNC_ID, syncId)
+    }
+
+    override fun build(from: VToDo, to: Entity) {
         to.entityValues.put(Tasks._SYNC_ID, syncId)
     }
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/UidBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/UidBuilder.kt
@@ -6,12 +6,20 @@ package at.bitfire.synctools.mapping.tasks.builder
 
 import android.content.Entity
 import at.bitfire.ical4android.Task
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Uid
 import org.dmfs.tasks.contract.TaskContract.Tasks
+import kotlin.jvm.optionals.getOrNull
 
-class UidBuilder : DmfsTaskFieldBuilder {
+class UidBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo {
 
     override fun build(from: Task, to: Entity) {
         to.entityValues.put(Tasks._UID, from.uid)
+    }
+
+    override fun build(from: VToDo, to: Entity) {
+        val uid = from.getProperty<Uid>(Uid.UID).getOrNull()
+        to.entityValues.put(Tasks._UID, uid?.value)
     }
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/CreatedBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/CreatedBuilderTest.kt
@@ -8,11 +8,15 @@ import android.content.ContentValues
 import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.mapping.tasks.VToDoUtil
 import at.bitfire.synctools.test.assertContentValuesEqual
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Created
 import org.dmfs.tasks.contract.TaskContract.Tasks
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.time.Instant
 
 @RunWith(RobolectricTestRunner::class)
 class CreatedBuilderTest {
@@ -20,7 +24,7 @@ class CreatedBuilderTest {
     private val builder = CreatedBuilder()
 
     @Test
-    fun `No CREATED stores null`() {
+    fun `old No CREATED stores null`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(),
@@ -32,10 +36,34 @@ class CreatedBuilderTest {
     }
 
     @Test
-    fun `CREATED is stored`() {
+    fun `old CREATED is stored`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(createdAt = 1593771404L),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.CREATED to 1593771404L
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `No CREATED stores null`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDo(),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.CREATED to null
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `CREATED is stored`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(Created(null, Instant.ofEpochMilli(1593771404L))),
             to = result
         )
         assertContentValuesEqual(contentValuesOf(

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/CreatedBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/CreatedBuilderTest.kt
@@ -63,7 +63,7 @@ class CreatedBuilderTest {
     fun `CREATED is stored`() {
         val result = Entity(ContentValues())
         builder.build(
-            from = VToDoUtil.build(Created(null, Instant.ofEpochMilli(1593771404L))),
+            from = VToDoUtil.build(Created(Instant.ofEpochMilli(1593771404L))),
             to = result
         )
         assertContentValuesEqual(contentValuesOf(

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/CreatedBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/CreatedBuilderTest.kt
@@ -63,11 +63,11 @@ class CreatedBuilderTest {
     fun `CREATED is stored`() {
         val result = Entity(ContentValues())
         builder.build(
-            from = VToDoUtil.build(Created(Instant.ofEpochMilli(1593771404L))),
+            from = VToDoUtil.build(Created(Instant.ofEpochSecond(1593771404L))),
             to = result
         )
         assertContentValuesEqual(contentValuesOf(
-            Tasks.CREATED to 1593771404L
+            Tasks.CREATED to 1593771404000L
         ), result.entityValues)
     }
 

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/DirtyBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/DirtyBuilderTest.kt
@@ -9,6 +9,7 @@ import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
 import at.bitfire.synctools.test.assertContentValuesEqual
+import net.fortuna.ical4j.model.component.VToDo
 import org.dmfs.tasks.contract.TaskContract.Tasks
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -20,10 +21,22 @@ class DirtyBuilderTest {
     private val builder = DirtyBuilder()
 
     @Test
-    fun `DIRTY is set to 0`() {
+    fun `old DIRTY is set to 0`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks._DIRTY to 0
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `DIRTY is set to 0`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDo(),
             to = result
         )
         assertContentValuesEqual(contentValuesOf(

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/ETagBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/ETagBuilderTest.kt
@@ -10,6 +10,7 @@ import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
 import at.bitfire.synctools.storage.tasks.DmfsTask.Companion.COLUMN_ETAG
 import at.bitfire.synctools.test.assertContentValuesEqual
+import net.fortuna.ical4j.model.component.VToDo
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -18,7 +19,7 @@ import org.robolectric.RobolectricTestRunner
 class ETagBuilderTest {
 
     @Test
-    fun `ETag is set`() {
+    fun `old ETag is set`() {
         val result = Entity(ContentValues())
         ETagBuilder(eTag = "some-etag").build(
             from = Task(),
@@ -30,10 +31,34 @@ class ETagBuilderTest {
     }
 
     @Test
-    fun `ETag is null`() {
+    fun `old ETag is null`() {
         val result = Entity(ContentValues())
         ETagBuilder(eTag = null).build(
             from = Task(),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            COLUMN_ETAG to null
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `ETag is set`() {
+        val result = Entity(ContentValues())
+        ETagBuilder(eTag = "some-etag").build(
+            from = VToDo(),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            COLUMN_ETAG to "some-etag"
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `ETag is null`() {
+        val result = Entity(ContentValues())
+        ETagBuilder(eTag = null).build(
+            from = VToDo(),
             to = result
         )
         assertContentValuesEqual(contentValuesOf(

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/LastModifiedBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/LastModifiedBuilderTest.kt
@@ -8,11 +8,15 @@ import android.content.ContentValues
 import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.mapping.tasks.VToDoUtil
 import at.bitfire.synctools.test.assertContentValuesEqual
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.LastModified
 import org.dmfs.tasks.contract.TaskContract.Tasks
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.time.Instant
 
 @RunWith(RobolectricTestRunner::class)
 class LastModifiedBuilderTest {
@@ -20,7 +24,7 @@ class LastModifiedBuilderTest {
     private val builder = LastModifiedBuilder()
 
     @Test
-    fun `No LAST_MODIFIED stores null`() {
+    fun `old No LAST_MODIFIED stores null`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(),
@@ -32,10 +36,34 @@ class LastModifiedBuilderTest {
     }
 
     @Test
-    fun `LAST_MODIFIED is stored`() {
+    fun `old LAST_MODIFIED is stored`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(lastModified = 1593771404L),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.LAST_MODIFIED to 1593771404L
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `No LAST_MODIFIED stores null`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDo(),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.LAST_MODIFIED to null
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `LAST_MODIFIED is stored`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(LastModified(Instant.ofEpochMilli(1593771404L))),
             to = result
         )
         assertContentValuesEqual(contentValuesOf(

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/LastModifiedBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/LastModifiedBuilderTest.kt
@@ -63,11 +63,11 @@ class LastModifiedBuilderTest {
     fun `LAST_MODIFIED is stored`() {
         val result = Entity(ContentValues())
         builder.build(
-            from = VToDoUtil.build(LastModified(Instant.ofEpochMilli(1593771404L))),
+            from = VToDoUtil.build(LastModified(Instant.ofEpochSecond(1593771404L))),
             to = result
         )
         assertContentValuesEqual(contentValuesOf(
-            Tasks.LAST_MODIFIED to 1593771404L
+            Tasks.LAST_MODIFIED to 1593771404000L
         ), result.entityValues)
     }
 

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/SequenceBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/SequenceBuilderTest.kt
@@ -8,7 +8,10 @@ import android.content.ContentValues
 import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.mapping.tasks.VToDoUtil
 import at.bitfire.synctools.test.assertContentValuesEqual
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Sequence
 import org.dmfs.tasks.contract.TaskContract.Tasks
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -20,7 +23,7 @@ class SequenceBuilderTest {
     private val builder = SequenceBuilder()
 
     @Test
-    fun `No SEQUENCE defaults to 0`() {
+    fun `old No SEQUENCE defaults to 0`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(),
@@ -32,7 +35,7 @@ class SequenceBuilderTest {
     }
 
     @Test
-    fun `SEQUENCE is 0`() {
+    fun `old SEQUENCE is 0`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task().also { it.sequence = 0 },
@@ -44,10 +47,46 @@ class SequenceBuilderTest {
     }
 
     @Test
-    fun `SEQUENCE is 1`() {
+    fun `old SEQUENCE is 1`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task().also { it.sequence = 1 },
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.SYNC_VERSION to 1
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `No SEQUENCE defaults to 0`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDo(),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.SYNC_VERSION to 0
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `SEQUENCE is 0`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(Sequence(0)),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.SYNC_VERSION to 0
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `SEQUENCE is 1`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(Sequence(1)),
             to = result
         )
         assertContentValuesEqual(contentValuesOf(

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/SyncFlagsBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/SyncFlagsBuilderTest.kt
@@ -10,6 +10,7 @@ import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
 import at.bitfire.synctools.storage.tasks.DmfsTask.Companion.COLUMN_FLAGS
 import at.bitfire.synctools.test.assertContentValuesEqual
+import net.fortuna.ical4j.model.component.VToDo
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -18,10 +19,22 @@ import org.robolectric.RobolectricTestRunner
 class SyncFlagsBuilderTest {
 
     @Test
-    fun `Flags set to 123`() {
+    fun `old Flags set to 123`() {
         val result = Entity(ContentValues())
         SyncFlagsBuilder(123).build(
             from = Task(),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            COLUMN_FLAGS to 123
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `Flags set to 123`() {
+        val result = Entity(ContentValues())
+        SyncFlagsBuilder(123).build(
+            from = VToDo(),
             to = result
         )
         assertContentValuesEqual(contentValuesOf(

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/SyncIdBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/SyncIdBuilderTest.kt
@@ -9,6 +9,7 @@ import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
 import at.bitfire.synctools.test.assertContentValuesEqual
+import net.fortuna.ical4j.model.component.VToDo
 import org.dmfs.tasks.contract.TaskContract.Tasks
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -18,7 +19,7 @@ import org.robolectric.RobolectricTestRunner
 class SyncIdBuilderTest {
 
     @Test
-    fun `SyncId sets _SYNC_ID`() {
+    fun `old SyncId sets _SYNC_ID`() {
         val result = Entity(ContentValues())
         SyncIdBuilder("sync-id").build(
             from = Task(),
@@ -30,10 +31,34 @@ class SyncIdBuilderTest {
     }
 
     @Test
-    fun `SyncId is null`() {
+    fun `old SyncId is null`() {
         val result = Entity(ContentValues())
         SyncIdBuilder(null).build(
             from = Task(),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks._SYNC_ID to null
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `SyncId sets _SYNC_ID`() {
+        val result = Entity(ContentValues())
+        SyncIdBuilder("sync-id").build(
+            from = VToDo(),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks._SYNC_ID to "sync-id"
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `SyncId is null`() {
+        val result = Entity(ContentValues())
+        SyncIdBuilder(null).build(
+            from = VToDo(),
             to = result
         )
         assertContentValuesEqual(contentValuesOf(

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/UidBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/UidBuilderTest.kt
@@ -8,7 +8,10 @@ import android.content.ContentValues
 import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.mapping.tasks.VToDoUtil
 import at.bitfire.synctools.test.assertContentValuesEqual
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Uid
 import org.dmfs.tasks.contract.TaskContract.Tasks
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -20,7 +23,7 @@ class UidBuilderTest {
     private val builder = UidBuilder()
 
     @Test
-    fun `No UID`() {
+    fun `old No UID`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task(),
@@ -32,10 +35,34 @@ class UidBuilderTest {
     }
 
     @Test
-    fun `UID is set`() {
+    fun `old UID is set`() {
         val result = Entity(ContentValues())
         builder.build(
             from = Task().also { it.uid = "some-uid" },
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks._UID to "some-uid"
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `No UID`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDo(),
+            to = result
+        )
+        assertContentValuesEqual(contentValuesOf(
+            Tasks._UID to null
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `UID is set`() {
+        val result = Entity(ContentValues())
+        builder.build(
+            from = VToDoUtil.build(Uid("some-uid")),
             to = result
         )
         assertContentValuesEqual(contentValuesOf(


### PR DESCRIPTION
### Purpose

Finish migrating the rest of builders to `VToDo`

### Short description

- Created
- Dirty
- ETag
- LastModified
- Sequence
- SyncFlags
- SyncId
- Uid

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

