### PR TITLE
Add RecurrenceFieldsHandler with tests

### DIFF
--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/JtxTimeField.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/JtxTimeField.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.synctools.mapping.jtx.handler
+
+import at.techbee.jtx.JtxContract
+import java.time.DateTimeException
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.temporal.Temporal
+
+/**
+ * Converts a jtx timestamp and timezone column pair into the matching iCalendar [Temporal] type.
+ *
+ * @param timestamp  epoch milliseconds from a jtx time column
+ * @param timeZone   value of the matching jtx timezone column:
+ *                   [JtxContract.JtxICalObject.TZ_ALLDAY] for DATE values,
+ *                   `null` or empty for floating DATE-TIME values,
+ *                   or a timezone ID for DATE-TIME values with timezone
+ */
+internal class JtxTimeField(
+    private val timestamp: Long,
+    private val timeZone: String?
+) {
+
+    /**
+     * Converts the stored value according to jtx timezone semantics.
+     *
+     * Invalid timezone IDs are interpreted as UTC, as documented by [JtxContract.JtxICalObject.DTSTART_TIMEZONE].
+     */
+    fun toTemporal(): Temporal {
+        val instant = Instant.ofEpochMilli(timestamp)
+
+        return when (timeZone) {
+            JtxContract.JtxICalObject.TZ_ALLDAY ->
+                LocalDate.ofInstant(instant, ZoneOffset.UTC)
+
+            ZoneOffset.UTC.id ->
+                ZonedDateTime.ofInstant(instant, ZoneOffset.UTC)
+
+            null, "" ->
+                LocalDateTime.ofInstant(instant, ZoneId.systemDefault())
+
+            else ->
+                ZonedDateTime.ofInstant(instant, zoneIdOrUtc(timeZone))
+        }
+    }
+
+    private fun zoneIdOrUtc(tzId: String): ZoneId =
+        try {
+            ZoneId.of(tzId)
+        } catch (_: DateTimeException) {
+            ZoneOffset.UTC
+        }
+
+}

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/JtxTimeField.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/JtxTimeField.kt
@@ -4,6 +4,7 @@
 
 package at.bitfire.synctools.mapping.jtx.handler
 
+import at.bitfire.synctools.util.AndroidTimeUtils.isUtcTzId
 import at.techbee.jtx.JtxContract
 import java.time.DateTimeException
 import java.time.Instant
