### PR TITLE
DmfsTask: Migrate title, UID, and status handlers to VToDo

### DIFF
--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/StatusHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/StatusHandler.kt
@@ -10,7 +10,6 @@ import at.bitfire.ical4android.Task
 import at.bitfire.synctools.icalendar.plusAssign
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.property.Status
-import net.fortuna.ical4j.model.property.immutable.ImmutableStatus
 import org.dmfs.tasks.contract.TaskContract.Tasks
 
 class StatusHandler : DmfsTaskFieldHandler, DmfsTaskFieldHandler2 {
@@ -26,10 +25,10 @@ class StatusHandler : DmfsTaskFieldHandler, DmfsTaskFieldHandler2 {
 
     override fun process(from: Entity, main: Entity, to: VToDo) {
         val status = when (from.entityValues.getAsInteger(Tasks.STATUS)) {
-            Tasks.STATUS_IN_PROCESS -> Status(ImmutableStatus.VALUE_IN_PROCESS)
-            Tasks.STATUS_COMPLETED -> Status(ImmutableStatus.VALUE_COMPLETED)
-            Tasks.STATUS_CANCELLED -> Status(ImmutableStatus.VALUE_CANCELLED)
-            else -> Status(ImmutableStatus.VALUE_NEEDS_ACTION)
+            Tasks.STATUS_IN_PROCESS -> Status(Status.VALUE_IN_PROCESS)
+            Tasks.STATUS_COMPLETED -> Status(Status.VALUE_COMPLETED)
+            Tasks.STATUS_CANCELLED -> Status(Status.VALUE_CANCELLED)
+            else -> Status(Status.VALUE_NEEDS_ACTION)
         }
         to += status
     }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/StatusHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/StatusHandler.kt
@@ -5,11 +5,15 @@
 package at.bitfire.synctools.mapping.tasks.handler
 
 import android.content.ContentValues
+import android.content.Entity
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.icalendar.plusAssign
+import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.property.Status
+import net.fortuna.ical4j.model.property.immutable.ImmutableStatus
 import org.dmfs.tasks.contract.TaskContract.Tasks
 
-class StatusHandler : DmfsTaskFieldHandler {
+class StatusHandler : DmfsTaskFieldHandler, DmfsTaskFieldHandler2 {
 
     override fun process(from: ContentValues, to: Task) {
         to.status = when (from.getAsInteger(Tasks.STATUS)) {
@@ -18,6 +22,16 @@ class StatusHandler : DmfsTaskFieldHandler {
             Tasks.STATUS_CANCELLED ->  Status(Status.VALUE_CANCELLED)
             else ->                    Status(Status.VALUE_NEEDS_ACTION)
         }
+    }
+
+    override fun process(from: Entity, main: Entity, to: VToDo) {
+        val status = when (from.entityValues.getAsInteger(Tasks.STATUS)) {
+            Tasks.STATUS_IN_PROCESS -> Status(ImmutableStatus.VALUE_IN_PROCESS)
+            Tasks.STATUS_COMPLETED -> Status(ImmutableStatus.VALUE_COMPLETED)
+            Tasks.STATUS_CANCELLED -> Status(ImmutableStatus.VALUE_CANCELLED)
+            else -> Status(ImmutableStatus.VALUE_NEEDS_ACTION)
+        }
+        to += status
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/TitleHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/TitleHandler.kt
@@ -5,13 +5,24 @@
 package at.bitfire.synctools.mapping.tasks.handler
 
 import android.content.ContentValues
+import android.content.Entity
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.icalendar.plusAssign
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Summary
 import org.dmfs.tasks.contract.TaskContract.Tasks
 
-class TitleHandler : DmfsTaskFieldHandler {
+class TitleHandler : DmfsTaskFieldHandler, DmfsTaskFieldHandler2 {
 
     override fun process(from: ContentValues, to: Task) {
         to.summary = from.getAsString(Tasks.TITLE)
+    }
+
+    override fun process(from: Entity, main: Entity, to: VToDo) {
+        val title = from.entityValues.getAsString(Tasks.TITLE)
+        if (title != null) {
+            to += Summary(title)
+        }
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/UidHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/UidHandler.kt
@@ -5,13 +5,24 @@
 package at.bitfire.synctools.mapping.tasks.handler
 
 import android.content.ContentValues
+import android.content.Entity
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.icalendar.plusAssign
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Uid
 import org.dmfs.tasks.contract.TaskContract.Tasks
 
-class UidHandler : DmfsTaskFieldHandler {
+class UidHandler : DmfsTaskFieldHandler, DmfsTaskFieldHandler2 {
 
     override fun process(from: ContentValues, to: Task) {
         to.uid = from.getAsString(Tasks._UID)
+    }
+
+    override fun process(from: Entity, main: Entity, to: VToDo) {
+        val uid = from.entityValues.getAsString(Tasks._UID)
+        if (uid != null) {
+            to += Uid(uid)
+        }
     }
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/StatusHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/StatusHandlerTest.kt
@@ -5,9 +5,12 @@
 package at.bitfire.synctools.mapping.tasks.handler
 
 import android.content.ContentValues
+import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
+import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.property.Status
+import net.fortuna.ical4j.model.property.immutable.ImmutableStatus
 import org.dmfs.tasks.contract.TaskContract.Tasks
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -20,45 +23,105 @@ class StatusHandlerTest {
     private val handler = StatusHandler()
 
     @Test
-    fun `No STATUS defaults to NEEDS-ACTION`() {
+    fun `legacy No STATUS defaults to NEEDS-ACTION`() {
         val task = Task()
         handler.process(ContentValues(), task)
         assertEquals(Status(Status.VALUE_NEEDS_ACTION), task.status)
     }
 
     @Test
-    fun `STATUS_NEEDS_ACTION maps to NEEDS-ACTION`() {
+    fun `legacy STATUS_NEEDS_ACTION maps to NEEDS-ACTION`() {
         val task = Task()
         handler.process(contentValuesOf(Tasks.STATUS to Tasks.STATUS_NEEDS_ACTION), task)
         assertEquals(Status(Status.VALUE_NEEDS_ACTION), task.status)
     }
 
     @Test
-    fun `STATUS_IN_PROCESS maps to IN-PROCESS`() {
+    fun `legacy STATUS_IN_PROCESS maps to IN-PROCESS`() {
         val task = Task()
         handler.process(contentValuesOf(Tasks.STATUS to Tasks.STATUS_IN_PROCESS), task)
         assertEquals(Status(Status.VALUE_IN_PROCESS), task.status)
     }
 
     @Test
-    fun `STATUS_COMPLETED maps to COMPLETED`() {
+    fun `legacy STATUS_COMPLETED maps to COMPLETED`() {
         val task = Task()
         handler.process(contentValuesOf(Tasks.STATUS to Tasks.STATUS_COMPLETED), task)
         assertEquals(Status(Status.VALUE_COMPLETED), task.status)
     }
 
     @Test
-    fun `STATUS_CANCELLED maps to CANCELLED`() {
+    fun `legacy STATUS_CANCELLED maps to CANCELLED`() {
         val task = Task()
         handler.process(contentValuesOf(Tasks.STATUS to Tasks.STATUS_CANCELLED), task)
         assertEquals(Status(Status.VALUE_CANCELLED), task.status)
     }
 
     @Test
-    fun `Unknown STATUS defaults to NEEDS-ACTION`() {
+    fun `legacy Unknown STATUS defaults to NEEDS-ACTION`() {
         val task = Task()
         handler.process(contentValuesOf(Tasks.STATUS to 99), task)
         assertEquals(Status(Status.VALUE_NEEDS_ACTION), task.status)
+    }
+
+    @Test
+    fun `No STATUS defaults to NEEDS-ACTION`() {
+        val input = Entity(ContentValues())
+        val task = VToDo()
+
+        handler.process(from = input, main = input, to = task)
+
+        assertEquals(ImmutableStatus.VALUE_NEEDS_ACTION, task.status?.value)
+    }
+
+    @Test
+    fun `STATUS_NEEDS_ACTION maps to NEEDS-ACTION`() {
+        val input = Entity(contentValuesOf(Tasks.STATUS to Tasks.STATUS_NEEDS_ACTION))
+        val task = VToDo()
+
+        handler.process(from = input, main = input, to = task)
+
+        assertEquals(ImmutableStatus.VALUE_NEEDS_ACTION, task.status?.value)
+    }
+
+    @Test
+    fun `STATUS_IN_PROCESS maps to IN-PROCESS`() {
+        val input = Entity(contentValuesOf(Tasks.STATUS to Tasks.STATUS_IN_PROCESS))
+        val task = VToDo()
+
+        handler.process(from = input, main = input, to = task)
+
+        assertEquals(ImmutableStatus.VALUE_IN_PROCESS, task.status?.value)
+    }
+
+    @Test
+    fun `STATUS_COMPLETED maps to COMPLETED`() {
+        val input = Entity(contentValuesOf(Tasks.STATUS to Tasks.STATUS_COMPLETED))
+        val task = VToDo()
+
+        handler.process(from = input, main = input, to = task)
+
+        assertEquals(ImmutableStatus.VALUE_COMPLETED, task.status?.value)
+    }
+
+    @Test
+    fun `STATUS_CANCELLED maps to CANCELLED`() {
+        val input = Entity(contentValuesOf(Tasks.STATUS to Tasks.STATUS_CANCELLED))
+        val task = VToDo()
+
+        handler.process(from = input, main = input, to = task)
+
+        assertEquals(ImmutableStatus.VALUE_CANCELLED, task.status?.value)
+    }
+
+    @Test
+    fun `Unknown STATUS defaults to NEEDS-ACTION`() {
+        val input = Entity(contentValuesOf(Tasks.STATUS to 99))
+        val task = VToDo()
+
+        handler.process(from = input, main = input, to = task)
+
+        assertEquals(ImmutableStatus.VALUE_NEEDS_ACTION, task.status?.value)
     }
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/StatusHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/StatusHandlerTest.kt
@@ -10,7 +10,6 @@ import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.property.Status
-import net.fortuna.ical4j.model.property.immutable.ImmutableStatus
 import org.dmfs.tasks.contract.TaskContract.Tasks
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -71,7 +70,7 @@ class StatusHandlerTest {
 
         handler.process(from = input, main = input, to = task)
 
-        assertEquals(ImmutableStatus.VALUE_NEEDS_ACTION, task.status?.value)
+        assertEquals(Status(Status.VALUE_NEEDS_ACTION), task.status)
     }
 
     @Test
@@ -81,7 +80,7 @@ class StatusHandlerTest {
 
         handler.process(from = input, main = input, to = task)
 
-        assertEquals(ImmutableStatus.VALUE_NEEDS_ACTION, task.status?.value)
+        assertEquals(Status(Status.VALUE_NEEDS_ACTION), task.status)
     }
 
     @Test
@@ -91,7 +90,7 @@ class StatusHandlerTest {
 
         handler.process(from = input, main = input, to = task)
 
-        assertEquals(ImmutableStatus.VALUE_IN_PROCESS, task.status?.value)
+        assertEquals(Status(Status.VALUE_IN_PROCESS), task.status)
     }
 
     @Test
@@ -101,7 +100,7 @@ class StatusHandlerTest {
 
         handler.process(from = input, main = input, to = task)
 
-        assertEquals(ImmutableStatus.VALUE_COMPLETED, task.status?.value)
+        assertEquals(Status(Status.VALUE_COMPLETED), task.status)
     }
 
     @Test
@@ -111,7 +110,7 @@ class StatusHandlerTest {
 
         handler.process(from = input, main = input, to = task)
 
-        assertEquals(ImmutableStatus.VALUE_CANCELLED, task.status?.value)
+        assertEquals(Status(Status.VALUE_CANCELLED), task.status)
     }
 
     @Test
@@ -121,7 +120,7 @@ class StatusHandlerTest {
 
         handler.process(from = input, main = input, to = task)
 
-        assertEquals(ImmutableStatus.VALUE_NEEDS_ACTION, task.status?.value)
+        assertEquals(Status(Status.VALUE_NEEDS_ACTION), task.status)
     }
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/TitleHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/TitleHandlerTest.kt
@@ -5,8 +5,11 @@
 package at.bitfire.synctools.mapping.tasks.handler
 
 import android.content.ContentValues
+import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Summary
 import org.dmfs.tasks.contract.TaskContract.Tasks
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -20,17 +23,37 @@ class TitleHandlerTest {
     private val handler = TitleHandler()
 
     @Test
-    fun `No title`() {
+    fun `legacy No title`() {
         val task = Task()
         handler.process(ContentValues(), task)
         assertNull(task.summary)
     }
 
     @Test
-    fun `Title set`() {
+    fun `legacy Title set`() {
         val task = Task()
         handler.process(contentValuesOf(Tasks.TITLE to "Test Task"), task)
         assertEquals("Test Task", task.summary)
+    }
+
+    @Test
+    fun `No title`() {
+        val input = Entity(ContentValues())
+        val task = VToDo()
+
+        handler.process(from = input, main = input, to = task)
+
+        assertNull(task.summary)
+    }
+
+    @Test
+    fun `Title set`() {
+        val input = Entity(contentValuesOf(Tasks.TITLE to "Test Task"))
+        val task = VToDo()
+
+        handler.process(from = input, main = input, to = task)
+
+        assertEquals(Summary("Test Task"), task.summary)
     }
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/UidHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/UidHandlerTest.kt
@@ -5,14 +5,17 @@
 package at.bitfire.synctools.mapping.tasks.handler
 
 import android.content.ContentValues
+import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
+import net.fortuna.ical4j.model.component.VToDo
 import org.dmfs.tasks.contract.TaskContract.Tasks
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import kotlin.jvm.optionals.getOrNull
 
 @RunWith(RobolectricTestRunner::class)
 class UidHandlerTest {
@@ -20,17 +23,37 @@ class UidHandlerTest {
     private val handler = UidHandler()
 
     @Test
-    fun `No UID`() {
+    fun `legacy No UID`() {
         val task = Task()
         handler.process(ContentValues(), task)
         assertNull(task.uid)
     }
 
     @Test
-    fun `UID set`() {
+    fun `legacy UID set`() {
         val task = Task()
         handler.process(contentValuesOf(Tasks._UID to "test-uid-123"), task)
         assertEquals("test-uid-123", task.uid)
+    }
+
+    @Test
+    fun `No UID`() {
+        val input = Entity(ContentValues())
+        val task = VToDo()
+
+        handler.process(from = input, main = input, to = task)
+
+        assertNull(task.uid.getOrNull())
+    }
+
+    @Test
+    fun `UID set`() {
+        val input = Entity(contentValuesOf(Tasks._UID to "test-uid-123"))
+        val task = VToDo()
+
+        handler.process(from = input, main = input, to = task)
+
+        assertEquals("test-uid-123", task.uid.getOrNull()?.value)
     }
 
 }


### PR DESCRIPTION
### Purpose

Migrate title, UID, and status handlers to VToDo.

### Short description

* Implement `DmfsTaskFieldHandler2` for `TitleHandler`, `UidHandler`, and `StatusHandler`
* Add VToDo-based tests and rename legacy tests
* Use Entity and VToDo in new handler implementations


### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

