### PR TITLE
Don't add SEQUENCE to iCalendar for non-group-scheduled events

### DIFF
--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/SequenceUpdater.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/SequenceUpdater.kt
@@ -49,22 +49,14 @@ class SequenceUpdater {
                 (currentSeq + 1).also { newSeq ->
                     mainValues.put(EventsContract.COLUMN_SEQUENCE, newSeq)
                 }
-            } else
-            /* Upload of a group-scheduled event and we are not the organizer, so we don't increase the SEQUENCE. */
-                null
-
-        } else /* not group-scheduled */  {
-            return if (currentSeq == 0) {
-                /* The event was uploaded once and has SEQUENCE of 0 (which is mapped to an empty SEQUENCE property).
-                We don't need to increase the SEQUENCE because the event is not group-scheduled. */
-                null
             } else {
-                /* Upload of a non-group-scheduled event where a SEQUENCE > 0 is present. Increase by one after upload.
-                We also have to store it into the Entity so that the new value will be mapped. */
-                (currentSeq + 1).also { newSeq ->
-                    mainValues.put(EventsContract.COLUMN_SEQUENCE, newSeq)
-                }
+                /* Upload of a group-scheduled event and we are not the organizer, so we don't increase the SEQUENCE. */
+                null
             }
+
+        } else /* not group-scheduled */ {
+            // SEQUENCE is not emitted for non-group-scheduled events, no need to increase.
+            return null
         }
     }
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/SequenceHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/SequenceHandler.kt
@@ -5,6 +5,7 @@
 package at.bitfire.synctools.mapping.calendar.handler
 
 import android.content.Entity
+import android.provider.CalendarContract
 import at.bitfire.synctools.icalendar.plusAssign
 import at.bitfire.synctools.storage.calendar.EventsContract
 import net.fortuna.ical4j.model.component.VEvent
