### PR TITLE
Fix all-day event timezone handling (always treat as UTC)

### DIFF
--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/AndroidTimeField.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/AndroidTimeField.kt
@@ -9,6 +9,7 @@ import java.time.DateTimeException
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
+import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.temporal.Temporal
 import java.time.zone.ZoneRulesException
@@ -18,13 +19,14 @@ import java.time.zone.ZoneRulesException
  * fields into other representations.
  *
  * @param timestamp     value of the Android `DTSTART`/`DTEND` field (timestamp in milliseconds)
- * @param timeZone      value of the respective Android timezone field or `null` for system default time zone
+ * @param timeZone      value of the respective Android timezone field or `null` for system default time zone;
+ *                      ignored for [allDay] events (those are always UTC, see [android.provider.CalendarContract.Events])
  * @param allDay        whether Android `ALL_DAY` field is non-null and not zero
  */
 class AndroidTimeField(
     private val timestamp: Long,
     private val timeZone: String?,
-    private val allDay: Boolean,
+    private val allDay: Boolean
 ) {
 
     /** ID of system default timezone */
@@ -39,8 +41,11 @@ class AndroidTimeField(
     fun toTemporal(): Temporal {
         val instant = Instant.ofEpochMilli(timestamp)
 
-        if (allDay)
-            return LocalDate.ofInstant(instant, ZoneId.of(timeZone ?: defaultTzId))
+        if (allDay) {
+            /* All-day timestamps are always stored as midnight UTC, so we can ignore
+            EVENT_TIMEZONE (and there were actual cases of invalid strings for all-day events). */
+            return LocalDate.ofInstant(instant, ZoneOffset.UTC)
+        }
 
         // non-all-day
         val tzId = timeZone

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/AndroidTimeFieldTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/AndroidTimeFieldTest.kt
@@ -14,7 +14,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import java.time.Instant
-import java.time.ZoneOffset
 
 class AndroidTimeFieldTest {
 
@@ -28,7 +27,21 @@ class AndroidTimeFieldTest {
         val androidTimeField = AndroidTimeField(
             timestamp = 1760521619000,      // Wed Oct 15 2025 11:46:59 GMT+0200
             timeZone = "Europe/Paris",
-            allDay = true,
+            allDay = true
+        )
+
+        val result = androidTimeField.toTemporal()
+
+        assertEquals(dateValue("20251015"), result)
+    }
+
+    @Test
+    fun `toTemporal with all-day and invalid timezone returns LocalDate`() {
+        val androidTimeField = AndroidTimeField(
+            timestamp = 1760521619000,      // Wed Oct 15 2025 09:46:59 GMT+0000
+            // the following timezone string was actually encountered (https://github.com/bitfireAT/davx5-ose/issues/2483)
+            timeZone = "java.util.SimpleTimeZone[id=UTC,offset=0,dstSavings=3600000,useDaylight=false,startYear=0,startMode=0,startMonth=0,startDay=0,startDayOfWeek=0,startTime=0,startTimeMode=0,endMode=0,endMonth=0,endDay=0,endDayOfWeek=0,endTime=0,endTimeMode=0]",
+            allDay = true
         )
 
         val result = androidTimeField.toTemporal()
@@ -41,7 +54,7 @@ class AndroidTimeFieldTest {
         val androidTimeField = AndroidTimeField(
             timestamp = 1760521619000,      // Wed Oct 15 2025 09:46:59 GMT+0000
             timeZone = "Europe/Vienna",
-            allDay = false,
+            allDay = false
         )
 
         val result = androidTimeField.toTemporal()
@@ -57,7 +70,7 @@ class AndroidTimeFieldTest {
         val androidTimeField = AndroidTimeField(
             timestamp = 1760521619000,
             timeZone = AndroidTimeUtils.TZID_UTC,
-            allDay = false,
+            allDay = false
         )
 
         val result = androidTimeField.toTemporal()
@@ -70,7 +83,7 @@ class AndroidTimeFieldTest {
         val androidTimeField = AndroidTimeField(
             timestamp = 1760521619000,
             timeZone = TimeZones.UTC_ID,
-            allDay = false,
+            allDay = false
         )
 
         val result = androidTimeField.toTemporal()
@@ -83,7 +96,7 @@ class AndroidTimeFieldTest {
         val androidTimeField = AndroidTimeField(
             timestamp = 1760521619000,      // Wed Oct 15 2025 09:46:59 GMT+0000
             timeZone = null,
-            allDay = false,
+            allDay = false
         )
 
         val result = androidTimeField.toTemporal()
@@ -96,7 +109,7 @@ class AndroidTimeFieldTest {
         val androidTimeField = AndroidTimeField(
             timestamp = 1760521619000,      // Wed Oct 15 2025 09:46:59 GMT+0000
             timeZone = "absolutely/unknown",
-            allDay = false,
+            allDay = false
         )
 
         val result = androidTimeField.toTemporal()


### PR DESCRIPTION
### Purpose

Fixes handling of all-day events to properly ignore invalid timezones.

### Short description

- Updated all-day event logic to disregard invalid timezone inputs.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.