### PR TITLE
[jtx rewrite] Add builder `GeoBuilder` -> `GEO_LAT`+`GEO_LONG`

### DIFF
--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/GeoBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/GeoBuilder.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.synctools.mapping.jtx.builder
+
+import android.content.Entity
+import at.techbee.jtx.JtxContract
+import net.fortuna.ical4j.model.component.CalendarComponent
+import net.fortuna.ical4j.model.property.Geo
+import kotlin.jvm.optionals.getOrNull
+
+class GeoBuilder : JtxObjectEntityBuilder {
+    override fun build(from: CalendarComponent, main: CalendarComponent, to: Entity) {
+        val geo = from.getProperty<Geo>(Geo.GEO).getOrNull()
+        to.entityValues.put(JtxContract.JtxICalObject.GEO_LAT, geo?.latitude?.toDouble())
+        to.entityValues.put(JtxContract.JtxICalObject.GEO_LONG, geo?.longitude?.toDouble())
+    }
+}

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/builder/GeoBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/builder/GeoBuilderTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.synctools.mapping.jtx.builder
+
+import android.content.ContentValues
+import android.content.Entity
+import at.bitfire.synctools.icalendar.propertyListOf
+import at.techbee.jtx.JtxContract
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.property.Geo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GeoBuilderTest {
+
+    private val builder = GeoBuilder()
+
+    @Test
+    fun `No GEO`() {
+        val task = VToDo()
+        val output = Entity(ContentValues())
+
+        builder.build(from = task, main = task, to = output)
+
+        assertTrue(output.entityValues.containsKey(JtxContract.JtxICalObject.GEO_LAT))
+        assertNull(output.entityValues.get(JtxContract.JtxICalObject.GEO_LAT))
+        assertTrue(output.entityValues.containsKey(JtxContract.JtxICalObject.GEO_LONG))
+        assertNull(output.entityValues.get(JtxContract.JtxICalObject.GEO_LONG))
+    }
+
+    @Test
+    fun `GEO stores latitude and longitude as Double`() {
+        val task = VToDo(propertyListOf(Geo(48.2.toBigDecimal(), 16.3.toBigDecimal())))
+        val main = VToDo()
+        val output = Entity(ContentValues())
+
+        builder.build(from = task, main = main, to = output)
+
+        assertEquals(48.2, output.entityValues.getAsDouble(JtxContract.JtxICalObject.GEO_LAT), 0.0)
+        assertEquals(16.3, output.entityValues.getAsDouble(JtxContract.JtxICalObject.GEO_LONG), 0.0)
+    }
+}


### PR DESCRIPTION
### Purpose

Continues the work in https://github.com/bitfireAT/davx5-ose/issues/2376 by implementing geo properties.

### Short description

- Implement `GeoBuilder`.
- Add test for no geo.
- Add test for valid geo+make sure type is correctly given as `Double`.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

