### PR TITLE
[Dmfstask] Fix `AlarmsHandler`, `CategoriesHandler`, `CommentsHandler`, `UnknownPropertiesHandler` not using sub-values

### DIFF
--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskBuilderTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskBuilderTest.kt
@@ -17,6 +17,7 @@ import at.bitfire.ical4android.UnknownProperty
 import at.bitfire.ical4android.impl.TestTaskList
 import at.bitfire.synctools.storage.tasks.DmfsTask
 import at.bitfire.synctools.storage.tasks.DmfsTaskList
+import at.bitfire.synctools.storage.tasks.DmfsTasksContract.UNKNOWN_PROPERTY_DATA
 import at.bitfire.synctools.util.AndroidTimeUtils.toTimestamp
 import net.fortuna.ical4j.model.DateList
 import net.fortuna.ical4j.model.TimeZoneRegistryFactory
@@ -808,7 +809,7 @@ class DmfsTaskBuilderTest (
             val unknownProperty = firstProperty(taskId, UnknownProperty.CONTENT_ITEM_TYPE)!!
             assertEquals(
                 xProperty,
-                UnknownProperty.fromJsonString(unknownProperty.getAsString(DmfsTask.UNKNOWN_PROPERTY_DATA))
+                UnknownProperty.fromJsonString(unknownProperty.getAsString(UNKNOWN_PROPERTY_DATA))
             )
         }
     }

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskTest.kt
@@ -13,6 +13,8 @@ import at.bitfire.ical4android.Task
 import at.bitfire.ical4android.TaskProvider
 import at.bitfire.ical4android.impl.TestTaskList
 import at.bitfire.synctools.storage.LocalStorageException
+import at.bitfire.synctools.storage.tasks.DmfsTasksContract.COLUMN_ETAG
+import at.bitfire.synctools.storage.tasks.DmfsTasksContract.COLUMN_FLAGS
 import net.fortuna.ical4j.model.TimeZoneRegistryFactory
 import net.fortuna.ical4j.model.component.VAlarm
 import net.fortuna.ical4j.model.parameter.RelType
@@ -70,8 +72,8 @@ class DmfsTaskTest(
             taskList!!, Entity(contentValuesOf(
                 Tasks._ID to 123,
                 Tasks._SYNC_ID to "some-ical.ics",
-                DmfsTask.COLUMN_ETAG to "some-etag",
-                DmfsTask.COLUMN_FLAGS to 45
+                COLUMN_ETAG to "some-etag",
+                COLUMN_FLAGS to 45
             ))
         )
         assertEquals(123L, dmfsTask.id)

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/AlarmsHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/AlarmsHandler.kt
@@ -9,6 +9,7 @@ import android.content.Entity
 import at.bitfire.ical4android.Task
 import at.bitfire.synctools.icalendar.plusAssign
 import at.bitfire.synctools.icalendar.propertyListOf
+import at.bitfire.synctools.mapping.tasks.mimeType
 import net.fortuna.ical4j.model.Property
 import net.fortuna.ical4j.model.component.VAlarm
 import net.fortuna.ical4j.model.component.VToDo
