### PR TITLE
[jtx rewrite] Add `AttachmentsHandler`

### DIFF
--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxCollectionTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxCollectionTest.kt
@@ -6,8 +6,10 @@ package at.bitfire.synctools.storage.jtx
 
 import android.accounts.Account
 import android.content.ContentProviderClient
+import android.content.ContentUris
 import android.content.ContentValues
 import android.content.Entity
+import android.os.ParcelFileDescriptor
 import androidx.core.content.contentValuesOf
 import androidx.core.net.toUri
 import androidx.test.platform.app.InstrumentationRegistry
@@ -125,10 +127,7 @@ class JtxCollectionTest {
         val attachmentSubValue = jtxObject.subValues.first { it.uri.equals(JtxContract.JtxAttachment.CONTENT_URI) }
         val uri = attachmentSubValue.values.getAsString(JtxContract.JtxAttachment.URI).toUri()
         assertEquals("content", uri.scheme)
-        val context = InstrumentationRegistry.getInstrumentation().targetContext
-        val attachmentData = context.contentResolver.openInputStream(uri)!!.use { inputStream ->
-            inputStream.readBytes().decodeToString()
-        }
+        val attachmentData = fetchAttachmentData(attachmentSubValue)
         assertEquals("Hello, world!", attachmentData)
     }
 
