### PR TITLE
[jtx rewrite] Add builder `LocationBuilder` -> `LOCATION`+`LOCATION_ALTREP`

### DIFF
--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/LocationBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/LocationBuilder.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.synctools.mapping.jtx.builder
+
+import android.content.Entity
+import at.techbee.jtx.JtxContract
+import net.fortuna.ical4j.model.component.CalendarComponent
+import net.fortuna.ical4j.model.parameter.AltRep
+import net.fortuna.ical4j.model.property.Location
+import kotlin.jvm.optionals.getOrNull
+
+class LocationBuilder : JtxObjectEntityBuilder {
+    override fun build(from: CalendarComponent, main: CalendarComponent, to: Entity) {
+        val location = from.getProperty<Location>(Location.LOCATION).getOrNull()
+        val altRep = location?.getParameter<AltRep>(AltRep.ALTREP)?.getOrNull()
+        to.entityValues.put(JtxContract.JtxICalObject.LOCATION, location?.value)
+        to.entityValues.put(JtxContract.JtxICalObject.LOCATION_ALTREP, altRep?.value)
+    }
+}

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/builder/LocationBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/builder/LocationBuilderTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.synctools.mapping.jtx.builder
+
+import android.content.ContentValues
+import android.content.Entity
+import at.bitfire.synctools.icalendar.propertyListOf
+import at.techbee.jtx.JtxContract
+import net.fortuna.ical4j.model.ParameterList
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.parameter.AltRep
+import net.fortuna.ical4j.model.property.Location
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.net.URI
+
+@RunWith(RobolectricTestRunner::class)
+class LocationBuilderTest {
+
+    private val builder = LocationBuilder()
+
+    @Test
+    fun `No LOCATION`() {
+        val task = VToDo()
+        val output = Entity(ContentValues())
+
+        builder.build(from = task, main = task, to = output)
+
+        assertTrue(output.entityValues.containsKey(JtxContract.JtxICalObject.LOCATION))
+        assertNull(output.entityValues.get(JtxContract.JtxICalObject.LOCATION))
+        assertTrue(output.entityValues.containsKey(JtxContract.JtxICalObject.LOCATION_ALTREP))
+        assertNull(output.entityValues.get(JtxContract.JtxICalObject.LOCATION_ALTREP))
+    }
+
+    @Test
+    fun `LOCATION has value`() {
+        val task = VToDo(propertyListOf(Location("Office")))
+        val main = VToDo()
+        val output = Entity(ContentValues())
+
+        builder.build(from = task, main = main, to = output)
+
+        assertEquals("Office", output.entityValues.get(JtxContract.JtxICalObject.LOCATION))
+        assertTrue(output.entityValues.containsKey(JtxContract.JtxICalObject.LOCATION_ALTREP))
+        assertNull(output.entityValues.get(JtxContract.JtxICalObject.LOCATION_ALTREP))
+    }
+
+    @Test
+    fun `LOCATION with ALTREP`() {
+        val task = VToDo(
+            propertyListOf(
+                Location(
+                    ParameterList(listOf(AltRep(URI.create("https://example.com/location")))),
+                    "Office"
+                )
+            )
+        )
+        val main = VToDo()
+        val output = Entity(ContentValues())
+
+        builder.build(from = task, main = main, to = output)
+
+        assertEquals("Office", output.entityValues.get(JtxContract.JtxICalObject.LOCATION))
+        assertEquals(
+            "https://example.com/location",
+            output.entityValues.get(JtxContract.JtxICalObject.LOCATION_ALTREP)
+        )
+    }
+}


### PR DESCRIPTION
### Purpose

Continues the work in https://github.com/bitfireAT/davx5-ose/issues/2376 by implementing the builder for Locations.

### Short description

- Implement `LocationBuilder`
- Add tests for a location being added
- Add tests for no location
- Add tests for altrep

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

