### PR TITLE
[jtxBoard] Add `VALUE=DATE` param to all-day `ExDate` tasks

### DIFF
--- a/synctools/src/androidTest/kotlin/at/bitfire/ical4android/JtxICalObjectTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/ical4android/JtxICalObjectTest.kt
@@ -26,9 +26,11 @@ import junit.framework.TestCase.assertNotNull
 import junit.framework.TestCase.assertNull
 import junit.framework.TestCase.assertTrue
 import net.fortuna.ical4j.model.Calendar
+import net.fortuna.ical4j.model.Parameter
 import net.fortuna.ical4j.model.Property
 import net.fortuna.ical4j.model.component.VAlarm
 import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.parameter.Value
 import net.fortuna.ical4j.model.property.Action
 import net.fortuna.ical4j.model.property.RecurrenceId
 import net.fortuna.ical4j.model.property.Trigger
@@ -947,6 +949,67 @@ class JtxICalObjectTest {
         val valarm = valarms.first()
         assertEquals(ImmutableAction.DISPLAY, valarm.getProperty<Action>(Property.ACTION).get())
         assertEquals("-PT15M", valarm.getProperty<Trigger>(Property.TRIGGER).get().value)
+    }
+
+    @Test
+    fun getICalendarFormat_ExDateAllDay_hasValueDateParameter() {
+        // Test that ExDate for all-day events includes VALUE=DATE parameter
+        val obj = JtxICalObject(collection!!).apply {
+            component = Component.VTODO.name
+            uid = "exdate-allday-test@test"
+            summary = "All-day task with exception"
+            dtstart = 1744972800000L  // 2025-04-19T00:00:00Z
+            dtstartTimezone = JtxContract.JtxICalObject.TZ_ALLDAY
+            exdate = "1745059200000"  // 2025-04-20T00:00:00Z (exception date)
+        }
+
+        // Generate iCalendar VTODO from data object
+        val ical = obj.getICalendarFormat(testProdId)
+        assertNotNull(ical)
+
+        // Extract VTODO
+        val vtodos = ical!!.getComponents<VToDo>(Component.VTODO.name)
+        assertEquals(1, vtodos.size)
+
+        // Verify ExDate property has VALUE=DATE parameter
+        val exdateProp = vtodos[0].getProperty<net.fortuna.ical4j.model.property.ExDate<*>>(Property.EXDATE)
+        assertTrue("ExDate property should be present", exdateProp.isPresent)
+        
+        val exdate = exdateProp.get()
+        // Check that the ExDate has VALUE=DATE parameter
+        assertEquals("ExDate should have VALUE=DATE parameter for all-day events", 
+            Value.DATE, exdate.getParameter<Value>(Parameter.VALUE).get())
+    }
+
+    @Test
+    fun getICalendarFormat_ExDateWithTimezone_noValueDateParameter() {
+        // Test that ExDate for events with timezone does NOT include VALUE=DATE parameter
+        val obj = JtxICalObject(collection!!).apply {
+            component = Component.VTODO.name
+            uid = "exdate-timezone-test@test"
+            summary = "Task with exception and timezone"
+            dtstart = 1744972800000L  // 2025-04-19T00:00:00Z
+            dtstartTimezone = "Europe/Vienna"
+            exdate = "1745059200000"  // 2025-04-20T00:00:00Z (exception date)
+        }
+
+        // Generate iCalendar VTODO from data object
+        val ical = obj.getICalendarFormat(testProdId)
+        assertNotNull(ical)
+
+        // Extract VTODO
+        val vtodos = ical!!.getComponents<VToDo>(Component.VTODO.name)
+        assertEquals(1, vtodos.size)
+
+        // Verify ExDate property does NOT have VALUE=DATE parameter (should use default)
+        val exdateProp = vtodos[0].getProperty<net.fortuna.ical4j.model.property.ExDate<*>>(Property.EXDATE)
+        assertTrue("ExDate property should be present", exdateProp.isPresent)
+        
+        val exdate = exdateProp.get()
+        // For non-all-day events with timezone, VALUE parameter should not be DATE
+        // (it will default to DATE-TIME or have a TZID parameter)
+        assertEquals("ExDate for timezone events should not have VALUE=DATE", 
+            null, exdate.getParameter<Value>(Parameter.VALUE).orElse(null))
     }
 
 