@@ -182,14 +181,11 @@ class JtxCollectionTest {
 
         val id = collection.addJtxObjects(listOf(jtxEntityOne, jtxEntityTwo))
 
-        val context = InstrumentationRegistry.getInstrumentation().targetContext
         val jtxObjectOne = collection.getJtxObject(id)!!
         val attachmentOne = jtxObjectOne.subValues.first { it.uri.equals(JtxContract.JtxAttachment.CONTENT_URI) }
         val uriOne = attachmentOne.values.getAsString(JtxContract.JtxAttachment.URI).toUri()
         assertEquals("content", uriOne.scheme)
-        val attachmentDataOne = context.contentResolver.openInputStream(uriOne)!!.use { inputStream ->
-            inputStream.readBytes().decodeToString()
-        }
+        val attachmentDataOne = fetchAttachmentData(attachmentOne)
         assertEquals("ONE", attachmentDataOne)
         val jtxObjectTwo = collection.findJtxObject(
             where = "${JtxContract.JtxICalObject.SUMMARY} = ?",
@@ -198,9 +194,7 @@ class JtxCollectionTest {
         val attachmentTwo = jtxObjectTwo.subValues.first { it.uri.equals(JtxContract.JtxAttachment.CONTENT_URI) }
         val uriTwo = attachmentTwo.values.getAsString(JtxContract.JtxAttachment.URI).toUri()
         assertEquals("content", uriTwo.scheme)
-        val attachmentDataTwo = context.contentResolver.openInputStream(uriTwo)!!.use { inputStream ->
-            inputStream.readBytes().decodeToString()
-        }
+        val attachmentDataTwo = fetchAttachmentData(attachmentTwo)
         assertEquals("TWO", attachmentDataTwo)
     }
 
@@ -468,4 +462,17 @@ class JtxCollectionTest {
         }
     }
 
+
+    private fun fetchAttachmentData(attachmentSubValue: Entity.NamedContentValues): String {
+        val attachmentUri = ContentUris.withAppendedId(
+            JtxContract.JtxAttachment.CONTENT_URI.asSyncAdapter(collection.account),
+            attachmentSubValue.values.getAsLong(JtxContract.JtxAttachment.ID)
+        )
+
+        return collection.client.openFile(attachmentUri, "r")!!.let { parcelFileDescriptor ->
+            ParcelFileDescriptor.AutoCloseInputStream(parcelFileDescriptor).use { inputStream ->
+                inputStream.readBytes().decodeToString()
+            }
+        }
+    }
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/AttachmentsBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/AttachmentsBuilder.kt
@@ -17,10 +17,10 @@ import java.nio.ByteBuffer
 import kotlin.jvm.optionals.getOrNull
 
 // used for filename in KOrganizer
-private const val X_PARAM_ATTACH_LABEL = "X-LABEL"
+internal const val X_PARAM_ATTACH_LABEL = "X-LABEL"
 
 // used for filename in GNOME Evolution
-private const val X_PARAM_FILENAME = "FILENAME"
+internal const val X_PARAM_FILENAME = "FILENAME"
 
 class AttachmentsBuilder : JtxObjectBinaryDataRowBuilder {
     override fun build(from: CalendarComponent): List<BinaryDataRow> {

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/AndroidAttachmentFetcher.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/AndroidAttachmentFetcher.kt
@@ -4,15 +4,38 @@
 
 package at.bitfire.synctools.mapping.jtx.handler
 
-import android.content.ContentResolver
-import androidx.core.net.toUri
+import android.accounts.Account
+import android.content.ContentProviderClient
+import android.content.ContentUris
+import android.os.ParcelFileDescriptor
+import at.techbee.jtx.JtxContract
+import at.techbee.jtx.JtxContract.asSyncAdapter
+import java.util.logging.Level
+import java.util.logging.Logger
 
 class AndroidAttachmentFetcher(
-    private val contentResolver: ContentResolver
+    private val client: ContentProviderClient,
+    private val account: Account
 ) : AttachmentFetcher {
-    override fun getAttachmentData(uri: String): ByteArray? {
-        return contentResolver.openInputStream(uri.toUri())?.use { inputStream ->
-            inputStream.readBytes()
+
+    private val logger
+        get() = Logger.getLogger(javaClass.name)
+
+    override fun getAttachmentData(attachmentId: Long): ByteArray? {
+        return try {
+            val uri = ContentUris.withAppendedId(
+                JtxContract.JtxAttachment.CONTENT_URI.asSyncAdapter(account),
+                attachmentId
+            )
+
+            client.openFile(uri, "r")?.let { parcelFileDescriptor ->
+                ParcelFileDescriptor.AutoCloseInputStream(parcelFileDescriptor).use { inputSteam ->
+                    inputSteam.readBytes()
+                }
+            }
+        } catch (e: Exception) {
+            logger.log(Level.WARNING, "Error fetching attachment data: $attachmentId", e)
+            null
         }
     }
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/AndroidAttachmentFetcher.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/AndroidAttachmentFetcher.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.synctools.mapping.jtx.handler
+
+import android.content.ContentResolver
+import androidx.core.net.toUri
+
+class AndroidAttachmentFetcher(
+    private val contentResolver: ContentResolver
+) : AttachmentFetcher {
+    override fun getAttachmentData(uri: String): ByteArray? {
+        return contentResolver.openInputStream(uri.toUri())?.use { inputStream ->
+            inputStream.readBytes()
+        }
+    }
+}

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/AttachmentFetcher.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/AttachmentFetcher.kt
@@ -1,0 +1,9 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.synctools.mapping.jtx.handler
+
+interface AttachmentFetcher {
+    fun getAttachmentData(uri: String): ByteArray?
+}

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/AttachmentFetcher.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/AttachmentFetcher.kt
@@ -5,5 +5,5 @@
 package at.bitfire.synctools.mapping.jtx.handler
 
 interface AttachmentFetcher {
-    fun getAttachmentData(uri: String): ByteArray?
+    fun getAttachmentData(attachmentId: Long): ByteArray?
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/AttachmentsHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/AttachmentsHandler.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.synctools.mapping.jtx.handler
+
+import android.content.Entity
+import at.bitfire.synctools.icalendar.plusAssign
+import at.bitfire.synctools.mapping.jtx.builder.X_PARAM_ATTACH_LABEL
+import at.bitfire.synctools.mapping.jtx.builder.X_PARAM_FILENAME
+import at.techbee.jtx.JtxContract
+import net.fortuna.ical4j.model.component.CalendarComponent
+import net.fortuna.ical4j.model.parameter.FmtType
+import net.fortuna.ical4j.model.parameter.XParameter
+import net.fortuna.ical4j.model.property.Attach
+import java.net.URI
+import java.nio.ByteBuffer
+import java.util.logging.Level
+import java.util.logging.Logger
+
+class AttachmentsHandler(
+    private val attachmentFetcher: AttachmentFetcher
+) : JtxObjectEntityHandler {
+
+    private val logger
+        get() = Logger.getLogger(javaClass.name)
+
+    override fun process(from: Entity, main: Entity, to: CalendarComponent) {
+        val attachments = from.subValues.filter { it.uri == JtxContract.JtxAttachment.CONTENT_URI }
+
+        for (attachmentValues in attachments) {
+            buildAttachProperty(attachmentValues, to)
+        }
+    }
+
+    private fun buildAttachProperty(attachmentValues: Entity.NamedContentValues, to: CalendarComponent) {
+        val uriString = attachmentValues.values.getAsString(JtxContract.JtxAttachment.URI) ?: return
+
+        val attach = if (uriString.startsWith("content://")) {
+            val binaryData = attachmentFetcher.getAttachmentData(uriString)?.let { ByteBuffer.wrap(it) }
+            if (binaryData == null) {
+                logger.warning("Failed to read attachment data from URI: $uriString")
+                return
+            }
+
+            Attach(binaryData)
+        } else {
+            val uri = try {
+                URI.create(uriString)
+            } catch (e: Exception) {
+                logger.log(Level.WARNING, "Ignoring invalid attachment URI: $uriString", e)
+                return
+            }
+
+            Attach(uri)
+        }
+
+        attachmentValues.values.getAsString(JtxContract.JtxAttachment.FMTTYPE)?.let { fmtType ->
+            attach += FmtType(fmtType)
+        }
+
+        attachmentValues.values.getAsString(JtxContract.JtxAttachment.FILENAME)?.let { filename ->
+            attach += XParameter(X_PARAM_FILENAME, filename)
+            attach += XParameter(X_PARAM_ATTACH_LABEL, filename)
+        }
+
+        attachmentValues.values.getAsString(JtxContract.JtxAttachment.OTHER)?.let { other ->
+            val otherParameters = JtxContract.getXParametersFromJson(other)
+            for (parameter in otherParameters) {
+                attach += parameter
+            }
+        }
+
+        to += attach
+    }
+}

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/AttachmentsHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/AttachmentsHandler.kt
@@ -37,11 +37,8 @@ class AttachmentsHandler(
         val uriString = attachmentValues.values.getAsString(JtxContract.JtxAttachment.URI) ?: return
 
         val attach = if (uriString.startsWith("content://")) {
-            val binaryData = attachmentFetcher.getAttachmentData(uriString)?.let { ByteBuffer.wrap(it) }
-            if (binaryData == null) {
-                logger.warning("Failed to read attachment data from URI: $uriString")
-                return
-            }
+            val attachmentId = attachmentValues.values.getAsLong(JtxContract.JtxAttachment.ID)
+            val binaryData = attachmentFetcher.getAttachmentData(attachmentId)?.let { ByteBuffer.wrap(it) } ?: return
 
             Attach(binaryData)
         } else {

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/handler/AttachmentsHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/handler/AttachmentsHandlerTest.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.synctools.mapping.jtx.handler
+
+import android.content.ContentValues
+import android.content.Entity
+import androidx.core.content.contentValuesOf
+import at.bitfire.parameterListOf
+import at.techbee.jtx.JtxContract
+import net.fortuna.ical4j.model.Property
+import net.fortuna.ical4j.model.component.VToDo
+import net.fortuna.ical4j.model.parameter.FmtType
+import net.fortuna.ical4j.model.parameter.XParameter
+import net.fortuna.ical4j.model.property.Attach
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.net.URI
+
+@RunWith(RobolectricTestRunner::class)
+class AttachmentsHandlerTest {
+
+    private val attachmentFetcher = FakeAttachmentFetcher()
+    private val handler = AttachmentsHandler(attachmentFetcher)
+
+    @Test
+    fun `no attachment sub-values`() {
+        val input = Entity(ContentValues())
+        val output = VToDo()
+
+        handler.process(from = input, main = input, to = output)
+
+        assertEquals(0, output.getProperties<Attach>(Property.ATTACH).size)
+    }
+
+    @Test
+    fun `URI attachment`() {
+        val input = Entity(ContentValues()).apply {
+            addSubValue(
+                JtxContract.JtxAttachment.CONTENT_URI, contentValuesOf(
+                    JtxContract.JtxAttachment.URI to "https://domain.example/file.txt",
+                    JtxContract.JtxAttachment.FMTTYPE to "text/plain",
+                    JtxContract.JtxAttachment.FILENAME to "file.txt",
+                    JtxContract.JtxAttachment.OTHER to """{"key":"value"}"""
+                )
+            )
+        }
+        val output = VToDo()
+
+        handler.process(from = input, main = input, to = output)
+
+        assertEquals(
+            Attach(
+                parameterListOf(
+                    FmtType("text/plain"),
+                    XParameter("FILENAME", "file.txt"),
+                    XParameter("X-LABEL", "file.txt"),
+                    XParameter("key", "value")
+                ),
+                URI.create("https://domain.example/file.txt")
+            ),
+            output.getRequiredProperty<Attach>(Property.ATTACH)
+        )
+    }
+
+    @Test
+    fun `binary attachment`() {
+        attachmentFetcher.attachmentData = "Binary attachment data".toByteArray()
+        val input = Entity(ContentValues()).apply {
+            addSubValue(
+                JtxContract.JtxAttachment.CONTENT_URI, contentValuesOf(
+                    JtxContract.JtxAttachment.URI to "content://fakedata",
+                    JtxContract.JtxAttachment.FMTTYPE to "text/plain",
+                    JtxContract.JtxAttachment.FILENAME to "file.txt"
+                )
+            )
+        }
+        val output = VToDo()
+
+        handler.process(from = input, main = input, to = output)
+
+        assertEquals(
+            "ATTACH;ENCODING=BASE64;VALUE=BINARY;FMTTYPE=text/plain;FILENAME=file.txt;X-LABEL=file.txt:" +
+                    "QmluYXJ5IGF0dGFjaG1lbnQgZGF0YQ==\r\n",
+            output.getRequiredProperty<Attach>(Property.ATTACH).toString()
+        )
+        assertEquals("content://fakedata", attachmentFetcher.lastUri)
+    }
+
+    @Test
+    fun `binary attachment that can't be fetched should be skipped`() {
+        attachmentFetcher.attachmentData = null
+        val input = Entity(ContentValues()).apply {
+            addSubValue(
+                JtxContract.JtxAttachment.CONTENT_URI,
+                contentValuesOf(
+                    JtxContract.JtxAttachment.URI to "content://fakedata/failing"
+                )
+            )
+        }
+        val output = VToDo()
+
+        handler.process(from = input, main = input, to = output)
+
+        assertEquals(0, output.getProperties<Attach>(Property.ATTACH).size)
+        assertEquals("content://fakedata/failing", attachmentFetcher.lastUri)
+    }
+
+    @Test
+    fun `attachment with invalid URI should be skipped`() {
+        val input = Entity(ContentValues()).apply {
+            addSubValue(
+                JtxContract.JtxAttachment.CONTENT_URI,
+                contentValuesOf(
+                    JtxContract.JtxAttachment.URI to "invalid uri"
+                )
+            )
+        }
+        val output = VToDo()
+
+        handler.process(from = input, main = input, to = output)
+
+        assertEquals(0, output.getProperties<Attach>(Property.ATTACH).size)
+    }
+}
+
+private class FakeAttachmentFetcher : AttachmentFetcher {
+    var lastUri: String? = null
+        private set
+
+    var attachmentData: ByteArray? = null
+
+    override fun getAttachmentData(uri: String): ByteArray? {
+        lastUri = uri
+        return attachmentData
+    }
+}

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/handler/AttachmentsHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/handler/AttachmentsHandlerTest.kt
@@ -72,6 +72,7 @@ class AttachmentsHandlerTest {
         val input = Entity(ContentValues()).apply {
             addSubValue(
                 JtxContract.JtxAttachment.CONTENT_URI, contentValuesOf(
+                    JtxContract.JtxAttachment.ID to 2L,
                     JtxContract.JtxAttachment.URI to "content://fakedata",
                     JtxContract.JtxAttachment.FMTTYPE to "text/plain",
                     JtxContract.JtxAttachment.FILENAME to "file.txt"
@@ -87,7 +88,7 @@ class AttachmentsHandlerTest {
                     "QmluYXJ5IGF0dGFjaG1lbnQgZGF0YQ==\r\n",
             output.getRequiredProperty<Attach>(Property.ATTACH).toString()
         )
-        assertEquals("content://fakedata", attachmentFetcher.lastUri)
+        assertEquals(2L, attachmentFetcher.lastAttachmentId)
     }
 
     @Test
@@ -97,6 +98,7 @@ class AttachmentsHandlerTest {
             addSubValue(
                 JtxContract.JtxAttachment.CONTENT_URI,
                 contentValuesOf(
+                    JtxContract.JtxAttachment.ID to 42L,
                     JtxContract.JtxAttachment.URI to "content://fakedata/failing"
                 )
             )
@@ -106,7 +108,7 @@ class AttachmentsHandlerTest {
         handler.process(from = input, main = input, to = output)
 
         assertEquals(0, output.getProperties<Attach>(Property.ATTACH).size)
-        assertEquals("content://fakedata/failing", attachmentFetcher.lastUri)
+        assertEquals(42L, attachmentFetcher.lastAttachmentId)
     }
 
     @Test
@@ -128,13 +130,13 @@ class AttachmentsHandlerTest {
 }
 
 private class FakeAttachmentFetcher : AttachmentFetcher {
-    var lastUri: String? = null
+    var lastAttachmentId: Long? = null
         private set
 
     var attachmentData: ByteArray? = null
 
-    override fun getAttachmentData(uri: String): ByteArray? {
-        lastUri = uri
+    override fun getAttachmentData(attachmentId: Long): ByteArray? {
+        lastAttachmentId = attachmentId
         return attachmentData
     }
 }


### PR DESCRIPTION
Adds `AttachmentsHandler` to create `ATTACH` properties.

The `AttachmentFetcher` interface is used when needing to fetch attachment data stored in a content provider.