### PR TITLE
DmfsTask: Migrate unknown properties and URL handlers to VToDo

### DIFF
--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/UnknownPropertiesHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/UnknownPropertiesHandler.kt
@@ -5,13 +5,16 @@
 package at.bitfire.synctools.mapping.tasks.handler
 
 import android.content.ContentValues
+import android.content.Entity
 import at.bitfire.ical4android.Task
 import at.bitfire.ical4android.UnknownProperty
+import at.bitfire.synctools.icalendar.plusAssign
 import at.bitfire.synctools.storage.tasks.DmfsTask.Companion.UNKNOWN_PROPERTY_DATA
+import net.fortuna.ical4j.model.component.VToDo
 import org.json.JSONException
 import java.util.logging.Logger
 
-class UnknownPropertiesHandler : DmfsTaskFieldHandler {
+class UnknownPropertiesHandler : DmfsTaskFieldHandler, DmfsTaskFieldHandler2 {
 
     private val logger
         get() = Logger.getLogger(javaClass.name)
@@ -20,6 +23,17 @@ class UnknownPropertiesHandler : DmfsTaskFieldHandler {
         from.getAsString(UNKNOWN_PROPERTY_DATA)?.let { properties ->
             try {
                 to.unknownProperties += UnknownProperty.fromJsonString(properties)
+            } catch (e: JSONException) {
+                // Ignore properties with invalid JSON
+                logger.warning("Got an unknown property with invalid JSON: $e")
+            }
+        }
+    }
+
+    override fun process(from: Entity, main: Entity, to: VToDo) {
+        from.entityValues.getAsString(UNKNOWN_PROPERTY_DATA)?.let { properties ->
+            try {
+                to += UnknownProperty.fromJsonString(properties)
             } catch (e: JSONException) {
                 // Ignore properties with invalid JSON
                 logger.warning("Got an unknown property with invalid JSON: $e")

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/UrlHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/UrlHandler.kt
@@ -13,8 +13,13 @@ import net.fortuna.ical4j.model.property.Url
 import org.dmfs.tasks.contract.TaskContract.Tasks
 import java.net.URI
 import java.net.URISyntaxException
+import java.util.logging.Level
+import java.util.logging.Logger
 
 class UrlHandler : DmfsTaskFieldHandler, DmfsTaskFieldHandler2 {
+
+    private val logger
+        get() = Logger.getLogger(UrlHandler::class.java.name)
 
     override fun process(from: ContentValues, to: Task) {
         to.url = from.getAsString(Tasks.URL)
@@ -25,8 +30,9 @@ class UrlHandler : DmfsTaskFieldHandler, DmfsTaskFieldHandler2 {
         if (url != null) {
             try {
                 to += Url(URI(url))
-            } catch (_: URISyntaxException) {
+            } catch (e: URISyntaxException) {
                 // Ignore invalid URLs
+                logger.log(Level.WARNING, "Ignoring invalid task URL: $url", e)
             }
         }
     }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/UrlHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/UrlHandler.kt
@@ -5,13 +5,30 @@
 package at.bitfire.synctools.mapping.tasks.handler
 
 import android.content.ContentValues
+import android.content.Entity
 import at.bitfire.ical4android.Task
+import at.bitfire.synctools.icalendar.plusAssign
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Url
 import org.dmfs.tasks.contract.TaskContract.Tasks
+import java.net.URI
+import java.net.URISyntaxException
 
-class UrlHandler : DmfsTaskFieldHandler {
+class UrlHandler : DmfsTaskFieldHandler, DmfsTaskFieldHandler2 {
 
     override fun process(from: ContentValues, to: Task) {
         to.url = from.getAsString(Tasks.URL)
+    }
+
+    override fun process(from: Entity, main: Entity, to: VToDo) {
+        val url = from.entityValues.getAsString(Tasks.URL)
+        if (url != null) {
+            try {
+                to += Url(URI(url))
+            } catch (_: URISyntaxException) {
+                // Ignore invalid URLs
+            }
+        }
     }
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/UnknownPropertiesHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/UnknownPropertiesHandlerTest.kt
@@ -5,11 +5,13 @@
 package at.bitfire.synctools.mapping.tasks.handler
 
 import android.content.ContentValues
+import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
 import at.bitfire.synctools.storage.tasks.DmfsTask.Companion.UNKNOWN_PROPERTY_DATA
 import net.fortuna.ical4j.model.Parameter
 import net.fortuna.ical4j.model.Property
+import net.fortuna.ical4j.model.component.VToDo
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -22,14 +24,14 @@ class UnknownPropertiesHandlerTest {
     private val handler = UnknownPropertiesHandler()
 
     @Test
-    fun `No unknown properties`() {
+    fun `legacy No unknown properties`() {
         val task = Task()
         handler.process(ContentValues(), task)
         assertTrue(task.unknownProperties.isEmpty())
     }
 
     @Test
-    fun `Single unknown property`() {
+    fun `legacy Single unknown property`() {
         val task = Task()
         handler.process(contentValuesOf(
             UNKNOWN_PROPERTY_DATA to "[\"UID\", \"test-property\", {}]"
@@ -42,7 +44,7 @@ class UnknownPropertiesHandlerTest {
     }
 
     @Test
-    fun `Unknown property with parameters`() {
+    fun `legacy Unknown property with parameters`() {
         val task = Task()
         handler.process(contentValuesOf(
             UNKNOWN_PROPERTY_DATA to "[\"UID\", \"prop-value\", {\"X-CUSTOM\": \"custom-value\"}]"
@@ -56,7 +58,7 @@ class UnknownPropertiesHandlerTest {
     }
 
     @Test
-    fun `Multiple unknown properties accumulate`() {
+    fun `legacy Multiple unknown properties accumulate`() {
         val task = Task()
         handler.process(contentValuesOf(
             UNKNOWN_PROPERTY_DATA to "[\"X-PROP1\", \"value1\", {}]"
@@ -69,7 +71,7 @@ class UnknownPropertiesHandlerTest {
     }
 
     @Test
-    fun `Null unknown property data is skipped`() {
+    fun `legacy Null unknown property data is skipped`() {
         val task = Task()
         handler.process(ContentValues().apply {
             putNull(UNKNOWN_PROPERTY_DATA)
@@ -78,13 +80,99 @@ class UnknownPropertiesHandlerTest {
     }
 
     @Test
-    fun `Unknown property with invalid JSON`() {
+    fun `legacy Unknown property with invalid JSON`() {
         val task = Task()
         handler.process(contentValuesOf(
             UNKNOWN_PROPERTY_DATA to "not json"
         ), task)
 
         assertTrue(task.unknownProperties.isEmpty())
+    }
+
+    @Test
+    fun `No unknown properties`() {
+        val input = Entity(ContentValues())
+        val task = VToDo()
+        val initialPropertyCount = task.propertyList.all.size
+
+        handler.process(from = input, main = input, to = task)
+
+        assertEquals(initialPropertyCount, task.propertyList.all.size)
+    }
+
+    @Test
+    fun `Single unknown property`() {
+        val input = Entity(contentValuesOf(
+            UNKNOWN_PROPERTY_DATA to "[\"X-CUSTOM-PROP\", \"test-property\", {}]"
+        ))
+        val task = VToDo()
+        val initialPropertyCount = task.propertyList.all.size
+
+        handler.process(from = input, main = input, to = task)
+
+        assertEquals(initialPropertyCount + 1, task.propertyList.all.size)
+        val prop = task.propertyList.all.find { it.name == "X-CUSTOM-PROP" }!!
+        assertEquals("test-property", prop.value)
+    }
+
+    @Test
+    fun `Unknown property with parameters`() {
+        val input = Entity(contentValuesOf(
+            UNKNOWN_PROPERTY_DATA to "[\"X-CUSTOM-PROP\", \"prop-value\", {\"X-CUSTOM\": \"custom-value\"}]"
+        ))
+        val task = VToDo()
+        val initialPropertyCount = task.propertyList.all.size
+
+        handler.process(from = input, main = input, to = task)
+
+        assertEquals(initialPropertyCount + 1, task.propertyList.all.size)
+        val prop = task.propertyList.all.find { it.name == "X-CUSTOM-PROP" }!!
+        assertEquals("prop-value", prop.value)
+        assertEquals("custom-value", prop.getRequiredParameter<Parameter>("X-CUSTOM").value)
+    }
+
+    @Test
+    fun `Multiple unknown properties accumulate`() {
+        val input = Entity(contentValuesOf(
+            UNKNOWN_PROPERTY_DATA to "[\"X-PROP1\", \"value1\", {}]"
+        ))
+        val task = VToDo()
+        val initialPropertyCount = task.propertyList.all.size
+
+        handler.process(from = input, main = input, to = task)
+
+        val input2 = Entity(contentValuesOf(
+            UNKNOWN_PROPERTY_DATA to "[\"X-PROP2\", \"value2\", {}]"
+        ))
+        handler.process(from = input2, main = input2, to = task)
+
+        assertEquals(initialPropertyCount + 2, task.propertyList.all.size)
+    }
+
+    @Test
+    fun `Null unknown property data is skipped`() {
+        val input = Entity(ContentValues().apply {
+            putNull(UNKNOWN_PROPERTY_DATA)
+        })
+        val task = VToDo()
+        val initialPropertyCount = task.propertyList.all.size
+
+        handler.process(from = input, main = input, to = task)
+
+        assertEquals(initialPropertyCount, task.propertyList.all.size)
+    }
+
+    @Test
+    fun `Unknown property with invalid JSON`() {
+        val input = Entity(contentValuesOf(
+            UNKNOWN_PROPERTY_DATA to "not json"
+        ))
+        val task = VToDo()
+        val initialPropertyCount = task.propertyList.all.size
+
+        handler.process(from = input, main = input, to = task)
+
+        assertEquals(initialPropertyCount, task.propertyList.all.size)
     }
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/UrlHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/UrlHandlerTest.kt
@@ -5,14 +5,20 @@
 package at.bitfire.synctools.mapping.tasks.handler
 
 import android.content.ContentValues
+import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
+import net.fortuna.ical4j.model.Property
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Url
 import org.dmfs.tasks.contract.TaskContract.Tasks
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.net.URI
+import kotlin.jvm.optionals.getOrNull
 
 @RunWith(RobolectricTestRunner::class)
 class UrlHandlerTest {
@@ -20,17 +26,38 @@ class UrlHandlerTest {
     private val handler = UrlHandler()
 
     @Test
-    fun `No URL`() {
+    fun `legacy No URL`() {
         val task = Task()
         handler.process(ContentValues(), task)
         assertNull(task.url)
     }
 
     @Test
-    fun `URL set`() {
+    fun `legacy URL set`() {
         val task = Task()
         handler.process(contentValuesOf(Tasks.URL to "https://example.com"), task)
         assertEquals("https://example.com", task.url)
+    }
+
+    @Test
+    fun `No URL`() {
+        val input = Entity(ContentValues())
+        val task = VToDo()
+
+        handler.process(from = input, main = input, to = task)
+
+        assertNull(task.getProperty<Url>(Property.URL).getOrNull())
+    }
+
+    @Test
+    fun `URL set`() {
+        val input = Entity(contentValuesOf(Tasks.URL to "https://example.com"))
+        val task = VToDo()
+
+        handler.process(from = input, main = input, to = task)
+
+        val actual = task.getProperty<Url>(Property.URL).getOrNull()?.uri
+        assertEquals(URI("https://example.com"), actual)
     }
 
 }


### PR DESCRIPTION
### Purpose

Migrate unknown properties and URL handlers to VToDo.

### Short description

* Implement DmfsTaskFieldHandler2 for UnknownPropertiesHandler and UrlHandler
* Add process(Entity, Entity, VToDo) methods to handle VToDo components
* Update tests to include both legacy ContentValues and new Entity/VToDo cases
* Add proper error handling for invalid JSON and URIs

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