--- a/synctools/src/androidTest/kotlin/at/bitfire/ical4android/JtxICalObjectTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/ical4android/JtxICalObjectTest.kt
@@ -32,6 +32,7 @@ import net.fortuna.ical4j.model.component.VAlarm
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.parameter.Value
 import net.fortuna.ical4j.model.property.Action
+import net.fortuna.ical4j.model.property.ExDate
 import net.fortuna.ical4j.model.property.RecurrenceId
 import net.fortuna.ical4j.model.property.Trigger
 import net.fortuna.ical4j.model.property.immutable.ImmutableAction
@@ -972,7 +973,7 @@ class JtxICalObjectTest {
         assertEquals(1, vtodos.size)
 
         // Verify ExDate property has VALUE=DATE parameter
-        val exdateProp = vtodos[0].getProperty<net.fortuna.ical4j.model.property.ExDate<*>>(Property.EXDATE)
+        val exdateProp = vtodos[0].getProperty<ExDate<*>>(Property.EXDATE)
         assertTrue("ExDate property should be present", exdateProp.isPresent)
         
         val exdate = exdateProp.get()
@@ -1002,7 +1003,7 @@ class JtxICalObjectTest {
         assertEquals(1, vtodos.size)
 
         // Verify ExDate property does NOT have VALUE=DATE parameter (should use default)
-        val exdateProp = vtodos[0].getProperty<net.fortuna.ical4j.model.property.ExDate<*>>(Property.EXDATE)
+        val exdateProp = vtodos[0].getProperty<ExDate<*>>(Property.EXDATE)
         assertTrue("ExDate property should be present", exdateProp.isPresent)
         
         val exdate = exdateProp.get()

--- a/synctools/src/main/kotlin/at/bitfire/ical4android/JtxICalObject.kt
+++ b/synctools/src/main/kotlin/at/bitfire/ical4android/JtxICalObject.kt
@@ -1031,7 +1031,7 @@ open class JtxICalObject(
 
         exdate?.let { exdateString ->
             val exdates: MutableList<Long> = JtxContract.getLongListFromString(exdateString)
-            val prop = when {
+            val dateList = when {
                 dtstartTimezone == TZ_ALLDAY ->
                     DateList<LocalDate>(exdates.map {
                         LocalDate.ofInstant(Instant.ofEpochMilli(it), ZoneOffset.UTC)
@@ -1051,9 +1051,9 @@ open class JtxICalObject(
             }
 
             props += if (dtstartTimezone == TZ_ALLDAY) {
-                ExDate(ParameterList(listOf(Value.DATE)), prop)
+                ExDate(ParameterList(listOf(Value.DATE)), dateList)
             } else {
-                ExDate(prop)
+                ExDate(dateList)
             }
         }
 

--- a/synctools/src/main/kotlin/at/bitfire/ical4android/JtxICalObject.kt
+++ b/synctools/src/main/kotlin/at/bitfire/ical4android/JtxICalObject.kt
@@ -1031,7 +1031,7 @@ open class JtxICalObject(
 
         exdate?.let { exdateString ->
             val exdates: MutableList<Long> = JtxContract.getLongListFromString(exdateString)
-            props += ExDate(when {
+            val prop = when {
                 dtstartTimezone == TZ_ALLDAY ->
                     DateList<LocalDate>(exdates.map {
                         LocalDate.ofInstant(Instant.ofEpochMilli(it), ZoneOffset.UTC)
@@ -1048,7 +1048,13 @@ open class JtxICalObject(
                     DateList<ZonedDateTime>(exdates.map {
                         ZonedDateTime.ofInstant(Instant.ofEpochMilli(it), ZoneId.of(dtstartTimezone))
                     })
-            })
+            }
+
+            props += if (dtstartTimezone == TZ_ALLDAY) {
+                ExDate(ParameterList(listOf(Value.DATE)), prop)
+            } else {
+                ExDate(prop)
+            }
         }
 
         duration?.let {


### PR DESCRIPTION
### Purpose

Fix ExDate timezone handling for all-day events. Without the fix nextcloud would return HTTP 415 on syncing new recurring tasks with one or more marked as "done" (which adds the EXDATE without VALUE=DATE). 

Technically we don't _have_ to add VALUE=DATE, but it's good practice to do so anyway and some servers seem to hiccup if we don't.

### Short description

* Add `VALUE=DATE` parameter for all-day `ExDate` properties

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

