### PR TITLE
[jtx rewrite] Add remaining builders to `JtxObjectBuilder`

### DIFF
--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/JtxObjectBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/JtxObjectBuilder.kt
@@ -8,21 +8,40 @@ import android.content.ContentValues
 import android.content.Entity
 import at.bitfire.synctools.icalendar.AssociatedComponents
 import at.bitfire.synctools.mapping.jtx.builder.AttachmentsBuilder
+import at.bitfire.synctools.mapping.jtx.builder.AttendeesBuilder
 import at.bitfire.synctools.mapping.jtx.builder.CategoriesBuilder
+import at.bitfire.synctools.mapping.jtx.builder.ClassificationBuilder
 import at.bitfire.synctools.mapping.jtx.builder.CollectionIdBuilder
+import at.bitfire.synctools.mapping.jtx.builder.ColorBuilder
 import at.bitfire.synctools.mapping.jtx.builder.CommentsBuilder
+import at.bitfire.synctools.mapping.jtx.builder.CompletedBuilder
 import at.bitfire.synctools.mapping.jtx.builder.ComponentBuilder
+import at.bitfire.synctools.mapping.jtx.builder.ContactBuilder
+import at.bitfire.synctools.mapping.jtx.builder.CreatedBuilder
 import at.bitfire.synctools.mapping.jtx.builder.DescriptionBuilder
+import at.bitfire.synctools.mapping.jtx.builder.DirtyAndDeletedBuilder
+import at.bitfire.synctools.mapping.jtx.builder.DtStampBuilder
 import at.bitfire.synctools.mapping.jtx.builder.ExtendedStatusBuilder
+import at.bitfire.synctools.mapping.jtx.builder.GeoBuilder
 import at.bitfire.synctools.mapping.jtx.builder.JtxObjectBinaryDataRowBuilder
 import at.bitfire.synctools.mapping.jtx.builder.JtxObjectEntityBuilder
+import at.bitfire.synctools.mapping.jtx.builder.LastModifiedBuilder
+import at.bitfire.synctools.mapping.jtx.builder.LocationBuilder
+import at.bitfire.synctools.mapping.jtx.builder.OrganizerBuilder
+import at.bitfire.synctools.mapping.jtx.builder.PercentCompleteBuilder
 import at.bitfire.synctools.mapping.jtx.builder.PriorityBuilder
 import at.bitfire.synctools.mapping.jtx.builder.RecurrenceFieldsBuilder
+import at.bitfire.synctools.mapping.jtx.builder.RelatedToBuilder
 import at.bitfire.synctools.mapping.jtx.builder.RemindersBuilder
 import at.bitfire.synctools.mapping.jtx.builder.ResourcesBuilder
+import at.bitfire.synctools.mapping.jtx.builder.SequenceBuilder
+import at.bitfire.synctools.mapping.jtx.builder.StatusBuilder
+import at.bitfire.synctools.mapping.jtx.builder.SummaryBuilder
 import at.bitfire.synctools.mapping.jtx.builder.SyncPropertiesBuilder
 import at.bitfire.synctools.mapping.jtx.builder.TimeFieldsBuilder
 import at.bitfire.synctools.mapping.jtx.builder.UidBuilder
+import at.bitfire.synctools.mapping.jtx.builder.UnknownPropertiesBuilder
+import at.bitfire.synctools.mapping.jtx.builder.UrlBuilder
 import at.bitfire.synctools.storage.jtx.JtxEntity
 import at.bitfire.synctools.storage.jtx.JtxEntityAndExceptions
 import net.fortuna.ical4j.model.component.CalendarComponent
