### PR TITLE
Simplify TaskProvider

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/JtxSyncManagerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/JtxSyncManagerTest.kt
@@ -60,7 +60,7 @@ class JtxSyncManagerTest {
     val hiltRule = HiltAndroidRule(this)
 
     @get:Rule
-    val permissionRule = GrantPermissionOrSkipRule(TaskProvider.PERMISSIONS_JTX.toSet())
+    val permissionRule = GrantPermissionOrSkipRule(TaskProvider.ProviderName.JtxBoard.permissions.toSet())
 
     lateinit var account: Account
 
@@ -73,7 +73,7 @@ class JtxSyncManagerTest {
         hiltRule.inject()
 
         // Check jtxBoard permissions were granted (+jtxBoard is installed); skip test otherwise
-        assumeTrue(PermissionUtils.havePermissions(context, TaskProvider.PERMISSIONS_JTX))
+        assumeTrue(PermissionUtils.havePermissions(context, TaskProvider.ProviderName.JtxBoard.permissions))
 
         // Acquire the jtx content provider
         val providerOrNull = context.contentResolver.acquireContentProviderClient(JtxContract.AUTHORITY)

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/JtxSyncManagerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/JtxSyncManagerTest.kt
@@ -15,7 +15,7 @@ import at.bitfire.davdroid.resource.LocalJtxCollection
 import at.bitfire.davdroid.resource.LocalJtxCollectionStore
 import at.bitfire.davdroid.sync.account.TestAccount
 import at.bitfire.davdroid.util.PermissionUtils
-import at.bitfire.ical4android.TaskProvider
+import at.bitfire.synctools.storage.TaskProvider
 import at.bitfire.synctools.test.GrantPermissionOrSkipRule
 import at.techbee.jtx.JtxContract
 import dagger.hilt.android.qualifiers.ApplicationContext

--- a/core/src/main/kotlin/at/bitfire/davdroid/db/migration/AutoMigration18.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/migration/AutoMigration18.kt
@@ -11,7 +11,7 @@ import androidx.room.RenameColumn
 import androidx.room.migration.AutoMigrationSpec
 import androidx.sqlite.db.SupportSQLiteDatabase
 import at.bitfire.davdroid.sync.SyncDataType
-import at.bitfire.ical4android.TaskProvider
+import at.bitfire.synctools.storage.TaskProvider
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalTask.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalTask.kt
@@ -8,7 +8,7 @@ import android.content.ContentUris
 import android.content.Context
 import android.net.Uri
 import androidx.core.content.contentValuesOf
-import at.bitfire.ical4android.TaskProvider
+import at.bitfire.synctools.storage.TaskProvider
 import at.bitfire.synctools.storage.tasks.DmfsRecurringTaskList
 import at.bitfire.synctools.storage.tasks.DmfsTasksContract
 import at.bitfire.synctools.storage.tasks.TaskAndExceptions

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskListStore.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskListStore.kt
@@ -15,7 +15,7 @@ import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.util.DavUtils.lastSegment
-import at.bitfire.ical4android.TaskProvider
+import at.bitfire.synctools.storage.TaskProvider
 import at.bitfire.synctools.storage.tasks.DmfsTaskList
 import at.bitfire.synctools.storage.tasks.DmfsTaskListProvider
 import dagger.assisted.Assisted

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration10.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration10.kt
@@ -37,7 +37,7 @@ class AccountSettingsMigration10 @Inject constructor(
 
     override fun migrate(account: Account) {
         val providerName = TaskProvider.ProviderName.OpenTasks
-        TaskProvider.acquireClient(context, providerName)?.use { client ->
+        TaskProvider.acquireRecentClient(context, providerName)?.use { client ->
             val tasksUri = TaskContract.Tasks.getContentUri(providerName.authority)!!.asSyncAdapter(account)
             val emptyETag = contentValuesOf(DmfsTasksContract.COLUMN_ETAG to null)
             client.update(tasksUri, emptyETag, "${TaskContract.Tasks._DIRTY}=0 AND ${TaskContract.Tasks._DELETED}=0", null)

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration10.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration10.kt
@@ -38,7 +38,7 @@ class AccountSettingsMigration10 @Inject constructor(
 
     override fun migrate(account: Account) {
         TaskProvider.acquire(context, TaskProvider.ProviderName.OpenTasks)?.use { provider ->
-            val tasksUri = provider.tasksUri().asSyncAdapter(account)
+            val tasksUri = TaskContract.Tasks.getContentUri(provider.name.authority)!!.asSyncAdapter(account)
             val emptyETag = contentValuesOf(DmfsTasksContract.COLUMN_ETAG to null)
             provider.client.update(tasksUri, emptyETag, "${TaskContract.Tasks._DIRTY}=0 AND ${TaskContract.Tasks._DELETED}=0", null)
         }

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration10.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration10.kt
@@ -12,7 +12,7 @@ import android.provider.CalendarContract.Calendars
 import android.provider.CalendarContract.Reminders
 import androidx.core.content.ContextCompat
 import androidx.core.content.contentValuesOf
-import at.bitfire.ical4android.TaskProvider
+import at.bitfire.synctools.storage.TaskProvider
 import at.bitfire.synctools.storage.tasks.DmfsTasksContract
 import at.techbee.jtx.JtxContract.asSyncAdapter
 import dagger.Binds

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration10.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration10.kt
@@ -24,7 +24,6 @@ import dagger.multibindings.IntKey
 import dagger.multibindings.IntoMap
 import org.dmfs.tasks.contract.TaskContract
 import javax.inject.Inject
-import kotlin.use
 
 /**
  * Task synchronization now handles alarms, categories, relations and unknown properties.
@@ -37,10 +36,11 @@ class AccountSettingsMigration10 @Inject constructor(
 ): AccountSettingsMigration {
 
     override fun migrate(account: Account) {
-        TaskProvider.acquire(context, TaskProvider.ProviderName.OpenTasks)?.use { provider ->
-            val tasksUri = TaskContract.Tasks.getContentUri(provider.name.authority)!!.asSyncAdapter(account)
+        val providerName = TaskProvider.ProviderName.OpenTasks
+        TaskProvider.acquireClient(context, providerName)?.use { client ->
+            val tasksUri = TaskContract.Tasks.getContentUri(providerName.authority)!!.asSyncAdapter(account)
             val emptyETag = contentValuesOf(DmfsTasksContract.COLUMN_ETAG to null)
-            provider.client.update(tasksUri, emptyETag, "${TaskContract.Tasks._DIRTY}=0 AND ${TaskContract.Tasks._DELETED}=0", null)
+            client.update(tasksUri, emptyETag, "${TaskContract.Tasks._DIRTY}=0 AND ${TaskContract.Tasks._DELETED}=0", null)
         }
 
         if (ContextCompat.checkSelfPermission(context, android.Manifest.permission.WRITE_CALENDAR) == PackageManager.PERMISSION_GRANTED)

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration14.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration14.kt
@@ -9,7 +9,7 @@ import android.content.ContentResolver
 import android.provider.CalendarContract
 import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.sync.SyncDataType
-import at.bitfire.ical4android.TaskProvider
+import at.bitfire.synctools.storage.TaskProvider
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration19.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration19.kt
@@ -9,7 +9,7 @@ import android.content.Context
 import android.provider.CalendarContract
 import androidx.work.WorkManager
 import at.bitfire.davdroid.sync.AutomaticSyncManager
-import at.bitfire.ical4android.TaskProvider
+import at.bitfire.synctools.storage.TaskProvider
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -36,7 +36,7 @@ class AccountSettingsMigration19 @Inject constructor(
         val authorities = listOf(
             "at.bitfire.davdroid.addressbooks",
             CalendarContract.AUTHORITY,
-            *TaskProvider.TASK_PROVIDERS.map { it.authority }.toTypedArray()
+            TaskProvider.ProviderName.entries.map { it.authority }.toTypedArray()
         )
         for (authority in authorities) {
             val oldWorkerName = "periodic-sync $authority ${account.type}/${account.name}"

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration19.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration19.kt
@@ -36,8 +36,7 @@ class AccountSettingsMigration19 @Inject constructor(
         val authorities = listOf(
             "at.bitfire.davdroid.addressbooks",
             CalendarContract.AUTHORITY,
-            TaskProvider.ProviderName.entries.map { it.authority }.toTypedArray()
-        )
+        ) + TaskProvider.ProviderName.entries.map { it.authority }
         for (authority in authorities) {
             val oldWorkerName = "periodic-sync $authority ${account.type}/${account.name}"
             workManager.cancelUniqueWork(oldWorkerName)

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration8.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration8.kt
@@ -8,7 +8,7 @@ import android.accounts.Account
 import android.content.ContentUris
 import android.content.Context
 import androidx.core.content.contentValuesOf
-import at.bitfire.ical4android.TaskProvider
+import at.bitfire.synctools.storage.TaskProvider
 import at.techbee.jtx.JtxContract.asSyncAdapter
 import dagger.Binds
 import dagger.Module

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration8.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration8.kt
@@ -33,7 +33,7 @@ class AccountSettingsMigration8 @Inject constructor(
      */
     override fun migrate(account: Account) {
         val providerName = TaskProvider.ProviderName.OpenTasks
-        TaskProvider.acquireClient(context, providerName)?.use { client ->
+        TaskProvider.acquireRecentClient(context, providerName)?.use { client ->
             // ETag is now in sync_version instead of sync1
             // UID  is now in _uid         instead of sync2
             val tasksUri = TaskContract.Tasks.getContentUri(providerName.authority)!!

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration8.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration8.kt
@@ -35,7 +35,9 @@ class AccountSettingsMigration8 @Inject constructor(
         TaskProvider.acquire(context, TaskProvider.ProviderName.OpenTasks)?.use { provider ->
             // ETag is now in sync_version instead of sync1
             // UID  is now in _uid         instead of sync2
-            provider.client.query(provider.tasksUri().asSyncAdapter(account),
+            val tasksUri = TaskContract.Tasks.getContentUri(provider.name.authority)!!
+            provider.client.query(
+                tasksUri.asSyncAdapter(account),
                 arrayOf(TaskContract.Tasks._ID, TaskContract.Tasks.SYNC1, TaskContract.Tasks.SYNC2),
                 "${TaskContract.Tasks.ACCOUNT_TYPE}=? AND ${TaskContract.Tasks.ACCOUNT_NAME}=?",
                 arrayOf(account.type, account.name), null)!!.use { cursor ->
@@ -51,7 +53,7 @@ class AccountSettingsMigration8 @Inject constructor(
                     )
                     logger.log(Level.FINE, "Updating task $id", values)
                     provider.client.update(
-                        ContentUris.withAppendedId(provider.tasksUri(), id).asSyncAdapter(account),
+                        ContentUris.withAppendedId(tasksUri, id).asSyncAdapter(account),
                         values, null, null)
                 }
             }

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration8.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration8.kt
@@ -32,11 +32,12 @@ class AccountSettingsMigration8 @Inject constructor(
      * SEQUENCE and should not be used for the eTag.
      */
     override fun migrate(account: Account) {
-        TaskProvider.acquire(context, TaskProvider.ProviderName.OpenTasks)?.use { provider ->
+        val providerName = TaskProvider.ProviderName.OpenTasks
+        TaskProvider.acquireClient(context, providerName)?.use { client ->
             // ETag is now in sync_version instead of sync1
             // UID  is now in _uid         instead of sync2
-            val tasksUri = TaskContract.Tasks.getContentUri(provider.name.authority)!!
-            provider.client.query(
+            val tasksUri = TaskContract.Tasks.getContentUri(providerName.authority)!!
+            client.query(
                 tasksUri.asSyncAdapter(account),
                 arrayOf(TaskContract.Tasks._ID, TaskContract.Tasks.SYNC1, TaskContract.Tasks.SYNC2),
                 "${TaskContract.Tasks.ACCOUNT_TYPE}=? AND ${TaskContract.Tasks.ACCOUNT_NAME}=?",
@@ -52,7 +53,7 @@ class AccountSettingsMigration8 @Inject constructor(
                         TaskContract.Tasks.SYNC2 to null
                     )
                     logger.log(Level.FINE, "Updating task $id", values)
-                    provider.client.update(
+                    client.update(
                         ContentUris.withAppendedId(tasksUri, id).asSyncAdapter(account),
                         values, null, null)
                 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration9.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration9.kt
@@ -8,7 +8,7 @@ import android.accounts.Account
 import android.content.ContentResolver
 import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.Service
-import at.bitfire.ical4android.TaskProvider
+import at.bitfire.synctools.storage.TaskProvider
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn

--- a/core/src/main/kotlin/at/bitfire/davdroid/startup/TasksAppWatcher.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/startup/TasksAppWatcher.kt
@@ -8,7 +8,7 @@ import android.content.Context
 import at.bitfire.davdroid.startup.StartupPlugin.Companion.PRIORITY_DEFAULT
 import at.bitfire.davdroid.sync.TasksAppManager
 import at.bitfire.davdroid.util.packageChangedFlow
-import at.bitfire.ical4android.TaskProvider
+import at.bitfire.synctools.storage.TaskProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.util.logging.Logger
 import javax.inject.Inject

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncer.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncer.kt
@@ -12,7 +12,7 @@ import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service
 import at.bitfire.davdroid.resource.LocalJtxCollection
 import at.bitfire.davdroid.resource.LocalJtxCollectionStore
-import at.bitfire.ical4android.TaskProvider
+import at.bitfire.synctools.storage.TaskProvider
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncDataType.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncDataType.kt
@@ -7,7 +7,7 @@ package at.bitfire.davdroid.sync
 import android.content.Context
 import android.provider.CalendarContract
 import android.provider.ContactsContract
-import at.bitfire.ical4android.TaskProvider
+import at.bitfire.synctools.storage.TaskProvider
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/TaskSyncer.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/TaskSyncer.kt
@@ -12,7 +12,7 @@ import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service
 import at.bitfire.davdroid.resource.LocalTaskList
 import at.bitfire.davdroid.resource.LocalTaskListStore
-import at.bitfire.ical4android.TaskProvider
+import at.bitfire.synctools.storage.TaskProvider
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/TasksAppManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/TasksAppManager.kt
@@ -22,8 +22,8 @@ import at.bitfire.davdroid.settings.Settings
 import at.bitfire.davdroid.settings.SettingsManager
 import at.bitfire.davdroid.ui.NotificationRegistry
 import at.bitfire.davdroid.util.PermissionUtils
-import at.bitfire.ical4android.TaskProvider
-import at.bitfire.ical4android.TaskProvider.ProviderName
+import at.bitfire.synctools.storage.TaskProvider
+import at.bitfire.synctools.storage.TaskProvider.ProviderName
 import dagger.Lazy
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
@@ -33,7 +33,7 @@ import at.bitfire.davdroid.sync.worker.BaseSyncWorker.Companion.RESYNC_ENTRIES
 import at.bitfire.davdroid.sync.worker.BaseSyncWorker.Companion.RESYNC_LIST
 import at.bitfire.davdroid.sync.worker.BaseSyncWorker.Companion.commonTag
 import at.bitfire.davdroid.ui.NotificationRegistry
-import at.bitfire.ical4android.TaskProvider
+import at.bitfire.synctools.storage.TaskProvider
 import dagger.Lazy
 import kotlinx.coroutines.delay
 import java.util.Collections

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoActivity.kt
@@ -22,7 +22,7 @@ import androidx.core.content.IntentCompat
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.sync.SyncDataType
 import at.bitfire.davdroid.sync.TasksAppManager
-import at.bitfire.ical4android.TaskProvider
+import at.bitfire.synctools.storage.TaskProvider
 import at.techbee.jtx.JtxContract
 import com.google.common.base.Ascii
 import dagger.Lazy

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoGenerator.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoGenerator.kt
@@ -43,7 +43,7 @@ import at.bitfire.davdroid.sync.account.InvalidAccountException
 import at.bitfire.davdroid.sync.adapter.SyncFrameworkIntegration
 import at.bitfire.davdroid.sync.worker.BaseSyncWorker
 import at.bitfire.davdroid.util.TextTable
-import at.bitfire.ical4android.TaskProvider
+import at.bitfire.synctools.storage.TaskProvider
 import at.techbee.jtx.JtxContract
 import dagger.hilt.android.qualifiers.ApplicationContext
 import org.dmfs.tasks.contract.TaskContract

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/PermissionsScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/PermissionsScreen.kt
@@ -42,7 +42,7 @@ import at.bitfire.davdroid.ui.composable.AppTheme
 import at.bitfire.davdroid.ui.composable.CardWithImage
 import at.bitfire.davdroid.ui.composable.PermissionSwitchRow
 import at.bitfire.davdroid.util.PermissionUtils
-import at.bitfire.ical4android.TaskProvider
+import at.bitfire.synctools.storage.TaskProvider
 import java.util.logging.Level
 import java.util.logging.Logger
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/PermissionsScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/PermissionsScreen.kt
@@ -162,11 +162,11 @@ fun PermissionsScreen(
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
                 allPermissions += Manifest.permission.POST_NOTIFICATIONS
             if (openTasksAvailable == true)
-                allPermissions.addAll(TaskProvider.PERMISSIONS_OPENTASKS)
+                allPermissions.addAll(TaskProvider.ProviderName.OpenTasks.permissions)
             if (tasksOrgAvailable == true)
-                allPermissions.addAll(TaskProvider.PERMISSIONS_TASKS_ORG)
+                allPermissions.addAll(TaskProvider.ProviderName.TasksOrg.permissions)
             if (jtxAvailable == true)
-                allPermissions.addAll(TaskProvider.PERMISSIONS_JTX)
+                allPermissions.addAll(TaskProvider.ProviderName.JtxBoard.permissions)
             PermissionSwitchRow(
                 text = stringResource(R.string.permissions_all_title),
                 permissions = allPermissions,
@@ -205,7 +205,7 @@ fun PermissionsScreen(
                     text = stringResource(R.string.permissions_jtx_title),
                     summaryWhenGranted = stringResource(R.string.permissions_tasks_status_on),
                     summaryWhenNotGranted = stringResource(R.string.permissions_tasks_status_off),
-                    permissions = TaskProvider.PERMISSIONS_JTX.toList(),
+                    permissions = TaskProvider.ProviderName.JtxBoard.permissions.toList(),
                     modifier = Modifier.padding(vertical = 4.dp)
                 )
             if (openTasksAvailable == true)
@@ -213,7 +213,7 @@ fun PermissionsScreen(
                     text = stringResource(R.string.permissions_opentasks_title),
                     summaryWhenGranted = stringResource(R.string.permissions_tasks_status_on),
                     summaryWhenNotGranted = stringResource(R.string.permissions_tasks_status_off),
-                    permissions = TaskProvider.PERMISSIONS_OPENTASKS.toList(),
+                    permissions = TaskProvider.ProviderName.OpenTasks.permissions.toList(),
                     modifier = Modifier.padding(vertical = 4.dp)
                 )
             if (tasksOrgAvailable == true)
@@ -221,7 +221,7 @@ fun PermissionsScreen(
                     text = stringResource(R.string.permissions_tasksorg_title),
                     summaryWhenGranted = stringResource(R.string.permissions_tasks_status_on),
                     summaryWhenNotGranted = stringResource(R.string.permissions_tasks_status_off),
-                    permissions = TaskProvider.PERMISSIONS_TASKS_ORG.toList(),
+                    permissions = TaskProvider.ProviderName.TasksOrg.permissions.toList(),
                     modifier = Modifier.padding(vertical = 4.dp)
                 )
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/PermissionsViewModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/PermissionsViewModel.kt
@@ -12,7 +12,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import at.bitfire.davdroid.util.packageChangedFlow
-import at.bitfire.ical4android.TaskProvider
+import at.bitfire.synctools.storage.TaskProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.launch

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/TasksScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/TasksScreen.kt
@@ -49,7 +49,7 @@ import at.bitfire.davdroid.ui.UiUtils.toAnnotatedString
 import at.bitfire.davdroid.ui.composable.AppTheme
 import at.bitfire.davdroid.ui.composable.CardWithImage
 import at.bitfire.davdroid.ui.composable.RadioWithSwitch
-import at.bitfire.ical4android.TaskProvider
+import at.bitfire.synctools.storage.TaskProvider
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/TasksViewModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/TasksViewModel.kt
@@ -15,7 +15,7 @@ import at.bitfire.davdroid.di.qualifier.DefaultDispatcher
 import at.bitfire.davdroid.settings.SettingsManager
 import at.bitfire.davdroid.sync.TasksAppManager
 import at.bitfire.davdroid.util.packageChangedFlow
-import at.bitfire.ical4android.TaskProvider
+import at.bitfire.synctools.storage.TaskProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreen.kt
@@ -90,7 +90,7 @@ import at.bitfire.davdroid.ui.account.RenameAccountDialog
 import at.bitfire.davdroid.ui.composable.ActionCard
 import at.bitfire.davdroid.ui.composable.AppTheme
 import at.bitfire.davdroid.ui.composable.ProgressBar
-import at.bitfire.ical4android.TaskProvider
+import at.bitfire.synctools.storage.TaskProvider
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.rememberMultiplePermissionsState
 import kotlinx.coroutines.delay

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/intro/PermissionsIntroPage.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/intro/PermissionsIntroPage.kt
@@ -11,7 +11,7 @@ import at.bitfire.davdroid.ui.PermissionsViewModel
 import at.bitfire.davdroid.util.PermissionUtils
 import at.bitfire.davdroid.util.PermissionUtils.CALENDAR_PERMISSIONS
 import at.bitfire.davdroid.util.PermissionUtils.CONTACT_PERMISSIONS
-import at.bitfire.ical4android.TaskProvider
+import at.bitfire.synctools.storage.TaskProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/intro/PermissionsIntroPage.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/intro/PermissionsIntroPage.kt
@@ -25,8 +25,8 @@ class PermissionsIntroPage @Inject constructor(
         // show PermissionsFragment as intro fragment when no permissions are granted
         val permissions = CONTACT_PERMISSIONS + CALENDAR_PERMISSIONS +
                 TaskProvider.ProviderName.JtxBoard.permissions +
+                TaskProvider.ProviderName.OpenTasks.permissions +
                 TaskProvider.ProviderName.TasksOrg.permissions
-        TaskProvider.ProviderName.OpenTasks.permissions
         return if (PermissionUtils.haveAnyPermission(context, permissions))
             ShowPolicy.DONT_SHOW
         else

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/intro/PermissionsIntroPage.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/intro/PermissionsIntroPage.kt
@@ -24,7 +24,9 @@ class PermissionsIntroPage @Inject constructor(
     override fun getShowPolicy(): ShowPolicy {
         // show PermissionsFragment as intro fragment when no permissions are granted
         val permissions = CONTACT_PERMISSIONS + CALENDAR_PERMISSIONS +
-                TaskProvider.ProviderName.entries.flatMap { it.permissions.toList() }
+                TaskProvider.ProviderName.JtxBoard.permissions +
+                TaskProvider.ProviderName.TasksOrg.permissions
+        TaskProvider.ProviderName.OpenTasks.permissions
         return if (PermissionUtils.haveAnyPermission(context, permissions))
             ShowPolicy.DONT_SHOW
         else

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/intro/PermissionsIntroPage.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/intro/PermissionsIntroPage.kt
@@ -24,9 +24,7 @@ class PermissionsIntroPage @Inject constructor(
     override fun getShowPolicy(): ShowPolicy {
         // show PermissionsFragment as intro fragment when no permissions are granted
         val permissions = CONTACT_PERMISSIONS + CALENDAR_PERMISSIONS +
-                TaskProvider.PERMISSIONS_JTX +
-                TaskProvider.PERMISSIONS_OPENTASKS +
-                TaskProvider.PERMISSIONS_TASKS_ORG
+                TaskProvider.ProviderName.entries.flatMap { it.permissions.toList() }
         return if (PermissionUtils.haveAnyPermission(context, permissions))
             ShowPolicy.DONT_SHOW
         else

--- a/synctools/src/androidTest/kotlin/at/bitfire/ical4android/JtxICalObjectTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/ical4android/JtxICalObjectTest.kt
@@ -53,7 +53,7 @@ import kotlin.jvm.optionals.getOrNull
 class JtxICalObjectTest {
 
     @get:Rule
-    val permissionRule = GrantPermissionOrSkipRule(TaskProvider.PERMISSIONS_JTX.toSet())
+    val permissionRule = GrantPermissionOrSkipRule(TaskProvider.ProviderName.JtxBoard.permissions.toSet())
 
     val context = InstrumentationRegistry.getInstrumentation().targetContext
     private lateinit var client: ContentProviderClient

--- a/synctools/src/androidTest/kotlin/at/bitfire/ical4android/JtxICalObjectTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/ical4android/JtxICalObjectTest.kt
@@ -14,6 +14,7 @@ import androidx.core.content.pm.PackageInfoCompat
 import androidx.test.platform.app.InstrumentationRegistry
 import at.bitfire.synctools.icalendar.ICalendarParser
 import at.bitfire.synctools.icalendar.recurrenceId
+import at.bitfire.synctools.storage.TaskProvider
 import at.bitfire.synctools.storage.jtx.JtxCollection
 import at.bitfire.synctools.storage.jtx.JtxCollectionProvider
 import at.bitfire.synctools.test.GrantPermissionOrSkipRule

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxBatchOperationTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxBatchOperationTest.kt
@@ -8,9 +8,9 @@ import android.accounts.Account
 import android.content.ContentProviderClient
 import androidx.core.content.contentValuesOf
 import androidx.test.platform.app.InstrumentationRegistry
-import at.bitfire.ical4android.TaskProvider
 import at.bitfire.ical4android.util.MiscUtils.asSyncAdapter
 import at.bitfire.synctools.storage.BatchOperation
+import at.bitfire.synctools.storage.TaskProvider
 import at.bitfire.synctools.test.BuildConfig
 import at.bitfire.synctools.test.GrantPermissionOrSkipRule
 import at.techbee.jtx.JtxContract

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxBatchOperationTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxBatchOperationTest.kt
@@ -22,7 +22,7 @@ import org.junit.Test
 class JtxBatchOperationTest {
 
     @get:Rule
-    val permissionRule = GrantPermissionOrSkipRule(TaskProvider.PERMISSIONS_JTX.toSet())
+    val permissionRule = GrantPermissionOrSkipRule(TaskProvider.ProviderName.JtxBoard.permissions.toSet())
 
     private val testAccount = Account(javaClass.name, BuildConfig.APPLICATION_ID)
 

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxCollectionProviderTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxCollectionProviderTest.kt
@@ -8,7 +8,7 @@ import android.accounts.Account
 import android.content.ContentProviderClient
 import androidx.core.content.contentValuesOf
 import androidx.test.platform.app.InstrumentationRegistry
-import at.bitfire.ical4android.TaskProvider
+import at.bitfire.synctools.storage.TaskProvider
 import at.bitfire.synctools.test.GrantPermissionOrSkipRule
 import at.techbee.jtx.JtxContract
 import org.junit.After

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxCollectionProviderTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxCollectionProviderTest.kt
@@ -22,7 +22,7 @@ import org.junit.Test
 class JtxCollectionProviderTest {
 
     @get:Rule
-    val permissionRule = GrantPermissionOrSkipRule(TaskProvider.PERMISSIONS_JTX.toSet())
+    val permissionRule = GrantPermissionOrSkipRule(TaskProvider.ProviderName.JtxBoard.permissions.toSet())
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
 

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxCollectionTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxCollectionTest.kt
@@ -33,7 +33,7 @@ class JtxCollectionTest {
 
         @JvmField
         @ClassRule
-        val permissionRule = GrantPermissionOrSkipRule(TaskProvider.PERMISSIONS_JTX.toSet())
+        val permissionRule = GrantPermissionOrSkipRule(TaskProvider.ProviderName.JtxBoard.permissions.toSet())
 
         private val testAccount = Account(
             JtxCollectionTest::class.java.name,

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxCollectionTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxCollectionTest.kt
@@ -11,8 +11,8 @@ import android.content.ContentValues
 import android.content.Entity
 import androidx.core.content.contentValuesOf
 import androidx.test.platform.app.InstrumentationRegistry
-import at.bitfire.ical4android.TaskProvider
 import at.bitfire.synctools.storage.BatchOperation
+import at.bitfire.synctools.storage.TaskProvider
 import at.bitfire.synctools.test.GrantPermissionOrSkipRule
 import at.bitfire.synctools.test.assertEntitiesEqual
 import at.techbee.jtx.JtxContract

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxRecurringCollectionTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxRecurringCollectionTest.kt
@@ -10,8 +10,8 @@ import android.content.ContentValues
 import android.content.Entity
 import androidx.core.content.contentValuesOf
 import androidx.test.platform.app.InstrumentationRegistry
-import at.bitfire.ical4android.TaskProvider
 import at.bitfire.synctools.storage.LocalStorageException
+import at.bitfire.synctools.storage.TaskProvider
 import at.bitfire.synctools.test.GrantPermissionOrSkipRule
 import at.bitfire.synctools.test.assertJtxObjectAndExceptionsEqual
 import at.bitfire.synctools.test.withJtxId

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxRecurringCollectionTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxRecurringCollectionTest.kt
@@ -39,7 +39,7 @@ class JtxRecurringCollectionTest {
 
         @JvmField
         @ClassRule
-        val permissionRule = GrantPermissionOrSkipRule(TaskProvider.PERMISSIONS_JTX.toSet())
+        val permissionRule = GrantPermissionOrSkipRule(TaskProvider.ProviderName.JtxBoard.permissions.toSet())
 
         private val testAccount = Account(
             JtxRecurringCollectionTest::class.java.name,

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsRecurringTaskListTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsRecurringTaskListTest.kt
@@ -57,7 +57,7 @@ class DmfsRecurringTaskListTest(providerName: TaskProvider.ProviderName) :
         // - lists in fake non-local accounts are removed by the tasks provider as stale lists
         // The account is created once per class to avoid repeated AccountManager churn while
         // still creating a fresh list for every test method.
-        taskList = TestTaskList.create(testAccount, provider)
+        taskList = TestTaskList.create(testAccount, providerName, provider)
         recurringTaskList = spyk(DmfsRecurringTaskList(taskList))
     }
 

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsRecurringTaskListTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsRecurringTaskListTest.kt
@@ -9,7 +9,7 @@ import android.content.ContentUris
 import android.content.ContentValues
 import android.content.Entity
 import androidx.core.content.contentValuesOf
-import at.bitfire.ical4android.TaskProvider
+import at.bitfire.synctools.storage.TaskProvider
 import at.bitfire.synctools.test.account.TestAccount
 import at.bitfire.synctools.test.assertEntitiesEqual
 import at.bitfire.synctools.test.assertExceptionsEqual

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsStyleProvidersTaskTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsStyleProvidersTaskTest.kt
@@ -4,6 +4,7 @@
 
 package at.bitfire.synctools.storage.tasks
 
+import android.content.ContentProviderClient
 import android.os.Build
 import androidx.annotation.CallSuper
 import androidx.test.platform.app.InstrumentationRegistry
@@ -38,17 +39,17 @@ abstract class DmfsStyleProvidersTaskTest(
     @get:Rule
     val permissionRule = GrantPermissionOrSkipRule(providerName.permissions.toSet())
 
-    var providerOrNull: TaskProvider? = null
-    lateinit var provider: TaskProvider
+    var providerOrNull: ContentProviderClient? = null
+    lateinit var provider: ContentProviderClient
 
     @Before
     @CallSuper
     open fun prepare() {
-        providerOrNull = TaskProvider.acquire(InstrumentationRegistry.getInstrumentation().context, providerName)
+        providerOrNull = TaskProvider.acquireClient(InstrumentationRegistry.getInstrumentation().context, providerName)
         assertNotNull("$providerName is not installed", providerOrNull != null)
 
         provider = providerOrNull!!
-        Logger.getLogger(javaClass.name).fine("Using task provider: $provider")
+        Logger.getLogger(javaClass.name).fine("Using task provider: $providerName")
     }
 
     @After

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsStyleProvidersTaskTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsStyleProvidersTaskTest.kt
@@ -45,7 +45,7 @@ abstract class DmfsStyleProvidersTaskTest(
     @Before
     @CallSuper
     open fun prepare() {
-        providerOrNull = TaskProvider.acquireClient(InstrumentationRegistry.getInstrumentation().context, providerName)
+        providerOrNull = TaskProvider.acquireRecentClient(InstrumentationRegistry.getInstrumentation().context, providerName)
         assertNotNull("$providerName is not installed", providerOrNull != null)
 
         provider = providerOrNull!!

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsStyleProvidersTaskTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsStyleProvidersTaskTest.kt
@@ -7,7 +7,7 @@ package at.bitfire.synctools.storage.tasks
 import android.os.Build
 import androidx.annotation.CallSuper
 import androidx.test.platform.app.InstrumentationRegistry
-import at.bitfire.ical4android.TaskProvider
+import at.bitfire.synctools.storage.TaskProvider
 import at.bitfire.synctools.test.GrantPermissionOrSkipRule
 import org.junit.After
 import org.junit.Assert.assertNotNull

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListProviderTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListProviderTest.kt
@@ -24,7 +24,7 @@ class DmfsTaskListProviderTest(providerName: TaskProvider.ProviderName) :
 
     private val testAccount = Account(javaClass.name, TaskContract.LOCAL_ACCOUNT_TYPE)
     private val dmfsTaskListProvider by lazy {
-        DmfsTaskListProvider(testAccount, provider.client, providerName)
+        DmfsTaskListProvider(testAccount, provider, providerName)
     }
 
     @Test

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListProviderTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListProviderTest.kt
@@ -7,7 +7,7 @@ package at.bitfire.synctools.storage.tasks
 import android.accounts.Account
 import android.content.ContentValues
 import androidx.core.content.contentValuesOf
-import at.bitfire.ical4android.TaskProvider
+import at.bitfire.synctools.storage.TaskProvider
 import at.bitfire.synctools.storage.plusAssign
 import org.dmfs.tasks.contract.TaskContract
 import org.dmfs.tasks.contract.TaskContract.TaskLists

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
@@ -10,7 +10,7 @@ import android.content.ContentValues
 import android.content.Entity
 import android.database.DatabaseUtils
 import androidx.core.content.contentValuesOf
-import at.bitfire.ical4android.TaskProvider
+import at.bitfire.synctools.storage.TaskProvider
 import org.dmfs.tasks.contract.TaskContract
 import org.dmfs.tasks.contract.TaskContract.Property
 import org.dmfs.tasks.contract.TaskContract.TaskLists

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
@@ -33,7 +33,7 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName) :
         info.put(TaskLists.SYNC_ENABLED, 1)
         info.put(TaskLists.VISIBLE, 1)
 
-        val dmfsTaskListProvider = DmfsTaskListProvider(testAccount, provider.client, providerName)
+        val dmfsTaskListProvider = DmfsTaskListProvider(testAccount, provider, providerName)
         return dmfsTaskListProvider.createAndGetTaskList(info)
     }
 

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/TasksBatchOperationTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/TasksBatchOperationTest.kt
@@ -19,12 +19,12 @@ class TasksBatchOperationTest(
 
     @Test(expected = LocalStorageException::class)
     fun testTasksProvider_OperationsPerYieldPoint_500_WithoutMax() {
-        val batch = BatchOperation(provider.client, maxOperationsPerYieldPoint = null)
-        val taskList = TestTaskList.create(testAccount, provider)
+        val batch = BatchOperation(provider, maxOperationsPerYieldPoint = null)
+        val taskList = TestTaskList.create(testAccount, providerName, provider)
         try {
             // 500 operations should fail with BatchOperation(maxOperationsPerYieldPoint = null) (max. 499)
             repeat(500) { idx ->
-                batch += BatchOperation.CpoBuilder.newInsert(TaskContract.Tasks.getContentUri(provider.name.authority)!!)
+                batch += BatchOperation.CpoBuilder.newInsert(TaskContract.Tasks.getContentUri(providerName.authority)!!)
                     .withValue(TaskContract.Tasks.LIST_ID, taskList.id)
                     .withValue(TaskContract.Tasks.TITLE, "Task $idx")
             }
@@ -36,12 +36,12 @@ class TasksBatchOperationTest(
 
     @Test
     fun testTasksProvider_OperationsPerYieldPoint_501() {
-        val batch = TasksBatchOperation(provider.client)
-        val taskList = TestTaskList.create(testAccount, provider)
+        val batch = TasksBatchOperation(provider)
+        val taskList = TestTaskList.create(testAccount, providerName, provider)
         try {
             // 501 operations should succeed with ContactsBatchOperation
             repeat(501) { idx ->
-                batch += BatchOperation.CpoBuilder.newInsert(TaskContract.Tasks.getContentUri(provider.name.authority)!!)
+                batch += BatchOperation.CpoBuilder.newInsert(TaskContract.Tasks.getContentUri(providerName.authority)!!)
                     .withValue(TaskContract.Tasks.LIST_ID, taskList.id)
                     .withValue(TaskContract.Tasks.TITLE, "Task $idx")
             }

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/TasksBatchOperationTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/TasksBatchOperationTest.kt
@@ -24,7 +24,7 @@ class TasksBatchOperationTest(
         try {
             // 500 operations should fail with BatchOperation(maxOperationsPerYieldPoint = null) (max. 499)
             repeat(500) { idx ->
-                batch += BatchOperation.CpoBuilder.newInsert(provider.tasksUri())
+                batch += BatchOperation.CpoBuilder.newInsert(TaskContract.Tasks.getContentUri(provider.name.authority)!!)
                     .withValue(TaskContract.Tasks.LIST_ID, taskList.id)
                     .withValue(TaskContract.Tasks.TITLE, "Task $idx")
             }
@@ -41,7 +41,7 @@ class TasksBatchOperationTest(
         try {
             // 501 operations should succeed with ContactsBatchOperation
             repeat(501) { idx ->
-                batch += BatchOperation.CpoBuilder.newInsert(provider.tasksUri())
+                batch += BatchOperation.CpoBuilder.newInsert(TaskContract.Tasks.getContentUri(provider.name.authority)!!)
                     .withValue(TaskContract.Tasks.LIST_ID, taskList.id)
                     .withValue(TaskContract.Tasks.TITLE, "Task $idx")
             }

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/TasksBatchOperationTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/TasksBatchOperationTest.kt
@@ -5,9 +5,9 @@
 package at.bitfire.synctools.storage.tasks
 
 import android.accounts.Account
-import at.bitfire.ical4android.TaskProvider
 import at.bitfire.synctools.storage.BatchOperation
 import at.bitfire.synctools.storage.LocalStorageException
+import at.bitfire.synctools.storage.TaskProvider
 import org.dmfs.tasks.contract.TaskContract
 import org.junit.Test
 

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/TestTaskList.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/TestTaskList.kt
@@ -5,6 +5,7 @@
 package at.bitfire.synctools.storage.tasks
 
 import android.accounts.Account
+import android.content.ContentProviderClient
 import androidx.core.content.contentValuesOf
 import at.bitfire.synctools.storage.TaskProvider
 import org.dmfs.tasks.contract.TaskContract
@@ -14,20 +15,21 @@ object TestTaskList {
     /**
      * Creates a test task list on the given test account.
      *
-     * @param account   test account (must have a real account type or [TaskContract.LOCAL_ACCOUNT_TYPE],
-     *                  otherwise the provider may immediately remove the account again)
-     * @param provider  tasks provider to use
+     * @param account       test account (must have a real account type or [TaskContract.LOCAL_ACCOUNT_TYPE],
+     *                      otherwise the provider may immediately remove the account again)
+     * @param client        content provider client to use
+     * @param providerName  task provider name
      * @return the created test task List (don't forget to delete it when tests are finished)
      */
-    fun create(account: Account, provider: TaskProvider): DmfsTaskList {
+    fun create(account: Account, providerName: TaskProvider.ProviderName, client: ContentProviderClient): DmfsTaskList {
         val values = contentValuesOf(
             TaskContract.TaskListColumns.LIST_NAME to "Test Task List",
             TaskContract.TaskListColumns.LIST_COLOR to 0xffff0000,
             TaskContract.TaskListColumns.SYNC_ENABLED to 1,
             TaskContract.TaskListColumns.VISIBLE to 1
         )
-        
-        val dmfsTaskListProvider = DmfsTaskListProvider(account, provider.client, provider.name)
+
+        val dmfsTaskListProvider = DmfsTaskListProvider(account, client, providerName)
         return dmfsTaskListProvider.createAndGetTaskList(values)
     }
 

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/TestTaskList.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/TestTaskList.kt
@@ -6,7 +6,7 @@ package at.bitfire.synctools.storage.tasks
 
 import android.accounts.Account
 import androidx.core.content.contentValuesOf
-import at.bitfire.ical4android.TaskProvider
+import at.bitfire.synctools.storage.TaskProvider
 import org.dmfs.tasks.contract.TaskContract
 
 object TestTaskList {

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/test/account/TestAccount.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/test/account/TestAccount.kt
@@ -8,7 +8,7 @@ import android.accounts.Account
 import android.accounts.AccountManager
 import android.os.Build
 import androidx.test.platform.app.InstrumentationRegistry
-import at.bitfire.ical4android.TaskProvider
+import at.bitfire.synctools.storage.TaskProvider
 import at.bitfire.synctools.test.R
 import at.bitfire.synctools.util.AndroidAccountUtils
 import org.junit.Assert.assertTrue

--- a/synctools/src/main/kotlin/at/bitfire/ical4android/JtxICalObject.kt
+++ b/synctools/src/main/kotlin/at/bitfire/ical4android/JtxICalObject.kt
@@ -20,6 +20,7 @@ import at.bitfire.synctools.icalendar.DatePropertyTzMapper.normalizedDates
 import at.bitfire.synctools.icalendar.ICalendarParser
 import at.bitfire.synctools.icalendar.plusAssign
 import at.bitfire.synctools.storage.BatchOperation
+import at.bitfire.synctools.storage.TaskProvider
 import at.bitfire.synctools.storage.jtx.JtxBatchOperation
 import at.bitfire.synctools.storage.jtx.JtxCollection
 import at.bitfire.synctools.storage.toContentValues

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/JtxObjectBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/JtxObjectBuilder.kt
@@ -37,6 +37,10 @@ class JtxObjectBuilder(
     flags: Int
 ) {
 
+    /* Note: the storage layer (JtxCollection) doesn't read/write all sub-rows,
+    but only those defined in JtxCollection.SUB_VALUE_URIS – so all sub-rows
+    that are supported by builders/handlers should also be present there. */
+
     private val entityBuilders: Array<JtxObjectEntityBuilder> = arrayOf(
         CollectionIdBuilder(collectionId),
         ComponentBuilder(),

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/JtxObjectHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/JtxObjectHandler.kt
@@ -28,6 +28,11 @@ import java.util.UUID
 class JtxObjectHandler(
     private val prodId: ProdId
 ) {
+
+    /* Note: the storage layer (JtxCollection) doesn't read/write all sub-rows,
+    but only those defined in JtxCollection.SUB_VALUE_URIS – so all sub-rows
+    that are supported by builders/handlers should also be present there. */
+
     private val entityHandlers: Array<JtxObjectEntityHandler> = arrayOf(
         CategoriesHandler(),
         CommentsHandler(),

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskHandler.kt
@@ -6,7 +6,6 @@ package at.bitfire.synctools.mapping.tasks
 
 import android.content.Entity
 import at.bitfire.ical4android.ICalendar.Companion.withUserAgents
-import at.bitfire.ical4android.TaskProvider
 import at.bitfire.synctools.icalendar.AssociatedTasks
 import at.bitfire.synctools.icalendar.plusAssign
 import at.bitfire.synctools.mapping.tasks.handler.AlarmsHandler
@@ -33,6 +32,7 @@ import at.bitfire.synctools.mapping.tasks.handler.TitleHandler
 import at.bitfire.synctools.mapping.tasks.handler.UidHandler
 import at.bitfire.synctools.mapping.tasks.handler.UnknownPropertiesHandler
 import at.bitfire.synctools.mapping.tasks.handler.UrlHandler
+import at.bitfire.synctools.storage.TaskProvider
 import at.bitfire.synctools.storage.tasks.TaskAndExceptions
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.property.ProdId

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/TaskProvider.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/TaskProvider.kt
@@ -2,7 +2,7 @@
  * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
  */
 
-package at.bitfire.ical4android
+package at.bitfire.synctools.storage
 
 import android.annotation.SuppressLint
 import android.content.ContentProviderClient
@@ -14,7 +14,10 @@ import java.io.Closeable
 import java.util.logging.Level
 import java.util.logging.Logger
 
-
+/**
+ * Basic properties of and access to supported task providers on
+ * application/content provider level.
+ */
 class TaskProvider private constructor(
     val name: ProviderName,
     val client: ContentProviderClient
@@ -28,18 +31,31 @@ class TaskProvider private constructor(
         private val readPermission: String,
         private val writePermission: String
     ) {
-        JtxBoard("at.techbee.jtx.provider", "at.techbee.jtx", 210000000, "2.10.00", PERMISSION_JTX_READ, PERMISSION_JTX_WRITE),
-        TasksOrg("org.tasks.opentasks", "org.tasks", 100000, "10.0", PERMISSION_TASKS_ORG_READ, PERMISSION_TASKS_ORG_WRITE),
-        OpenTasks("org.dmfs.tasks", "org.dmfs.tasks", 103, "1.1.8.2", PERMISSION_OPENTASKS_READ, PERMISSION_OPENTASKS_WRITE);
 
-        companion object {
-            fun fromAuthority(authority: String): ProviderName {
-                for (provider in values())
-                    if (provider.authority == authority)
-                        return provider
-                throw IllegalArgumentException("Unknown tasks authority $authority")
-            }
-        }
+        JtxBoard(
+            authority = "at.techbee.jtx.provider",
+            packageName = "at.techbee.jtx",
+            minVersionCode = 210000000,
+            minVersionName = "2.10.00",
+            readPermission = PERMISSION_JTX_READ,
+            writePermission = PERMISSION_JTX_WRITE
+        ),
+        TasksOrg(
+            authority = "org.tasks.opentasks",
+            packageName = "org.tasks",
+            minVersionCode = 100000,
+            minVersionName = "10.0",
+            readPermission = PERMISSION_TASKS_ORG_READ,
+            writePermission = PERMISSION_TASKS_ORG_WRITE
+        ),
+        OpenTasks(
+            authority = "org.dmfs.tasks",
+            packageName = "org.dmfs.tasks",
+            minVersionCode = 103,
+            minVersionName = "1.1.8.2",
+            readPermission = PERMISSION_OPENTASKS_READ,
+            writePermission = PERMISSION_OPENTASKS_WRITE
+        );
 
         val permissions: Array<String>
             get() = arrayOf(readPermission, writePermission)
@@ -49,13 +65,7 @@ class TaskProvider private constructor(
     companion object {
 
         private val logger
-            get() = Logger.getLogger(TaskProvider::javaClass.name)
-
-        val TASK_PROVIDERS = listOf(
-                ProviderName.OpenTasks,
-                ProviderName.TasksOrg,
-                ProviderName.JtxBoard
-        )
+            get() = Logger.getLogger(TaskProvider::class.java.name)
 
         const val PERMISSION_OPENTASKS_READ = "org.dmfs.permission.READ_TASKS"
         const val PERMISSION_OPENTASKS_WRITE = "org.dmfs.permission.WRITE_TASKS"
@@ -97,15 +107,6 @@ class TaskProvider private constructor(
             return null
         }
 
-        fun fromProviderClient(
-                context: Context,
-                provider: ProviderName,
-                client: ContentProviderClient
-        ): TaskProvider {
-            checkVersion(context, provider)
-            return TaskProvider(provider, client)
-        }
-
         /**
          * Checks the version code of an installed tasks provider.
          * @throws PackageManager.NameNotFoundException if the tasks provider is not installed
@@ -124,14 +125,7 @@ class TaskProvider private constructor(
 
     }
 
-
-    fun taskListsUri() = TaskContract.TaskLists.getContentUri(name.authority)!!
-    fun syncStateUri() = TaskContract.SyncState.getContentUri(name.authority)!!
-
     fun tasksUri() = TaskContract.Tasks.getContentUri(name.authority)!!
-    fun propertiesUri() = TaskContract.Properties.getContentUri(name.authority)!!
-    fun alarmsUri() = TaskContract.Alarms.getContentUri(name.authority)!!
-    fun categoriesUri() = TaskContract.Categories.getContentUri(name.authority)!!
 
 
     override fun close() {
@@ -140,9 +134,9 @@ class TaskProvider private constructor(
 
 
     class ProviderTooOldException(
-            val provider: ProviderName,
-            installedVersionCode: Long,
-            val installedVersionName: String?
+        val provider: ProviderName,
+        installedVersionCode: Long,
+        val installedVersionName: String?
     ): Exception("Package ${provider.packageName} has version $installedVersionName ($installedVersionCode), " +
             "required: ${provider.minVersionName} (${provider.minVersionCode})")
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/TaskProvider.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/TaskProvider.kt
@@ -80,7 +80,7 @@ object TaskProvider {
      * Checks the version code of an installed tasks provider.
      * @throws PackageManager.NameNotFoundException if the tasks provider is not installed
      * @throws [ProviderTooOldException] if the tasks provider is installed, but doesn't meet the minimum version requirement
-     * */
+     */
     fun checkVersion(context: Context, name: ProviderName) {
         // check whether package is available with required minimum version
         val info = context.packageManager.getPackageInfo(name.packageName, 0)

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/TaskProvider.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/TaskProvider.kt
@@ -54,32 +54,27 @@ object TaskProvider {
         get() = Logger.getLogger(javaClass.name)
 
     /**
-     * Acquires a content provider client for a given task provider after verifying its version.
-     * The caller is responsible for closing the returned client.
+     * Acquires a content provider client for a given task provider after verifying that it's new
+     * enough. The caller is responsible for closing the returned client.
      *
      * @param context will be used to acquire the content provider client
-     * @param name task provider to acquire content provider for; `null` to try all supported providers
+     * @param name task provider to acquire content provider for
      *
      * @return content provider client for the given task provider (`null` if not available)
      * @throws [ProviderTooOldException] if the tasks provider is installed, but doesn't meet the minimum version requirement
      */
     @MustBeClosed
-    fun acquireClient(context: Context, name: ProviderName? = null): ContentProviderClient? {
-        val providers = name?.let { arrayOf(it) } ?: ProviderName.entries.toTypedArray()
-        for (provider in providers)
-            try {
-                checkVersion(context, provider)
-
-                val client = context.contentResolver.acquireContentProviderClient(provider.authority)
-                if (client != null)
-                    return client
-            } catch (e: SecurityException) {
-                logger.log(Level.WARNING, "Not allowed to access task provider", e)
-            } catch (e: PackageManager.NameNotFoundException) {
-                logger.warning("Package ${provider.packageName} not installed")
-            }
-        return null
-    }
+    fun acquireRecentClient(context: Context, name: ProviderName): ContentProviderClient? =
+        try {
+            checkVersion(context, name)
+            context.contentResolver.acquireContentProviderClient(name.authority)
+        } catch (e: SecurityException) {
+            logger.log(Level.WARNING, "Not allowed to access task provider", e)
+            null
+        } catch (_: PackageManager.NameNotFoundException) {
+            logger.warning("Package ${name.packageName} not installed")
+            null
+        }
 
     /**
      * Checks the version code of an installed tasks provider.

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/TaskProvider.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/TaskProvider.kt
@@ -9,7 +9,6 @@ import android.content.ContentProviderClient
 import android.content.Context
 import android.content.pm.PackageManager
 import androidx.core.content.pm.PackageInfoCompat
-import org.dmfs.tasks.contract.TaskContract
 import java.io.Closeable
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -28,8 +27,7 @@ class TaskProvider private constructor(
         val packageName: String,
         val minVersionCode: Long,
         val minVersionName: String,
-        private val readPermission: String,
-        private val writePermission: String
+        val permissions: Array<String>
     ) {
 
         JtxBoard(
@@ -37,28 +35,22 @@ class TaskProvider private constructor(
             packageName = "at.techbee.jtx",
             minVersionCode = 210000000,
             minVersionName = "2.10.00",
-            readPermission = PERMISSION_JTX_READ,
-            writePermission = PERMISSION_JTX_WRITE
+            permissions = arrayOf("at.techbee.jtx.permission.READ", "at.techbee.jtx.permission.WRITE")
         ),
         TasksOrg(
             authority = "org.tasks.opentasks",
             packageName = "org.tasks",
             minVersionCode = 100000,
             minVersionName = "10.0",
-            readPermission = PERMISSION_TASKS_ORG_READ,
-            writePermission = PERMISSION_TASKS_ORG_WRITE
+            permissions = arrayOf("org.tasks.permission.READ_TASKS", "org.tasks.permission.WRITE_TASKS")
         ),
         OpenTasks(
             authority = "org.dmfs.tasks",
             packageName = "org.dmfs.tasks",
             minVersionCode = 103,
             minVersionName = "1.1.8.2",
-            readPermission = PERMISSION_OPENTASKS_READ,
-            writePermission = PERMISSION_OPENTASKS_WRITE
+            permissions = arrayOf("org.dmfs.permission.READ_TASKS", "org.dmfs.permission.WRITE_TASKS")
         );
-
-        val permissions: Array<String>
-            get() = arrayOf(readPermission, writePermission)
     }
 
 
@@ -66,18 +58,6 @@ class TaskProvider private constructor(
 
         private val logger
             get() = Logger.getLogger(TaskProvider::class.java.name)
-
-        const val PERMISSION_OPENTASKS_READ = "org.dmfs.permission.READ_TASKS"
-        const val PERMISSION_OPENTASKS_WRITE = "org.dmfs.permission.WRITE_TASKS"
-        val PERMISSIONS_OPENTASKS = arrayOf(PERMISSION_OPENTASKS_READ, PERMISSION_OPENTASKS_WRITE)
-
-        const val PERMISSION_TASKS_ORG_READ = "org.tasks.permission.READ_TASKS"
-        const val PERMISSION_TASKS_ORG_WRITE = "org.tasks.permission.WRITE_TASKS"
-        val PERMISSIONS_TASKS_ORG = arrayOf(PERMISSION_TASKS_ORG_READ, PERMISSION_TASKS_ORG_WRITE)
-
-        const val PERMISSION_JTX_READ = "at.techbee.jtx.permission.READ"
-        const val PERMISSION_JTX_WRITE = "at.techbee.jtx.permission.WRITE"
-        val PERMISSIONS_JTX = arrayOf(PERMISSION_JTX_READ, PERMISSION_JTX_WRITE)
 
         /**
          * Acquires a content provider for a given task provider. The content provider will
@@ -124,9 +104,6 @@ class TaskProvider private constructor(
         }
 
     }
-
-    fun tasksUri() = TaskContract.Tasks.getContentUri(name.authority)!!
-
 
     override fun close() {
         client.close()

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/TaskProvider.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/TaskProvider.kt
@@ -4,12 +4,11 @@
 
 package at.bitfire.synctools.storage
 
-import android.annotation.SuppressLint
 import android.content.ContentProviderClient
 import android.content.Context
 import android.content.pm.PackageManager
 import androidx.core.content.pm.PackageInfoCompat
-import java.io.Closeable
+import com.google.errorprone.annotations.MustBeClosed
 import java.util.logging.Level
 import java.util.logging.Logger
 
@@ -17,10 +16,7 @@ import java.util.logging.Logger
  * Basic properties of and access to supported task providers on
  * application/content provider level.
  */
-class TaskProvider private constructor(
-    val name: ProviderName,
-    val client: ContentProviderClient
-): Closeable {
+object TaskProvider {
 
     enum class ProviderName(
         val authority: String,
@@ -54,59 +50,51 @@ class TaskProvider private constructor(
     }
 
 
-    companion object {
+    private val logger
+        get() = Logger.getLogger(javaClass.name)
 
-        private val logger
-            get() = Logger.getLogger(TaskProvider::class.java.name)
+    /**
+     * Acquires a content provider client for a given task provider after verifying its version.
+     * The caller is responsible for closing the returned client.
+     *
+     * @param context will be used to acquire the content provider client
+     * @param name task provider to acquire content provider for; `null` to try all supported providers
+     *
+     * @return content provider client for the given task provider (`null` if not available)
+     * @throws [ProviderTooOldException] if the tasks provider is installed, but doesn't meet the minimum version requirement
+     */
+    @MustBeClosed
+    fun acquireClient(context: Context, name: ProviderName? = null): ContentProviderClient? {
+        val providers = name?.let { arrayOf(it) } ?: ProviderName.entries.toTypedArray()
+        for (provider in providers)
+            try {
+                checkVersion(context, provider)
 
-        /**
-         * Acquires a content provider for a given task provider. The content provider will
-         * be released when the TaskProvider is closed with [close].
-         * @param context will be used to acquire the content provider client
-         * @param name task provider to acquire content provider for; *null* to try all supported providers
-         * @return content provider for the given task provider (may be *null*)
-         * @throws [ProviderTooOldException] if the tasks provider is installed, but doesn't meet the minimum version requirement
-         */
-        @SuppressLint("Recycle")
-        fun acquire(context: Context, name: ProviderName? = null): TaskProvider? {
-            val providers =
-                    name?.let { arrayOf(it) }       // provider name given? create array from it
-                    ?: ProviderName.values()        // otherwise, try all providers
-            for (provider in providers)
-                try {
-                    checkVersion(context, provider)
-
-                    val client = context.contentResolver.acquireContentProviderClient(provider.authority)
-                    if (client != null)
-                        return TaskProvider(provider, client)
-                } catch(e: SecurityException) {
-                    logger.log(Level.WARNING, "Not allowed to access task provider", e)
-                } catch(e: PackageManager.NameNotFoundException) {
-                    logger.warning("Package ${provider.packageName} not installed")
-                }
-            return null
-        }
-
-        /**
-         * Checks the version code of an installed tasks provider.
-         * @throws PackageManager.NameNotFoundException if the tasks provider is not installed
-         * @throws [ProviderTooOldException] if the tasks provider is installed, but doesn't meet the minimum version requirement
-         * */
-        fun checkVersion(context: Context, name: ProviderName) {
-            // check whether package is available with required minimum version
-            val info = context.packageManager.getPackageInfo(name.packageName, 0)
-            val installedVersionCode = PackageInfoCompat.getLongVersionCode(info)
-            if (installedVersionCode < name.minVersionCode) {
-                val exception = ProviderTooOldException(name, installedVersionCode, info.versionName)
-                logger.log(Level.WARNING, "Task provider too old", exception)
-                throw exception
+                val client = context.contentResolver.acquireContentProviderClient(provider.authority)
+                if (client != null)
+                    return client
+            } catch (e: SecurityException) {
+                logger.log(Level.WARNING, "Not allowed to access task provider", e)
+            } catch (e: PackageManager.NameNotFoundException) {
+                logger.warning("Package ${provider.packageName} not installed")
             }
-        }
-
+        return null
     }
 
-    override fun close() {
-        client.close()
+    /**
+     * Checks the version code of an installed tasks provider.
+     * @throws PackageManager.NameNotFoundException if the tasks provider is not installed
+     * @throws [ProviderTooOldException] if the tasks provider is installed, but doesn't meet the minimum version requirement
+     * */
+    fun checkVersion(context: Context, name: ProviderName) {
+        // check whether package is available with required minimum version
+        val info = context.packageManager.getPackageInfo(name.packageName, 0)
+        val installedVersionCode = PackageInfoCompat.getLongVersionCode(info)
+        if (installedVersionCode < name.minVersionCode) {
+            val exception = ProviderTooOldException(name, installedVersionCode, info.versionName)
+            logger.log(Level.WARNING, "Task provider too old", exception)
+            throw exception
+        }
     }
 
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollection.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollection.kt
@@ -549,26 +549,28 @@ class JtxCollection(
         /**
          * Column name used in all jtx Board sub-tables to reference the parent [JtxContract.JtxICalObject] row.
          *
-         * All sub-table contract objects define `ICALOBJECT_ID` with this same value.
+         * All sub-table contract objects define `ICALOBJECT_ID` with this same value,
+         * so we can use the value of [JtxContract.JtxAttendee].
          */
-        internal const val ICALOBJECT_ID = "icalObjectId"
+        private const val ICALOBJECT_ID = JtxContract.JtxAttendee.ICALOBJECT_ID
 
         /**
-         * Content URIs of all known jtx Board sub-tables.
+         * Content URIs of all supported jtx Board sub-tables.
          *
          * Used to read sub-rows into [Entity] objects and to delete sub-rows on jtx object update.
          */
-        internal val SUB_VALUE_URIS: List<Uri> = listOf(
-            JtxContract.JtxAttendee.CONTENT_URI,
-            JtxContract.JtxCategory.CONTENT_URI,
-            JtxContract.JtxComment.CONTENT_URI,
-            JtxContract.JtxOrganizer.CONTENT_URI,
-            JtxContract.JtxRelatedto.CONTENT_URI,
-            JtxContract.JtxResource.CONTENT_URI,
-            JtxContract.JtxAttachment.CONTENT_URI,
-            JtxContract.JtxAlarm.CONTENT_URI,
-            JtxContract.JtxUnknown.CONTENT_URI
-        )
+        private val SUB_VALUE_URIS: List<Uri>
+            get() = listOf(
+                JtxContract.JtxAttendee.CONTENT_URI,
+                JtxContract.JtxCategory.CONTENT_URI,
+                JtxContract.JtxComment.CONTENT_URI,
+                JtxContract.JtxOrganizer.CONTENT_URI,
+                JtxContract.JtxRelatedto.CONTENT_URI,
+                JtxContract.JtxResource.CONTENT_URI,
+                JtxContract.JtxAttachment.CONTENT_URI,
+                JtxContract.JtxAlarm.CONTENT_URI,
+                JtxContract.JtxUnknown.CONTENT_URI
+            )
 
     }
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
@@ -9,10 +9,10 @@ import android.content.ContentValues
 import android.content.Entity
 import android.net.Uri
 import android.os.RemoteException
-import at.bitfire.ical4android.TaskProvider
 import at.bitfire.ical4android.util.MiscUtils.asSyncAdapter
 import at.bitfire.synctools.storage.BatchOperation
 import at.bitfire.synctools.storage.LocalStorageException
+import at.bitfire.synctools.storage.TaskProvider
 import at.bitfire.synctools.storage.toContentValues
 import org.dmfs.tasks.contract.TaskContract
 import org.dmfs.tasks.contract.TaskContract.Tasks

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListProvider.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListProvider.kt
@@ -9,9 +9,9 @@ import android.content.ContentProviderClient
 import android.content.ContentUris
 import android.content.ContentValues
 import android.os.RemoteException
-import at.bitfire.ical4android.TaskProvider
 import at.bitfire.ical4android.util.MiscUtils.asSyncAdapter
 import at.bitfire.synctools.storage.LocalStorageException
+import at.bitfire.synctools.storage.TaskProvider
 import at.bitfire.synctools.storage.toContentValues
 import org.dmfs.tasks.contract.TaskContract
 import java.util.LinkedList


### PR DESCRIPTION

### Purpose

Simplify `TaskProvider` and permission declarations; remove all features that are not actually used.

Also get rid of the bad pattern that `TaskProvider` instances could be returned and was `Closable` instead of just returning the `ContentProviderClient`.

Some Contract-related minor cleanups.

Added notes for jtx Board handlers/builders that refers to which sub-row types are used by storage layer.


### Short description

- Renamed `TaskProvider.acquireClient` to `acquireRecentClient` and simplified its implementation
- Modified `TaskProvider.acquireClient` to return `ContentProviderClient` directly
- Replaced `PERMISSIONS_*` constants with `TaskProvider.ProviderName` permissions
- Moved and simplified `TaskProvider` structure
- Added note about `JtxCollection` sub-row handling and made `ICALOBJECT_ID` private

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.