### PR TITLE
[Contacts rewrite] Create CRUD for raw contacts and groups

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -148,6 +148,7 @@ open class LocalAddressBook @AssistedInject constructor(
             return false
 
         // move contacts and groups to new account
+        // no explicit account WHERE needed: updateGroups/updateRawContactRows scope via asSyncAdapter(addressBookAccount)
         val batch = ContactsBatchOperation(ab.provider)
         ab.updateGroups(
             contentValuesOf(Groups.ACCOUNT_NAME to newAccount.name, Groups.ACCOUNT_TYPE to newAccount.type),

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -20,7 +20,6 @@ import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.sync.SyncDataType
 import at.bitfire.davdroid.sync.adapter.SyncFrameworkIntegration
 import at.bitfire.synctools.mapping.contacts.Contact
-import at.bitfire.synctools.storage.BatchOperation
 import at.bitfire.synctools.storage.contacts.AddressContract.GroupColumns
 import at.bitfire.synctools.storage.contacts.AddressContract.RawContactColumns
 import at.bitfire.synctools.storage.contacts.AddressContract.asSyncAdapter
@@ -28,7 +27,6 @@ import at.bitfire.synctools.storage.contacts.AndroidAddressBook
 import at.bitfire.synctools.storage.contacts.AndroidContact
 import at.bitfire.synctools.storage.contacts.AndroidGroup
 import at.bitfire.synctools.storage.contacts.ContactsBatchOperation
-import at.bitfire.synctools.storage.toContentValues
 import at.bitfire.synctools.util.AndroidAccountUtils
 import at.bitfire.synctools.util.setAndVerifyUserData
 import at.bitfire.synctools.vcard.GroupMethod
@@ -114,26 +112,17 @@ open class LocalAddressBook @AssistedInject constructor(
     override fun markNotDirty(flags: Int): Int {
         val batch = ContactsBatchOperation(ab.provider)
         ab.updateRawContactRows(contentValuesOf(RawContactColumns.FLAGS to flags), "${RawContacts.DIRTY}=0", null, batch)
-        var number = batch.commit()
-
         if (includeGroups)
-            number += ab.provider.update(ab.groupsSyncUri(), contentValuesOf(GroupColumns.FLAGS to flags), "NOT ${Groups.DIRTY}", null)
-
-        return number
+            ab.updateGroups(contentValuesOf(GroupColumns.FLAGS to flags), "NOT ${Groups.DIRTY}", null, batch)
+        return batch.commit()
     }
 
     override fun removeNotDirtyMarked(flags: Int): Int {
         val batch = ContactsBatchOperation(ab.provider)
         ab.deleteRawContacts("NOT ${RawContacts.DIRTY} AND ${RawContactColumns.FLAGS}=?", arrayOf(flags.toString()), batch)
-        var number = batch.commit()
-
         if (includeGroups)
-            number += ab.provider.delete(
-                ab.groupsSyncUri(),
-                "NOT ${Groups.DIRTY} AND ${GroupColumns.FLAGS}=?", arrayOf(flags.toString())
-            )
-
-        return number
+            ab.deleteGroups("NOT ${Groups.DIRTY} AND ${GroupColumns.FLAGS}=?", arrayOf(flags.toString()), batch)
+        return batch.commit()
     }
 
     /**
@@ -160,11 +149,10 @@ open class LocalAddressBook @AssistedInject constructor(
 
         // move contacts and groups to new account
         val batch = ContactsBatchOperation(ab.provider)
-        batch += BatchOperation.CpoBuilder
-            .newUpdate(ab.groupsSyncUri())
-            .withSelection(Groups.ACCOUNT_NAME + "=? AND " + Groups.ACCOUNT_TYPE + "=?", arrayOf(oldAccount.name, oldAccount.type))
-            .withValue(Groups.ACCOUNT_NAME, newAccount.name)
-            .withValue(Groups.ACCOUNT_TYPE, newAccount.type)
+        ab.updateGroups(
+            contentValuesOf(Groups.ACCOUNT_NAME to newAccount.name, Groups.ACCOUNT_TYPE to newAccount.type),
+            null, null, batch
+        )
         ab.updateRawContactRows(
             contentValuesOf(RawContacts.ACCOUNT_NAME to newAccount.name, RawContacts.ACCOUNT_TYPE to newAccount.type),
             null, null, batch
@@ -244,12 +232,11 @@ open class LocalAddressBook @AssistedInject constructor(
     fun findDirtyGroups() = queryGroups(Groups.DIRTY, null)
 
     override fun forgetETags() {
-        if (includeGroups) {
-            val values = contentValuesOf(GroupColumns.ETAG to null)
-            ab.provider.update(ab.groupsSyncUri(), values, null, null)
-        }
-        val values = contentValuesOf(RawContactColumns.ETAG to null)
-        ab.provider.update(ab.rawContactsSyncUri(), values, null, null)
+        val batch = ContactsBatchOperation(ab.provider)
+        if (includeGroups)
+            ab.updateGroups(contentValuesOf(GroupColumns.ETAG to null), null, null, batch)
+        ab.updateRawContactRows(contentValuesOf(RawContactColumns.ETAG to null), null, null, batch)
+        batch.commit()
     }
 
 
@@ -272,9 +259,8 @@ open class LocalAddressBook @AssistedInject constructor(
     }
 
     fun queryGroups(where: String?, whereArgs: Array<String>?): List<LocalGroup> = buildList {
-        ab.provider.query(ab.groupsSyncUri(), null, where, whereArgs, null)?.use { cursor ->
-            while (cursor.moveToNext())
-                add(LocalGroup(AndroidGroup(ab, cursor.toContentValues())))
+        ab.iterateGroups(null, where, whereArgs) { values ->
+            add(LocalGroup(AndroidGroup(ab, values)))
         }
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -253,7 +253,7 @@ open class LocalAddressBook @AssistedInject constructor(
     }
 
     fun queryContacts(where: String?, whereArgs: Array<String>?): List<LocalContact> = buildList {
-        ab.iterateRawContactRows(null, where, whereArgs) { values ->
+        ab.iterateRawContactRows(where, whereArgs) { values ->
             add(LocalContact(this@LocalAddressBook, AndroidContact(ab, values)))
         }
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -112,23 +112,20 @@ open class LocalAddressBook @AssistedInject constructor(
     /* operations on the collection (address book) itself */
 
     override fun markNotDirty(flags: Int): Int {
-        val values = contentValuesOf(RawContactColumns.FLAGS to flags)
-        var number = ab.provider.update(ab.rawContactsSyncUri(), values, "${RawContacts.DIRTY}=0", null)
+        val batch = ContactsBatchOperation(ab.provider)
+        ab.updateRawContactRows(contentValuesOf(RawContactColumns.FLAGS to flags), "${RawContacts.DIRTY}=0", null, batch)
+        var number = batch.commit()
 
-        if (includeGroups) {
-            values.clear()
-            values.put(GroupColumns.FLAGS, flags)
-            number += ab.provider.update(ab.groupsSyncUri(), values, "NOT ${Groups.DIRTY}", null)
-        }
+        if (includeGroups)
+            number += ab.provider.update(ab.groupsSyncUri(), contentValuesOf(GroupColumns.FLAGS to flags), "NOT ${Groups.DIRTY}", null)
 
         return number
     }
 
     override fun removeNotDirtyMarked(flags: Int): Int {
-        var number = ab.provider.delete(
-            ab.rawContactsSyncUri(),
-            "NOT ${RawContacts.DIRTY} AND ${RawContactColumns.FLAGS}=?", arrayOf(flags.toString())
-        )
+        val batch = ContactsBatchOperation(ab.provider)
+        ab.deleteRawContacts("NOT ${RawContacts.DIRTY} AND ${RawContactColumns.FLAGS}=?", arrayOf(flags.toString()), batch)
+        var number = batch.commit()
 
         if (includeGroups)
             number += ab.provider.delete(
@@ -168,11 +165,10 @@ open class LocalAddressBook @AssistedInject constructor(
             .withSelection(Groups.ACCOUNT_NAME + "=? AND " + Groups.ACCOUNT_TYPE + "=?", arrayOf(oldAccount.name, oldAccount.type))
             .withValue(Groups.ACCOUNT_NAME, newAccount.name)
             .withValue(Groups.ACCOUNT_TYPE, newAccount.type)
-        batch += BatchOperation.CpoBuilder
-            .newUpdate(ab.rawContactsSyncUri())
-            .withSelection(RawContacts.ACCOUNT_NAME + "=? AND " + RawContacts.ACCOUNT_TYPE + "=?", arrayOf(oldAccount.name, oldAccount.type))
-            .withValue(RawContacts.ACCOUNT_NAME, newAccount.name)
-            .withValue(RawContacts.ACCOUNT_TYPE, newAccount.type)
+        ab.updateRawContactRows(
+            contentValuesOf(RawContacts.ACCOUNT_NAME to newAccount.name, RawContacts.ACCOUNT_TYPE to newAccount.type),
+            null, null, batch
+        )
         batch.commit()
 
         // update addressBookAccount
@@ -270,9 +266,8 @@ open class LocalAddressBook @AssistedInject constructor(
     }
 
     fun queryContacts(where: String?, whereArgs: Array<String>?): List<LocalContact> = buildList {
-        ab.provider.query(ab.rawContactsSyncUri(), null, where, whereArgs, null)?.use { cursor ->
-            while (cursor.moveToNext())
-                add(LocalContact(this@LocalAddressBook, AndroidContact(ab, cursor.toContentValues())))
+        ab.iterateRawContactRows(null, where, whereArgs) { values ->
+            add(LocalContact(this@LocalAddressBook, AndroidContact(ab, values)))
         }
     }
 

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBookTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBookTest.kt
@@ -231,7 +231,7 @@ class AndroidAddressBookTest {
             )))
             try {
                 val ids = mutableListOf<Long>()
-                addressBook.iterateRawContactRows(null, "${AddressContract.RawContactColumns.UID}=?", arrayOf("row-uid-1")) { values ->
+                addressBook.iterateRawContactRows("${AddressContract.RawContactColumns.UID}=?", arrayOf("row-uid-1")) { values ->
                     ids += values.getAsLong(RawContacts._ID)
                 }
                 assertEquals(listOf(id1), ids)
@@ -259,7 +259,7 @@ class AndroidAddressBookTest {
                 batch.commit()
 
                 val uids = mutableListOf<String>()
-                addressBook.iterateRawContactRows(arrayOf(AddressContract.RawContactColumns.UID)) { values ->
+                addressBook.iterateRawContactRows { values ->
                     uids += values.getAsString(AddressContract.RawContactColumns.UID)
                 }
                 assertEquals(2, uids.count { it == "updated-uid" })
@@ -289,7 +289,7 @@ class AndroidAddressBookTest {
 
                 var uid1: String? = "not-set"
                 var uid2: String? = "not-set"
-                addressBook.iterateRawContactRows(arrayOf(RawContacts._ID, AddressContract.RawContactColumns.UID)) { values ->
+                addressBook.iterateRawContactRows { values ->
                     when (values.getAsLong(RawContacts._ID)) {
                         id1 -> uid1 = values.getAsString(AddressContract.RawContactColumns.UID)
                         id2 -> uid2 = values.getAsString(AddressContract.RawContactColumns.UID)

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBookTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBookTest.kt
@@ -69,15 +69,10 @@ class AndroidAddressBookTest {
     fun testCountContacts_withRawContacts() {
         val addressBook = TestAddressBook.create(provider)
         try {
-            val id1 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Test Contact 1")))
-            val id2 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Test Contact 2")))
-            try {
-                val count = addressBook.countRawContacts(null, null)
-                assertEquals(2, count)
-            } finally {
-                provider.delete(addressBook.rawContactSyncUri(id1), null, null)
-                provider.delete(addressBook.rawContactSyncUri(id2), null, null)
-            }
+            addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Test Contact 1")))
+            addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Test Contact 2")))
+            val count = addressBook.countRawContacts(null, null)
+            assertEquals(2, count)
         } finally {
             TestAddressBook.remove(addressBook)
         }
@@ -87,7 +82,7 @@ class AndroidAddressBookTest {
     fun testCountRawContacts_withFilter() {
         val addressBook = TestAddressBook.create(provider)
         try {
-            val id1 = addressBook.addRawContact(
+            addressBook.addRawContact(
                 Entity(
                     contentValuesOf(
                         RawContacts.DISPLAY_NAME_PRIMARY to "Filter Test 1",
@@ -95,7 +90,7 @@ class AndroidAddressBookTest {
                     )
                 )
             )
-            val id2 = addressBook.addRawContact(
+            addressBook.addRawContact(
                 Entity(
                     contentValuesOf(
                         RawContacts.DISPLAY_NAME_PRIMARY to "Filter Test 2",
@@ -103,16 +98,11 @@ class AndroidAddressBookTest {
                     )
                 )
             )
-            try {
-                val filteredCount = addressBook.countRawContacts("${AddressContract.RawContactColumns.UID}=?", arrayOf("test-uid-1"))
-                assertEquals(1, filteredCount)
+            val filteredCount = addressBook.countRawContacts("${AddressContract.RawContactColumns.UID}=?", arrayOf("test-uid-1"))
+            assertEquals(1, filteredCount)
 
-                val noMatchCount = addressBook.countRawContacts("${AddressContract.RawContactColumns.UID}=?", arrayOf("non-existent"))
-                assertEquals(0, noMatchCount)
-            } finally {
-                provider.delete(addressBook.rawContactSyncUri(id1), null, null)
-                provider.delete(addressBook.rawContactSyncUri(id2), null, null)
-            }
+            val noMatchCount = addressBook.countRawContacts("${AddressContract.RawContactColumns.UID}=?", arrayOf("non-existent"))
+            assertEquals(0, noMatchCount)
         } finally {
             TestAddressBook.remove(addressBook)
         }
@@ -139,16 +129,11 @@ class AndroidAddressBookTest {
         try {
             val id1 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Iterate Contact 1")))
             val id2 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Iterate Contact 2")))
-            try {
-                val ids = mutableListOf<Long>()
-                addressBook.iterateRawContacts { entity ->
-                    ids += entity.entityValues.getAsLong(RawContacts._ID)
-                }
-                assertEquals(setOf(id1, id2), ids.toSet())
-            } finally {
-                provider.delete(addressBook.rawContactSyncUri(id1), null, null)
-                provider.delete(addressBook.rawContactSyncUri(id2), null, null)
+            val ids = mutableListOf<Long>()
+            addressBook.iterateRawContacts { entity ->
+                ids += entity.entityValues.getAsLong(RawContacts._ID)
             }
+            assertEquals(setOf(id1, id2), ids.toSet())
         } finally {
             TestAddressBook.remove(addressBook)
         }
@@ -162,20 +147,17 @@ class AndroidAddressBookTest {
                 RawContacts.DISPLAY_NAME_PRIMARY to "Iterate Filter 1",
                 AddressContract.RawContactColumns.UID to "iter-uid-1"
             )))
-            val id2 = addressBook.addRawContact(Entity(contentValuesOf(
+            addressBook.addRawContact(
+                Entity(
+                    contentValuesOf(
                 RawContacts.DISPLAY_NAME_PRIMARY to "Iterate Filter 2",
                 AddressContract.RawContactColumns.UID to "iter-uid-2"
             )))
-            try {
-                val ids = mutableListOf<Long>()
-                addressBook.iterateRawContacts("${AddressContract.RawContactColumns.UID}=?", arrayOf("iter-uid-1")) { entity ->
-                    ids += entity.entityValues.getAsLong(RawContacts._ID)
-                }
-                assertEquals(listOf(id1), ids)
-            } finally {
-                provider.delete(addressBook.rawContactSyncUri(id1), null, null)
-                provider.delete(addressBook.rawContactSyncUri(id2), null, null)
+            val ids = mutableListOf<Long>()
+            addressBook.iterateRawContacts("${AddressContract.RawContactColumns.UID}=?", arrayOf("iter-uid-1")) { entity ->
+                ids += entity.entityValues.getAsLong(RawContacts._ID)
             }
+            assertEquals(listOf(id1), ids)
         } finally {
             TestAddressBook.remove(addressBook)
         }
@@ -202,16 +184,11 @@ class AndroidAddressBookTest {
         try {
             val id1 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Row Contact 1")))
             val id2 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Row Contact 2")))
-            try {
-                val ids = mutableListOf<Long>()
-                addressBook.iterateRawContactRows { values ->
-                    ids += values.getAsLong(RawContacts._ID)
-                }
-                assertEquals(setOf(id1, id2), ids.toSet())
-            } finally {
-                provider.delete(addressBook.rawContactSyncUri(id1), null, null)
-                provider.delete(addressBook.rawContactSyncUri(id2), null, null)
+            val ids = mutableListOf<Long>()
+            addressBook.iterateRawContactRows { values ->
+                ids += values.getAsLong(RawContacts._ID)
             }
+            assertEquals(setOf(id1, id2), ids.toSet())
         } finally {
             TestAddressBook.remove(addressBook)
         }
@@ -225,20 +202,17 @@ class AndroidAddressBookTest {
                 RawContacts.DISPLAY_NAME_PRIMARY to "Row Filter 1",
                 AddressContract.RawContactColumns.UID to "row-uid-1"
             )))
-            val id2 = addressBook.addRawContact(Entity(contentValuesOf(
+            addressBook.addRawContact(
+                Entity(
+                    contentValuesOf(
                 RawContacts.DISPLAY_NAME_PRIMARY to "Row Filter 2",
                 AddressContract.RawContactColumns.UID to "row-uid-2"
             )))
-            try {
-                val ids = mutableListOf<Long>()
-                addressBook.iterateRawContactRows("${AddressContract.RawContactColumns.UID}=?", arrayOf("row-uid-1")) { values ->
-                    ids += values.getAsLong(RawContacts._ID)
-                }
-                assertEquals(listOf(id1), ids)
-            } finally {
-                provider.delete(addressBook.rawContactSyncUri(id1), null, null)
-                provider.delete(addressBook.rawContactSyncUri(id2), null, null)
+            val ids = mutableListOf<Long>()
+            addressBook.iterateRawContactRows("${AddressContract.RawContactColumns.UID}=?", arrayOf("row-uid-1")) { values ->
+                ids += values.getAsLong(RawContacts._ID)
             }
+            assertEquals(listOf(id1), ids)
         } finally {
             TestAddressBook.remove(addressBook)
         }
@@ -251,22 +225,17 @@ class AndroidAddressBookTest {
     fun testUpdateRawContactRows_all() {
         val addressBook = TestAddressBook.create(provider)
         try {
-            val id1 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Update Contact 1")))
-            val id2 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Update Contact 2")))
-            try {
-                val batch = ContactsBatchOperation(provider)
-                addressBook.updateRawContactRows(contentValuesOf(AddressContract.RawContactColumns.UID to "updated-uid"), null, null, batch)
-                batch.commit()
+            addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Update Contact 1")))
+            addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Update Contact 2")))
+            val batch = ContactsBatchOperation(provider)
+            addressBook.updateRawContactRows(contentValuesOf(AddressContract.RawContactColumns.UID to "updated-uid"), null, null, batch)
+            batch.commit()
 
-                val uids = mutableListOf<String>()
-                addressBook.iterateRawContactRows { values ->
-                    uids += values.getAsString(AddressContract.RawContactColumns.UID)
-                }
-                assertEquals(2, uids.count { it == "updated-uid" })
-            } finally {
-                provider.delete(addressBook.rawContactSyncUri(id1), null, null)
-                provider.delete(addressBook.rawContactSyncUri(id2), null, null)
+            val uids = mutableListOf<String>()
+            addressBook.iterateRawContactRows { values ->
+                uids += values.getAsString(AddressContract.RawContactColumns.UID)
             }
+            assertEquals(2, uids.count { it == "updated-uid" })
         } finally {
             TestAddressBook.remove(addressBook)
         }
@@ -278,29 +247,24 @@ class AndroidAddressBookTest {
         try {
             val id1 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Update Filter 1")))
             val id2 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Update Filter 2")))
-            try {
-                val batch = ContactsBatchOperation(provider)
-                addressBook.updateRawContactRows(
-                    contentValuesOf(AddressContract.RawContactColumns.UID to "only-id1"),
-                    "${RawContacts._ID}=?", arrayOf(id1.toString()),
-                    batch
-                )
-                batch.commit()
+            val batch = ContactsBatchOperation(provider)
+            addressBook.updateRawContactRows(
+                contentValuesOf(AddressContract.RawContactColumns.UID to "only-id1"),
+                "${RawContacts._ID}=?", arrayOf(id1.toString()),
+                batch
+            )
+            batch.commit()
 
-                var uid1: String? = "not-set"
-                var uid2: String? = "not-set"
-                addressBook.iterateRawContactRows { values ->
-                    when (values.getAsLong(RawContacts._ID)) {
-                        id1 -> uid1 = values.getAsString(AddressContract.RawContactColumns.UID)
-                        id2 -> uid2 = values.getAsString(AddressContract.RawContactColumns.UID)
-                    }
+            var uid1: String? = "not-set"
+            var uid2: String? = "not-set"
+            addressBook.iterateRawContactRows { values ->
+                when (values.getAsLong(RawContacts._ID)) {
+                    id1 -> uid1 = values.getAsString(AddressContract.RawContactColumns.UID)
+                    id2 -> uid2 = values.getAsString(AddressContract.RawContactColumns.UID)
                 }
-                assertEquals("only-id1", uid1)
-                assertNull(uid2)
-            } finally {
-                provider.delete(addressBook.rawContactSyncUri(id1), null, null)
-                provider.delete(addressBook.rawContactSyncUri(id2), null, null)
             }
+            assertEquals("only-id1", uid1)
+            assertNull(uid2)
         } finally {
             TestAddressBook.remove(addressBook)
         }
@@ -327,16 +291,11 @@ class AndroidAddressBookTest {
         try {
             val id1 = addressBook.findOrCreateGroup("Iterate Group 1")
             val id2 = addressBook.findOrCreateGroup("Iterate Group 2")
-            try {
-                val ids = mutableListOf<Long>()
-                addressBook.iterateGroups { values ->
-                    ids += values.getAsLong(Groups._ID)
-                }
-                assertEquals(setOf(id1, id2), ids.toSet())
-            } finally {
-                provider.delete(addressBook.groupsSyncUri(), "${Groups._ID}=?", arrayOf(id1.toString()))
-                provider.delete(addressBook.groupsSyncUri(), "${Groups._ID}=?", arrayOf(id2.toString()))
+            val ids = mutableListOf<Long>()
+            addressBook.iterateGroups { values ->
+                ids += values.getAsLong(Groups._ID)
             }
+            assertEquals(setOf(id1, id2), ids.toSet())
         } finally {
             TestAddressBook.remove(addressBook)
         }
@@ -347,17 +306,12 @@ class AndroidAddressBookTest {
         val addressBook = TestAddressBook.create(provider)
         try {
             val id1 = addressBook.findOrCreateGroup("Iterate Filter Group 1")
-            val id2 = addressBook.findOrCreateGroup("Iterate Filter Group 2")
-            try {
-                val ids = mutableListOf<Long>()
-                addressBook.iterateGroups(null, "${Groups._ID}=?", arrayOf(id1.toString())) { values ->
-                    ids += values.getAsLong(Groups._ID)
-                }
-                assertEquals(listOf(id1), ids)
-            } finally {
-                provider.delete(addressBook.groupsSyncUri(), "${Groups._ID}=?", arrayOf(id1.toString()))
-                provider.delete(addressBook.groupsSyncUri(), "${Groups._ID}=?", arrayOf(id2.toString()))
+            addressBook.findOrCreateGroup("Iterate Filter Group 2")
+            val ids = mutableListOf<Long>()
+            addressBook.iterateGroups(null, "${Groups._ID}=?", arrayOf(id1.toString())) { values ->
+                ids += values.getAsLong(Groups._ID)
             }
+            assertEquals(listOf(id1), ids)
         } finally {
             TestAddressBook.remove(addressBook)
         }
@@ -370,23 +324,18 @@ class AndroidAddressBookTest {
     fun testUpdateGroups_all() {
         val addressBook = TestAddressBook.create(provider)
         try {
-            val id1 = addressBook.findOrCreateGroup("Update Group 1")
-            val id2 = addressBook.findOrCreateGroup("Update Group 2")
-            try {
-                val batch = ContactsBatchOperation(provider)
-                addressBook.updateGroups(contentValuesOf(AddressContract.GroupColumns.ETAG to "updated-etag"), null, null, batch)
-                batch.commit()
+            addressBook.findOrCreateGroup("Update Group 1")
+            addressBook.findOrCreateGroup("Update Group 2")
+            val batch = ContactsBatchOperation(provider)
+            addressBook.updateGroups(contentValuesOf(AddressContract.GroupColumns.ETAG to "updated-etag"), null, null, batch)
+            batch.commit()
 
-                var count = 0
-                provider.query(addressBook.groupsSyncUri(), arrayOf(AddressContract.GroupColumns.ETAG), null, null, null)!!.use { cursor ->
-                    while (cursor.moveToNext())
-                        if (cursor.getString(0) == "updated-etag") count++
-                }
-                assertEquals(2, count)
-            } finally {
-                provider.delete(addressBook.groupsSyncUri(), "${Groups._ID}=?", arrayOf(id1.toString()))
-                provider.delete(addressBook.groupsSyncUri(), "${Groups._ID}=?", arrayOf(id2.toString()))
+            var count = 0
+            provider.query(addressBook.groupsSyncUri(), arrayOf(AddressContract.GroupColumns.ETAG), null, null, null)!!.use { cursor ->
+                while (cursor.moveToNext())
+                    if (cursor.getString(0) == "updated-etag") count++
             }
+            assertEquals(2, count)
         } finally {
             TestAddressBook.remove(addressBook)
         }
@@ -398,31 +347,26 @@ class AndroidAddressBookTest {
         try {
             val id1 = addressBook.findOrCreateGroup("Filter Group 1")
             val id2 = addressBook.findOrCreateGroup("Filter Group 2")
-            try {
-                val batch = ContactsBatchOperation(provider)
-                addressBook.updateGroups(
-                    contentValuesOf(AddressContract.GroupColumns.ETAG to "only-group1"),
-                    "${Groups._ID}=?", arrayOf(id1.toString()),
-                    batch
-                )
-                batch.commit()
+            val batch = ContactsBatchOperation(provider)
+            addressBook.updateGroups(
+                contentValuesOf(AddressContract.GroupColumns.ETAG to "only-group1"),
+                "${Groups._ID}=?", arrayOf(id1.toString()),
+                batch
+            )
+            batch.commit()
 
-                var etag1: String? = null
-                var etag2: String? = "not-set"
-                provider.query(addressBook.groupsSyncUri(), arrayOf(Groups._ID, AddressContract.GroupColumns.ETAG), null, null, null)!!.use { cursor ->
-                    while (cursor.moveToNext()) {
-                        when (cursor.getLong(0)) {
-                            id1 -> etag1 = cursor.getString(1)
-                            id2 -> etag2 = cursor.getString(1)
-                        }
+            var etag1: String? = null
+            var etag2: String? = "not-set"
+            provider.query(addressBook.groupsSyncUri(), arrayOf(Groups._ID, AddressContract.GroupColumns.ETAG), null, null, null)!!.use { cursor ->
+                while (cursor.moveToNext()) {
+                    when (cursor.getLong(0)) {
+                        id1 -> etag1 = cursor.getString(1)
+                        id2 -> etag2 = cursor.getString(1)
                     }
                 }
-                assertEquals("only-group1", etag1)
-                assertNull(etag2)
-            } finally {
-                provider.delete(addressBook.groupsSyncUri(), "${Groups._ID}=?", arrayOf(id1.toString()))
-                provider.delete(addressBook.groupsSyncUri(), "${Groups._ID}=?", arrayOf(id2.toString()))
             }
+            assertEquals("only-group1", etag1)
+            assertNull(etag2)
         } finally {
             TestAddressBook.remove(addressBook)
         }
@@ -456,19 +400,14 @@ class AndroidAddressBookTest {
         try {
             val id1 = addressBook.findOrCreateGroup("Delete Filter Group 1")
             val id2 = addressBook.findOrCreateGroup("Delete Filter Group 2")
-            try {
-                val batch = ContactsBatchOperation(provider)
-                addressBook.deleteGroups("${Groups._ID}=?", arrayOf(id1.toString()), batch)
-                batch.commit()
+            val batch = ContactsBatchOperation(provider)
+            addressBook.deleteGroups("${Groups._ID}=?", arrayOf(id1.toString()), batch)
+            batch.commit()
 
-                provider.query(addressBook.groupsSyncUri(), arrayOf(Groups._ID), null, null, null)!!.use { cursor ->
-                    assertEquals(1, cursor.count)
-                    assertTrue(cursor.moveToNext())
-                    assertEquals(id2, cursor.getLong(0))
-                }
-            } finally {
-                provider.delete(addressBook.groupsSyncUri(), "${Groups._ID}=?", arrayOf(id1.toString()))
-                provider.delete(addressBook.groupsSyncUri(), "${Groups._ID}=?", arrayOf(id2.toString()))
+            provider.query(addressBook.groupsSyncUri(), arrayOf(Groups._ID), null, null, null)!!.use { cursor ->
+                assertEquals(1, cursor.count)
+                assertTrue(cursor.moveToNext())
+                assertEquals(id2, cursor.getLong(0))
             }
         } finally {
             TestAddressBook.remove(addressBook)
@@ -482,18 +421,13 @@ class AndroidAddressBookTest {
     fun testDeleteRawContacts_all() {
         val addressBook = TestAddressBook.create(provider)
         try {
-            val id1 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Delete Contact 1")))
-            val id2 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Delete Contact 2")))
-            try {
-                val batch = ContactsBatchOperation(provider)
-                addressBook.deleteRawContacts(null, null, batch)
-                batch.commit()
+            addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Delete Contact 1")))
+            addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Delete Contact 2")))
+            val batch = ContactsBatchOperation(provider)
+            addressBook.deleteRawContacts(null, null, batch)
+            batch.commit()
 
-                assertEquals(0, addressBook.countRawContacts(null, null))
-            } finally {
-                provider.delete(addressBook.rawContactSyncUri(id1), null, null)
-                provider.delete(addressBook.rawContactSyncUri(id2), null, null)
-            }
+            assertEquals(0, addressBook.countRawContacts(null, null))
         } finally {
             TestAddressBook.remove(addressBook)
         }
@@ -504,17 +438,12 @@ class AndroidAddressBookTest {
         val addressBook = TestAddressBook.create(provider)
         try {
             val id1 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Delete Filter 1")))
-            val id2 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Delete Filter 2")))
-            try {
-                val batch = ContactsBatchOperation(provider)
-                addressBook.deleteRawContacts("${RawContacts._ID}=?", arrayOf(id1.toString()), batch)
-                batch.commit()
+            addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Delete Filter 2")))
+            val batch = ContactsBatchOperation(provider)
+            addressBook.deleteRawContacts("${RawContacts._ID}=?", arrayOf(id1.toString()), batch)
+            batch.commit()
 
-                assertEquals(1, addressBook.countRawContacts(null, null))
-            } finally {
-                provider.delete(addressBook.rawContactSyncUri(id1), null, null)
-                provider.delete(addressBook.rawContactSyncUri(id2), null, null)
-            }
+            assertEquals(1, addressBook.countRawContacts(null, null))
         } finally {
             TestAddressBook.remove(addressBook)
         }
@@ -568,29 +497,25 @@ class AndroidAddressBookTest {
         val addressBook = TestAddressBook.create(provider)
         try {
             val rawContactId = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Contact with photo")))
-            try {
-                val photo = TestUtils.resourceToByteArray("/large.jpg")
-                addressBook.setPhoto(rawContactId, photo)
+            val photo = TestUtils.resourceToByteArray("/large.jpg")
+            addressBook.setPhoto(rawContactId, photo)
 
-                // the photo is processed and often resized by the contacts provider
-                val photo2 = addressBook.findContactById(rawContactId).getContact().photo!!
+            // the photo is processed and often resized by the contacts provider
+            val photo2 = addressBook.findContactById(rawContactId).getContact().photo!!
 
-                // verify that the image is in JPEG format (some Samsung devices seem to save as PNG)
-                val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-                BitmapFactory.decodeByteArray(photo2, 0, photo2.size, options)
-                assertEquals("image/jpeg", options.outMimeType)
+            // verify that the image is in JPEG format (some Samsung devices seem to save as PNG)
+            val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+            BitmapFactory.decodeByteArray(photo2, 0, photo2.size, options)
+            assertEquals("image/jpeg", options.outMimeType)
 
-                // verify that contact is not dirty
-                provider.query(
-                    ContentUris.withAppendedId(RawContacts.CONTENT_URI, rawContactId),
-                    arrayOf(RawContacts.DIRTY),
-                    null, null, null
-                )!!.use { cursor ->
-                    assertTrue(cursor.moveToNext())
-                    assertEquals(0, cursor.getInt(0))
-                }
-            } finally {
-                provider.delete(addressBook.rawContactSyncUri(rawContactId), null, null)
+            // verify that contact is not dirty
+            provider.query(
+                ContentUris.withAppendedId(RawContacts.CONTENT_URI, rawContactId),
+                arrayOf(RawContacts.DIRTY),
+                null, null, null
+            )!!.use { cursor ->
+                assertTrue(cursor.moveToNext())
+                assertEquals(0, cursor.getInt(0))
             }
         } finally {
             TestAddressBook.remove(addressBook)
@@ -602,13 +527,9 @@ class AndroidAddressBookTest {
         val addressBook = TestAddressBook.create(provider)
         try {
             val rawContactId = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Contact with invalid photo")))
-            try {
-                addressBook.setPhoto(rawContactId, ByteArray(100) /* invalid photo */)
-                // no exception; photo remains absent
-                assertNull(addressBook.findContactById(rawContactId).getContact().photo)
-            } finally {
-                provider.delete(addressBook.rawContactSyncUri(rawContactId), null, null)
-            }
+            addressBook.setPhoto(rawContactId, ByteArray(100) /* invalid photo */)
+            // no exception; photo remains absent
+            assertNull(addressBook.findContactById(rawContactId).getContact().photo)
         } finally {
             TestAddressBook.remove(addressBook)
         }
@@ -619,26 +540,22 @@ class AndroidAddressBookTest {
         val addressBook = TestAddressBook.create(provider)
         try {
             val rawContactId = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Contact photo delete")))
-            try {
-                // set a valid photo first
-                addressBook.setPhoto(rawContactId, TestUtils.resourceToByteArray("/large.jpg"))
-                assertNotNull(addressBook.findContactById(rawContactId).getContact().photo)
+            // set a valid photo first
+            addressBook.setPhoto(rawContactId, TestUtils.resourceToByteArray("/large.jpg"))
+            assertNotNull(addressBook.findContactById(rawContactId).getContact().photo)
 
-                // now clear it
-                addressBook.setPhoto(rawContactId, null)
-                assertNull(addressBook.findContactById(rawContactId).getContact().photo)
+            // now clear it
+            addressBook.setPhoto(rawContactId, null)
+            assertNull(addressBook.findContactById(rawContactId).getContact().photo)
 
-                // contact must not be dirty
-                provider.query(
-                    ContentUris.withAppendedId(RawContacts.CONTENT_URI, rawContactId),
-                    arrayOf(RawContacts.DIRTY),
-                    null, null, null
-                )!!.use { cursor ->
-                    assertTrue(cursor.moveToNext())
-                    assertEquals(0, cursor.getInt(0))
-                }
-            } finally {
-                provider.delete(addressBook.rawContactSyncUri(rawContactId), null, null)
+            // contact must not be dirty
+            provider.query(
+                ContentUris.withAppendedId(RawContacts.CONTENT_URI, rawContactId),
+                arrayOf(RawContacts.DIRTY),
+                null, null, null
+            )!!.use { cursor ->
+                assertTrue(cursor.moveToNext())
+                assertEquals(0, cursor.getInt(0))
             }
         } finally {
             TestAddressBook.remove(addressBook)
@@ -651,23 +568,19 @@ class AndroidAddressBookTest {
         val addressBook = TestAddressBook.create(provider)
         try {
             val rawContactId = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Read-only photo contact")))
-            try {
-                // Set initial photo so that a photo data row exists.
-                addressBook.setPhoto(rawContactId, TestUtils.resourceToByteArray("/large.jpg"))
-                val photo1 = addressBook.findContactById(rawContactId).getContact().photo
-                assertNotNull("Initial photo should be set", photo1)
+            // Set initial photo so that a photo data row exists.
+            addressBook.setPhoto(rawContactId, TestUtils.resourceToByteArray("/large.jpg"))
+            val photo1 = addressBook.findContactById(rawContactId).getContact().photo
+            assertNotNull("Initial photo should be set", photo1)
 
-                // Mark address book as read-only: stamps IS_READ_ONLY=1 on the photo data row.
-                addressBook.readOnly = true
+            // Mark address book as read-only: stamps IS_READ_ONLY=1 on the photo data row.
+            addressBook.readOnly = true
 
-                // Updating the photo on a read-only contact must still succeed.
-                addressBook.setPhoto(rawContactId, TestUtils.resourceToByteArray("/small.jpg"))
-                val photo2 = addressBook.findContactById(rawContactId).getContact().photo
-                assertNotNull("Photo should still be present after update", photo2)
-                assertFalse("Photo should have been updated despite read-only flag", photo1!!.contentEquals(photo2!!))
-            } finally {
-                provider.delete(addressBook.rawContactSyncUri(rawContactId), null, null)
-            }
+            // Updating the photo on a read-only contact must still succeed.
+            addressBook.setPhoto(rawContactId, TestUtils.resourceToByteArray("/small.jpg"))
+            val photo2 = addressBook.findContactById(rawContactId).getContact().photo
+            assertNotNull("Photo should still be present after update", photo2)
+            assertFalse("Photo should have been updated despite read-only flag", photo1!!.contentEquals(photo2!!))
         } finally {
             TestAddressBook.remove(addressBook)
         }
@@ -698,18 +611,14 @@ class AndroidAddressBookTest {
         try {
             val groupId = addressBook.findOrCreateGroup("Group with member")
             val rawContactId = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Member")))
-            try {
-                val batch = ContactsBatchOperation(provider)
-                addressBook.findContactById(rawContactId).addToGroup(batch, groupId)
-                batch.commit()
+            val batch = ContactsBatchOperation(provider)
+            addressBook.findContactById(rawContactId).addToGroup(batch, groupId)
+            batch.commit()
 
-                addressBook.deleteGroupsWithoutMembers()
+            addressBook.deleteGroupsWithoutMembers()
 
-                provider.query(addressBook.groupsSyncUri(), arrayOf(Groups._ID), null, null, null)!!.use { cursor ->
-                    assertEquals(1, cursor.count)
-                }
-            } finally {
-                provider.delete(addressBook.rawContactSyncUri(rawContactId), null, null)
+            provider.query(addressBook.groupsSyncUri(), arrayOf(Groups._ID), null, null, null)!!.use { cursor ->
+                assertEquals(1, cursor.count)
             }
         } finally {
             TestAddressBook.remove(addressBook)

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBookTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBookTest.kt
@@ -307,6 +307,175 @@ class AndroidAddressBookTest {
     }
 
 
+    // iterateGroups
+
+    @Test
+    fun testIterateGroups_empty() {
+        val addressBook = TestAddressBook.create(provider)
+        try {
+            var count = 0
+            addressBook.iterateGroups { count++ }
+            assertEquals(0, count)
+        } finally {
+            TestAddressBook.remove(addressBook)
+        }
+    }
+
+    @Test
+    fun testIterateGroups_all() {
+        val addressBook = TestAddressBook.create(provider)
+        try {
+            val id1 = addressBook.findOrCreateGroup("Iterate Group 1")
+            val id2 = addressBook.findOrCreateGroup("Iterate Group 2")
+            try {
+                val ids = mutableListOf<Long>()
+                addressBook.iterateGroups { values ->
+                    ids += values.getAsLong(Groups._ID)
+                }
+                assertEquals(setOf(id1, id2), ids.toSet())
+            } finally {
+                provider.delete(addressBook.groupsSyncUri(), "${Groups._ID}=?", arrayOf(id1.toString()))
+                provider.delete(addressBook.groupsSyncUri(), "${Groups._ID}=?", arrayOf(id2.toString()))
+            }
+        } finally {
+            TestAddressBook.remove(addressBook)
+        }
+    }
+
+    @Test
+    fun testIterateGroups_filter() {
+        val addressBook = TestAddressBook.create(provider)
+        try {
+            val id1 = addressBook.findOrCreateGroup("Iterate Filter Group 1")
+            val id2 = addressBook.findOrCreateGroup("Iterate Filter Group 2")
+            try {
+                val ids = mutableListOf<Long>()
+                addressBook.iterateGroups(null, "${Groups._ID}=?", arrayOf(id1.toString())) { values ->
+                    ids += values.getAsLong(Groups._ID)
+                }
+                assertEquals(listOf(id1), ids)
+            } finally {
+                provider.delete(addressBook.groupsSyncUri(), "${Groups._ID}=?", arrayOf(id1.toString()))
+                provider.delete(addressBook.groupsSyncUri(), "${Groups._ID}=?", arrayOf(id2.toString()))
+            }
+        } finally {
+            TestAddressBook.remove(addressBook)
+        }
+    }
+
+
+    // updateGroups
+
+    @Test
+    fun testUpdateGroups_all() {
+        val addressBook = TestAddressBook.create(provider)
+        try {
+            val id1 = addressBook.findOrCreateGroup("Update Group 1")
+            val id2 = addressBook.findOrCreateGroup("Update Group 2")
+            try {
+                val batch = ContactsBatchOperation(provider)
+                addressBook.updateGroups(contentValuesOf(AddressContract.GroupColumns.ETAG to "updated-etag"), null, null, batch)
+                batch.commit()
+
+                var count = 0
+                provider.query(addressBook.groupsSyncUri(), arrayOf(AddressContract.GroupColumns.ETAG), null, null, null)!!.use { cursor ->
+                    while (cursor.moveToNext())
+                        if (cursor.getString(0) == "updated-etag") count++
+                }
+                assertEquals(2, count)
+            } finally {
+                provider.delete(addressBook.groupsSyncUri(), "${Groups._ID}=?", arrayOf(id1.toString()))
+                provider.delete(addressBook.groupsSyncUri(), "${Groups._ID}=?", arrayOf(id2.toString()))
+            }
+        } finally {
+            TestAddressBook.remove(addressBook)
+        }
+    }
+
+    @Test
+    fun testUpdateGroups_filter() {
+        val addressBook = TestAddressBook.create(provider)
+        try {
+            val id1 = addressBook.findOrCreateGroup("Filter Group 1")
+            val id2 = addressBook.findOrCreateGroup("Filter Group 2")
+            try {
+                val batch = ContactsBatchOperation(provider)
+                addressBook.updateGroups(
+                    contentValuesOf(AddressContract.GroupColumns.ETAG to "only-group1"),
+                    "${Groups._ID}=?", arrayOf(id1.toString()),
+                    batch
+                )
+                batch.commit()
+
+                var etag1: String? = null
+                var etag2: String? = "not-set"
+                provider.query(addressBook.groupsSyncUri(), arrayOf(Groups._ID, AddressContract.GroupColumns.ETAG), null, null, null)!!.use { cursor ->
+                    while (cursor.moveToNext()) {
+                        when (cursor.getLong(0)) {
+                            id1 -> etag1 = cursor.getString(1)
+                            id2 -> etag2 = cursor.getString(1)
+                        }
+                    }
+                }
+                assertEquals("only-group1", etag1)
+                assertNull(etag2)
+            } finally {
+                provider.delete(addressBook.groupsSyncUri(), "${Groups._ID}=?", arrayOf(id1.toString()))
+                provider.delete(addressBook.groupsSyncUri(), "${Groups._ID}=?", arrayOf(id2.toString()))
+            }
+        } finally {
+            TestAddressBook.remove(addressBook)
+        }
+    }
+
+
+    // deleteGroups
+
+    @Test
+    fun testDeleteGroups_all() {
+        val addressBook = TestAddressBook.create(provider)
+        try {
+            addressBook.findOrCreateGroup("Delete Group 1")
+            addressBook.findOrCreateGroup("Delete Group 2")
+
+            val batch = ContactsBatchOperation(provider)
+            addressBook.deleteGroups(null, null, batch)
+            batch.commit()
+
+            provider.query(addressBook.groupsSyncUri(), arrayOf(Groups._ID), null, null, null)!!.use { cursor ->
+                assertEquals(0, cursor.count)
+            }
+        } finally {
+            TestAddressBook.remove(addressBook)
+        }
+    }
+
+    @Test
+    fun testDeleteGroups_filter() {
+        val addressBook = TestAddressBook.create(provider)
+        try {
+            val id1 = addressBook.findOrCreateGroup("Delete Filter Group 1")
+            val id2 = addressBook.findOrCreateGroup("Delete Filter Group 2")
+            try {
+                val batch = ContactsBatchOperation(provider)
+                addressBook.deleteGroups("${Groups._ID}=?", arrayOf(id1.toString()), batch)
+                batch.commit()
+
+                provider.query(addressBook.groupsSyncUri(), arrayOf(Groups._ID), null, null, null)!!.use { cursor ->
+                    assertEquals(1, cursor.count)
+                    assertTrue(cursor.moveToNext())
+                    assertEquals(id2, cursor.getLong(0))
+                }
+            } finally {
+                provider.delete(addressBook.groupsSyncUri(), "${Groups._ID}=?", arrayOf(id1.toString()))
+                provider.delete(addressBook.groupsSyncUri(), "${Groups._ID}=?", arrayOf(id2.toString()))
+            }
+        } finally {
+            TestAddressBook.remove(addressBook)
+        }
+    }
+
+
     // deleteRawContacts
 
     @Test

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBookTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBookTest.kt
@@ -119,6 +119,239 @@ class AndroidAddressBookTest {
     }
 
 
+    // iterateRawContacts
+
+    @Test
+    fun testIterateRawContacts_empty() {
+        val addressBook = TestAddressBook.create(provider)
+        try {
+            var count = 0
+            addressBook.iterateRawContacts { count++ }
+            assertEquals(0, count)
+        } finally {
+            TestAddressBook.remove(addressBook)
+        }
+    }
+
+    @Test
+    fun testIterateRawContacts_all() {
+        val addressBook = TestAddressBook.create(provider)
+        try {
+            val id1 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Iterate Contact 1")))
+            val id2 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Iterate Contact 2")))
+            try {
+                val ids = mutableListOf<Long>()
+                addressBook.iterateRawContacts { entity ->
+                    ids += entity.entityValues.getAsLong(RawContacts._ID)
+                }
+                assertEquals(setOf(id1, id2), ids.toSet())
+            } finally {
+                provider.delete(addressBook.rawContactSyncUri(id1), null, null)
+                provider.delete(addressBook.rawContactSyncUri(id2), null, null)
+            }
+        } finally {
+            TestAddressBook.remove(addressBook)
+        }
+    }
+
+    @Test
+    fun testIterateRawContacts_filter() {
+        val addressBook = TestAddressBook.create(provider)
+        try {
+            val id1 = addressBook.addRawContact(Entity(contentValuesOf(
+                RawContacts.DISPLAY_NAME_PRIMARY to "Iterate Filter 1",
+                AddressContract.RawContactColumns.UID to "iter-uid-1"
+            )))
+            val id2 = addressBook.addRawContact(Entity(contentValuesOf(
+                RawContacts.DISPLAY_NAME_PRIMARY to "Iterate Filter 2",
+                AddressContract.RawContactColumns.UID to "iter-uid-2"
+            )))
+            try {
+                val ids = mutableListOf<Long>()
+                addressBook.iterateRawContacts("${AddressContract.RawContactColumns.UID}=?", arrayOf("iter-uid-1")) { entity ->
+                    ids += entity.entityValues.getAsLong(RawContacts._ID)
+                }
+                assertEquals(listOf(id1), ids)
+            } finally {
+                provider.delete(addressBook.rawContactSyncUri(id1), null, null)
+                provider.delete(addressBook.rawContactSyncUri(id2), null, null)
+            }
+        } finally {
+            TestAddressBook.remove(addressBook)
+        }
+    }
+
+
+    // iterateRawContactRows
+
+    @Test
+    fun testIterateRawContactRows_empty() {
+        val addressBook = TestAddressBook.create(provider)
+        try {
+            var count = 0
+            addressBook.iterateRawContactRows { count++ }
+            assertEquals(0, count)
+        } finally {
+            TestAddressBook.remove(addressBook)
+        }
+    }
+
+    @Test
+    fun testIterateRawContactRows_all() {
+        val addressBook = TestAddressBook.create(provider)
+        try {
+            val id1 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Row Contact 1")))
+            val id2 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Row Contact 2")))
+            try {
+                val ids = mutableListOf<Long>()
+                addressBook.iterateRawContactRows { values ->
+                    ids += values.getAsLong(RawContacts._ID)
+                }
+                assertEquals(setOf(id1, id2), ids.toSet())
+            } finally {
+                provider.delete(addressBook.rawContactSyncUri(id1), null, null)
+                provider.delete(addressBook.rawContactSyncUri(id2), null, null)
+            }
+        } finally {
+            TestAddressBook.remove(addressBook)
+        }
+    }
+
+    @Test
+    fun testIterateRawContactRows_filter() {
+        val addressBook = TestAddressBook.create(provider)
+        try {
+            val id1 = addressBook.addRawContact(Entity(contentValuesOf(
+                RawContacts.DISPLAY_NAME_PRIMARY to "Row Filter 1",
+                AddressContract.RawContactColumns.UID to "row-uid-1"
+            )))
+            val id2 = addressBook.addRawContact(Entity(contentValuesOf(
+                RawContacts.DISPLAY_NAME_PRIMARY to "Row Filter 2",
+                AddressContract.RawContactColumns.UID to "row-uid-2"
+            )))
+            try {
+                val ids = mutableListOf<Long>()
+                addressBook.iterateRawContactRows(null, "${AddressContract.RawContactColumns.UID}=?", arrayOf("row-uid-1")) { values ->
+                    ids += values.getAsLong(RawContacts._ID)
+                }
+                assertEquals(listOf(id1), ids)
+            } finally {
+                provider.delete(addressBook.rawContactSyncUri(id1), null, null)
+                provider.delete(addressBook.rawContactSyncUri(id2), null, null)
+            }
+        } finally {
+            TestAddressBook.remove(addressBook)
+        }
+    }
+
+
+    // updateRawContactRows
+
+    @Test
+    fun testUpdateRawContactRows_all() {
+        val addressBook = TestAddressBook.create(provider)
+        try {
+            val id1 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Update Contact 1")))
+            val id2 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Update Contact 2")))
+            try {
+                val batch = ContactsBatchOperation(provider)
+                addressBook.updateRawContactRows(contentValuesOf(AddressContract.RawContactColumns.UID to "updated-uid"), null, null, batch)
+                batch.commit()
+
+                val uids = mutableListOf<String>()
+                addressBook.iterateRawContactRows(arrayOf(AddressContract.RawContactColumns.UID)) { values ->
+                    uids += values.getAsString(AddressContract.RawContactColumns.UID)
+                }
+                assertEquals(2, uids.count { it == "updated-uid" })
+            } finally {
+                provider.delete(addressBook.rawContactSyncUri(id1), null, null)
+                provider.delete(addressBook.rawContactSyncUri(id2), null, null)
+            }
+        } finally {
+            TestAddressBook.remove(addressBook)
+        }
+    }
+
+    @Test
+    fun testUpdateRawContactRows_filter() {
+        val addressBook = TestAddressBook.create(provider)
+        try {
+            val id1 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Update Filter 1")))
+            val id2 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Update Filter 2")))
+            try {
+                val batch = ContactsBatchOperation(provider)
+                addressBook.updateRawContactRows(
+                    contentValuesOf(AddressContract.RawContactColumns.UID to "only-id1"),
+                    "${RawContacts._ID}=?", arrayOf(id1.toString()),
+                    batch
+                )
+                batch.commit()
+
+                var uid1: String? = "not-set"
+                var uid2: String? = "not-set"
+                addressBook.iterateRawContactRows(arrayOf(RawContacts._ID, AddressContract.RawContactColumns.UID)) { values ->
+                    when (values.getAsLong(RawContacts._ID)) {
+                        id1 -> uid1 = values.getAsString(AddressContract.RawContactColumns.UID)
+                        id2 -> uid2 = values.getAsString(AddressContract.RawContactColumns.UID)
+                    }
+                }
+                assertEquals("only-id1", uid1)
+                assertNull(uid2)
+            } finally {
+                provider.delete(addressBook.rawContactSyncUri(id1), null, null)
+                provider.delete(addressBook.rawContactSyncUri(id2), null, null)
+            }
+        } finally {
+            TestAddressBook.remove(addressBook)
+        }
+    }
+
+
+    // deleteRawContacts
+
+    @Test
+    fun testDeleteRawContacts_all() {
+        val addressBook = TestAddressBook.create(provider)
+        try {
+            val id1 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Delete Contact 1")))
+            val id2 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Delete Contact 2")))
+            try {
+                val batch = ContactsBatchOperation(provider)
+                addressBook.deleteRawContacts(null, null, batch)
+                batch.commit()
+
+                assertEquals(0, addressBook.countRawContacts(null, null))
+            } finally {
+                provider.delete(addressBook.rawContactSyncUri(id1), null, null)
+                provider.delete(addressBook.rawContactSyncUri(id2), null, null)
+            }
+        } finally {
+            TestAddressBook.remove(addressBook)
+        }
+    }
+
+    @Test
+    fun testDeleteRawContacts_filter() {
+        val addressBook = TestAddressBook.create(provider)
+        try {
+            val id1 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Delete Filter 1")))
+            val id2 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Delete Filter 2")))
+            try {
+                val batch = ContactsBatchOperation(provider)
+                addressBook.deleteRawContacts("${RawContacts._ID}=?", arrayOf(id1.toString()), batch)
+                batch.commit()
+
+                assertEquals(1, addressBook.countRawContacts(null, null))
+            } finally {
+                provider.delete(addressBook.rawContactSyncUri(id1), null, null)
+                provider.delete(addressBook.rawContactSyncUri(id2), null, null)
+            }
+        } finally {
+            TestAddressBook.remove(addressBook)
+        }
+    }
+
+
     @Test
     fun testSettings() {
         val addressBook = TestAddressBook.create(provider)

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
@@ -43,7 +43,7 @@ import java.util.logging.Logger
  * so changes bypass the dirty-flag and read-only restrictions.
  *
  * @param context            application context (used to obtain the [AccountManager])
- * @param addressBookAccount account whose contacts and groups are managed by this instance
+ * @param addressBookAccount account whose contacts and groups are managed
  * @param provider           content provider client for [ContactsContract]
  */
 class AndroidAddressBook(

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
@@ -158,6 +158,7 @@ class AndroidAddressBook(
      * @return The number of contacts matching the selection criteria.
      */
     fun countRawContacts(where: String?, whereArgs: Array<String>?): Int {
+        // account is implicitly restricted via the URI (asSyncAdapter appends ACCOUNT_NAME/ACCOUNT_TYPE)
         provider.query(
             rawContactsSyncUri(), arrayOf(RawContacts._ID),
             where, whereArgs, null
@@ -179,6 +180,7 @@ class AndroidAddressBook(
      * @throws LocalStorageException on content provider errors
      */
     fun iterateRawContacts(where: String? = null, whereArgs: Array<String>? = null, block: (Entity) -> Unit) {
+        // account is implicitly restricted via the URI (asSyncAdapter appends ACCOUNT_NAME/ACCOUNT_TYPE)
         try {
             provider.query(
                 ContactsContract.RawContactsEntity.CONTENT_URI.asSyncAdapter(addressBookAccount),
@@ -205,6 +207,7 @@ class AndroidAddressBook(
      * @throws LocalStorageException on content provider errors
      */
     fun iterateRawContactRows(projection: Array<String>? = null, where: String? = null, whereArgs: Array<String>? = null, block: (ContentValues) -> Unit) {
+        // account is implicitly restricted via the URI (asSyncAdapter appends ACCOUNT_NAME/ACCOUNT_TYPE)
         try {
             provider.query(rawContactsSyncUri(), projection, where, whereArgs, null)?.use { cursor ->
                 while (cursor.moveToNext())
@@ -226,6 +229,7 @@ class AndroidAddressBook(
      * @param batch     batch operation to enqueue the update into
      */
     fun updateRawContactRows(values: ContentValues, where: String? = null, whereArgs: Array<String>? = null, batch: ContactsBatchOperation) {
+        // account is implicitly restricted via the URI (asSyncAdapter appends ACCOUNT_NAME/ACCOUNT_TYPE)
         val builder = BatchOperation.CpoBuilder
             .newUpdate(rawContactsSyncUri())
             .withValues(values)
@@ -244,6 +248,7 @@ class AndroidAddressBook(
      * @param batch     batch operation to enqueue the deletion into
      */
     fun deleteRawContacts(where: String? = null, whereArgs: Array<String>? = null, batch: ContactsBatchOperation) {
+        // account is implicitly restricted via the URI (asSyncAdapter appends ACCOUNT_NAME/ACCOUNT_TYPE)
         val builder = BatchOperation.CpoBuilder
             .newDelete(rawContactsSyncUri())
         if (where != null)
@@ -284,6 +289,7 @@ class AndroidAddressBook(
      * @throws LocalStorageException on content provider errors
      */
     fun iterateGroups(projection: Array<String>? = null, where: String? = null, whereArgs: Array<String>? = null, block: (ContentValues) -> Unit) {
+        // account is implicitly restricted via the URI (asSyncAdapter appends ACCOUNT_NAME/ACCOUNT_TYPE)
         try {
             provider.query(groupsSyncUri(), projection, where, whereArgs, null)?.use { cursor ->
                 while (cursor.moveToNext())
@@ -305,6 +311,7 @@ class AndroidAddressBook(
      * @param batch     batch operation to enqueue the update into
      */
     fun updateGroups(values: ContentValues, where: String? = null, whereArgs: Array<String>? = null, batch: ContactsBatchOperation) {
+        // account is implicitly restricted via the URI (asSyncAdapter appends ACCOUNT_NAME/ACCOUNT_TYPE)
         val builder = BatchOperation.CpoBuilder
             .newUpdate(groupsSyncUri())
             .withValues(values)
@@ -323,6 +330,7 @@ class AndroidAddressBook(
      * @param batch     batch operation to enqueue the deletion into
      */
     fun deleteGroups(where: String? = null, whereArgs: Array<String>? = null, batch: ContactsBatchOperation) {
+        // account is implicitly restricted via the URI (asSyncAdapter appends ACCOUNT_NAME/ACCOUNT_TYPE)
         val builder = BatchOperation.CpoBuilder
             .newDelete(groupsSyncUri())
         if (where != null)

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
@@ -168,19 +168,87 @@ class AndroidAddressBook(
         return 0
     }
 
+    /**
+     * Iterates raw contacts with their associated data rows (as [Entity]) from this address book.
+     *
+     * This method operates "as sync adapter" and doesn't take the [readOnly] flag into account.
+     *
+     * @param where     optional selection (only applied to raw contact rows, not data rows)
+     * @param whereArgs optional arguments for [where]
+     * @param block     callback invoked for each raw contact entity
+     * @throws LocalStorageException on content provider errors
+     */
     fun iterateRawContacts(where: String? = null, whereArgs: Array<String>? = null, block: (Entity) -> Unit) {
-        // protected where/whereArgs with addressBookAccount
-        TODO("Similar to AndroidCalendar.iterateEvents")
+        try {
+            provider.query(
+                ContactsContract.RawContactsEntity.CONTENT_URI.asSyncAdapter(addressBookAccount),
+                null, where, whereArgs, null
+            )?.use { cursor ->
+                val iterator = RawContacts.newEntityIterator(cursor)
+                for (entity in iterator)
+                    block(entity)
+            }
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't iterate raw contacts", e)
+        }
     }
 
+    /**
+     * Iterates raw contact rows (without associated data rows) from this address book.
+     *
+     * This method operates "as sync adapter" and doesn't take the [readOnly] flag into account.
+     *
+     * @param projection optional column projection
+     * @param where      optional selection
+     * @param whereArgs  optional arguments for [where]
+     * @param block      callback invoked for each raw contact row
+     * @throws LocalStorageException on content provider errors
+     */
+    fun iterateRawContactRows(projection: Array<String>? = null, where: String? = null, whereArgs: Array<String>? = null, block: (ContentValues) -> Unit) {
+        try {
+            provider.query(rawContactsSyncUri(), projection, where, whereArgs, null)?.use { cursor ->
+                while (cursor.moveToNext())
+                    block(cursor.toContentValues())
+            }
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't iterate raw contact rows", e)
+        }
+    }
+
+    /**
+     * Enqueues an update of raw contact rows in this address book to the given batch.
+     *
+     * This method operates "as sync adapter" and doesn't take the [readOnly] flag into account.
+     *
+     * @param values    values to update
+     * @param where     optional selection
+     * @param whereArgs optional arguments for [where]
+     * @param batch     batch operation to enqueue the update into
+     */
     fun updateRawContactRows(values: ContentValues, where: String? = null, whereArgs: Array<String>? = null, batch: ContactsBatchOperation) {
-        // protected where/whereArgs with addressBookAccount
-        TODO("Similar to AndroidCalendar.updateEventRows")
+        val builder = BatchOperation.CpoBuilder
+            .newUpdate(rawContactsSyncUri())
+            .withValues(values)
+        if (where != null)
+            builder.withSelection(where, whereArgs ?: emptyArray())
+        batch += builder
     }
 
+    /**
+     * Enqueues a deletion of raw contacts in this address book to the given batch.
+     *
+     * This method operates "as sync adapter" and doesn't take the [readOnly] flag into account.
+     *
+     * @param where     optional selection
+     * @param whereArgs optional arguments for [where]
+     * @param batch     batch operation to enqueue the deletion into
+     */
     fun deleteRawContacts(where: String? = null, whereArgs: Array<String>? = null, batch: ContactsBatchOperation) {
-        // protected where/whereArgs with addressBookAccount
-        TODO()
+        val builder = BatchOperation.CpoBuilder
+            .newDelete(rawContactsSyncUri())
+        if (where != null)
+            builder.withSelection(where, whereArgs ?: emptyArray())
+        batch += builder
     }
 
     // ContactsContract.Groups CRUD

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
@@ -272,6 +272,64 @@ class AndroidAddressBook(
         return ContentUris.parseId(uri)
     }
 
+    /**
+     * Iterates group rows in this address book.
+     *
+     * This method operates "as sync adapter" and doesn't take the [readOnly] flag into account.
+     *
+     * @param projection optional column projection
+     * @param where      optional selection
+     * @param whereArgs  optional arguments for [where]
+     * @param block      callback invoked for each group row
+     * @throws LocalStorageException on content provider errors
+     */
+    fun iterateGroups(projection: Array<String>? = null, where: String? = null, whereArgs: Array<String>? = null, block: (ContentValues) -> Unit) {
+        try {
+            provider.query(groupsSyncUri(), projection, where, whereArgs, null)?.use { cursor ->
+                while (cursor.moveToNext())
+                    block(cursor.toContentValues())
+            }
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't iterate groups", e)
+        }
+    }
+
+    /**
+     * Enqueues an update of group rows in this address book to the given batch.
+     *
+     * This method operates "as sync adapter" and doesn't take the [readOnly] flag into account.
+     *
+     * @param values    values to update
+     * @param where     optional selection
+     * @param whereArgs optional arguments for [where]
+     * @param batch     batch operation to enqueue the update into
+     */
+    fun updateGroups(values: ContentValues, where: String? = null, whereArgs: Array<String>? = null, batch: ContactsBatchOperation) {
+        val builder = BatchOperation.CpoBuilder
+            .newUpdate(groupsSyncUri())
+            .withValues(values)
+        if (where != null)
+            builder.withSelection(where, whereArgs ?: emptyArray())
+        batch += builder
+    }
+
+    /**
+     * Enqueues a deletion of group rows in this address book to the given batch.
+     *
+     * This method operates "as sync adapter" and doesn't take the [readOnly] flag into account.
+     *
+     * @param where     optional selection
+     * @param whereArgs optional arguments for [where]
+     * @param batch     batch operation to enqueue the deletion into
+     */
+    fun deleteGroups(where: String? = null, whereArgs: Array<String>? = null, batch: ContactsBatchOperation) {
+        val builder = BatchOperation.CpoBuilder
+            .newDelete(groupsSyncUri())
+        if (where != null)
+            builder.withSelection(where, whereArgs ?: emptyArray())
+        batch += builder
+    }
+
     fun deleteGroupsWithoutMembers() {
         queryGroups(null, null).filter { it.getMembers().isEmpty() }.forEach { group ->
             logger.log(Level.FINE, "Deleting empty group", group)
@@ -391,13 +449,10 @@ class AndroidAddressBook(
     }
 
     @VisibleForTesting
-    internal fun queryGroups(where: String?, whereArgs: Array<String>?): List<AndroidGroup> {
-        val groups = LinkedList<AndroidGroup>()
-        provider.query(groupsSyncUri(), null, where, whereArgs, null)?.use { cursor ->
-            while (cursor.moveToNext())
-                groups += AndroidGroup(this, cursor.toContentValues())
+    internal fun queryGroups(where: String?, whereArgs: Array<String>?): List<AndroidGroup> = buildList {
+        iterateGroups(null, where, whereArgs) { values ->
+            add(AndroidGroup(this@AndroidAddressBook, values))
         }
-        return groups
     }
 
     @TestOnly

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
@@ -206,10 +206,10 @@ class AndroidAddressBook(
      * @param block      callback invoked for each raw contact row
      * @throws LocalStorageException on content provider errors
      */
-    fun iterateRawContactRows(projection: Array<String>? = null, where: String? = null, whereArgs: Array<String>? = null, block: (ContentValues) -> Unit) {
+    fun iterateRawContactRows(where: String? = null, whereArgs: Array<String>? = null, block: (ContentValues) -> Unit) {
         // account is implicitly restricted via the URI (asSyncAdapter appends ACCOUNT_NAME/ACCOUNT_TYPE)
         try {
-            provider.query(rawContactsSyncUri(), projection, where, whereArgs, null)?.use { cursor ->
+            provider.query(rawContactsSyncUri(), null, where, whereArgs, null)?.use { cursor ->
                 while (cursor.moveToNext())
                     block(cursor.toContentValues())
             }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
@@ -200,7 +200,6 @@ class AndroidAddressBook(
      *
      * This method operates "as sync adapter" and doesn't take the [readOnly] flag into account.
      *
-     * @param projection optional column projection
      * @param where      optional selection
      * @param whereArgs  optional arguments for [where]
      * @param block      callback invoked for each raw contact row

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
@@ -168,6 +168,21 @@ class AndroidAddressBook(
         return 0
     }
 
+    fun iterateRawContacts(where: String? = null, whereArgs: Array<String>? = null, block: (Entity) -> Unit) {
+        // protected where/whereArgs with addressBookAccount
+        TODO("Similar to AndroidCalendar.iterateEvents")
+    }
+
+    fun updateRawContactRows(values: ContentValues, where: String? = null, whereArgs: Array<String>? = null, batch: ContactsBatchOperation) {
+        // protected where/whereArgs with addressBookAccount
+        TODO("Similar to AndroidCalendar.updateEventRows")
+    }
+
+    fun deleteRawContacts(where: String? = null, whereArgs: Array<String>? = null, batch: ContactsBatchOperation) {
+        // protected where/whereArgs with addressBookAccount
+        TODO()
+    }
+
     // ContactsContract.Groups CRUD
 
     @Throws(FileNotFoundException::class)

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
@@ -35,6 +35,17 @@ import java.util.LinkedList
 import java.util.logging.Level
 import java.util.logging.Logger
 
+/**
+ * Represents an Android address book backed by the contacts content provider for a given
+ * [addressBookAccount] (operations are restricted to that account).
+ *
+ * Provides CRUD operations for raw contacts and groups, always operating "as sync adapter"
+ * so changes bypass the dirty-flag and read-only restrictions.
+ *
+ * @param context            application context (used to obtain the [AccountManager])
+ * @param addressBookAccount account whose contacts and groups are managed by this instance
+ * @param provider           content provider client for [ContactsContract]
+ */
 class AndroidAddressBook(
     private val context: Context,
     var addressBookAccount: Account,
@@ -108,12 +119,12 @@ class AndroidAddressBook(
         get() = ContactsContract.SyncState.get(provider, addressBookAccount)
         set(data) = ContactsContract.SyncState.set(provider, addressBookAccount, data)
 
-    // ContactsContract.RawContacts CRUD
+    // region ContactsContract.RawContacts CRUD
 
     /**
      * Adds a raw contact and its associated data to the address book.
      *
-     * This method operates "as sync adapter" and doesn't take the [readOnly] flag into account.
+     * This method operates "as sync adapter" on [addressBookAccount] and doesn't take the [readOnly] flag into account.
      *
      * @param rawContact The raw contact entity to add, containing main values and sub-values.
      * @return The ID of the newly created raw contact.
@@ -153,6 +164,8 @@ class AndroidAddressBook(
     /**
      * Counts the number of contacts in the address book that match the given selection criteria.
      *
+     * This method operates "as sync adapter" on [addressBookAccount] and doesn't take the [readOnly] flag into account.
+     *
      * @param where An optional filter declaring which rows to return.
      * @param whereArgs Optional arguments for [where].
      * @return The number of contacts matching the selection criteria.
@@ -172,7 +185,7 @@ class AndroidAddressBook(
     /**
      * Iterates raw contacts with their associated data rows (as [Entity]) from this address book.
      *
-     * This method operates "as sync adapter" and doesn't take the [readOnly] flag into account.
+     * This method operates "as sync adapter" on [addressBookAccount] and doesn't take the [readOnly] flag into account.
      *
      * @param where     optional selection (only applied to raw contact rows, not data rows)
      * @param whereArgs optional arguments for [where]
@@ -198,7 +211,7 @@ class AndroidAddressBook(
     /**
      * Iterates raw contact rows (without associated data rows) from this address book.
      *
-     * This method operates "as sync adapter" and doesn't take the [readOnly] flag into account.
+     * This method operates "as sync adapter" on [addressBookAccount] and doesn't take the [readOnly] flag into account.
      *
      * @param where      optional selection
      * @param whereArgs  optional arguments for [where]
@@ -220,7 +233,7 @@ class AndroidAddressBook(
     /**
      * Enqueues an update of raw contact rows in this address book to the given batch.
      *
-     * This method operates "as sync adapter" and doesn't take the [readOnly] flag into account.
+     * This method operates "as sync adapter" on [addressBookAccount] and doesn't take the [readOnly] flag into account.
      *
      * @param values    values to update
      * @param where     optional selection
@@ -240,7 +253,7 @@ class AndroidAddressBook(
     /**
      * Enqueues a deletion of raw contacts in this address book to the given batch.
      *
-     * This method operates "as sync adapter" and doesn't take the [readOnly] flag into account.
+     * This method operates "as sync adapter" on [addressBookAccount] and doesn't take the [readOnly] flag into account.
      *
      * @param where     optional selection
      * @param whereArgs optional arguments for [where]
@@ -255,7 +268,9 @@ class AndroidAddressBook(
         batch += builder
     }
 
-    // ContactsContract.Groups CRUD
+    // endregion
+
+    // region ContactsContract.Groups CRUD
 
     @Throws(FileNotFoundException::class)
     fun findGroupById(id: Long) =
@@ -279,7 +294,7 @@ class AndroidAddressBook(
     /**
      * Iterates group rows in this address book.
      *
-     * This method operates "as sync adapter" and doesn't take the [readOnly] flag into account.
+     * This method operates "as sync adapter" on [addressBookAccount] and doesn't take the [readOnly] flag into account.
      *
      * @param projection optional column projection
      * @param where      optional selection
@@ -302,7 +317,7 @@ class AndroidAddressBook(
     /**
      * Enqueues an update of group rows in this address book to the given batch.
      *
-     * This method operates "as sync adapter" and doesn't take the [readOnly] flag into account.
+     * This method operates "as sync adapter" on [addressBookAccount] and doesn't take the [readOnly] flag into account.
      *
      * @param values    values to update
      * @param where     optional selection
@@ -322,7 +337,7 @@ class AndroidAddressBook(
     /**
      * Enqueues a deletion of group rows in this address book to the given batch.
      *
-     * This method operates "as sync adapter" and doesn't take the [readOnly] flag into account.
+     * This method operates "as sync adapter" on [addressBookAccount] and doesn't take the [readOnly] flag into account.
      *
      * @param where     optional selection
      * @param whereArgs optional arguments for [where]
@@ -344,7 +359,9 @@ class AndroidAddressBook(
         }
     }
 
-    // high-res photo access
+    // endregion
+
+    // region high-res photo access
 
     /**
      * Sets or clears the photo for a raw contact.
@@ -440,7 +457,9 @@ class AndroidAddressBook(
         return null
     }
 
-    // legacy AndroidContact/AndroidGroup CRUD
+    // endregion
+
+    // region legacy AndroidContact/AndroidGroup CRUD
 
     @Deprecated("Use iterateRawContacts instead")
     fun queryContacts(where: String?, whereArgs: Array<String>?): List<AndroidContact> {
@@ -467,12 +486,15 @@ class AndroidAddressBook(
     fun findContactById(id: Long) =
         queryContacts("${RawContacts._ID}=?", arrayOf(id.toString())).firstOrNull() ?: throw FileNotFoundException()
 
+    // endregion
 
-    // helpers
+    // region helpers
 
     fun rawContactSyncUri(id: Long) = ContentUris.withAppendedId(RawContacts.CONTENT_URI, id).asSyncAdapter(addressBookAccount)
     fun rawContactsSyncUri() = RawContacts.CONTENT_URI.asSyncAdapter(addressBookAccount)
     fun groupsSyncUri() = Groups.CONTENT_URI.asSyncAdapter(addressBookAccount)
+
+    // endregion
 
 
     companion object {


### PR DESCRIPTION
### Purpose

Adds raw contact and group CRUD methods to `AndroidAddressBook` as part of the contacts storage rewrite (#2513).

### Short description

- Added `addRawContact`, `countRawContacts`, `iterateRawContacts`, `iterateRawContactRows`, `updateRawContactRows`, `deleteRawContacts` to `AndroidAddressBook`
- Added `iterateGroups`, `updateGroups`, `deleteGroups` to `AndroidAddressBook`
- Refactored `LocalAddressBook` to use the new methods instead of direct provider calls where already possible
- Added instrumented tests for all new methods

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have self-reviewed the PR.
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.