@@ -36,26 +37,28 @@ internal class JtxTimeField(
     fun toTemporal(): Temporal {
         val instant = Instant.ofEpochMilli(timestamp)
 
-        return when (timeZone) {
-            JtxContract.JtxICalObject.TZ_ALLDAY ->
+        return when {
+            timeZone == JtxContract.JtxICalObject.TZ_ALLDAY ->
                 LocalDate.ofInstant(instant, ZoneOffset.UTC)
 
-            ZoneOffset.UTC.id ->
-                ZonedDateTime.ofInstant(instant, ZoneOffset.UTC)
+            timeZone == ZoneOffset.UTC.id || isUtcTzId(timeZone) ->
+                instant
 
-            null, "" ->
+            timeZone.isNullOrEmpty() ->
                 LocalDateTime.ofInstant(instant, ZoneId.systemDefault())
 
             else ->
-                ZonedDateTime.ofInstant(instant, zoneIdOrUtc(timeZone))
+                zoneIdOrNull(timeZone)
+                    ?.let { zoneId -> ZonedDateTime.ofInstant(instant, zoneId) }
+                    ?: instant
         }
     }
 
-    private fun zoneIdOrUtc(tzId: String): ZoneId =
+    private fun zoneIdOrNull(tzId: String): ZoneId? =
         try {
             ZoneId.of(tzId)
         } catch (_: DateTimeException) {
-            ZoneOffset.UTC
+            null
         }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/RecurrenceFieldsHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/RecurrenceFieldsHandler.kt
@@ -1,0 +1,249 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.synctools.mapping.jtx.handler
+
+import android.content.ContentValues
+import android.content.Entity
+import at.bitfire.synctools.icalendar.plusAssign
+import at.bitfire.synctools.util.AndroidTimeUtils.isUtcTzId
+import at.bitfire.synctools.util.AndroidTimeUtils.toTimestamp
+import at.bitfire.synctools.util.AndroidTimeUtils.toZonedDateTime
+import at.bitfire.synctools.util.TimeApiExtensions.isDateTime
+import at.bitfire.synctools.util.TimeApiExtensions.toLocalDate
+import at.techbee.jtx.JtxContract
+import net.fortuna.ical4j.model.DateList
+import net.fortuna.ical4j.model.ParameterList
+import net.fortuna.ical4j.model.Recur
+import net.fortuna.ical4j.model.component.CalendarComponent
+import net.fortuna.ical4j.model.parameter.TzId
+import net.fortuna.ical4j.model.parameter.Value
+import net.fortuna.ical4j.model.property.ExDate
+import net.fortuna.ical4j.model.property.RDate
+import net.fortuna.ical4j.model.property.RRule
+import net.fortuna.ical4j.model.property.RecurrenceId
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.temporal.Temporal
+import java.util.logging.Level
+import java.util.logging.Logger
+
+/**
+ * Reads recurrence fields from a jtx Board [ContentValues] row and populates the given [CalendarComponent].
+ *
+ * Handles [JtxContract.JtxICalObject.RRULE], [JtxContract.JtxICalObject.RDATE], and
+ * [JtxContract.JtxICalObject.EXDATE]. Unlike the Calendar provider, jtx providers store at most one RRULE
+ * per object, so no RRULE separator logic is needed.
+ *
+ * **timezone format:** RDATE/EXDATE values are stored as timestamp lists with the timezone stored
+ * separately in [JtxContract.JtxICalObject.DTSTART_TIMEZONE]. These timestamps are converted to the
+ * appropriate temporal type before they are added to the iCalendar component.
+ *
+ * **UNTIL alignment:** RFC 5545 §3.3.10 requires the RRULE `UNTIL` value to be in UTC when
+ * DTSTART is a DATE-TIME, and to be a bare DATE when DTSTART is a DATE. [alignUntil] enforces
+ * this, and rules whose UNTIL falls on or before DTSTART are silently dropped.
+ *
+ * Parse errors in any individual field are caught and logged as warnings so that a single
+ * malformed value never prevents the rest of the jtx object from being read.
+ */
+class RecurrenceFieldsHandler : JtxObjectEntityHandler {
+
+    private val logger
+        get() = Logger.getLogger(javaClass.name)
+
+    /**
+     * Reads [JtxContract.JtxICalObject.RRULE], [JtxContract.JtxICalObject.RDATE], and
+     * [JtxContract.JtxICalObject.EXDATE] from [from] and populates [to].
+     *
+     * @param from  provider row for a single jtx object
+     * @param to    iCalendar component to populate
+     */
+    override fun process(from: Entity, main: Entity, to: CalendarComponent) {
+        val values = from.entityValues
+
+        if (from === main) {
+            processMain(values, to)
+        } else {
+            processException(values, to)
+        }
+    }
+
+    // Process exception
+    private fun processException(values: ContentValues, to: CalendarComponent) {
+        val recurId = values.getAsString(JtxContract.JtxICalObject.RECURID) ?: return
+
+        val parameters = when (val timeZone = values.getAsString(JtxContract.JtxICalObject.RECURID_TIMEZONE)) {
+            JtxContract.JtxICalObject.TZ_ALLDAY -> ParameterList(listOf(Value.DATE))
+            null, "", ZoneOffset.UTC.id -> ParameterList()
+            else -> if (isUtcTzId(timeZone))
+                ParameterList()
+            else
+                ParameterList(listOf(TzId(timeZone)))
+        }
+
+        to += RecurrenceId<Temporal>(parameters, recurId)
+    }
+
+    // Process main
+    private fun processMain(values: ContentValues, to: CalendarComponent) {
+        // process RRULE field
+        val rRule = rRule(values)
+
+        // process RDATE field
+        val rDate = rDate(values)
+        val recurring = rRule != null || rDate != null
+
+        // Check that we are recurring
+        if (!recurring) {
+            return
+        }
+        rRule?.let { to += it }
+        rDate?.let { to += it }
+
+        // process EXDATE field
+        exDate(values)?.let { to += it }
+    }
+
+    // process RRULE field
+    private fun rRule(values: ContentValues): RRule<Temporal>? =
+        values.getAsString(JtxContract.JtxICalObject.RRULE)?.let { rRule ->
+            try {
+                var rule = RRule<Temporal>(rRule)
+                val startTemporal = values.getAsLong(JtxContract.JtxICalObject.DTSTART)
+                    ?.let { timestamp ->
+                        JtxTimeField(
+                            timestamp = timestamp,
+                            timeZone = values.getAsString(JtxContract.JtxICalObject.DTSTART_TIMEZONE)
+                        ).toTemporal()
+                    }
+
+                // align RRULE UNTIL to DTSTART, if needed
+                if (startTemporal != null) {
+                    rule = RRule(alignUntil(rule.recur, startTemporal))
+
+                    // skip if UNTIL is before object's DTSTART
+                    val tsStart = values.getAsLong(JtxContract.JtxICalObject.DTSTART)!!
+                    val tsUntil = rule.recur.until?.toTimestamp()
+                    if (tsUntil != null && tsUntil <= tsStart) {
+                        logger.warning("Ignoring $rule because UNTIL ($tsUntil) is not after DTSTART ($tsStart)")
+                        return@let null
+                    }
+                }
+
+                rule
+            } catch (e: Exception) {
+                logger.log(Level.WARNING, "Couldn't parse RRULE field, ignoring", e)
+                null
+            }
+        }
+
+    // process RDATE field
+    private fun rDate(values: ContentValues): RDate<*>? =
+        values.getAsString(JtxContract.JtxICalObject.RDATE)?.let { rDate ->
+            try {
+                val timestamps = JtxContract.getLongListFromString(rDate)
+                if (timestamps.isEmpty())
+                    return@let null
+
+                val timeZone = values.getAsString(JtxContract.JtxICalObject.DTSTART_TIMEZONE)
+                val dates = timestamps.map {
+                    JtxTimeField(
+                        timestamp = it,
+                        timeZone = timeZone
+                    ).toTemporal()
+                }
+
+                RDate(DateList(dates))
+            } catch (e: Exception) {
+                logger.log(Level.WARNING, "Couldn't parse RDATE field, ignoring", e)
+                null
+            }
+        }
+
+    // process EXDATE field
+    private fun exDate(values: ContentValues): ExDate<*>? =
+        values.getAsString(JtxContract.JtxICalObject.EXDATE)?.let { exDate ->
+            try {
+                val timestamps = JtxContract.getLongListFromString(exDate)
+                if (timestamps.isEmpty())
+                    return@let null
+
+                val timeZone = values.getAsString(JtxContract.JtxICalObject.DTSTART_TIMEZONE)
+                val dates = timestamps.map {
+                    JtxTimeField(
+                        timestamp = it,
+                        timeZone = timeZone
+                    ).toTemporal()
+                }
+                val dateList = DateList(dates)
+
+                if (timeZone == JtxContract.JtxICalObject.TZ_ALLDAY) {
+                    ExDate(ParameterList(listOf(Value.DATE)), dateList)
+                } else {
+                    ExDate(dateList)
+                }
+            } catch (e: Exception) {
+                logger.log(Level.WARNING, "Couldn't parse EXDATE field, ignoring", e)
+                null
+            }
+        }
+
+    /**
+     * Aligns the `UNTIL` of the given recurrence info to the VALUE-type (DATE-TIME/DATE) of [startTemporal].
+     *
+     * If the aligned `UNTIL` is a DATE-TIME, this method also makes sure that it's specified in UTC format
+     * as required by RFC 5545 3.3.10.
+     *
+     * @param recur             recurrence info whose `UNTIL` shall be aligned
+     * @param startTemporal     `DTSTART` date to compare with
+     *
+     * @return
+     *
+     * - UNTIL not set → original recur
+     * - UNTIL and DTSTART are both either DATE or DATE-TIME → original recur
+     * - UNTIL is DATE, DTSTART is DATE-TIME → UNTIL is amended to DATE-TIME with time and timezone from DTSTART
+     * - UNTIL is DATE-TIME, DTSTART is DATE → UNTIL is reduced to its date component
+     *
+     * @see at.bitfire.synctools.mapping.calendar.handler.RecurrenceFieldsHandler.alignUntil
+     */
+    fun alignUntil(recur: Recur<Temporal>, startTemporal: Temporal): Recur<Temporal> {
+        val until: Temporal = recur.until ?: return recur
+
+        if (until.isDateTime()) {
+            // UNTIL is DATE-TIME
+            if (startTemporal.isDateTime()) {
+                // DTSTART is DATE-TIME → ensure UNTIL is in UTC
+                val untilZoned = until.toZonedDateTime()
+                return if (untilZoned.zone == ZoneOffset.UTC) {
+                    recur
+                } else {
+                    Recur.Builder(recur)
+                        .until(untilZoned.withZoneSameInstant(ZoneOffset.UTC).toInstant())
+                        .build()
+                }
+            } else {
+                // DTSTART is DATE → only take date part for UNTIL
+                val untilDate = until.toLocalDate()
+                return Recur.Builder(recur)
+                    .until(untilDate)
+                    .build()
+            }
+        } else {
+            // UNTIL is DATE
+            if (startTemporal.isDateTime()) {
+                // DTSTART is DATE-TIME → amend UNTIL to UTC DATE-TIME
+                val untilDate = until.toLocalDate()
+                val startTime = startTemporal.toZonedDateTime()
+                val untilDateWithTime = ZonedDateTime.of(untilDate, startTime.toLocalTime(), startTime.zone)
+                return Recur.Builder(recur)
+                    .until(untilDateWithTime.toInstant()) // convert to Instant for UTC with "Z" suffix
+                    .build()
+            } else {
+                // DTSTART is DATE
+                return recur
+            }
+        }
+    }
+
+}

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/RecurrenceFieldsHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/RecurrenceFieldsHandler.kt
@@ -70,7 +70,6 @@ class RecurrenceFieldsHandler : JtxObjectEntityHandler {
         }
     }
 
-    // Process exception
     private fun processException(values: ContentValues, to: CalendarComponent) {
         val recurId = values.getAsString(JtxContract.JtxICalObject.RECURID) ?: return
 
@@ -86,7 +85,6 @@ class RecurrenceFieldsHandler : JtxObjectEntityHandler {
         to += RecurrenceId<Temporal>(parameters, recurId)
     }
 
-    // Process main
     private fun processMain(values: ContentValues, to: CalendarComponent) {
         // process RRULE field
         val rRule = rRule(values)
@@ -106,7 +104,6 @@ class RecurrenceFieldsHandler : JtxObjectEntityHandler {
         exDate(values)?.let { to += it }
     }
 
-    // process RRULE field
     private fun rRule(values: ContentValues): RRule<Temporal>? =
         values.getAsString(JtxContract.JtxICalObject.RRULE)?.let { rRule ->
             try {
@@ -139,7 +136,6 @@ class RecurrenceFieldsHandler : JtxObjectEntityHandler {
             }
         }
 
-    // process RDATE field
     private fun rDate(values: ContentValues): RDate<*>? =
         values.getAsString(JtxContract.JtxICalObject.RDATE)?.let { rDate ->
             try {
@@ -163,7 +159,6 @@ class RecurrenceFieldsHandler : JtxObjectEntityHandler {
             }
         }
 
-    // process EXDATE field
     private fun exDate(values: ContentValues): ExDate<*>? =
         values.getAsString(JtxContract.JtxICalObject.EXDATE)?.let { exDate ->
             try {

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/RecurrenceFieldsHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/RecurrenceFieldsHandler.kt
@@ -188,10 +188,10 @@ class RecurrenceFieldsHandler : JtxObjectEntityHandler {
                 ParameterList(listOf(Value.DATE))
 
             is ZonedDateTime ->
-                ParameterList(listOf(Value.DATE_TIME, TzId(firstDate.zone.id)))
+                ParameterList(listOf(TzId(firstDate.zone.id))) // implicit VALUE=DATE-TIME
 
             else ->
-                ParameterList(listOf(Value.DATE_TIME))
+                ParameterList() // implicit VALUE=DATE-TIME
         }
 
     /**

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/RecurrenceFieldsHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/RecurrenceFieldsHandler.kt
@@ -23,6 +23,7 @@ import net.fortuna.ical4j.model.property.ExDate
 import net.fortuna.ical4j.model.property.RDate
 import net.fortuna.ical4j.model.property.RRule
 import net.fortuna.ical4j.model.property.RecurrenceId
+import java.time.LocalDate
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.temporal.Temporal
@@ -153,8 +154,9 @@ class RecurrenceFieldsHandler : JtxObjectEntityHandler {
                         timeZone = timeZone
                     ).toTemporal()
                 }
+                val dateList = DateList(dates)
 
-                RDate(DateList(dates))
+                RDate(dateListPropertyParameters(dates.first()), dateList)
             } catch (e: Exception) {
                 logger.log(Level.WARNING, "Couldn't parse RDATE field, ignoring", e)
                 null
@@ -178,15 +180,23 @@ class RecurrenceFieldsHandler : JtxObjectEntityHandler {
                 }
                 val dateList = DateList(dates)
 
-                if (timeZone == JtxContract.JtxICalObject.TZ_ALLDAY) {
-                    ExDate(ParameterList(listOf(Value.DATE)), dateList)
-                } else {
-                    ExDate(dateList)
-                }
+                ExDate(dateListPropertyParameters(dates.first()), dateList)
             } catch (e: Exception) {
                 logger.log(Level.WARNING, "Couldn't parse EXDATE field, ignoring", e)
                 null
             }
+        }
+
+    private fun dateListPropertyParameters(firstDate: Temporal): ParameterList =
+        when (firstDate) {
+            is LocalDate ->
+                ParameterList(listOf(Value.DATE))
+
+            is ZonedDateTime ->
+                ParameterList(listOf(Value.DATE_TIME, TzId(firstDate.zone.id)))
+
+            else ->
+                ParameterList(listOf(Value.DATE_TIME))
         }
 
     /**

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/handler/JtxTimeFieldTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/handler/JtxTimeFieldTest.kt
@@ -11,6 +11,7 @@ import at.techbee.jtx.JtxContract
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
+import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZoneOffset
@@ -33,7 +34,7 @@ class JtxTimeFieldTest {
     }
 
     @Test
-    fun `toTemporal with UTC timezone returns ZonedDateTime`() {
+    fun `toTemporal with UTC offset ID returns Instant`() {
         val jtxTimeField = JtxTimeField(
             timestamp = TIMESTAMP,
             timeZone = ZoneOffset.UTC.id
@@ -41,7 +42,19 @@ class JtxTimeFieldTest {
 
         val result = jtxTimeField.toTemporal()
 
-        assertEquals(dateTimeValue("20251015T094659", ZoneOffset.UTC), result)
+        assertEquals(Instant.ofEpochMilli(TIMESTAMP), result)
+    }
+
+    @Test
+    fun `toTemporal with UTC timezone ID returns Instant`() {
+        val jtxTimeField = JtxTimeField(
+            timestamp = TIMESTAMP,
+            timeZone = "UTC"
+        )
+
+        val result = jtxTimeField.toTemporal()
+
+        assertEquals(Instant.ofEpochMilli(TIMESTAMP), result)
     }
 
     @Test
@@ -69,7 +82,7 @@ class JtxTimeFieldTest {
     }
 
     @Test
-    fun `toTemporal with invalid timezone returns UTC ZonedDateTime`() {
+    fun `toTemporal with invalid timezone returns Instant`() {
         val jtxTimeField = JtxTimeField(
             timestamp = TIMESTAMP,
             timeZone = "Invalid/Timezone"
@@ -77,7 +90,7 @@ class JtxTimeFieldTest {
 
         val result = jtxTimeField.toTemporal()
 
-        assertEquals(dateTimeValue("20251015T094659", ZoneOffset.UTC), result)
+        assertEquals(Instant.ofEpochMilli(TIMESTAMP), result)
     }
 
     companion object {

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/handler/JtxTimeFieldTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/handler/JtxTimeFieldTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.synctools.mapping.jtx.handler
+
+import at.bitfire.DefaultTimezoneRule
+import at.bitfire.dateTimeValue
+import at.bitfire.dateValue
+import at.techbee.jtx.JtxContract
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+class JtxTimeFieldTest {
+
+    @get:Rule
+    val tzRule = DefaultTimezoneRule("Pacific/Honolulu")
+
+    @Test
+    fun `toTemporal with all-day timezone returns LocalDate`() {
+        val jtxTimeField = JtxTimeField(
+            timestamp = TIMESTAMP,
+            timeZone = JtxContract.JtxICalObject.TZ_ALLDAY
+        )
+
+        val result = jtxTimeField.toTemporal()
+
+        assertEquals(dateValue("20251015"), result)
+    }
+
+    @Test
+    fun `toTemporal with UTC timezone returns ZonedDateTime`() {
+        val jtxTimeField = JtxTimeField(
+            timestamp = TIMESTAMP,
+            timeZone = ZoneOffset.UTC.id
+        )
+
+        val result = jtxTimeField.toTemporal()
+
+        assertEquals(dateTimeValue("20251015T094659", ZoneOffset.UTC), result)
+    }
+
+    @Test
+    fun `toTemporal with floating timezone returns LocalDateTime`() {
+        val jtxTimeField = JtxTimeField(
+            timestamp = TIMESTAMP,
+            timeZone = null
+        )
+
+        val result = jtxTimeField.toTemporal()
+
+        assertEquals(LocalDateTime.of(2025, 10, 14, 23, 46, 59), result)
+    }
+
+    @Test
+    fun `toTemporal with named timezone returns ZonedDateTime`() {
+        val jtxTimeField = JtxTimeField(
+            timestamp = TIMESTAMP,
+            timeZone = "Europe/Vienna"
+        )
+
+        val result = jtxTimeField.toTemporal()
+
+        assertEquals(dateTimeValue("20251015T114659", ZoneId.of("Europe/Vienna")), result)
+    }
+
+    @Test
+    fun `toTemporal with invalid timezone returns UTC ZonedDateTime`() {
+        val jtxTimeField = JtxTimeField(
+            timestamp = TIMESTAMP,
+            timeZone = "Invalid/Timezone"
+        )
+
+        val result = jtxTimeField.toTemporal()
+
+        assertEquals(dateTimeValue("20251015T094659", ZoneOffset.UTC), result)
+    }
+
+    companion object {
+        private const val TIMESTAMP = 1760521619000L
+    }
+
+}

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/handler/JtxTimeFieldTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/handler/JtxTimeFieldTest.kt
@@ -12,7 +12,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import java.time.Instant
-import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZoneOffset
 
@@ -66,7 +65,7 @@ class JtxTimeFieldTest {
 
         val result = jtxTimeField.toTemporal()
 
-        assertEquals(LocalDateTime.of(2025, 10, 14, 23, 46, 59), result)
+        assertEquals(dateTimeValue("20251014T234659"), result)
     }
 
     @Test

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/handler/RecurrenceFieldsHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/handler/RecurrenceFieldsHandlerTest.kt
@@ -161,7 +161,7 @@ class RecurrenceFieldsHandlerTest {
 
         assertEquals(1, output.rDates.size)
         assertEquals(
-            RDate<Temporal>(ParameterList(listOf(Value.DATE_TIME)), "20260522T120000Z"),
+            RDate<Temporal>(ParameterList(), "20260522T120000Z"),
             output.rDates.first()
         )
     }
@@ -254,7 +254,7 @@ class RecurrenceFieldsHandlerTest {
 
         assertEquals(1, output.rDates.size)
         assertEquals(
-            RDate<Temporal>(ParameterList(listOf(Value.DATE_TIME)), "20260522T120000Z"),
+            RDate<Temporal>(ParameterList(), "20260522T120000Z"),
             output.rDates.first()
         )
     }
@@ -289,7 +289,7 @@ class RecurrenceFieldsHandlerTest {
 
         assertEquals(1, output.rDates.size)
         assertEquals(
-            RDate<Temporal>(ParameterList(listOf(Value.DATE_TIME, TzId("Europe/Vienna"))), "20260522T140000"),
+            RDate<Temporal>(ParameterList(listOf(TzId("Europe/Vienna"))), "20260522T140000"),
             output.rDates.first()
         )
     }
@@ -308,7 +308,7 @@ class RecurrenceFieldsHandlerTest {
 
         assertEquals(1, output.rDates.size)
         assertEquals(
-            RDate<Temporal>(ParameterList(listOf(Value.DATE_TIME)), "20260522T120000Z"),
+            RDate<Temporal>(ParameterList(), "20260522T120000Z"),
             output.rDates.first()
         )
     }
@@ -328,7 +328,7 @@ class RecurrenceFieldsHandlerTest {
 
         assertEquals(1, output.exDates.size)
         assertEquals(
-            ExDate<Temporal>(ParameterList(listOf(Value.DATE_TIME, TzId("Europe/Vienna"))), "20260522T140000"),
+            ExDate<Temporal>(ParameterList(listOf(TzId("Europe/Vienna"))), "20260522T140000"),
             output.exDates.first()
         )
     }
@@ -348,7 +348,7 @@ class RecurrenceFieldsHandlerTest {
 
         assertEquals(1, output.exDates.size)
         assertEquals(
-            ExDate<Temporal>(ParameterList(listOf(Value.DATE_TIME)), "20260522T120000Z"),
+            ExDate<Temporal>(ParameterList(), "20260522T120000Z"),
             output.exDates.first()
         )
     }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/handler/RecurrenceFieldsHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/handler/RecurrenceFieldsHandlerTest.kt
@@ -1,0 +1,552 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.synctools.mapping.jtx.handler
+
+import android.content.ContentValues
+import android.content.Entity
+import androidx.core.content.contentValuesOf
+import at.bitfire.dateTimeValue
+import at.bitfire.dateValue
+import at.bitfire.synctools.util.AndroidTimeUtils.toTimestamp
+import at.techbee.jtx.JtxContract
+import io.mockk.mockk
+import net.fortuna.ical4j.model.ParameterList
+import net.fortuna.ical4j.model.Property
+import net.fortuna.ical4j.model.Recur
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.parameter.TzId
+import net.fortuna.ical4j.model.parameter.Value
+import net.fortuna.ical4j.model.property.ExDate
+import net.fortuna.ical4j.model.property.RDate
+import net.fortuna.ical4j.model.property.RRule
+import net.fortuna.ical4j.model.property.RecurrenceId
+import net.fortuna.ical4j.transform.recurrence.Frequency
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.temporal.Temporal
+import kotlin.jvm.optionals.getOrNull
+
+@RunWith(RobolectricTestRunner::class)
+class RecurrenceFieldsHandlerTest {
+
+    private val tzVienna = ZoneId.of("Europe/Vienna")
+
+    private val handler = RecurrenceFieldsHandler()
+
+    @Test
+    fun `No recurrence fields leaves task empty`() {
+        val input = Entity(ContentValues())
+        val output = VToDo()
+
+        handler.process(from = input, main = input, to = output)
+
+        assertNull(output.rRule)
+        assertTrue(output.rDates.isEmpty())
+        assertTrue(output.exDates.isEmpty())
+        assertNull(output.recurrenceId)
+    }
+
+    @Test
+    fun `RRULE without DTSTART is parsed without alignment`() {
+        val input = Entity(contentValuesOf(JtxContract.JtxICalObject.RRULE to "FREQ=DAILY;COUNT=10"))
+        val output = VToDo()
+
+        handler.process(from = input, main = input, to = output)
+
+        assertEquals(RRule<Temporal>("FREQ=DAILY;COUNT=10"), output.rRule)
+    }
+
+    @Test
+    fun `RRULE with COUNT is parsed correctly`() {
+        val input = Entity(
+            contentValuesOf(
+                JtxContract.JtxICalObject.DTSTART to timestamp("20251002T111413Z"),
+                JtxContract.JtxICalObject.DTSTART_TIMEZONE to "UTC",
+                JtxContract.JtxICalObject.RRULE to "FREQ=WEEKLY;COUNT=5"
+            )
+        )
+        val output = VToDo()
+
+        handler.process(from = input, main = input, to = output)
+
+        assertEquals(RRule<Temporal>("FREQ=WEEKLY;COUNT=5"), output.rRule)
+    }
+
+    @Test
+    fun `RRULE with UNTIL before DTSTART is skipped`() {
+        val input = Entity(
+            contentValuesOf(
+                JtxContract.JtxICalObject.DTSTART to timestamp("20251002T111413Z"),
+                JtxContract.JtxICalObject.DTSTART_TIMEZONE to "UTC",
+                JtxContract.JtxICalObject.RRULE to "FREQ=DAILY;UNTIL=20251002T111300Z"
+            )
+        )
+        val output = VToDo()
+
+        handler.process(from = input, main = input, to = output)
+
+        assertNull(output.rRule)
+    }
+
+    @Test
+    fun `RRULE with DATE UNTIL aligned to UTC DATE-TIME when DTSTART is DATE-TIME`() {
+        val input = Entity(
+            contentValuesOf(
+                JtxContract.JtxICalObject.DTSTART to timestamp("20251002T111413Z"),
+                JtxContract.JtxICalObject.DTSTART_TIMEZONE to "UTC",
+                JtxContract.JtxICalObject.RRULE to "FREQ=DAILY;UNTIL=20251015"
+            )
+        )
+        val output = VToDo()
+
+        handler.process(from = input, main = input, to = output)
+
+        assertEquals("FREQ=DAILY;UNTIL=20251015T111413Z", output.rRule!!.value)
+    }
+
+    @Test
+    fun `RRULE with DATE-TIME UNTIL aligned to DATE when DTSTART is all-day`() {
+        val input = Entity(
+            contentValuesOf(
+                JtxContract.JtxICalObject.DTSTART to timestamp("20251002T000000Z"),
+                JtxContract.JtxICalObject.DTSTART_TIMEZONE to JtxContract.JtxICalObject.TZ_ALLDAY,
+                JtxContract.JtxICalObject.RRULE to "FREQ=DAILY;UNTIL=20251015T153118Z"
+            )
+        )
+        val output = VToDo()
+
+        handler.process(from = input, main = input, to = output)
+
+        assertEquals("FREQ=DAILY;UNTIL=20251015", output.rRule!!.value)
+    }
+
+    @Test
+    fun `RRULE with invalid DTSTART timezone falls back to UTC`() {
+        val input = Entity(
+            contentValuesOf(
+                JtxContract.JtxICalObject.DTSTART to timestamp("20251002T111413Z"),
+                JtxContract.JtxICalObject.DTSTART_TIMEZONE to "Invalid/Timezone",
+                JtxContract.JtxICalObject.RRULE to "FREQ=DAILY;UNTIL=20251015"
+            )
+        )
+        val output = VToDo()
+
+        handler.process(from = input, main = input, to = output)
+
+        assertEquals("FREQ=DAILY;UNTIL=20251015T111413Z", output.rRule!!.value)
+    }
+
+    @Test
+    fun `RDATE is parsed into rDates`() {
+        val input = Entity(
+            contentValuesOf(
+                JtxContract.JtxICalObject.DTSTART_TIMEZONE to "UTC",
+                JtxContract.JtxICalObject.RDATE to timestamp("20260522T120000Z")
+            )
+        )
+        val output = VToDo()
+
+        handler.process(from = input, main = input, to = output)
+
+        assertEquals(1, output.rDates.size)
+        assertEquals(
+            RDate<Temporal>(ParameterList(), "20260522T120000"),
+            output.rDates.first()
+        )
+    }
+
+    @Test
+    fun `EXDATE all-day has VALUE=DATE`() {
+        val input = Entity(
+            contentValuesOf(
+                JtxContract.JtxICalObject.DTSTART_TIMEZONE to JtxContract.JtxICalObject.TZ_ALLDAY,
+                JtxContract.JtxICalObject.RRULE to "FREQ=DAILY;COUNT=5",
+                JtxContract.JtxICalObject.EXDATE to timestamp("20260522T120000Z")
+            )
+        )
+        val output = VToDo()
+
+        handler.process(from = input, main = input, to = output)
+
+        assertEquals(1, output.exDates.size)
+        assertEquals(
+            ExDate<Temporal>(ParameterList(listOf(Value.DATE)), "20260522"),
+            output.exDates.first()
+        )
+    }
+
+    @Test
+    fun `EXDATE without RRULE or RDATE is ignored`() {
+        val input = Entity(
+            contentValuesOf(
+                JtxContract.JtxICalObject.DTSTART_TIMEZONE to "UTC",
+                JtxContract.JtxICalObject.EXDATE to timestamp("20260522T120000Z")
+            )
+        )
+        val output = VToDo()
+
+        handler.process(from = input, main = input, to = output)
+
+        assertTrue(output.exDates.isEmpty())
+    }
+
+    @Test
+    fun `Invalid RRULE is ignored without crash`() {
+        val input = Entity(contentValuesOf(JtxContract.JtxICalObject.RRULE to "NOT_A_VALID_RRULE"))
+        val output = VToDo()
+
+        handler.process(from = input, main = input, to = output)
+
+        assertNull(output.rRule)
+    }
+
+    @Test
+    fun `Invalid RDATE is ignored without crash`() {
+        val input = Entity(contentValuesOf(JtxContract.JtxICalObject.RDATE to "NOT_A_VALID_RDATE"))
+        val output = VToDo()
+
+        handler.process(from = input, main = input, to = output)
+
+        assertTrue(output.rDates.isEmpty())
+    }
+
+    @Test
+    fun `RDATE invalid timestamp entries are ignored`() {
+        val input = Entity(
+            contentValuesOf(
+                JtxContract.JtxICalObject.DTSTART_TIMEZONE to "UTC",
+                JtxContract.JtxICalObject.RDATE to "invalid,${timestamp("20260522T120000Z")}"
+            )
+        )
+        val output = VToDo()
+
+        handler.process(from = input, main = input, to = output)
+
+        assertEquals(1, output.rDates.size)
+        assertEquals(
+            RDate<Temporal>(ParameterList(), "20260522T120000"),
+            output.rDates.first()
+        )
+    }
+
+    @Test
+    fun `Invalid EXDATE is ignored without crash`() {
+        val input = Entity(
+            contentValuesOf(
+                JtxContract.JtxICalObject.RRULE to "FREQ=DAILY;COUNT=5",
+                JtxContract.JtxICalObject.EXDATE to "NOT_A_VALID_EXDATE"
+            )
+        )
+        val output = VToDo()
+
+        handler.process(from = input, main = input, to = output)
+
+        assertEquals(RRule<Temporal>("FREQ=DAILY;COUNT=5"), output.rRule)
+        assertTrue(output.exDates.isEmpty())
+    }
+
+    @Test
+    fun `RDATE with named DTSTART timezone uses timezone`() {
+        val input = Entity(
+            contentValuesOf(
+                JtxContract.JtxICalObject.DTSTART_TIMEZONE to "Europe/Vienna",
+                JtxContract.JtxICalObject.RDATE to timestamp("20260522T120000Z")
+            )
+        )
+        val output = VToDo()
+
+        handler.process(from = input, main = input, to = output)
+
+        assertEquals(1, output.rDates.size)
+        assertEquals(
+            RDate<Temporal>(ParameterList(), "20260522T140000"),
+            output.rDates.first()
+        )
+    }
+
+    @Test
+    fun `RDATE with invalid DTSTART timezone falls back to UTC`() {
+        val input = Entity(
+            contentValuesOf(
+                JtxContract.JtxICalObject.DTSTART_TIMEZONE to "Invalid/Timezone",
+                JtxContract.JtxICalObject.RDATE to timestamp("20260522T120000Z")
+            )
+        )
+        val output = VToDo()
+
+        handler.process(from = input, main = input, to = output)
+
+        assertEquals(1, output.rDates.size)
+        assertEquals(
+            RDate<Temporal>(ParameterList(), "20260522T120000"),
+            output.rDates.first()
+        )
+    }
+
+    @Test
+    fun `EXDATE with named DTSTART timezone uses timezone`() {
+        val input = Entity(
+            contentValuesOf(
+                JtxContract.JtxICalObject.DTSTART_TIMEZONE to "Europe/Vienna",
+                JtxContract.JtxICalObject.RRULE to "FREQ=DAILY;COUNT=5",
+                JtxContract.JtxICalObject.EXDATE to timestamp("20260522T120000Z")
+            )
+        )
+        val output = VToDo()
+
+        handler.process(from = input, main = input, to = output)
+
+        assertEquals(1, output.exDates.size)
+        assertEquals(
+            ExDate<Temporal>(ParameterList(), "20260522T140000"),
+            output.exDates.first()
+        )
+    }
+
+    @Test
+    fun `EXDATE with invalid DTSTART timezone falls back to UTC`() {
+        val input = Entity(
+            contentValuesOf(
+                JtxContract.JtxICalObject.DTSTART_TIMEZONE to "Invalid/Timezone",
+                JtxContract.JtxICalObject.RRULE to "FREQ=DAILY;COUNT=5",
+                JtxContract.JtxICalObject.EXDATE to timestamp("20260522T120000Z")
+            )
+        )
+        val output = VToDo()
+
+        handler.process(from = input, main = input, to = output)
+
+        assertEquals(1, output.exDates.size)
+        assertEquals(
+            ExDate<Temporal>(ParameterList(), "20260522T120000"),
+            output.exDates.first()
+        )
+    }
+
+    @Test
+    fun `alignUntil(recurUntil=null)`() {
+        val recur = Recur.Builder<Temporal>()
+            .frequency(Frequency.DAILY)
+            .build()
+        val result = handler.alignUntil(recur, mockk())
+
+        assertSame(recur, result)
+    }
+
+    @Test
+    fun `alignUntil(recurUntil=DATE, startDate=DATE)`() {
+        val recur = Recur.Builder<Temporal>()
+            .frequency(Frequency.DAILY)
+            .until(dateValue("20251015"))
+            .build()
+        val result = handler.alignUntil(recur, LocalDate.now())
+
+        assertSame(recur, result)
+    }
+
+    @Test
+    fun `alignUntil(recurUntil=DATE, startDate=DATE-TIME)`() {
+        val result = handler.alignUntil(
+            recur = Recur.Builder<Temporal>()
+                .frequency(Frequency.DAILY)
+                .until(dateValue("20251015"))
+                .build(),
+            startTemporal = dateTimeValue("20250101T010203", tzVienna)
+        )
+
+        assertEquals(
+            Recur.Builder<Temporal>()
+                .frequency(Frequency.DAILY)
+                .until(dateTimeValue("20251014T230203Z"))
+                .build(),
+            result
+        )
+    }
+
+    @Test
+    fun `alignUntil(recurUntil=DATE-TIME, startDate=DATE)`() {
+        val result = handler.alignUntil(
+            recur = Recur.Builder<Temporal>()
+                .frequency(Frequency.DAILY)
+                .until(dateTimeValue("20251015T153118", tzVienna))
+                .build(),
+            startTemporal = LocalDate.now()
+        )
+
+        assertEquals(
+            Recur.Builder<Temporal>()
+                .frequency(Frequency.DAILY)
+                .until(dateValue("20251015"))
+                .build(),
+            result
+        )
+    }
+
+    @Test
+    fun `alignUntil(recurUntil=DATE-TIME, startDate=DATE-TIME)`() {
+        val result = handler.alignUntil(
+            recur = Recur.Builder<Temporal>()
+                .frequency(Frequency.DAILY)
+                .until(dateTimeValue("20251015T153118", tzVienna))
+                .build(),
+            startTemporal = LocalDateTime.now()
+        )
+
+        assertEquals(
+            Recur.Builder<Temporal>()
+                .frequency(Frequency.DAILY)
+                .until(dateTimeValue("20251015T133118Z"))
+                .build(),
+            result
+        )
+    }
+
+    @Test
+    fun `Exception does not map RRULE RDATE or EXDATE`() {
+        val input = Entity(
+            contentValuesOf(
+                JtxContract.JtxICalObject.RECURID to "20260516T120000Z",
+                JtxContract.JtxICalObject.RECURID_TIMEZONE to "UTC",
+                JtxContract.JtxICalObject.RRULE to "FREQ=DAILY;COUNT=5",
+                JtxContract.JtxICalObject.RDATE to timestamp("20260522T120000Z"),
+                JtxContract.JtxICalObject.EXDATE to timestamp("20260522T120000Z")
+            )
+        )
+        val main = Entity(ContentValues())
+        val output = VToDo()
+
+        handler.process(from = input, main = main, to = output)
+
+        assertNull(output.rRule)
+        assertTrue(output.rDates.isEmpty())
+        assertTrue(output.exDates.isEmpty())
+        assertEquals(
+            RecurrenceId<Temporal>(ParameterList(), "20260516T120000Z"),
+            output.recurrenceId
+        )
+    }
+
+    @Test
+    fun `RECURRENCE-ID with UTC timezone is mapped`() {
+        val input = Entity(
+            contentValuesOf(
+                JtxContract.JtxICalObject.RECURID to "20260516T120000Z",
+                JtxContract.JtxICalObject.RECURID_TIMEZONE to "UTC"
+            )
+        )
+        val main = Entity(ContentValues())
+        val output = VToDo()
+
+        handler.process(from = input, main = main, to = output)
+
+        assertEquals(
+            RecurrenceId<Temporal>(ParameterList(), "20260516T120000Z"),
+            output.recurrenceId
+        )
+    }
+
+    @Test
+    fun `RECURRENCE-ID with UTC offset timezone is mapped without TZID`() {
+        val input = Entity(
+            contentValuesOf(
+                JtxContract.JtxICalObject.RECURID to "20260516T120000Z",
+                JtxContract.JtxICalObject.RECURID_TIMEZONE to ZoneOffset.UTC.id
+            )
+        )
+        val main = Entity(ContentValues())
+        val output = VToDo()
+
+        handler.process(from = input, main = main, to = output)
+
+        assertEquals(
+            RecurrenceId<Temporal>(ParameterList(), "20260516T120000Z"),
+            output.recurrenceId
+        )
+    }
+
+    @Test
+    fun `RECURRENCE-ID with named timezone is mapped`() {
+        val input = Entity(
+            contentValuesOf(
+                JtxContract.JtxICalObject.RECURID to "20260516T120000",
+                JtxContract.JtxICalObject.RECURID_TIMEZONE to "Europe/Vienna"
+            )
+        )
+        val main = Entity(ContentValues())
+        val output = VToDo()
+
+        handler.process(from = input, main = main, to = output)
+
+        assertEquals(
+            RecurrenceId<Temporal>(ParameterList(listOf(TzId("Europe/Vienna"))), "20260516T120000"),
+            output.recurrenceId
+        )
+    }
+
+    @Test
+    fun `RECURRENCE-ID with floating time is mapped`() {
+        val input = Entity(contentValuesOf(JtxContract.JtxICalObject.RECURID to "20260516T120000"))
+        val main = Entity(ContentValues())
+        val output = VToDo()
+
+        handler.process(from = input, main = main, to = output)
+
+        assertEquals(RecurrenceId<Temporal>(ParameterList(), "20260516T120000"), output.recurrenceId)
+    }
+
+    @Test
+    fun `RECURRENCE-ID with all-day timezone is mapped with VALUE DATE`() {
+        val input = Entity(
+            contentValuesOf(
+                JtxContract.JtxICalObject.RECURID to "20260523",
+                JtxContract.JtxICalObject.RECURID_TIMEZONE to JtxContract.JtxICalObject.TZ_ALLDAY
+            )
+        )
+        val main = Entity(ContentValues())
+        val output = VToDo()
+
+        handler.process(from = input, main = main, to = output)
+
+        assertEquals(
+            RecurrenceId<Temporal>(ParameterList(listOf(Value.DATE)), "20260523"),
+            output.recurrenceId
+        )
+    }
+
+    @Test
+    fun `Exception without RECURRENCE-ID is ignored`() {
+        val input = Entity(ContentValues())
+        val main = Entity(ContentValues())
+        val output = VToDo()
+
+        handler.process(from = input, main = main, to = output)
+
+        assertNull(output.recurrenceId)
+    }
+}
+
+private val VToDo.rRule: RRule<*>?
+    get() = getProperty<RRule<*>>(Property.RRULE).getOrNull()
+
+private val VToDo.rDates: List<RDate<Temporal>>
+    get() = getProperties(Property.RDATE)
+
+private val VToDo.exDates: List<ExDate<Temporal>>
+    get() = getProperties(Property.EXDATE)
+
+private val VToDo.recurrenceId: RecurrenceId<*>?
+    get() = getProperty<RecurrenceId<*>>(Property.RECURRENCE_ID).getOrNull()
+
+private fun timestamp(value: String): String =
+    dateTimeValue(value).toTimestamp().toString()

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/handler/RecurrenceFieldsHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/handler/RecurrenceFieldsHandlerTest.kt
@@ -161,7 +161,7 @@ class RecurrenceFieldsHandlerTest {
 
         assertEquals(1, output.rDates.size)
         assertEquals(
-            RDate<Temporal>(ParameterList(), "20260522T120000"),
+            RDate<Temporal>(ParameterList(), "20260522T120000Z"),
             output.rDates.first()
         )
     }
@@ -235,7 +235,7 @@ class RecurrenceFieldsHandlerTest {
 
         assertEquals(1, output.rDates.size)
         assertEquals(
-            RDate<Temporal>(ParameterList(), "20260522T120000"),
+            RDate<Temporal>(ParameterList(), "20260522T120000Z"),
             output.rDates.first()
         )
     }
@@ -289,7 +289,7 @@ class RecurrenceFieldsHandlerTest {
 
         assertEquals(1, output.rDates.size)
         assertEquals(
-            RDate<Temporal>(ParameterList(), "20260522T120000"),
+            RDate<Temporal>(ParameterList(), "20260522T120000Z"),
             output.rDates.first()
         )
     }
@@ -329,7 +329,7 @@ class RecurrenceFieldsHandlerTest {
 
         assertEquals(1, output.exDates.size)
         assertEquals(
-            ExDate<Temporal>(ParameterList(), "20260522T120000"),
+            ExDate<Temporal>(ParameterList(), "20260522T120000Z"),
             output.exDates.first()
         )
     }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/handler/RecurrenceFieldsHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/handler/RecurrenceFieldsHandlerTest.kt
@@ -161,7 +161,26 @@ class RecurrenceFieldsHandlerTest {
 
         assertEquals(1, output.rDates.size)
         assertEquals(
-            RDate<Temporal>(ParameterList(), "20260522T120000Z"),
+            RDate<Temporal>(ParameterList(listOf(Value.DATE_TIME)), "20260522T120000Z"),
+            output.rDates.first()
+        )
+    }
+
+    @Test
+    fun `RDATE all-day has VALUE=DATE`() {
+        val input = Entity(
+            contentValuesOf(
+                JtxContract.JtxICalObject.DTSTART_TIMEZONE to JtxContract.JtxICalObject.TZ_ALLDAY,
+                JtxContract.JtxICalObject.RDATE to timestamp("20260522T120000Z")
+            )
+        )
+        val output = VToDo()
+
+        handler.process(from = input, main = input, to = output)
+
+        assertEquals(1, output.rDates.size)
+        assertEquals(
+            RDate<Temporal>(ParameterList(listOf(Value.DATE)), "20260522"),
             output.rDates.first()
         )
     }
@@ -235,7 +254,7 @@ class RecurrenceFieldsHandlerTest {
 
         assertEquals(1, output.rDates.size)
         assertEquals(
-            RDate<Temporal>(ParameterList(), "20260522T120000Z"),
+            RDate<Temporal>(ParameterList(listOf(Value.DATE_TIME)), "20260522T120000Z"),
             output.rDates.first()
         )
     }
@@ -270,7 +289,7 @@ class RecurrenceFieldsHandlerTest {
 
         assertEquals(1, output.rDates.size)
         assertEquals(
-            RDate<Temporal>(ParameterList(), "20260522T140000"),
+            RDate<Temporal>(ParameterList(listOf(Value.DATE_TIME, TzId("Europe/Vienna"))), "20260522T140000"),
             output.rDates.first()
         )
     }
@@ -289,7 +308,7 @@ class RecurrenceFieldsHandlerTest {
 
         assertEquals(1, output.rDates.size)
         assertEquals(
-            RDate<Temporal>(ParameterList(), "20260522T120000Z"),
+            RDate<Temporal>(ParameterList(listOf(Value.DATE_TIME)), "20260522T120000Z"),
             output.rDates.first()
         )
     }
@@ -309,7 +328,7 @@ class RecurrenceFieldsHandlerTest {
 
         assertEquals(1, output.exDates.size)
         assertEquals(
-            ExDate<Temporal>(ParameterList(), "20260522T140000"),
+            ExDate<Temporal>(ParameterList(listOf(Value.DATE_TIME, TzId("Europe/Vienna"))), "20260522T140000"),
             output.exDates.first()
         )
     }
@@ -329,7 +348,7 @@ class RecurrenceFieldsHandlerTest {
 
         assertEquals(1, output.exDates.size)
         assertEquals(
-            ExDate<Temporal>(ParameterList(), "20260522T120000Z"),
+            ExDate<Temporal>(ParameterList(listOf(Value.DATE_TIME)), "20260522T120000Z"),
             output.exDates.first()
         )
     }


### PR DESCRIPTION
Adds jtx RecurrenceFieldsHandler + tests. 

Also adds `JtxTimeField` + `JtxTimeFieldTest`.

**Note1:** It aligns closely with the `RecurrenceFieldsHandler` calendar version, so good to check against that for reviewing. Notable differences are mentioned in the class kdoc.

**Note2:** The different `RecurrenceFieldsHandler`s for tasks, jtx and calendar resemble each other quite a bit. In order for this PR not to become too big/complex there is a separate issue for renaming and deduplication: https://github.com/bitfireAT/davx5-ose/issues/2510