@@ -45,20 +64,47 @@ class JtxObjectBuilder(
     that are supported by builders/handlers should also be present there. */
 
     private val entityBuilders: Array<JtxObjectEntityBuilder> = arrayOf(
+        // Metadata
         CollectionIdBuilder(collectionId),
         ComponentBuilder(),
         SyncPropertiesBuilder(fileName, eTag, scheduleTag, flags),
+        DirtyAndDeletedBuilder(),
 
+        // Main fields
+        UidBuilder(),
+        SummaryBuilder(),
         DescriptionBuilder(),
+        ClassificationBuilder(),
         PriorityBuilder(),
+        StatusBuilder(),
         ExtendedStatusBuilder(),
-        RecurrenceFieldsBuilder(),
+        PercentCompleteBuilder(),
+        CompletedBuilder(),
+        CreatedBuilder(),
+        LastModifiedBuilder(),
+        DtStampBuilder(),
+        SequenceBuilder(),
+
+        // Extra info
+        ColorBuilder(),
+        ContactBuilder(),
+        GeoBuilder(),
+        LocationBuilder(),
+        UrlBuilder(),
+
+        // Time fields, recurrence
         TimeFieldsBuilder(),
-        RemindersBuilder(),
+        RecurrenceFieldsBuilder(),
+
+        // Sub-rows
+        AttendeesBuilder(),
         CategoriesBuilder(),
         CommentsBuilder(),
+        OrganizerBuilder(),
+        RelatedToBuilder(),
+        RemindersBuilder(),
         ResourcesBuilder(),
-        UidBuilder(),
+        UnknownPropertiesBuilder(),
     )
 
     private val binaryDataRowBuilders = arrayOf<JtxObjectBinaryDataRowBuilder>(

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/JtxObjectBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/JtxObjectBuilderTest.kt
@@ -4,10 +4,14 @@
 
 package at.bitfire.synctools.mapping.jtx
 
+import android.content.Entity
+import android.net.Uri
 import at.bitfire.ical4android.JtxICalObject
 import at.bitfire.synctools.icalendar.AssociatedComponents
+import at.bitfire.synctools.icalendar.ICalendarParser
 import at.bitfire.synctools.icalendar.plusAssign
 import at.techbee.jtx.JtxContract
+import net.fortuna.ical4j.model.Component
 import net.fortuna.ical4j.model.component.CalendarComponent
 import net.fortuna.ical4j.model.component.VJournal
 import net.fortuna.ical4j.model.component.VToDo
@@ -22,6 +26,7 @@ import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.io.StringReader
 import java.time.Instant
 
 @RunWith(RobolectricTestRunner::class)
@@ -101,6 +106,126 @@ class JtxObjectBuilderTest {
     }
 
     @Test
+    fun `build() wires implemented builders`() {
+        val calendar = ICalendarParser().parse(
+            StringReader(
+                """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            PRODID:-//bitfire//test//EN
+            BEGIN:VTODO
+            UID:rich-uid
+            SUMMARY:Rich task
+            DESCRIPTION:Description
+            CLASS:PRIVATE
+            PRIORITY:4
+            STATUS:IN-PROCESS
+            X-STATUS:custom-status
+            PERCENT-COMPLETE:40
+            COMPLETED:20260610T120000Z
+            X-COMPLETEDTIMEZONE:UTC
+            CREATED:20260609T120000Z
+            LAST-MODIFIED:20260609T130000Z
+            DTSTAMP:20260609T140000Z
+            SEQUENCE:3
+            COLOR:#FF112233
+            CONTACT:Jane Contact
+            GEO:37.386013;-122.082932
+            X-GEOFENCE-RADIUS:25
+            LOCATION;ALTREP="https://domain.example/location":Conference Room
+            URL:https://domain.example/task
+            DTSTART:20260610T090000Z
+            DUE:20260610T100000Z
+            RRULE:FREQ=DAILY;COUNT=2
+            ATTENDEE;CN=Jane Attendee:mailto:attendee@domain.example
+            CATEGORIES:one,two
+            COMMENT:comment
+            ORGANIZER;CN=Jane Organizer:mailto:organizer@domain.example
+            RELATED-TO:parent-uid
+            RESOURCES:projector
+            BEGIN:VALARM
+            ACTION:DISPLAY
+            DESCRIPTION:reminder
+            TRIGGER:-PT15M
+            END:VALARM
+            ATTACH;FMTTYPE=text/plain;FILENAME=file.txt:https://domain.example/file.txt
+            X-UNKNOWN:unknown
+            END:VTODO
+            END:VCALENDAR
+            """.trimIndent()
+            )
+        )
+        val task = calendar.getComponent<VToDo>(Component.VTODO).get()
+        val builder = JtxObjectBuilder(
+            collectionId = 23,
+            fileName = "rich.ics",
+            eTag = "etag",
+            scheduleTag = "schedule-tag",
+            flags = 7
+        )
+        val component = AssociatedComponents<CalendarComponent>(
+            main = task,
+            exceptions = emptyList()
+        )
+
+        val result = builder.build(component)
+
+        val values = result.main.entity.entityValues
+        assertEquals(23L, values.getAsLong(JtxContract.JtxICalObject.ICALOBJECT_COLLECTIONID))
+        assertEquals("rich.ics", values.getAsString(JtxContract.JtxICalObject.FILENAME))
+        assertEquals("etag", values.getAsString(JtxContract.JtxICalObject.ETAG))
+        assertEquals("schedule-tag", values.getAsString(JtxContract.JtxICalObject.SCHEDULETAG))
+        assertEquals(7, values.getAsInteger(JtxContract.JtxICalObject.FLAGS))
+        assertEquals(false, values.getAsBoolean(JtxContract.JtxICalObject.DIRTY))
+        assertEquals(false, values.getAsBoolean(JtxContract.JtxICalObject.DELETED))
+        assertEquals("rich-uid", values.getAsString(JtxContract.JtxICalObject.UID))
+        assertEquals("Rich task", values.getAsString(JtxContract.JtxICalObject.SUMMARY))
+        assertEquals("PRIVATE", values.getAsString(JtxContract.JtxICalObject.CLASSIFICATION))
+        assertEquals("IN-PROCESS", values.getAsString(JtxContract.JtxICalObject.STATUS))
+        assertEquals("Conference Room", values.getAsString(JtxContract.JtxICalObject.LOCATION))
+        assertEquals("https://domain.example/task", values.getAsString(JtxContract.JtxICalObject.URL))
+        assertEquals(40, values.getAsInteger(JtxContract.JtxICalObject.PERCENT))
+        assertEquals(3L, values.getAsLong(JtxContract.JtxICalObject.SEQUENCE))
+        assertEquals(0xFF112233.toInt(), values.getAsInteger(JtxContract.JtxICalObject.COLOR))
+        assertEquals("Jane Contact", values.getAsString(JtxContract.JtxICalObject.CONTACT))
+        assertEquals(25, values.getAsInteger(JtxContract.JtxICalObject.GEOFENCE_RADIUS))
+        assertNotNull(values.get(JtxContract.JtxICalObject.COMPLETED))
+        assertNotNull(values.get(JtxContract.JtxICalObject.CREATED))
+        assertNotNull(values.get(JtxContract.JtxICalObject.LAST_MODIFIED))
+        assertNotNull(values.get(JtxContract.JtxICalObject.DTSTAMP))
+        assertNotNull(values.get(JtxContract.JtxICalObject.DTSTART))
+        assertNotNull(values.get(JtxContract.JtxICalObject.DUE))
+        assertEquals("FREQ=DAILY;COUNT=2", values.getAsString(JtxContract.JtxICalObject.RRULE))
+
+        val subValues = result.main.entity.subValues
+        assertSubValue(
+            subValues,
+            JtxContract.JtxAttendee.CONTENT_URI,
+            JtxContract.JtxAttendee.CALADDRESS,
+            "mailto:attendee@domain.example"
+        )
+        assertSubValue(subValues, JtxContract.JtxCategory.CONTENT_URI, JtxContract.JtxCategory.TEXT, "one")
+        assertSubValue(subValues, JtxContract.JtxComment.CONTENT_URI, JtxContract.JtxComment.TEXT, "comment")
+        assertSubValue(
+            subValues,
+            JtxContract.JtxOrganizer.CONTENT_URI,
+            JtxContract.JtxOrganizer.CALADDRESS,
+            "mailto:organizer@domain.example"
+        )
+        assertSubValue(subValues, JtxContract.JtxRelatedto.CONTENT_URI, JtxContract.JtxRelatedto.TEXT, "parent-uid")
+        assertSubValue(subValues, JtxContract.JtxResource.CONTENT_URI, JtxContract.JtxResource.TEXT, "projector")
+        assertSubValue(subValues, JtxContract.JtxAlarm.CONTENT_URI, JtxContract.JtxAlarm.DESCRIPTION, "reminder")
+        assertTrue(subValues.any {
+            it.uri == JtxContract.JtxUnknown.CONTENT_URI &&
+                    it.values.getAsString(JtxContract.JtxUnknown.UNKNOWN_VALUE).contains("X-UNKNOWN")
+        })
+
+        val attachment = result.main.binaryDataRows.single()
+        assertEquals(JtxContract.JtxAttachment.CONTENT_URI, attachment.uri)
+        assertEquals("https://domain.example/file.txt", attachment.values.getAsString(JtxContract.JtxAttachment.URI))
+    }
+
+    @Test
     fun `build() with VJournal`() {
         val component = AssociatedComponents<CalendarComponent>(
             main = VJournal(),
@@ -148,5 +273,14 @@ class JtxObjectBuilderTest {
         } catch (e: IllegalArgumentException) {
             assertEquals("Exceptions need to be of same type as main component", e.message)
         }
+    }
+
+    private fun assertSubValue(
+        subValues: List<Entity.NamedContentValues>,
+        uri: Uri,
+        column: String,
+        value: String
+    ) {
+        assertTrue(subValues.any { it.uri == uri && it.values.getAsString(column) == value })
     }
 }


### PR DESCRIPTION
### Purpose

  Wire the now-implemented JTX builders into `JtxObjectBuilder` so `VTODO`/`VJOURNAL` objects are fully mapped to jtx Board rows and supported sub-rows.

### Short description

- Added all implemented JTX entity builders to `JtxObjectBuilder`, grouped with short comments, while keeping attachment handling (`AttachmentsBuilder`)  in the binary row builder list. 
- Added one focused `JtxObjectBuilder` wiring test using a rich VTODO fixture to verify representative main fields, sub-rows, unknown properties, and attachment rows without duplicating individual builder tests.