@@ -13,6 +14,14 @@ import net.fortuna.ical4j.model.property.Sequence
 class SequenceHandler : AndroidEventEntityHandler {
 
     override fun process(from: Entity, main: Entity, to: VEvent) {
+        val groupScheduled = main.subValues.any { it.uri == CalendarContract.Attendees.CONTENT_URI }
+        if (!groupScheduled) {
+            /* Don't emit SEQUENCE for non-group-scheduled events. SEQUENCE is only useful/required
+            for coordinating group-scheduled events; see RFC 5545 3.8.7.4 Sequence Number,
+            RFC 5546 5.3 Sequence Number and RFC 6338 3.2.5 DTSTAMP and SEQUENCE Properties. */
+            return
+        }
+
         val seqNo = from.entityValues.getAsInteger(EventsContract.COLUMN_SEQUENCE)
         if (seqNo != null && seqNo > 0)
             to += Sequence(seqNo)

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/SequenceUpdaterTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/SequenceUpdaterTest.kt
@@ -99,10 +99,10 @@ class SequenceUpdaterTest {
         )
         val result = sequenceUpdater.increaseSequence(main)
 
-        // SEQUENCE column is increased to 2 for mapping, ...
-        Assert.assertEquals(2, main.entityValues.getAsInteger(EventsContract.COLUMN_SEQUENCE))
-        // ... and increased after upload.
-        Assert.assertEquals(2, result)
+        // Non-group scheduled event – SEQUENCE column is not touched and thus remains 1, ...
+        Assert.assertEquals(1, main.entityValues.getAsInteger(EventsContract.COLUMN_SEQUENCE))
+        // ... and is not increased after upload.
+        Assert.assertNull(result)
     }
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/SequenceUpdaterTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/SequenceUpdaterTest.kt
@@ -9,7 +9,8 @@ import android.content.Entity
 import android.provider.CalendarContract
 import androidx.core.content.contentValuesOf
 import at.bitfire.synctools.storage.calendar.EventsContract
-import org.junit.Assert
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -20,7 +21,7 @@ class SequenceUpdaterTest {
     private val sequenceUpdater = SequenceUpdater()
 
     @Test
-    fun testIncreaseSequence_NewEvent() {
+    fun `SEQUENCE is increased for new events`() {
         // In case of newly created events, it doesn't matter whether they're group-scheduled or not.
         val main = Entity(
             ContentValues(
@@ -30,13 +31,13 @@ class SequenceUpdaterTest {
         val result = sequenceUpdater.increaseSequence(main)
 
         // SEQUENCE column remains null for mapping ...
-        Assert.assertNull(main.entityValues.getAsInteger(EventsContract.COLUMN_SEQUENCE))
+        assertNull(main.entityValues.getAsInteger(EventsContract.COLUMN_SEQUENCE))
         // ... but SEQUENCE shall be set to 0 after upload
-        Assert.assertEquals(0, result)
+        assertEquals(0, result)
     }
 
     @Test
-    fun testIncreaseSequence_GroupScheduledEvent_AsOrganizer() {
+    fun `SEQUENCE is increased for group-scheduled events when we're ORGANIZER`() {
         val main = Entity(
             contentValuesOf(
                 EventsContract.COLUMN_SEQUENCE to 1,
@@ -50,12 +51,12 @@ class SequenceUpdaterTest {
             )
         }
         val result = sequenceUpdater.increaseSequence(main)
-        Assert.assertEquals(2, main.entityValues.getAsInteger(EventsContract.COLUMN_SEQUENCE))
-        Assert.assertEquals(2, result)
+        assertEquals(2, main.entityValues.getAsInteger(EventsContract.COLUMN_SEQUENCE))
+        assertEquals(2, result)
     }
 
     @Test
-    fun testIncreaseSequence_GroupScheduledEvent_NotAsOrganizer() {
+    fun `SEQUENCE is not increased for group-scheduled events when we're not ORGANIZER`() {
         val main = Entity(
             contentValuesOf(
                 EventsContract.COLUMN_SEQUENCE to 1,
@@ -70,28 +71,13 @@ class SequenceUpdaterTest {
         }
         val result = sequenceUpdater.increaseSequence(main)
         // SEQUENCE column remains 1 for mapping, ...
-        Assert.assertEquals(1, main.entityValues.getAsInteger(EventsContract.COLUMN_SEQUENCE))
+        assertEquals(1, main.entityValues.getAsInteger(EventsContract.COLUMN_SEQUENCE))
         // ... but don't increase after upload.
-        Assert.assertNull(result)
+        assertNull(result)
     }
 
     @Test
-    fun testIncreaseSequence_NonGroupScheduledEvent_WithoutSequence() {
-        val main = Entity(
-            contentValuesOf(
-                EventsContract.COLUMN_SEQUENCE to 0
-            )
-        )
-        val result = sequenceUpdater.increaseSequence(main)
-
-        // SEQUENCE column remains 0 for mapping (will be mapped to no SEQUENCE property), ...
-        Assert.assertEquals(0, main.entityValues.getAsInteger(EventsContract.COLUMN_SEQUENCE))
-        // ... but don't increase after upload.
-        Assert.assertNull(result)
-    }
-
-    @Test
-    fun testIncreaseSequence_NonGroupScheduledEvent_WithSequence() {
+    fun `SEQUENCE is not increased for non-group-scheduled events`() {
         val main = Entity(
             contentValuesOf(
                 EventsContract.COLUMN_SEQUENCE to 1
@@ -99,10 +85,10 @@ class SequenceUpdaterTest {
         )
         val result = sequenceUpdater.increaseSequence(main)
 
-        // Non-group scheduled event – SEQUENCE column is not touched and thus remains 1, ...
-        Assert.assertEquals(1, main.entityValues.getAsInteger(EventsContract.COLUMN_SEQUENCE))
+        // SEQUENCE column is not touched and remains 1 (will be mapped to no SEQUENCE property) ...
+        assertEquals(1, main.entityValues.getAsInteger(EventsContract.COLUMN_SEQUENCE))
         // ... and is not increased after upload.
-        Assert.assertNull(result)
+        assertNull(result)
     }
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/SequenceHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/SequenceHandlerTest.kt
@@ -6,6 +6,7 @@ package at.bitfire.synctools.mapping.calendar.handler
 
 import android.content.ContentValues
 import android.content.Entity
+import android.provider.CalendarContract
 import androidx.core.content.contentValuesOf
 import at.bitfire.synctools.storage.calendar.EventsContract
 import net.fortuna.ical4j.model.component.VEvent
@@ -39,10 +40,28 @@ class SequenceHandlerTest {
     }
 
     @Test
-    fun `Sequence is 1`() {
+    fun `Non-group-scheduled event, sequence is 1`() {
+        val entity = Entity(
+            contentValuesOf(
+                EventsContract.COLUMN_SEQUENCE to 1
+            )
+        )
+        val result = VEvent()
+        handler.process(entity, entity, result)
+        assertNull(result.sequence)
+    }
+
+    @Test
+    fun `Group-scheduled event, sequence is 1`() {
         val entity = Entity(contentValuesOf(
             EventsContract.COLUMN_SEQUENCE to 1
-        ))
+        )
+        ).apply {
+            addSubValue(
+                CalendarContract.Attendees.CONTENT_URI,
+                contentValuesOf(CalendarContract.Attendees.ATTENDEE_EMAIL to "test@example.com")
+            )
+        }
         val result = VEvent()
         handler.process(entity, entity, result)
         assertEquals(1, result.sequence.sequenceNo)

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/SequenceHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/SequenceHandlerTest.kt
@@ -40,7 +40,7 @@ class SequenceHandlerTest {
     }
 
     @Test
-    fun `Non-group-scheduled event, sequence is 1`() {
+    fun `Sequence is 1 (non-group-scheduled event)`() {
         val entity = Entity(
             contentValuesOf(
                 EventsContract.COLUMN_SEQUENCE to 1
@@ -52,7 +52,7 @@ class SequenceHandlerTest {
     }
 
     @Test
-    fun `Group-scheduled event, sequence is 1`() {
+    fun `Sequence is 1 (group-scheduled event)`() {
         val entity = Entity(contentValuesOf(
             EventsContract.COLUMN_SEQUENCE to 1
         )


### PR DESCRIPTION
### Purpose

Now the SEQUENCE property is only add to iCalendar exports for group-scheduled events in order to avoid confusion.

### Checklist

- [ ] The PR has a proper title, description and label.
- [ ] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [ ] I have added documentation to complex functions and functions that can be used by other modules.
- [ ] I have added reasonable tests or consciously decided to not add tests.