### PR TITLE
Add code style into repo; plus some reformatted sample files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ proguard/
 
 ## Directory-based project format:
 .idea/
+!.idea/codeStyles
+!.idea/copyright
+
 # if you remove the above rule, at least ignore the following:
 
 # User-specific stuff:

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,9 +1,53 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <option name="LINE_SEPARATOR" value="&#10;" />
-    <option name="RIGHT_MARGIN" value="180" />
+    <option name="RIGHT_MARGIN" value="160" />
+    <JavaCodeStyleSettings>
+      <option name="IMPORT_LAYOUT_TABLE">
+        <value>
+          <package name="android" withSubpackages="true" static="true" />
+          <package name="androidx" withSubpackages="true" static="true" />
+          <package name="com" withSubpackages="true" static="true" />
+          <package name="junit" withSubpackages="true" static="true" />
+          <package name="net" withSubpackages="true" static="true" />
+          <package name="org" withSubpackages="true" static="true" />
+          <package name="java" withSubpackages="true" static="true" />
+          <package name="javax" withSubpackages="true" static="true" />
+          <package name="" withSubpackages="true" static="true" />
+          <emptyLine />
+          <package name="android" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="androidx" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="com" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="junit" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="net" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="org" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="java" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="javax" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="" withSubpackages="true" static="false" />
+          <emptyLine />
+        </value>
+      </option>
+    </JavaCodeStyleSettings>
+    <JetCodeStyleSettings>
+      <option name="LINE_BREAK_AFTER_MULTILINE_WHEN_ENTRY" value="false" />
+      <option name="IF_RPAREN_ON_NEW_LINE" value="false" />
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    </JetCodeStyleSettings>
     <codeStyleSettings language="kotlin">
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+      <option name="BLOCK_COMMENT_AT_FIRST_COLUMN" value="false" />
+      <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
+      <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
+      <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
+      <option name="FIELD_ANNOTATION_WRAP" value="1" />
     </codeStyleSettings>
   </code_scheme>
 </component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,3 +1,8 @@
 <component name="CopyrightManager">
-  <settings default="LICENSE" />
+  <settings default="LICENSE">
+    <LanguageOptions name="XML">
+      <option name="fileTypeOverride" value="1" />
+      <option name="prefixLines" value="false" />
+    </LanguageOptions>
+  </settings>
 </component>

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
@@ -28,7 +28,6 @@ import at.bitfire.davdroid.resource.SyncState
 import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.util.DavUtils
 import at.bitfire.davdroid.util.DavUtils.lastSegment
-import at.bitfire.synctools.exception.InvalidICalendarException
 import at.bitfire.synctools.exception.InvalidResourceException
 import at.bitfire.synctools.icalendar.CalendarUidSplitter
 import at.bitfire.synctools.icalendar.ICalendarGenerator
@@ -67,7 +66,7 @@ class CalendarSyncManager @AssistedInject constructor(
     accountSettingsFactory: AccountSettings.Factory,
     private val productIds: ProductIds,
     @SyncDispatcher syncDispatcher: CoroutineDispatcher
-): SyncManager<LocalEvent, LocalCalendar, DavCalendar>(
+) : SyncManager<LocalEvent, LocalCalendar, DavCalendar>(
     account,
     httpClient,
     SyncDataType.EVENTS,

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -77,7 +77,7 @@ import javax.net.ssl.SSLHandshakeException
  * @param collection        collection info in the database
  * @param resync            whether re-synchronization is requested
  */
-abstract class SyncManager<LocalType: LocalResource, out CollectionType: LocalCollection<LocalType>, RemoteType: DavCollection>(
+abstract class SyncManager<LocalType : LocalResource, out CollectionType : LocalCollection<LocalType>, RemoteType : DavCollection>(
     val account: Account,
     val httpClient: OkHttpClient,
     val dataType: SyncDataType,
@@ -512,12 +512,14 @@ abstract class SyncManager<LocalType: LocalResource, out CollectionType: LocalCo
         scheduleTag: String?,
         context: GeneratedResource.OnSuccessContext?
     ) {
-        logger.log(Level.FINE, "Upload successful", arrayOf(
-            "File name = $newFileName",
-            "ETag = $eTag",
-            "Schedule-Tag = $scheduleTag",
-            "context = $context"
-        ))
+        logger.log(
+            Level.FINE, "Upload successful", arrayOf(
+                "File name = $newFileName",
+                "ETag = $eTag",
+                "Schedule-Tag = $scheduleTag",
+                "context = $context"
+            )
+        )
 
         // update SEQUENCE, if necessary
         if (context?.sequence != null)
@@ -740,12 +742,11 @@ abstract class SyncManager<LocalType: LocalResource, out CollectionType: LocalCo
     // sync helpers
 
     protected fun syncState(dav: Response) =
-            dav[SyncToken::class.java]?.token?.let {
-                SyncState(SyncState.Type.SYNC_TOKEN, it)
-            } ?:
-            dav[GetCTag::class.java]?.cTag?.let {
-                SyncState(SyncState.Type.CTAG, it)
-            }
+        dav[SyncToken::class.java]?.token?.let {
+            SyncState(SyncState.Type.SYNC_TOKEN, it)
+        } ?: dav[GetCTag::class.java]?.cTag?.let {
+            SyncState(SyncState.Type.CTAG, it)
+        }
 
     private suspend fun querySyncState(): SyncState? {
         var state: SyncState? = null

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/AccountsScreen.kt
@@ -329,7 +329,7 @@ fun AccountsScreen(
 @Preview
 fun AccountsScreen_Preview_Empty() {
     AccountsScreen(
-        accountsDrawerHandler = object: AccountsDrawerHandler() {
+        accountsDrawerHandler = object : AccountsDrawerHandler() {
             @Composable
             override fun MenuEntries(snackbarHostState: SnackbarHostState) {
                 Text("Menu entries")
@@ -345,7 +345,7 @@ fun AccountsScreen_Preview_Empty() {
 @Preview
 fun AccountsScreen_Preview_OneAccount() {
     AccountsScreen(
-        accountsDrawerHandler = object: AccountsDrawerHandler() {
+        accountsDrawerHandler = object : AccountsDrawerHandler() {
             @Composable
             override fun MenuEntries(snackbarHostState: SnackbarHostState) {
                 Text("Menu entries")

--- a/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/CalendarUidSplitter.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/CalendarUidSplitter.kt
@@ -9,7 +9,7 @@ import net.fortuna.ical4j.model.Calendar
 import net.fortuna.ical4j.model.component.CalendarComponent
 import kotlin.jvm.optionals.getOrNull
 
-class CalendarUidSplitter<T: CalendarComponent> {
+class CalendarUidSplitter<T : CalendarComponent> {
 
     /**
      * Splits iCalendar components by UID and classifies them as


### PR DESCRIPTION
I suggest to use these formatting rules, based on the `KOTLIN_OFFICIAL` style defaults + some additional specifications, notably the 160 characters line wrap.

With that we could use the Android Studio "Reformat code" feature when committing (or of course during work with Ctrl+L).

<img width="874" height="437" alt="Bildschirmfoto vom 2026-06-12 12-13-50" src="https://github.com/user-attachments/assets/87f21961-93b4-4edb-86f7-643e0c85f728" />

Some reformatted sample files are also in the PR.

What do you think?