### PR TITLE
DmfsTask: Update `RecurrenceFieldsBuilder` to allow `main` task

### DIFF
--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DmfsTaskFieldBuilderVToDo.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/DmfsTaskFieldBuilderVToDo.kt
@@ -22,4 +22,23 @@ interface DmfsTaskFieldBuilderVToDo {
      */
     fun build(from: VToDo, to: Entity)
 
+    /**
+     * Maps a specific part of the given [VToDo] into the provided [Entity].
+     *
+     * If [from] references the same object as [main], this is the main task (not an exception).
+     * If [from] references a different object, this is an exception instance.
+     *
+     * Use referential equality to distinguish them:
+     * ```
+     * val isMain = from === main
+     * ```
+     *
+     * By default delegates to [build] without [main]; override when the distinction matters.
+     *
+     * @param from  task to map
+     * @param main  main (non-exception) VToDo
+     * @param to    destination [Entity] where built values are stored (set `null` values, see note)
+     */
+    fun build(from: VToDo, main: VToDo, to: Entity) = build(from, to)
+
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/RecurrenceFieldsBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/RecurrenceFieldsBuilder.kt
@@ -40,28 +40,38 @@ class RecurrenceFieldsBuilder : DmfsTaskFieldBuilder, DmfsTaskFieldBuilderVToDo 
         )
     }
 
