### PR TITLE
Excluding exceptions in queries of ...Recurring... classes

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
@@ -75,9 +75,7 @@ class LocalCalendar @AssistedInject constructor(
 
     override fun findDeleted(): List<LocalEvent> {
         val result = LinkedList<LocalEvent>()
-        recurringCalendar.iterateEventAndExceptions(
-            "${Events.DELETED} AND ${Events.ORIGINAL_ID} IS NULL", null
-        ) { eventAndExceptions ->
+        recurringCalendar.iterateEventAndExceptions(Events.DELETED, null) { eventAndExceptions ->
             result += LocalEvent(recurringCalendar, eventAndExceptions)
         }
         return result
@@ -85,16 +83,14 @@ class LocalCalendar @AssistedInject constructor(
 
     override fun findDirty(): List<LocalEvent> {
         val dirty = LinkedList<LocalEvent>()
-        recurringCalendar.iterateEventAndExceptions(
-            "${Events.DIRTY} AND ${Events.ORIGINAL_ID} IS NULL", null
-        ) { eventAndExceptions ->
+        recurringCalendar.iterateEventAndExceptions(Events.DIRTY, null) { eventAndExceptions ->
             dirty += LocalEvent(recurringCalendar, eventAndExceptions)
         }
         return dirty
     }
 
     override fun findByName(name: String) =
-        recurringCalendar.findEventAndExceptions("${Events._SYNC_ID}=? AND ${Events.ORIGINAL_SYNC_ID} IS null", arrayOf(name))?.let {
+        recurringCalendar.findEventAndExceptions("${Events._SYNC_ID}=?", arrayOf(name))?.let {
             LocalEvent(recurringCalendar, it)
         }
 

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/calendar/AndroidRecurringCalendarTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/calendar/AndroidRecurringCalendarTest.kt
@@ -104,8 +104,29 @@ class AndroidRecurringCalendarTest {
     }
 
     @Test
+    fun testFindEventAndExceptions_IgnoresExceptionMatches() {
+        insertRecurring()
+
+        val result = recurringCalendar.findEventAndExceptions("${Events.TITLE}=?", arrayOf("Exception"))
+
+        assertNull(result)
+    }
+
+    @Test
     fun testFindEventAndExceptions_NotFound() {
         assertNull(recurringCalendar.findEventAndExceptions("${Events._SYNC_ID}=?", arrayOf("not-existent")))
+    }
+
+    @Test
+    fun testGetById_ExceptionId_ReturnsNull() {
+        val (mainEventId, _) = insertRecurring()
+        val exceptionId = calendar.findEventRow(
+            arrayOf(Events._ID),
+            "${Events.ORIGINAL_ID}=?",
+            arrayOf(mainEventId.toString())
+        )!!.getAsLong(Events._ID)!!
+
+        assertNull(recurringCalendar.getById(exceptionId))
     }
 
     @Test
@@ -129,6 +150,15 @@ class AndroidRecurringCalendarTest {
         assertEquals(2, orderedResult.size)
         assertEventAndExceptionsEqual(event1.withEventId(id1), orderedResult[0], onlyFieldsInExpected = true)
         assertEventAndExceptionsEqual(event2.withEventId(id2), orderedResult[1], onlyFieldsInExpected = true)
+    }
+
+    @Test
+    fun testIterateEventAndExceptions_IgnoresExceptionMatches() {
+        insertRecurring()
+
+        recurringCalendar.iterateEventAndExceptions("${Events.TITLE}=?", arrayOf("Exception")) {
+            fail("must not be called")
+        }
     }
 
     @Test

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsRecurringTaskListTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsRecurringTaskListTest.kt
@@ -94,8 +94,30 @@ class DmfsRecurringTaskListTest(providerName: TaskProvider.ProviderName) :
     }
 
     @Test
+    fun testFindTaskAndExceptions_IgnoresExceptionMatches() {
+        insertRecurring()
+
+        val result = recurringTaskList.findTaskAndExceptions("${Tasks.TITLE}=?", arrayOf("Exception"))
+
+        assertNull(result)
+    }
+
+    @Test
     fun testFindTaskAndExceptions_NotFound() {
         assertNull(recurringTaskList.findTaskAndExceptions("${Tasks._SYNC_ID}=?", arrayOf("not-existent")))
+    }
+
+    @Test
+    fun testGetById_ExceptionId_ReturnsNull() {
+        val task = insertRecurring()
+        val mainTaskId = task.main.entityValues.getAsLong(Tasks._ID)!!
+        val exceptionId = taskList.findTaskRow(
+            arrayOf(Tasks._ID),
+            "${Tasks.ORIGINAL_INSTANCE_ID}=?",
+            arrayOf(mainTaskId.toString())
+        )!!.getAsLong(Tasks._ID)!!
+
+        assertNull(recurringTaskList.getById(exceptionId))
     }
 
     @Test
@@ -119,6 +141,15 @@ class DmfsRecurringTaskListTest(providerName: TaskProvider.ProviderName) :
         assertEquals(2, orderedResult.size)
         assertTaskAndExceptionsEqual(task1, orderedResult[0], onlyFieldsInExpected = true)
         assertTaskAndExceptionsEqual(task2, orderedResult[1], onlyFieldsInExpected = true)
+    }
+
+    @Test
+    fun testIterateTaskAndExceptions_IgnoresExceptionMatches() {
+        insertRecurring()
+
+        recurringTaskList.iterateTaskAndExceptions("${Tasks.TITLE}=?", arrayOf("Exception")) {
+            fail("must not be called")
+        }
     }
 
     @Test

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidRecurringCalendar.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidRecurringCalendar.kt
@@ -102,9 +102,8 @@ class AndroidRecurringCalendar(
      *
      * @return event and exceptions
      */
-    fun getById(mainEventId: Long): EventAndExceptions? {
-        return findEventAndExceptions("${Events._ID}=?", arrayOf(mainEventId.toString()))
-    }
+    fun getById(mainEventId: Long): EventAndExceptions? =
+        findEventAndExceptions("${Events._ID}=?", arrayOf(mainEventId.toString()))
 
     /**
      * Iterates through main events together with their exceptions from the content provider.
@@ -116,9 +115,8 @@ class AndroidRecurringCalendar(
      * @param body          callback that is called for each event (including exceptions)
      */
     fun iterateEventAndExceptions(where: String?, whereArgs: Array<String>?, body: (EventAndExceptions) -> Unit) {
-        val (mainWhere, mainWhereArgs) = whereWithMainEventsOnly(where, whereArgs)
-
         // iterate through main events and attach exceptions
+        val (mainWhere, mainWhereArgs) = whereWithMainEventsOnly(where, whereArgs)
         calendar.iterateEvents(mainWhere, mainWhereArgs) { main ->
             val mainEventId = main.entityValues.getAsLong(Events._ID)
             body(EventAndExceptions(

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidRecurringCalendar.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidRecurringCalendar.kt
@@ -76,7 +76,7 @@ class AndroidRecurringCalendar(
     }
 
     /**
-     * Find first event (including exceptions) that matches the query from the content provider.
+     * Find first main event that matches the query from the content provider and attach its exceptions.
      *
      * Note that the exceptions may contain deleted events.
      *
@@ -84,7 +84,8 @@ class AndroidRecurringCalendar(
      * @param whereArgs     arguments for selection
      */
     fun findEventAndExceptions(where: String?, whereArgs: Array<String>?): EventAndExceptions? {
-        val main = calendar.findEvent(where, whereArgs) ?: return null
+        val (mainWhere, mainWhereArgs) = whereWithMainEventsOnly(where, whereArgs)
+        val main = calendar.findEvent(mainWhere, mainWhereArgs) ?: return null
 
         // attach exceptions
         val mainEventId = main.entityValues.getAsLong(Events._ID)
@@ -95,22 +96,18 @@ class AndroidRecurringCalendar(
     }
 
     /**
-     * Retrieves an event and its exceptions from the content provider (associated by [Events.ORIGINAL_ID]).
+     * Retrieves a main event and its exceptions from the content provider (associated by [Events.ORIGINAL_ID]).
      *
      * @param mainEventId   [Events._ID] of the main event
      *
      * @return event and exceptions
      */
     fun getById(mainEventId: Long): EventAndExceptions? {
-        val mainEvent = calendar.getEvent(mainEventId) ?: return null
-        return EventAndExceptions(
-            main = mainEvent,
-            exceptions = calendar.findEvents("${Events.ORIGINAL_ID}=?", arrayOf(mainEventId.toString()))
-        )
+        return findEventAndExceptions("${Events._ID}=?", arrayOf(mainEventId.toString()))
     }
 
     /**
-     * Iterates through events together with their exceptions from the content provider.
+     * Iterates through main events together with their exceptions from the content provider.
      *
      * Note that the exceptions may contain deleted events.
      *
@@ -119,8 +116,10 @@ class AndroidRecurringCalendar(
      * @param body          callback that is called for each event (including exceptions)
      */
     fun iterateEventAndExceptions(where: String?, whereArgs: Array<String>?, body: (EventAndExceptions) -> Unit) {
+        val (mainWhere, mainWhereArgs) = whereWithMainEventsOnly(where, whereArgs)
+
         // iterate through main events and attach exceptions
-        calendar.iterateEvents(where, whereArgs) { main ->
+        calendar.iterateEvents(mainWhere, mainWhereArgs) { main ->
             val mainEventId = main.entityValues.getAsLong(Events._ID)
             body(EventAndExceptions(
                 main = main,
@@ -130,7 +129,7 @@ class AndroidRecurringCalendar(
     }
 
     /**
-     * Updates an event and all its exceptions. Input data is first cleaned up using
+     * Updates a main event and all its exceptions. Input data is first cleaned up using
      * [cleanMainEvent] and [cleanException].
      *
      * @param id                    ID of the main event row
@@ -172,9 +171,9 @@ class AndroidRecurringCalendar(
     }
 
     /**
-     * Deletes an event and all its potential exceptions.
+     * Deletes a main event and all its potential exceptions.
      *
-     * @param id    ID of the event
+     * @param id    ID of the main event
      */
     fun deleteEventAndExceptions(id: Long) {
         try {
@@ -371,5 +370,10 @@ class AndroidRecurringCalendar(
         batch.commit()
     }
 
+    private fun whereWithMainEventsOnly(where: String?, whereArgs: Array<String>?): Pair<String, Array<String>> {
+        val protectedWhere = "(${where ?: "1"}) AND ${Events.ORIGINAL_ID} IS NULL AND ${Events.ORIGINAL_SYNC_ID} IS NULL"
+        val protectedWhereArgs = whereArgs ?: arrayOf()
+        return Pair(protectedWhere, protectedWhereArgs)
+    }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsRecurringTaskList.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsRecurringTaskList.kt
@@ -68,7 +68,9 @@ class DmfsRecurringTaskList(
     }
 
     /**
-     * Find first task (including exceptions) of [taskList] that matches the query from the content provider.
+     * Find first main task of [taskList] that matches the query from the content provider and attach its exceptions.
+     *
+     * Exception rows are excluded from the lookup by requiring [Tasks.ORIGINAL_INSTANCE_ID] to be `NULL`.
      *
      * Note that the exceptions may contain deleted tasks.
      *
@@ -76,7 +78,8 @@ class DmfsRecurringTaskList(
      * @param whereArgs     arguments for selection
      */
     fun findTaskAndExceptions(where: String?, whereArgs: Array<String>?): TaskAndExceptions? {
-        val main = taskList.findTask(where, whereArgs) ?: return null
+        val (mainWhere, mainWhereArgs) = whereWithMainTasksOnly(where, whereArgs)
+        val main = taskList.findTask(mainWhere, mainWhereArgs) ?: return null
 
         // attach exceptions
         val mainTaskId = main.entityValues.getAsLong(Tasks._ID)
@@ -87,22 +90,22 @@ class DmfsRecurringTaskList(
     }
 
     /**
-     * Retrieves a task and its exceptions from the content provider.
+     * Retrieves a main task and its exceptions from the content provider.
+     *
+     * Exception rows are excluded from the lookup by requiring [Tasks.ORIGINAL_INSTANCE_ID] to be `NULL`.
      *
      * @param mainTaskId   [TaskContract.Tasks._ID] of the main task
      *
      * @return the task and its exceptions, or _null_ if no task with the given id was found
      */
     fun getById(mainTaskId: Long): TaskAndExceptions? {
-        val mainTask = taskList.getTask(mainTaskId) ?: return null
-        return TaskAndExceptions(
-            main = mainTask,
-            exceptions = findExceptions(mainTaskId)
-        )
+        return findTaskAndExceptions("${Tasks._ID}=?", arrayOf(mainTaskId.toString()))
     }
 
     /**
-     * Iterates through tasks in [taskList] together with their exceptions.
+     * Iterates through main tasks in [taskList] together with their exceptions.
+     *
+     * Exception rows are excluded from the iteration by requiring [Tasks.ORIGINAL_INSTANCE_ID] to be `NULL`.
      *
      * Note that the exceptions may contain deleted tasks.
      *
@@ -111,7 +114,9 @@ class DmfsRecurringTaskList(
      * @param body          callback that is called for each task (including exceptions)
      */
     fun iterateTaskAndExceptions(where: String?, whereArgs: Array<String>?, body: (TaskAndExceptions) -> Unit) {
-        taskList.iterateTasks(where, whereArgs) { main ->
+        val (mainWhere, mainWhereArgs) = whereWithMainTasksOnly(where, whereArgs)
+
+        taskList.iterateTasks(mainWhere, mainWhereArgs) { main ->
             val mainTaskId = main.entityValues.getAsLong(Tasks._ID)
             body(
                 TaskAndExceptions(
@@ -369,5 +374,11 @@ class DmfsRecurringTaskList(
      */
     private fun findExceptions(mainTaskId: Long): List<Entity> =
         taskList.findTasks("${Tasks.ORIGINAL_INSTANCE_ID}=?", arrayOf(mainTaskId.toString()))
+
+    private fun whereWithMainTasksOnly(where: String?, whereArgs: Array<String>?): Pair<String, Array<String>> {
+        val protectedWhere = "(${where ?: "1"}) AND ${Tasks.ORIGINAL_INSTANCE_ID} IS NULL"
+        val protectedWhereArgs = whereArgs ?: arrayOf()
+        return Pair(protectedWhere, protectedWhereArgs)
+    }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsRecurringTaskList.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsRecurringTaskList.kt
@@ -70,8 +70,6 @@ class DmfsRecurringTaskList(
     /**
      * Find first main task of [taskList] that matches the query from the content provider and attach its exceptions.
      *
-     * Exception rows are excluded from the lookup by requiring [Tasks.ORIGINAL_INSTANCE_ID] to be `NULL`.
-     *
      * Note that the exceptions may contain deleted tasks.
      *
      * @param where         selection
@@ -92,20 +90,15 @@ class DmfsRecurringTaskList(
     /**
      * Retrieves a main task and its exceptions from the content provider.
      *
-     * Exception rows are excluded from the lookup by requiring [Tasks.ORIGINAL_INSTANCE_ID] to be `NULL`.
-     *
      * @param mainTaskId   [TaskContract.Tasks._ID] of the main task
      *
      * @return the task and its exceptions, or _null_ if no task with the given id was found
      */
-    fun getById(mainTaskId: Long): TaskAndExceptions? {
-        return findTaskAndExceptions("${Tasks._ID}=?", arrayOf(mainTaskId.toString()))
-    }
+    fun getById(mainTaskId: Long): TaskAndExceptions? =
+        findTaskAndExceptions("${Tasks._ID}=?", arrayOf(mainTaskId.toString()))
 
     /**
      * Iterates through main tasks in [taskList] together with their exceptions.
-     *
-     * Exception rows are excluded from the iteration by requiring [Tasks.ORIGINAL_INSTANCE_ID] to be `NULL`.
      *
      * Note that the exceptions may contain deleted tasks.
      *
@@ -115,7 +108,6 @@ class DmfsRecurringTaskList(
      */
     fun iterateTaskAndExceptions(where: String?, whereArgs: Array<String>?, body: (TaskAndExceptions) -> Unit) {
         val (mainWhere, mainWhereArgs) = whereWithMainTasksOnly(where, whereArgs)
-
         taskList.iterateTasks(mainWhere, mainWhereArgs) { main ->
             val mainTaskId = main.entityValues.getAsLong(Tasks._ID)
             body(


### PR DESCRIPTION
### Purpose

Moves the exclusion of exceptions from `LocalCalendar` to `AndroidRecurringCalendar` (which is responsible for handling exceptions).

Also makes sure that `AndroidRecurringCalendar` query methods only query main events.

Equivalent change for tasks.

### Checklist

- [ ] The PR has a proper title, description and label.
- [ ] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [ ] I have added documentation to complex functions and functions that can be used by other modules.
- [ ] I have added reasonable tests or consciously decided to not add tests.