@@ -48,23 +49,29 @@ class AlarmsHandler : DmfsTaskFieldHandler, DmfsTaskFieldHandler2 {
 
     override fun process(from: Entity, main: Entity, to: VToDo) {
         val summary = to.getProperty<Summary>(Property.SUMMARY).getOrNull()?.value
+        for (row in from.subValues.filter { it.mimeType == Alarm.CONTENT_ITEM_TYPE }) {
+            processAlarm(row.values, summary, to)
+        }
+    }
+
+    private fun processAlarm(values: ContentValues, summary: String?, to: VToDo) {
         val props = propertyListOf(
-            Trigger(Duration.ofMinutes(-from.entityValues.getAsLong(Alarm.MINUTES_BEFORE))).let {
-                when (from.entityValues.getAsInteger(Alarm.REFERENCE)) {
+            Trigger(Duration.ofMinutes(-values.getAsLong(Alarm.MINUTES_BEFORE))).let {
+                when (values.getAsInteger(Alarm.REFERENCE)) {
                     Alarm.ALARM_REFERENCE_START_DATE -> it.add(Related.START)
                     Alarm.ALARM_REFERENCE_DUE_DATE -> it.add(Related.END)
                     else -> it
                 }
             },
             Action(
-                when (from.entityValues.getAsInteger(Alarm.ALARM_TYPE)) {
+                when (values.getAsInteger(Alarm.ALARM_TYPE)) {
                     Alarm.ALARM_TYPE_EMAIL -> Action.VALUE_EMAIL
                     Alarm.ALARM_TYPE_SOUND -> Action.VALUE_AUDIO
                     // show alarm by default
                     else -> Action.VALUE_DISPLAY
                 }
             ),
-            Description(from.entityValues.getAsString(Alarm.MESSAGE) ?: summary)
+            Description(values.getAsString(Alarm.MESSAGE) ?: summary)
         )
 
         to += VAlarm(props)

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/CategoriesHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/CategoriesHandler.kt
@@ -8,6 +8,7 @@ import android.content.ContentValues
 import android.content.Entity
 import at.bitfire.ical4android.Task
 import at.bitfire.synctools.icalendar.plusAssign
+import at.bitfire.synctools.mapping.tasks.mimeType
 import net.fortuna.ical4j.model.TextList
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.property.Categories
@@ -19,7 +20,13 @@ class CategoriesHandler : DmfsTaskFieldHandler, DmfsTaskFieldHandler2 {
     }
 
     override fun process(from: Entity, main: Entity, to: VToDo) {
-        from.entityValues.getAsString(Category.CATEGORY_NAME)?.let { categoryName ->
+        for (row in from.subValues.filter { it.mimeType == Category.CONTENT_ITEM_TYPE }) {
+            processCategory(row.values, to)
+        }
+    }
+
+    private fun processCategory(values: ContentValues, to: VToDo) {
+        values.getAsString(Category.CATEGORY_NAME)?.let { categoryName ->
             to += Categories(TextList(categoryName))
         }
     }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/CommentsHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/CommentsHandler.kt
@@ -8,6 +8,7 @@ import android.content.ContentValues
 import android.content.Entity
 import at.bitfire.ical4android.Task
 import at.bitfire.synctools.icalendar.plusAssign
+import at.bitfire.synctools.mapping.tasks.mimeType
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.property.Comment
 import org.dmfs.tasks.contract.TaskContract.Property.Comment as DmfsComment
@@ -18,7 +19,13 @@ class CommentsHandler : DmfsTaskFieldHandler, DmfsTaskFieldHandler2 {
     }
 
     override fun process(from: Entity, main: Entity, to: VToDo) {
-        from.entityValues.getAsString(DmfsComment.COMMENT)?.let { commentText ->
+        for (row in from.subValues.filter { it.mimeType == DmfsComment.CONTENT_ITEM_TYPE }) {
+            processComment(row.values, to)
+        }
+    }
+
+    private fun processComment(values: ContentValues, to: VToDo) {
+        values.getAsString(DmfsComment.COMMENT)?.let { commentText ->
             to += Comment(commentText)
         }
     }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/UnknownPropertiesHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/UnknownPropertiesHandler.kt
@@ -9,6 +9,7 @@ import android.content.Entity
 import at.bitfire.ical4android.Task
 import at.bitfire.ical4android.UnknownProperty
 import at.bitfire.synctools.icalendar.plusAssign
+import at.bitfire.synctools.mapping.tasks.mimeType
 import at.bitfire.synctools.storage.tasks.DmfsTasksContract.UNKNOWN_PROPERTY_DATA
 import net.fortuna.ical4j.model.component.VToDo
 import org.json.JSONException
@@ -31,7 +32,13 @@ class UnknownPropertiesHandler : DmfsTaskFieldHandler, DmfsTaskFieldHandler2 {
     }
 
     override fun process(from: Entity, main: Entity, to: VToDo) {
-        from.entityValues.getAsString(UNKNOWN_PROPERTY_DATA)?.let { properties ->
+        for (row in from.subValues.filter { it.mimeType == UnknownProperty.CONTENT_ITEM_TYPE }) {
+            processUnknownProperty(row.values, to)
+        }
+    }
+
+    private fun processUnknownProperty(values: ContentValues, to: VToDo) {
+        values.getAsString(UNKNOWN_PROPERTY_DATA)?.let { properties ->
             try {
                 to += UnknownProperty.fromJsonString(properties)
             } catch (e: JSONException) {

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/ETagBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/ETagBuilderTest.kt
@@ -8,7 +8,7 @@ import android.content.ContentValues
 import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
-import at.bitfire.synctools.storage.tasks.DmfsTask.Companion.COLUMN_ETAG
+import at.bitfire.synctools.storage.tasks.DmfsTasksContract.COLUMN_ETAG
 import at.bitfire.synctools.test.assertContentValuesEqual
 import net.fortuna.ical4j.model.component.VToDo
 import org.junit.Test

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/SyncFlagsBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/SyncFlagsBuilderTest.kt
@@ -8,7 +8,7 @@ import android.content.ContentValues
 import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
-import at.bitfire.synctools.storage.tasks.DmfsTask.Companion.COLUMN_FLAGS
+import at.bitfire.synctools.storage.tasks.DmfsTasksContract.COLUMN_FLAGS
 import at.bitfire.synctools.test.assertContentValuesEqual
 import net.fortuna.ical4j.model.component.VToDo
 import org.junit.Test

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/UnknownPropertiesBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/builder/UnknownPropertiesBuilderTest.kt
@@ -11,8 +11,8 @@ import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
 import at.bitfire.ical4android.UnknownProperty
 import at.bitfire.synctools.mapping.tasks.VToDoUtil
-import at.bitfire.synctools.storage.tasks.DmfsTask.Companion.UNKNOWN_PROPERTY_DATA
 import at.bitfire.synctools.storage.tasks.DmfsTaskList
+import at.bitfire.synctools.storage.tasks.DmfsTasksContract.UNKNOWN_PROPERTY_DATA
 import at.bitfire.synctools.test.assertContentValuesEqual
 import io.mockk.every
 import io.mockk.mockk

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/AlarmsHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/AlarmsHandlerTest.kt
@@ -4,7 +4,9 @@
 
 package at.bitfire.synctools.mapping.tasks.handler
 
+import android.content.ContentValues
 import android.content.Entity
+import android.net.Uri
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
 import at.bitfire.synctools.icalendar.plusAssign
@@ -12,6 +14,7 @@ import net.fortuna.ical4j.model.Property
 import net.fortuna.ical4j.model.component.VAlarm
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.property.Action
+import net.fortuna.ical4j.model.property.Description
 import net.fortuna.ical4j.model.property.Summary
 import net.fortuna.ical4j.model.property.Trigger
 import net.fortuna.ical4j.model.property.immutable.ImmutableAction
@@ -117,11 +120,14 @@ class AlarmsHandlerTest {
     @Test
     fun `Display alarm relative to start`() {
         val vToDo = VToDo()
-        val input = Entity(contentValuesOf(
-            Alarm.MINUTES_BEFORE to 15L,
-            Alarm.REFERENCE to Alarm.ALARM_REFERENCE_START_DATE,
-            Alarm.ALARM_TYPE to Alarm.ALARM_TYPE_MESSAGE,
-        ))
+        val input = Entity(ContentValues()).apply {
+            addSubValue(Uri.parse("irrelevant:"), contentValuesOf(
+                Alarm.MIMETYPE to Alarm.CONTENT_ITEM_TYPE,
+                Alarm.MINUTES_BEFORE to 15L,
+                Alarm.REFERENCE to Alarm.ALARM_REFERENCE_START_DATE,
+                Alarm.ALARM_TYPE to Alarm.ALARM_TYPE_MESSAGE,
+            ))
+        }
         handler.process(from = input, main = input, to = vToDo)
 
         assertEquals(1, vToDo.alarms.size)
@@ -133,11 +139,14 @@ class AlarmsHandlerTest {
     @Test
     fun `Audio alarm relative to due`() {
         val vToDo = VToDo()
-        val input = Entity(contentValuesOf(
-            Alarm.MINUTES_BEFORE to 10L,
-            Alarm.REFERENCE to Alarm.ALARM_REFERENCE_DUE_DATE,
-            Alarm.ALARM_TYPE to Alarm.ALARM_TYPE_SOUND,
-        ))
+        val input = Entity(ContentValues()).apply {
+            addSubValue(Uri.parse("irrelevant:"), contentValuesOf(
+                Alarm.MIMETYPE to Alarm.CONTENT_ITEM_TYPE,
+                Alarm.MINUTES_BEFORE to 10L,
+                Alarm.REFERENCE to Alarm.ALARM_REFERENCE_DUE_DATE,
+                Alarm.ALARM_TYPE to Alarm.ALARM_TYPE_SOUND,
+            ))
+        }
         handler.process(from = input, main = input, to = vToDo)
 
         assertEquals(1, vToDo.alarms.size)
@@ -153,11 +162,14 @@ class AlarmsHandlerTest {
     @Test
     fun `Email alarm`() {
         val vToDo = VToDo()
-        val input = Entity(contentValuesOf(
-            Alarm.MINUTES_BEFORE to 5L,
-            Alarm.REFERENCE to Alarm.ALARM_REFERENCE_START_DATE,
-            Alarm.ALARM_TYPE to Alarm.ALARM_TYPE_EMAIL,
-        ))
+        val input = Entity(ContentValues()).apply {
+            addSubValue(Uri.parse("irrelevant:"), contentValuesOf(
+                Alarm.MIMETYPE to Alarm.CONTENT_ITEM_TYPE,
+                Alarm.MINUTES_BEFORE to 5L,
+                Alarm.REFERENCE to Alarm.ALARM_REFERENCE_START_DATE,
+                Alarm.ALARM_TYPE to Alarm.ALARM_TYPE_EMAIL,
+            ))
+        }
         handler.process(from = input, main = input, to = vToDo)
 
         assertEquals(1, vToDo.alarms.size)
@@ -167,42 +179,51 @@ class AlarmsHandlerTest {
     @Test
     fun `Alarm message is used as description`() {
         val vToDo = VToDo()
-        val input = Entity(contentValuesOf(
-            Alarm.MINUTES_BEFORE to 0L,
-            Alarm.ALARM_TYPE to Alarm.ALARM_TYPE_MESSAGE,
-            Alarm.MESSAGE to "Don't forget!",
-        ))
+        val input = Entity(ContentValues()).apply {
+            addSubValue(Uri.parse("irrelevant:"), contentValuesOf(
+                Alarm.MIMETYPE to Alarm.CONTENT_ITEM_TYPE,
+                Alarm.MINUTES_BEFORE to 0L,
+                Alarm.ALARM_TYPE to Alarm.ALARM_TYPE_MESSAGE,
+                Alarm.MESSAGE to "Don't forget!",
+            ))
+        }
         handler.process(from = input, main = input, to = vToDo)
 
-        assertEquals("Don't forget!", vToDo.alarms.first().description?.value)
+        assertEquals(Description("Don't forget!"), vToDo.alarms.first().description)
     }
 
     @Test
     fun `Task summary used as description when no alarm message`() {
         val vToDo = VToDo()
         vToDo += Summary("Task Title")
-        val input = Entity(contentValuesOf(
-            Alarm.MINUTES_BEFORE to 0L,
-            Alarm.ALARM_TYPE to Alarm.ALARM_TYPE_MESSAGE,
-        ))
+        val input = Entity(ContentValues()).apply {
+            addSubValue(Uri.parse("irrelevant:"), contentValuesOf(
+                Alarm.MIMETYPE to Alarm.CONTENT_ITEM_TYPE,
+                Alarm.MINUTES_BEFORE to 0L,
+                Alarm.ALARM_TYPE to Alarm.ALARM_TYPE_MESSAGE,
+            ))
+        }
         handler.process(from = input, main = input, to = vToDo)
 
-        assertEquals("Task Title", vToDo.alarms.first().description?.value)
+        assertEquals(Description("Task Title"), vToDo.alarms.first().description)
     }
 
     @Test
     fun `Multiple alarms accumulate`() {
         val vToDo = VToDo()
-        val input1 = Entity(contentValuesOf(
-            Alarm.MINUTES_BEFORE to 10L,
-            Alarm.ALARM_TYPE to Alarm.ALARM_TYPE_MESSAGE,
-        ))
-        val input2 = Entity(contentValuesOf(
-            Alarm.MINUTES_BEFORE to 20L,
-            Alarm.ALARM_TYPE to Alarm.ALARM_TYPE_SOUND,
-        ))
-        handler.process(from = input1, main = input1, to = vToDo)
-        handler.process(from = input2, main = input2, to = vToDo)
+        val input = Entity(ContentValues()).apply {
+            addSubValue(Uri.parse("irrelevant:"), contentValuesOf(
+                Alarm.MIMETYPE to Alarm.CONTENT_ITEM_TYPE,
+                Alarm.MINUTES_BEFORE to 10L,
+                Alarm.ALARM_TYPE to Alarm.ALARM_TYPE_MESSAGE,
+            ))
+            addSubValue(Uri.parse("irrelevant:"), contentValuesOf(
+                Alarm.MIMETYPE to Alarm.CONTENT_ITEM_TYPE,
+                Alarm.MINUTES_BEFORE to 20L,
+                Alarm.ALARM_TYPE to Alarm.ALARM_TYPE_SOUND,
+            ))
+        }
+        handler.process(from = input, main = input, to = vToDo)
 
         assertEquals(2, vToDo.alarms.size)
     }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/CategoriesHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/CategoriesHandlerTest.kt
@@ -125,10 +125,9 @@ class CategoriesHandlerTest {
         val vToDo = VToDo()
         val input = Entity(ContentValues()).apply {
             addSubValue(Uri.parse("irrelevant:"), contentValuesOf(
-                Category.MIMETYPE to Category.CONTENT_ITEM_TYPE
-            ).apply {
-                putNull(Category.CATEGORY_NAME)
-            })
+                Category.MIMETYPE to Category.CONTENT_ITEM_TYPE,
+                Category.CATEGORY_NAME to null
+            ))
         }
         handler.process(from = input, main = input, to = vToDo)
 

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/CategoriesHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/CategoriesHandlerTest.kt
@@ -6,6 +6,7 @@ package at.bitfire.synctools.mapping.tasks.handler
 
 import android.content.ContentValues
 import android.content.Entity
+import android.net.Uri
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
 import net.fortuna.ical4j.model.Property
@@ -72,7 +73,12 @@ class CategoriesHandlerTest {
     @Test
     fun `Single category`() {
         val vToDo = VToDo()
-        val input = Entity(contentValuesOf(Category.CATEGORY_NAME to "Work"))
+        val input = Entity(ContentValues()).apply {
+            addSubValue(Uri.parse("irrelevant:"), contentValuesOf(
+                Category.MIMETYPE to Category.CONTENT_ITEM_TYPE,
+                Category.CATEGORY_NAME to "Work"
+            ))
+        }
         handler.process(from = input, main = input, to = vToDo)
 
         // Collect all category texts from all Categories properties
@@ -89,10 +95,17 @@ class CategoriesHandlerTest {
     @Test
     fun `Multiple categories accumulate`() {
         val vToDo = VToDo()
-        val input1 = Entity(contentValuesOf(Category.CATEGORY_NAME to "Work"))
-        val input2 = Entity(contentValuesOf(Category.CATEGORY_NAME to "Personal"))
-        handler.process(from = input1, main = input1, to = vToDo)
-        handler.process(from = input2, main = input2, to = vToDo)
+        val input = Entity(ContentValues()).apply {
+            addSubValue(Uri.parse("irrelevant:"), contentValuesOf(
+                Category.MIMETYPE to Category.CONTENT_ITEM_TYPE,
+                Category.CATEGORY_NAME to "Work"
+            ))
+            addSubValue(Uri.parse("irrelevant:"), contentValuesOf(
+                Category.MIMETYPE to Category.CONTENT_ITEM_TYPE,
+                Category.CATEGORY_NAME to "Personal"
+            ))
+        }
+        handler.process(from = input, main = input, to = vToDo)
 
         // Collect all category texts from all Categories properties
         val allCategories = mutableListOf<String>()
@@ -110,9 +123,13 @@ class CategoriesHandlerTest {
     @Test
     fun `Null category is skipped`() {
         val vToDo = VToDo()
-        val input = Entity(ContentValues().apply {
-            putNull(Category.CATEGORY_NAME)
-        })
+        val input = Entity(ContentValues()).apply {
+            addSubValue(Uri.parse("irrelevant:"), contentValuesOf(
+                Category.MIMETYPE to Category.CONTENT_ITEM_TYPE
+            ).apply {
+                putNull(Category.CATEGORY_NAME)
+            })
+        }
         handler.process(from = input, main = input, to = vToDo)
 
         val categories = vToDo.getProperty<Categories>(Property.CATEGORIES).getOrNull()

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/CommentsHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/CommentsHandlerTest.kt
@@ -6,6 +6,7 @@ package at.bitfire.synctools.mapping.tasks.handler
 
 import android.content.ContentValues
 import android.content.Entity
+import android.net.Uri
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
 import net.fortuna.ical4j.model.Property
@@ -69,7 +70,12 @@ class CommentsHandlerTest {
     @Test
     fun `Comment set`() {
         val vToDo = VToDo()
-        val input = Entity(contentValuesOf(DmfsComment.COMMENT to "Task comment"))
+        val input = Entity(ContentValues()).apply {
+            addSubValue(Uri.parse("irrelevant:"), contentValuesOf(
+                DmfsComment.MIMETYPE to DmfsComment.CONTENT_ITEM_TYPE,
+                DmfsComment.COMMENT to "Task comment"
+            ))
+        }
         handler.process(from = input, main = input, to = vToDo)
 
         val comment = vToDo.getProperty<Comment>(Property.COMMENT).get()
@@ -79,10 +85,17 @@ class CommentsHandlerTest {
     @Test
     fun `Comment overwritten by subsequent call`() {
         val vToDo = VToDo()
-        val input1 = Entity(contentValuesOf(DmfsComment.COMMENT to "First comment"))
-        val input2 = Entity(contentValuesOf(DmfsComment.COMMENT to "Second comment"))
-        handler.process(from = input1, main = input1, to = vToDo)
-        handler.process(from = input2, main = input2, to = vToDo)
+        val input = Entity(ContentValues()).apply {
+            addSubValue(Uri.parse("irrelevant:"), contentValuesOf(
+                DmfsComment.MIMETYPE to DmfsComment.CONTENT_ITEM_TYPE,
+                DmfsComment.COMMENT to "First comment"
+            ))
+            addSubValue(Uri.parse("irrelevant:"), contentValuesOf(
+                DmfsComment.MIMETYPE to DmfsComment.CONTENT_ITEM_TYPE,
+                DmfsComment.COMMENT to "Second comment"
+            ))
+        }
+        handler.process(from = input, main = input, to = vToDo)
 
         // With current implementation, each comment is added as a separate Comment property
         // So we should have 2 properties.
@@ -95,9 +108,13 @@ class CommentsHandlerTest {
     @Test
     fun `Null comment is skipped`() {
         val vToDo = VToDo()
-        val input = Entity(ContentValues().apply {
-            putNull(DmfsComment.COMMENT)
-        })
+        val input = Entity(ContentValues()).apply {
+            addSubValue(Uri.parse("irrelevant:"), contentValuesOf(
+                DmfsComment.MIMETYPE to DmfsComment.CONTENT_ITEM_TYPE
+            ).apply {
+                putNull(DmfsComment.COMMENT)
+            })
+        }
         handler.process(from = input, main = input, to = vToDo)
 
         val comment = vToDo.getProperty<Comment>(Property.COMMENT).getOrNull()

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/UnknownPropertiesHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/UnknownPropertiesHandlerTest.kt
@@ -10,7 +10,7 @@ import android.net.Uri
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
 import at.bitfire.ical4android.UnknownProperty
-import at.bitfire.synctools.storage.tasks.DmfsTask.Companion.UNKNOWN_PROPERTY_DATA
+import at.bitfire.synctools.storage.tasks.DmfsTasksContract.UNKNOWN_PROPERTY_DATA
 import net.fortuna.ical4j.model.Parameter
 import net.fortuna.ical4j.model.Property
 import net.fortuna.ical4j.model.component.VToDo

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/UnknownPropertiesHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/UnknownPropertiesHandlerTest.kt
@@ -6,12 +6,15 @@ package at.bitfire.synctools.mapping.tasks.handler
 
 import android.content.ContentValues
 import android.content.Entity
+import android.net.Uri
 import androidx.core.content.contentValuesOf
 import at.bitfire.ical4android.Task
+import at.bitfire.ical4android.UnknownProperty
 import at.bitfire.synctools.storage.tasks.DmfsTask.Companion.UNKNOWN_PROPERTY_DATA
 import net.fortuna.ical4j.model.Parameter
 import net.fortuna.ical4j.model.Property
 import net.fortuna.ical4j.model.component.VToDo
+import org.dmfs.tasks.contract.TaskContract.Properties
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -102,9 +105,12 @@ class UnknownPropertiesHandlerTest {
 
     @Test
     fun `Single unknown property`() {
-        val input = Entity(contentValuesOf(
-            UNKNOWN_PROPERTY_DATA to "[\"X-CUSTOM-PROP\", \"test-property\", {}]"
-        ))
+        val input = Entity(ContentValues()).apply {
+            addSubValue(Uri.parse("irrelevant:"), contentValuesOf(
+                Properties.MIMETYPE to UnknownProperty.CONTENT_ITEM_TYPE,
+                UNKNOWN_PROPERTY_DATA to "[\"X-CUSTOM-PROP\", \"test-property\", {}]"
+            ))
+        }
         val task = VToDo()
         val initialPropertyCount = task.propertyList.all.size
 
@@ -117,9 +123,12 @@ class UnknownPropertiesHandlerTest {
 
     @Test
     fun `Unknown property with parameters`() {
-        val input = Entity(contentValuesOf(
-            UNKNOWN_PROPERTY_DATA to "[\"X-CUSTOM-PROP\", \"prop-value\", {\"X-CUSTOM\": \"custom-value\"}]"
-        ))
+        val input = Entity(ContentValues()).apply {
+            addSubValue(Uri.parse("irrelevant:"), contentValuesOf(
+                Properties.MIMETYPE to UnknownProperty.CONTENT_ITEM_TYPE,
+                UNKNOWN_PROPERTY_DATA to "[\"X-CUSTOM-PROP\", \"prop-value\", {\"X-CUSTOM\": \"custom-value\"}]"
+            ))
+        }
         val task = VToDo()
         val initialPropertyCount = task.propertyList.all.size
 
@@ -133,27 +142,33 @@ class UnknownPropertiesHandlerTest {
 
     @Test
     fun `Multiple unknown properties accumulate`() {
-        val input = Entity(contentValuesOf(
-            UNKNOWN_PROPERTY_DATA to "[\"X-PROP1\", \"value1\", {}]"
-        ))
+        val input = Entity(ContentValues()).apply {
+            addSubValue(Uri.parse("irrelevant:"), contentValuesOf(
+                Properties.MIMETYPE to UnknownProperty.CONTENT_ITEM_TYPE,
+                UNKNOWN_PROPERTY_DATA to "[\"X-PROP1\", \"value1\", {}]"
+            ))
+            addSubValue(Uri.parse("irrelevant:"), contentValuesOf(
+                Properties.MIMETYPE to UnknownProperty.CONTENT_ITEM_TYPE,
+                UNKNOWN_PROPERTY_DATA to "[\"X-PROP2\", \"value2\", {}]"
+            ))
+        }
         val task = VToDo()
         val initialPropertyCount = task.propertyList.all.size
 
         handler.process(from = input, main = input, to = task)
-
-        val input2 = Entity(contentValuesOf(
-            UNKNOWN_PROPERTY_DATA to "[\"X-PROP2\", \"value2\", {}]"
-        ))
-        handler.process(from = input2, main = input2, to = task)
 
         assertEquals(initialPropertyCount + 2, task.propertyList.all.size)
     }
 
     @Test
     fun `Null unknown property data is skipped`() {
-        val input = Entity(ContentValues().apply {
-            putNull(UNKNOWN_PROPERTY_DATA)
-        })
+        val input = Entity(ContentValues()).apply {
+            addSubValue(Uri.parse("irrelevant:"), contentValuesOf(
+                Properties.MIMETYPE to UnknownProperty.CONTENT_ITEM_TYPE
+            ).apply {
+                putNull(UNKNOWN_PROPERTY_DATA)
+            })
+        }
         val task = VToDo()
         val initialPropertyCount = task.propertyList.all.size
 
@@ -164,9 +179,12 @@ class UnknownPropertiesHandlerTest {
 
     @Test
     fun `Unknown property with invalid JSON`() {
-        val input = Entity(contentValuesOf(
-            UNKNOWN_PROPERTY_DATA to "not json"
-        ))
+        val input = Entity(ContentValues()).apply {
+            addSubValue(Uri.parse("irrelevant:"), contentValuesOf(
+                Properties.MIMETYPE to UnknownProperty.CONTENT_ITEM_TYPE,
+                UNKNOWN_PROPERTY_DATA to "not json"
+            ))
+        }
         val task = VToDo()
         val initialPropertyCount = task.propertyList.all.size
 


### PR DESCRIPTION
### Purpose

`AlarmsHandler`, `CategoriesHandler`, `CommentsHandler`, `UnknownPropertiesHandler` were not reading from sub-values.

### Short description

- Read from sub-values for each of the listed handlers instead 
- Adapt tests accordingly

**Note:** The changes are basically the same for each handler and its test class. 

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