-    override fun build(from: VToDo, to: Entity) {
-        val allDay = from.isAllDay()
-        val tz = if (allDay) null else allDayBuilder.getTimeZone(from)
+    override fun build(from: VToDo, to: Entity) = build(from, from, to)
 
+    override fun build(from: VToDo, main: VToDo, to: Entity) {
         val rRule = from.getProperty<RRule<*>>(RRule.RRULE).getOrNull()
-        to.entityValues.put(Tasks.RRULE, rRule?.value)
-
         val rDates = from.getProperties<RDate<*>>(RDate.RDATE)
-        to.entityValues.put(Tasks.RDATE,
-            if (rDates.isEmpty())
-                null
-            else
-                AndroidTimeUtils.recurrenceSetsToOpenTasksString(rDates, tz)
-        )
+        val recurring = rRule != null || rDates.isNotEmpty()
 
-        val exDates = from.getProperties<ExDate<*>>(ExDate.EXDATE)
-        to.entityValues.put(Tasks.EXDATE,
-            if (exDates.isEmpty())
-                null
-            else
-                AndroidTimeUtils.recurrenceSetsToOpenTasksString(exDates, tz)
-        )
+        if (recurring && from === main) {
+            val allDay = from.isAllDay()
+            val tz = if (allDay) null else allDayBuilder.getTimeZone(from)
+
+            to.entityValues.put(Tasks.RRULE, rRule?.value)
+
+            to.entityValues.put(Tasks.RDATE,
+                if (rDates.isEmpty())
+                    null
+                else
+                    AndroidTimeUtils.recurrenceSetsToOpenTasksString(rDates, tz)
+            )
+
+            val exDates = from.getProperties<ExDate<*>>(ExDate.EXDATE)
+            to.entityValues.put(Tasks.EXDATE,
+                if (exDates.isEmpty())
+                    null
+                else
+                    AndroidTimeUtils.recurrenceSetsToOpenTasksString(exDates, tz)
+            )
+        } else {
+            to.entityValues.putNull(Tasks.RRULE)
+            to.entityValues.putNull(Tasks.RDATE)
+            to.entityValues.putNull(Tasks.EXDATE)
+        }
     }
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/RecurrenceFieldsBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/RecurrenceFieldsBuilderTest.kt
@@ -90,11 +90,9 @@ class RecurrenceFieldsBuilderTest {
 
     @Test
     fun `No recurrence fields`() {
+        val vtodo = VToDoUtil.build()
         val result = Entity(ContentValues())
-        builder.build(
-            from = VToDoUtil.build(),
-            to = result
-        )
+        builder.build(from = vtodo, main = vtodo, to = result)
         assertContentValuesEqual(contentValuesOf(
             Tasks.RRULE to null,
             Tasks.RDATE to null,
@@ -104,14 +102,12 @@ class RecurrenceFieldsBuilderTest {
 
     @Test
     fun `RRULE is set`() {
-        val result = Entity(ContentValues())
-        builder.build(
-            from = VToDoUtil.build(
-                DtStart(LocalDate.of(2025, 1, 15)),
-                RRule<Temporal>("FREQ=DAILY;COUNT=10")
-            ),
-            to = result
+        val vtodo = VToDoUtil.build(
+            DtStart(LocalDate.of(2025, 1, 15)),
+            RRule<Temporal>("FREQ=DAILY;COUNT=10")
         )
+        val result = Entity(ContentValues())
+        builder.build(from = vtodo, main = vtodo, to = result)
         assertContentValuesEqual(contentValuesOf(
             Tasks.RRULE to "FREQ=DAILY;COUNT=10",
             Tasks.RDATE to null,
@@ -121,46 +117,59 @@ class RecurrenceFieldsBuilderTest {
 
     @Test
     fun `RDATE all-day dates`() {
-        val result = Entity(ContentValues())
-        builder.build(
-            from = VToDoUtil.build(
-                DtStart(LocalDate.of(2025, 1, 10)),
-                RDate(DateList(LocalDate.of(2025, 1, 15)))
-            ),
-            to = result
+        val vtodo = VToDoUtil.build(
+            DtStart(LocalDate.of(2025, 1, 10)),
+            RDate(DateList(LocalDate.of(2025, 1, 15)))
         )
+        val result = Entity(ContentValues())
+        builder.build(from = vtodo, main = vtodo, to = result)
         val rdate = result.entityValues.getAsString(Tasks.RDATE)
         assertNotNull("RDATE should be set", rdate)
     }
 
     @Test
     fun `EXDATE all-day dates`() {
-        val result = Entity(ContentValues())
-        builder.build(
-            from = VToDoUtil.build(
-                DtStart(LocalDate.of(2025, 1, 10)),
-                RRule<Temporal>("FREQ=DAILY;COUNT=10"),
-                ExDate(DateList(LocalDate.of(2025, 1, 15)))
-            ),
-            to = result
+        val vtodo = VToDoUtil.build(
+            DtStart(LocalDate.of(2025, 1, 10)),
+            RRule<Temporal>("FREQ=DAILY;COUNT=10"),
+            ExDate(DateList(LocalDate.of(2025, 1, 15)))
         )
+        val result = Entity(ContentValues())
+        builder.build(from = vtodo, main = vtodo, to = result)
         val exdate = result.entityValues.getAsString(Tasks.EXDATE)
         assertNotNull("EXDATE should be set", exdate)
     }
 
     @Test
     fun `RRULE with DATE-TIME DTSTART`() {
-        val result = Entity(ContentValues())
         val ts = ZonedDateTime.of(2025, 1, 15, 10, 0, 0, 0, ZoneOffset.UTC)
-        builder.build(
-            from = VToDoUtil.build(
-                DtStart(ts),
-                RRule<Temporal>("FREQ=DAILY;COUNT=5")
-            ),
-            to = result
+        val vtodo = VToDoUtil.build(
+            DtStart(ts),
+            RRule<Temporal>("FREQ=DAILY;COUNT=5")
         )
+        val result = Entity(ContentValues())
+        builder.build(from = vtodo, main = vtodo, to = result)
         assertContentValuesEqual(contentValuesOf(
             Tasks.RRULE to "FREQ=DAILY;COUNT=5",
+            Tasks.RDATE to null,
+            Tasks.EXDATE to null
+        ), result.entityValues)
+    }
+
+    @Test
+    fun `Exception VToDo - recurrence fields are nulled out`() {
+        val main = VToDoUtil.build(
+            DtStart(LocalDate.of(2025, 1, 15)),
+            RRule<Temporal>("FREQ=DAILY;COUNT=10")
+        )
+        val exception = VToDoUtil.build(
+            DtStart(LocalDate.of(2025, 1, 17)),
+            RRule<Temporal>("FREQ=DAILY;COUNT=5")
+        )
+        val result = Entity(ContentValues())
+        builder.build(from = exception, main = main, to = result)
+        assertContentValuesEqual(contentValuesOf(
+            Tasks.RRULE to null,
             Tasks.RDATE to null,
             Tasks.EXDATE to null
         ), result.entityValues)


### PR DESCRIPTION
### Purpose

Calendar's `RecurrenceFieldsBuilder` supports passing `main` event for recurrence exceptions.

### Short description

- Refactor task's `RecurrenceFieldsBuilder` to match the behavior.

I'm not sure if this

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

