### PR TITLE
[Sync] Don't keep all dirty/deleted entries in memory at once

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalGroupTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalGroupTest.kt
@@ -144,9 +144,9 @@ class LocalGroupTest {
             contact1.androidContact.addToGroup(batch, group.id!!)
             batch.commit()
 
-            assertEquals(0, localAddressBook.findDirty().size)
+            assertEquals(0, localAddressBook.findDirtyContacts().size)
             group.markMembersDirty()
-            assertEquals(contact1.id, localAddressBook.findDirty().first().id)
+            assertEquals(contact1.id, localAddressBook.findDirtyContacts().first().id)
         }
     }
 

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/LocalTestCollection.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/LocalTestCollection.kt
@@ -6,6 +6,7 @@ package at.bitfire.davdroid.sync
 
 import at.bitfire.davdroid.resource.LocalCollection
 import at.bitfire.davdroid.resource.SyncState
+import kotlinx.coroutines.flow.asFlow
 
 class LocalTestCollection(
     override val dbCollectionId: Long = 0L
@@ -21,14 +22,14 @@ class LocalTestCollection(
     override val readOnly: Boolean
         get() = throw NotImplementedError()
 
-    override fun findDeleted() = entries.filter { it.deleted }
-    override fun findDirty() = entries.filter { it.dirty }
+    override fun iterateDeleted() = entries.filter { it.deleted }.asFlow()
+    override fun iterateDirty() = entries.filter { it.dirty }.asFlow()
 
     override fun findByName(name: String) = entries.firstOrNull { it.fileName == name }
 
     override fun markNotDirty(flags: Int): Int {
         var updated = 0
-        for (dirty in findDirty()) {
+        for (dirty in entries.filter { it.dirty }) {
             dirty.flags = flags
             updated++
         }

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -36,6 +36,8 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import java.io.FileNotFoundException
 import java.util.Optional
 import java.util.logging.Logger
@@ -225,11 +227,13 @@ open class LocalAddressBook @AssistedInject constructor(
      * Returns an array of local contacts/groups which have been deleted locally. (DELETED != 0).
      * @throws RemoteException on content provider errors
      */
-    override fun findDeleted() =
+    override fun iterateDeleted(): Flow<LocalAddress> = flow {
+        for (contact in findDeletedContacts())
+            emit(contact)
         if (includeGroups)
-            findDeletedContacts() + findDeletedGroups()
-        else
-            findDeletedContacts()
+            for (group in findDeletedGroups())
+                emit(group)
+    }
 
     fun findDeletedContacts() = queryContacts(RawContacts.DELETED, null)
     fun findDeletedGroups() = queryGroups(Groups.DELETED, null)
@@ -238,11 +242,13 @@ open class LocalAddressBook @AssistedInject constructor(
      * Returns an array of local contacts/groups which have been changed locally (DIRTY != 0).
      * @throws RemoteException on content provider errors
      */
-    override fun findDirty() =
+    override fun iterateDirty(): Flow<LocalAddress> = flow {
         if (includeGroups)
-            findDirtyContacts() + findDirtyGroups()
-        else
-            findDirtyContacts()
+            for (group in findDirtyGroups())
+                emit(group)
+        for (contact in findDirtyContacts())
+            emit(contact)
+    }
 
     fun findDirtyContacts() = queryContacts(RawContacts.DIRTY, null)
     fun findDirtyGroups() = queryGroups(Groups.DIRTY, null)

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
@@ -17,6 +17,9 @@ import at.bitfire.synctools.storage.calendar.EventsContract
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 
 /**
  * Application-specific subclass of [AndroidCalendar] for local calendars.
@@ -72,16 +75,18 @@ class LocalCalendar @AssistedInject constructor(
     override fun countModified(): Int =
         androidCalendar.countEvents("${Events.DIRTY} AND NOT ${Events.DELETED}", null)
 
-    override fun findDeleted(): List<LocalEvent> = buildList {
+    override fun iterateDeleted(): Flow<LocalEvent> = callbackFlow {
         recurringCalendar.iterateEventAndExceptions(Events.DELETED, null) { eventAndExceptions ->
-            add(LocalEvent(recurringCalendar, eventAndExceptions))
+            trySendBlocking(LocalEvent(recurringCalendar, eventAndExceptions))
         }
+        close()
     }
 
-    override fun findDirty(): List<LocalEvent> = buildList {
+    override fun iterateDirty(): Flow<LocalEvent> = callbackFlow {
         recurringCalendar.iterateEventAndExceptions(Events.DIRTY, null) { eventAndExceptions ->
-            add(LocalEvent(recurringCalendar, eventAndExceptions))
+            trySendBlocking(LocalEvent(recurringCalendar, eventAndExceptions))
         }
+        close()
     }
 
     override fun findByName(name: String) =

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCollection.kt
@@ -4,6 +4,8 @@
 
 package at.bitfire.davdroid.resource
 
+import kotlinx.coroutines.flow.Flow
+
 /**
  * This is an interface between the Syncer/SyncManager and a collection in the local storage.
  *
@@ -29,20 +31,20 @@ interface LocalCollection<out T: LocalResource> {
     val readOnly: Boolean
 
     /**
-     * Finds local resources of this collection which have been marked as *deleted* by the user
+     * Iterates local resources of this collection which have been marked as *deleted* by the user
      * or an app acting on their behalf.
      *
-     * @return list of resources marked as *deleted*
+     * @return flow of resources marked as *deleted*
      */
-    fun findDeleted(): List<T>
+    fun iterateDeleted(): Flow<T>
 
     /**
-     * Finds local resources of this collection which have been marked as *dirty*, i.e. resources
+     * Iterates local resources of this collection which have been marked as *dirty*, i.e. resources
      * which have been modified by the user or an app acting on their behalf.
      *
-     * @return list of resources marked as *dirty*
+     * @return flow of resources marked as *dirty*
      */
-    fun findDirty(): List<T>
+    fun iterateDirty(): Flow<T>
 
     /**
      * Finds a local resource of this collection with a given file name. (File names are assigned

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollection.kt
@@ -10,6 +10,9 @@ import at.bitfire.synctools.storage.jtx.JtxCollection
 import at.bitfire.synctools.storage.jtx.JtxRecurringCollection
 import at.techbee.jtx.JtxContract
 import at.techbee.jtx.JtxContract.JtxICalObject
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 
 /**
  * Application-specific implementation for jtx collections.
@@ -56,16 +59,18 @@ class LocalJtxCollection(internal val jtxCollection: JtxCollection) :
     override fun countModified(): Int =
         jtxCollection.countJtxObjects("${JtxICalObject.DIRTY} AND NOT ${JtxICalObject.DELETED}", null)
 
-    override fun findDeleted(): List<LocalJtxICalObject> = buildList {
+    override fun iterateDeleted(): Flow<LocalJtxICalObject> = callbackFlow {
         JtxRecurringCollection(jtxCollection).iterateJtxObjectAndExceptions(JtxICalObject.DELETED, null) {
-            add(LocalJtxICalObject(jtxCollection, it.main.entityValues))
+            trySendBlocking(LocalJtxICalObject(jtxCollection, it.main.entityValues))
         }
+        close()
     }
 
-    override fun findDirty(): List<LocalJtxICalObject> = buildList {
+    override fun iterateDirty(): Flow<LocalJtxICalObject> = callbackFlow {
         JtxRecurringCollection(jtxCollection).iterateJtxObjectAndExceptions(JtxICalObject.DIRTY, null) {
-            add(LocalJtxICalObject(jtxCollection, it.main.entityValues))
+            trySendBlocking(LocalJtxICalObject(jtxCollection, it.main.entityValues))
         }
+        close()
     }
 
     override fun findByName(name: String): LocalJtxICalObject? =

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskList.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskList.kt
@@ -10,6 +10,9 @@ import at.bitfire.synctools.storage.tasks.DmfsRecurringTaskList
 import at.bitfire.synctools.storage.tasks.DmfsTaskList
 import at.bitfire.synctools.storage.tasks.DmfsTasksContract
 import at.bitfire.synctools.storage.tasks.TaskAndExceptions
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import org.dmfs.tasks.contract.TaskContract
 import org.dmfs.tasks.contract.TaskContract.TaskListColumns
 import org.dmfs.tasks.contract.TaskContract.Tasks
@@ -76,16 +79,18 @@ class LocalTaskList (
     override fun countModified(): Int =
         dmfsTaskList.countTasks("${Tasks._DIRTY} AND NOT ${Tasks._DELETED}", null)
 
-    override fun findDeleted(): List<LocalTask> = buildList {
+    override fun iterateDeleted(): Flow<LocalTask> = callbackFlow {
         recurringTaskList.iterateTaskAndExceptions(Tasks._DELETED, null) {
-            add(LocalTask(recurringTaskList, it))
+            trySendBlocking(LocalTask(recurringTaskList, it))
         }
+        close()
     }
 
-    override fun findDirty(): List<LocalTask> = buildList {
+    override fun iterateDirty(): Flow<LocalTask> = callbackFlow {
         recurringTaskList.iterateTaskAndExceptions(Tasks._DIRTY, null) {
-            add(LocalTask(recurringTaskList, it))
+            trySendBlocking(LocalTask(recurringTaskList, it))
         }
+        close()
     }
 
     override fun findByName(name: String): LocalTask? {

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/workaround/Android7DirtyVerifier.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/workaround/Android7DirtyVerifier.kt
@@ -51,7 +51,7 @@ class Android7DirtyVerifier @Inject constructor(
     override fun prepareAddressBook(addressBook: LocalAddressBook, isUpload: Boolean): Boolean {
         val reallyDirty = verifyDirtyContacts(addressBook)
 
-        val deleted = addressBook.findDeleted().size
+        val deleted = addressBook.countDeleted()
         if (isUpload && reallyDirty == 0 && deleted == 0) {
             logger.info("This sync was called to up-sync dirty/deleted contacts, but no contacts have been changed")
             return false

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
@@ -143,7 +143,7 @@ class CalendarSyncManager @AssistedInject constructor(
     override suspend fun processLocallyDeleted(): Boolean {
         if (localCollection.readOnly) {
             var modified = false
-            for (event in localCollection.findDeleted()) {
+            localCollection.iterateDeleted().collect { event ->
                 logger.warning("Restoring locally deleted event (read-only calendar!)")
                 SyncException.wrapWithLocalResource(event) {
                     event.resetDeleted()
@@ -166,7 +166,7 @@ class CalendarSyncManager @AssistedInject constructor(
     override suspend fun uploadDirty(): Boolean {
         var modified = false
         if (localCollection.readOnly) {
-            for (event in localCollection.findDirty()) {
+            localCollection.iterateDirty().collect { event ->
                 logger.warning("Resetting locally modified event to ETag=null (read-only calendar!)")
                 SyncException.wrapWithLocalResource(event) {
                     event.clearDirty(Optional.empty(), null, null)

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -325,8 +325,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
 
         // Remove locally deleted entries from server (if they have a name, i.e. if they were uploaded before),
         // but only if they don't have changed on the server. Then finally remove them from the local address book.
-        val localList = localCollection.findDeleted()
-        for (local in localList) {
+        localCollection.iterateDeleted().collect { local ->
             SyncException.wrapWithLocalResourceSuspending(local) {
                 val fileName = local.fileName
                 if (fileName != null) {
@@ -370,14 +369,11 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
     protected open suspend fun uploadDirty(): Boolean {
         var numUploaded = 0
 
-        coroutineScope {    // structured concurrency
-            for (local in localCollection.findDirty())
-                launch {
-                    SyncException.wrapWithLocalResourceSuspending(local) {
-                        uploadDirty(local)
-                        numUploaded++
-                    }
-                }
+        localCollection.iterateDirty().collect { local ->
+            SyncException.wrapWithLocalResourceSuspending(local) {
+                uploadDirty(local)
+                numUploaded++
+            }
         }
         logger.info("Sent $numUploaded record(s) to server")
         return numUploaded > 0


### PR DESCRIPTION
### Purpose

Previously, `findDeleted()` / `findDirty()` materialized all deleted/dirty resources into a `List<T>` before processing the first one. For large collections with big attachments or contact photos this wastes significant memory.

This is especially important because we now process full `Entity`s instead of only `ContentValues` like earlier – in the new storage/mapping API, a `LocalResource` usually holds the whole `Entity` + binary data etc. Earlier, we had `LocalResource` implementations that held only the main row or even only the ID and fetched the data on-demand when "populated".

Switching to `Flow<T>`-based iteration fetches and processes resources one at a time, keeping only a single entry in memory at any point.

> [!IMPORTANT]
> **Uploading dirty entries is now sequential instead of parallel.** The previous `coroutineScope { launch {} }` approach was replaced with a simple `collect {}` to keep the operation simple and traceable.


### Short description

- `LocalCollection`: `find...(): List<T>` → `iterate...(): Flow<T>`
- `LocalCalendar`, `LocalTaskList`, `LocalJtxCollection`: `buildList { … }` → `callbackFlow { trySendBlocking(…); close() }`
- `LocalAddressBook`: `flow { emit(…) }` wrapping existing list helpers (full callback iteration follows once the contacts rewrite lands)
- `SyncManager`: `iterate...().collect {}`; removed `coroutineScope { launch {} }` from `uploadDirty`
- `Android7DirtyVerifier`: `findDeleted().size` → `countDeleted()`


### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [ ] I have added documentation to complex functions and functions that can be used by other modules.
- [ ] I have added reasonable tests or consciously decided to not add tests.