### PR TITLE
[jtx rewrite] Deduplicate in the handlers

### DIFF
--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/EndTimeBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/EndTimeBuilder.kt
@@ -80,7 +80,7 @@ class EndTimeBuilder : AndroidEventEntityBuilder {
      * - DTEND is DATE, DTSTART is DATE-TIME → DTEND is amended to DATE-TIME with time and timezone from DTSTART
      * - DTEND is DATE-TIME, DTSTART is DATE → DTEND is reduced to its date component
      *
-     * @see at.bitfire.synctools.mapping.calendar.handler.RecurrenceFieldsHandler.alignUntil
+     * @see at.bitfire.synctools.util.RecurrenceUtils.alignUntil
      */
     @VisibleForTesting
     internal fun alignWithDtStart(endDate: Temporal, startDate: Temporal): Temporal {

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/RecurrenceFieldsHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/RecurrenceFieldsHandler.kt
@@ -9,18 +9,13 @@ import android.provider.CalendarContract.Events
 import at.bitfire.synctools.exception.InvalidLocalResourceException
 import at.bitfire.synctools.util.AndroidTimeUtils
 import at.bitfire.synctools.util.AndroidTimeUtils.toTimestamp
-import at.bitfire.synctools.util.AndroidTimeUtils.toZonedDateTime
-import at.bitfire.synctools.util.TimeApiExtensions.isDateTime
-import at.bitfire.synctools.util.TimeApiExtensions.toLocalDate
-import net.fortuna.ical4j.model.Recur
+import at.bitfire.synctools.util.RecurrenceUtils
 import net.fortuna.ical4j.model.component.VEvent
 import net.fortuna.ical4j.model.property.ExDate
 import net.fortuna.ical4j.model.property.ExRule
 import net.fortuna.ical4j.model.property.RDate
 import net.fortuna.ical4j.model.property.RRule
 import java.time.Instant
-import java.time.ZoneOffset
-import java.time.ZonedDateTime
 import java.time.temporal.Temporal
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -55,7 +50,7 @@ class RecurrenceFieldsHandler : AndroidEventEntityHandler {
                     val rule = RRule<Temporal>(rule)
 
                     // align RRULE UNTIL to DTSTART, if needed
-                    rule.recur = alignUntil(rule.recur, startDate)
+                    rule.recur = RecurrenceUtils.alignUntil(rule.recur, startDate)
 
                     // skip if UNTIL is before event's DTSTART
                     val tsUntil = rule.recur.until?.toTimestamp()
@@ -91,7 +86,7 @@ class RecurrenceFieldsHandler : AndroidEventEntityHandler {
                     val rule = ExRule<Temporal>(null, rule)
 
                     // align RRULE UNTIL to DTSTART, if needed
-                    rule.recur = alignUntil(rule.recur, startDate)
+                    rule.recur = RecurrenceUtils.alignUntil(rule.recur, startDate)
 
                     // skip if UNTIL is before event's DTSTART
                     val tsUntil = rule.recur.until?.toTimestamp()
@@ -111,7 +106,7 @@ class RecurrenceFieldsHandler : AndroidEventEntityHandler {
         val exDates = mutableListOf<ExDate<*>>()
         values.getAsString(Events.EXDATE)?.let { exDateField ->
             try {
-                AndroidTimeUtils.androidStringToRecurrenceSet(exDateField,  allDay) { ExDate(it) }?.let {
+                AndroidTimeUtils.androidStringToRecurrenceSet(exDateField, allDay) { ExDate(it) }?.let {
                     exDates += it
                 }
             } catch (e: Exception) {
@@ -123,63 +118,6 @@ class RecurrenceFieldsHandler : AndroidEventEntityHandler {
         val recurring = rRules.isNotEmpty() || rDates.isNotEmpty()
         if (from === main && recurring) {
             to.addAll<VEvent>(rRules + rDates + exRules + exDates)
-        }
-    }
-
-    /**
-     * Aligns the `UNTIL` of the given recurrence info to the VALUE-type (DATE-TIME/DATE) of [startTemporal].
-     *
-     * If the aligned `UNTIL` is a DATE-TIME, this method also makes sure that it's specified in UTC format
-     * as required by RFC 5545 3.3.10.
-     *
-     * @param recur             recurrence info whose `UNTIL` shall be aligned
-     * @param startTemporal     `DTSTART` date to compare with
-     *
-     * @return
-     *
-     * - UNTIL not set → original recur
-     * - UNTIL and DTSTART are both either DATE or DATE-TIME → original recur
-     * - UNTIL is DATE, DTSTART is DATE-TIME → UNTIL is amended to DATE-TIME with time and timezone from DTSTART
-     * - UNTIL is DATE-TIME, DTSTART is DATE → UNTIL is reduced to its date component
-     *
-     * @see at.bitfire.synctools.mapping.calendar.builder.EndTimeBuilder.alignWithDtStart
-     */
-    fun alignUntil(recur: Recur<Temporal>, startTemporal: Temporal): Recur<Temporal> {
-        val until: Temporal = recur.until ?: return recur
-
-        if (until.isDateTime()) {
-            // UNTIL is DATE-TIME
-            if (startTemporal.isDateTime()) {
-                // DTSTART is DATE-TIME → ensure UNTIL is in UTC
-                val untilZoned = until.toZonedDateTime()
-                return if (untilZoned.zone == ZoneOffset.UTC) {
-                    recur
-                } else {
-                    Recur.Builder(recur)
-                        .until(untilZoned.withZoneSameInstant(ZoneOffset.UTC).toInstant())
-                        .build()
-                }
-            } else {
-                // DTSTART is DATE → only take date part for UNTIL
-                val untilDate = until.toLocalDate()
-                return Recur.Builder(recur)
-                    .until(untilDate)
-                    .build()
-            }
-        } else {
-            // UNTIL is DATE
-            if (startTemporal.isDateTime()) {
-                // DTSTART is DATE-TIME → amend UNTIL to UTC DATE-TIME
-                val untilDate = until.toLocalDate()
-                val startTime = startTemporal.toZonedDateTime()
-                val untilDateWithTime = ZonedDateTime.of(untilDate, startTime.toLocalTime(), startTime.zone)
-                return Recur.Builder(recur)
-                    .until(untilDateWithTime.toInstant()) // convert to Instant for UTC with "Z" suffix
-                    .build()
-            } else {
-                // DTSTART is DATE
-                return recur
-            }
         }
     }
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/JtxTimeField.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/JtxTimeField.kt
@@ -14,6 +14,7 @@ import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.temporal.Temporal
+import java.util.logging.Level
 import java.util.logging.Logger
 
 /**
@@ -30,7 +31,8 @@ internal class JtxTimeField(
     private val timeZone: String?
 ) {
 
-    private val logger = Logger.getLogger(javaClass.name)
+    private val logger
+        get() = Logger.getLogger(javaClass.name)
 
     /**
      * Converts the stored value according to jtx timezone semantics.
@@ -61,7 +63,7 @@ internal class JtxTimeField(
         try {
             ZoneId.of(tzId)
         } catch (e: DateTimeException) {
-            logger.warning("Invalid timezone '$tzId', interpreting as UTC. Error: $e")
+            logger.log(Level.WARNING, "Invalid timezone '$tzId', interpreting as UTC.", e)
             null
         }
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/JtxTimeField.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/JtxTimeField.kt
@@ -14,6 +14,7 @@ import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.temporal.Temporal
+import java.util.logging.Logger
 
 /**
  * Converts a jtx timestamp and timezone column pair into the matching iCalendar [Temporal] type.
@@ -28,6 +29,8 @@ internal class JtxTimeField(
     private val timestamp: Long,
     private val timeZone: String?
 ) {
+
+    private val logger = Logger.getLogger(javaClass.name)
 
     /**
      * Converts the stored value according to jtx timezone semantics.
@@ -57,7 +60,8 @@ internal class JtxTimeField(
     private fun zoneIdOrNull(tzId: String): ZoneId? =
         try {
             ZoneId.of(tzId)
-        } catch (_: DateTimeException) {
+        } catch (e: DateTimeException) {
+            logger.warning("Invalid timezone '$tzId', interpreting as UTC. Error: $e")
             null
         }
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/RecurrenceFieldsHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/RecurrenceFieldsHandler.kt
@@ -9,13 +9,10 @@ import android.content.Entity
 import at.bitfire.synctools.icalendar.plusAssign
 import at.bitfire.synctools.util.AndroidTimeUtils.isUtcTzId
 import at.bitfire.synctools.util.AndroidTimeUtils.toTimestamp
-import at.bitfire.synctools.util.AndroidTimeUtils.toZonedDateTime
-import at.bitfire.synctools.util.TimeApiExtensions.isDateTime
-import at.bitfire.synctools.util.TimeApiExtensions.toLocalDate
+import at.bitfire.synctools.util.RecurrenceUtils
 import at.techbee.jtx.JtxContract
 import net.fortuna.ical4j.model.DateList
 import net.fortuna.ical4j.model.ParameterList
-import net.fortuna.ical4j.model.Recur
 import net.fortuna.ical4j.model.component.CalendarComponent
 import net.fortuna.ical4j.model.parameter.TzId
 import net.fortuna.ical4j.model.parameter.Value
@@ -42,7 +39,7 @@ import java.util.logging.Logger
  * appropriate temporal type before they are added to the iCalendar component.
  *
  * **UNTIL alignment:** RFC 5545 §3.3.10 requires the RRULE `UNTIL` value to be in UTC when
- * DTSTART is a DATE-TIME, and to be a bare DATE when DTSTART is a DATE. [alignUntil] enforces
+ * DTSTART is a DATE-TIME, and to be a bare DATE when DTSTART is a DATE. [RecurrenceUtils.alignUntil] enforces
  * this, and rules whose UNTIL falls on or before DTSTART are silently dropped.
  *
  * Parse errors in any individual field are caught and logged as warnings so that a single
@@ -118,7 +115,7 @@ class RecurrenceFieldsHandler : JtxObjectEntityHandler {
 
                 // align RRULE UNTIL to DTSTART, if needed
                 if (startTemporal != null) {
-                    rule = RRule(alignUntil(rule.recur, startTemporal))
+                    rule = RRule(RecurrenceUtils.alignUntil(rule.recur, startTemporal))
 
                     // skip if UNTIL is before object's DTSTART
                     val tsStart = values.getAsLong(JtxContract.JtxICalObject.DTSTART)!!
@@ -193,62 +190,5 @@ class RecurrenceFieldsHandler : JtxObjectEntityHandler {
             else ->
                 ParameterList() // implicit VALUE=DATE-TIME
         }
-
-    /**
-     * Aligns the `UNTIL` of the given recurrence info to the VALUE-type (DATE-TIME/DATE) of [startTemporal].
-     *
-     * If the aligned `UNTIL` is a DATE-TIME, this method also makes sure that it's specified in UTC format
-     * as required by RFC 5545 3.3.10.
-     *
-     * @param recur             recurrence info whose `UNTIL` shall be aligned
-     * @param startTemporal     `DTSTART` date to compare with
-     *
-     * @return
-     *
-     * - UNTIL not set → original recur
-     * - UNTIL and DTSTART are both either DATE or DATE-TIME → original recur
-     * - UNTIL is DATE, DTSTART is DATE-TIME → UNTIL is amended to DATE-TIME with time and timezone from DTSTART
-     * - UNTIL is DATE-TIME, DTSTART is DATE → UNTIL is reduced to its date component
-     *
-     * @see at.bitfire.synctools.mapping.calendar.handler.RecurrenceFieldsHandler.alignUntil
-     */
-    fun alignUntil(recur: Recur<Temporal>, startTemporal: Temporal): Recur<Temporal> {
-        val until: Temporal = recur.until ?: return recur
-
-        if (until.isDateTime()) {
-            // UNTIL is DATE-TIME
-            if (startTemporal.isDateTime()) {
-                // DTSTART is DATE-TIME → ensure UNTIL is in UTC
-                val untilZoned = until.toZonedDateTime()
-                return if (untilZoned.zone == ZoneOffset.UTC) {
-                    recur
-                } else {
-                    Recur.Builder(recur)
-                        .until(untilZoned.withZoneSameInstant(ZoneOffset.UTC).toInstant())
-                        .build()
-                }
-            } else {
-                // DTSTART is DATE → only take date part for UNTIL
-                val untilDate = until.toLocalDate()
-                return Recur.Builder(recur)
-                    .until(untilDate)
-                    .build()
-            }
-        } else {
-            // UNTIL is DATE
-            if (startTemporal.isDateTime()) {
-                // DTSTART is DATE-TIME → amend UNTIL to UTC DATE-TIME
-                val untilDate = until.toLocalDate()
-                val startTime = startTemporal.toZonedDateTime()
-                val untilDateWithTime = ZonedDateTime.of(untilDate, startTime.toLocalTime(), startTime.zone)
-                return Recur.Builder(recur)
-                    .until(untilDateWithTime.toInstant()) // convert to Instant for UTC with "Z" suffix
-                    .build()
-            } else {
-                // DTSTART is DATE
-                return recur
-            }
-        }
-    }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/TimeFieldsHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/TimeFieldsHandler.kt
@@ -16,21 +16,12 @@ import net.fortuna.ical4j.model.property.DtEnd
 import net.fortuna.ical4j.model.property.DtStart
 import net.fortuna.ical4j.model.property.Due
 import net.fortuna.ical4j.model.property.Duration
-import java.time.DateTimeException
-import java.time.Instant
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.ZoneId
-import java.time.ZoneOffset
-import java.time.ZonedDateTime
 import java.time.temporal.Temporal
-import java.util.logging.Logger
 
 /**
  * Handles the iCalendar properties: DTSTART, DTEND, DUE, DURATION
  */
 class TimeFieldsHandler : JtxObjectEntityHandler {
-    private val logger = Logger.getLogger(javaClass.name)
 
     override fun process(from: Entity, main: Entity, to: CalendarComponent) {
         appendDateField(from, to, JtxContract.JtxICalObject.DTSTART, JtxContract.JtxICalObject.DTSTART_TIMEZONE) { DtStart(it) }
@@ -56,20 +47,10 @@ class TimeFieldsHandler : JtxObjectEntityHandler {
 
     private fun appendDateField(from: Entity, to: CalendarComponent, property: String, timezoneProperty: String, builder: (Temporal) -> Property) {
         val epochMillis = from.entityValues.getAsLong(property) ?: return
-        val instant = Instant.ofEpochMilli(epochMillis)
-        val timezone = from.entityValues.getAsString(timezoneProperty)
-
-        val temporal: Temporal = when {
-            timezone == JtxContract.JtxICalObject.TZ_ALLDAY -> LocalDate.ofInstant(instant, ZoneOffset.UTC)
-            timezone == ZoneOffset.UTC.id || timezone == "UTC" -> instant
-            timezone.isNullOrEmpty() -> LocalDateTime.ofInstant(instant, ZoneId.systemDefault())
-            else -> try {
-                ZonedDateTime.ofInstant(instant, ZoneId.of(timezone))
-            } catch (e: DateTimeException) {
-                logger.warning("Invalid timezone '$timezone', interpreting as UTC. Error: $e")
-                instant
-            }
-        }
+        val temporal = JtxTimeField(
+            timestamp = epochMillis,
+            timeZone = from.entityValues.getAsString(timezoneProperty)
+        ).toTemporal()
 
         to += builder(temporal)
     }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/RecurrenceFieldsHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/handler/RecurrenceFieldsHandler.kt
@@ -10,17 +10,12 @@ import at.bitfire.synctools.icalendar.plusAssign
 import at.bitfire.synctools.util.AndroidTimeUtils
 import at.bitfire.synctools.util.AndroidTimeUtils.isUtcTzId
 import at.bitfire.synctools.util.AndroidTimeUtils.toTimestamp
-import at.bitfire.synctools.util.AndroidTimeUtils.toZonedDateTime
-import at.bitfire.synctools.util.TimeApiExtensions.isDateTime
-import at.bitfire.synctools.util.TimeApiExtensions.toLocalDate
-import net.fortuna.ical4j.model.Recur
+import at.bitfire.synctools.util.RecurrenceUtils
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.property.ExDate
 import net.fortuna.ical4j.model.property.RDate
 import net.fortuna.ical4j.model.property.RRule
 import org.dmfs.tasks.contract.TaskContract.Tasks
-import java.time.ZoneOffset
-import java.time.ZonedDateTime
 import java.time.temporal.Temporal
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -37,7 +32,7 @@ import java.util.logging.Logger
  * required `{tzId};` prefix so they can be parsed correctly.
  *
  * **UNTIL alignment:** RFC 5545 §3.3.10 requires the RRULE `UNTIL` value to be in UTC when
- * DTSTART is a DATE-TIME, and to be a bare DATE when DTSTART is a DATE. [alignUntil] enforces
+ * DTSTART is a DATE-TIME, and to be a bare DATE when DTSTART is a DATE. [RecurrenceUtils.alignUntil] enforces
  * this, and rules whose UNTIL falls on or before DTSTART are silently dropped.
  *
  * Parse errors in any individual field are caught and logged as warnings so that a single
@@ -66,11 +61,13 @@ class RecurrenceFieldsHandler : DmfsTaskEntityHandler {
 
         // provide start temporal lazily (only computed when UNTIL alignment is needed)
         val startTemporal: Temporal? by lazy {
-            tsStart?.let { TaskTimeField(
-                timestamp = it,
-                tzId = tzId,
-                allDay = allDay
-            ).toTemporal() }
+            tsStart?.let {
+                TaskTimeField(
+                    timestamp = it,
+                    tzId = tzId,
+                    allDay = allDay
+                ).toTemporal()
+            }
         }
 
         // process RRULE field
@@ -80,7 +77,7 @@ class RecurrenceFieldsHandler : DmfsTaskEntityHandler {
 
                 // align RRULE UNTIL to DTSTART, if needed
                 if (startTemporal != null) {
-                    rule = RRule(alignUntil(rule.recur, startTemporal!!))
+                    rule = RRule(RecurrenceUtils.alignUntil(rule.recur, startTemporal!!))
 
                     // skip if UNTIL is before task's DTSTART
                     val tsUntil = rule.recur.until?.toTimestamp()
@@ -135,63 +132,6 @@ class RecurrenceFieldsHandler : DmfsTaskEntityHandler {
         if (recurrenceStr.contains(';') || tzId == null || isUtcTzId(tzId))
             return recurrenceStr
         return "$tzId;$recurrenceStr"
-    }
-
-    /**
-     * Aligns the `UNTIL` of the given recurrence info to the VALUE-type (DATE-TIME/DATE) of [startTemporal].
-     *
-     * If the aligned `UNTIL` is a DATE-TIME, this method also makes sure that it's specified in UTC format
-     * as required by RFC 5545 3.3.10.
-     *
-     * @param recur             recurrence info whose `UNTIL` shall be aligned
-     * @param startTemporal     `DTSTART` date to compare with
-     *
-     * @return
-     *
-     * - UNTIL not set → original recur
-     * - UNTIL and DTSTART are both either DATE or DATE-TIME → original recur
-     * - UNTIL is DATE, DTSTART is DATE-TIME → UNTIL is amended to DATE-TIME with time and timezone from DTSTART
-     * - UNTIL is DATE-TIME, DTSTART is DATE → UNTIL is reduced to its date component
-     *
-     * @see at.bitfire.synctools.mapping.calendar.handler.RecurrenceFieldsHandler.alignUntil
-     */
-    fun alignUntil(recur: Recur<Temporal>, startTemporal: Temporal): Recur<Temporal> {
-        val until: Temporal = recur.until ?: return recur
-
-        if (until.isDateTime()) {
-            // UNTIL is DATE-TIME
-            if (startTemporal.isDateTime()) {
-                // DTSTART is DATE-TIME → ensure UNTIL is in UTC
-                val untilZoned = until.toZonedDateTime()
-                return if (untilZoned.zone == ZoneOffset.UTC) {
-                    recur
-                } else {
-                    Recur.Builder(recur)
-                        .until(untilZoned.withZoneSameInstant(ZoneOffset.UTC).toInstant())
-                        .build()
-                }
-            } else {
-                // DTSTART is DATE → only take date part for UNTIL
-                val untilDate = until.toLocalDate()
-                return Recur.Builder(recur)
-                    .until(untilDate)
-                    .build()
-            }
-        } else {
-            // UNTIL is DATE
-            if (startTemporal.isDateTime()) {
-                // DTSTART is DATE-TIME → amend UNTIL to UTC DATE-TIME
-                val untilDate = until.toLocalDate()
-                val startTime = startTemporal.toZonedDateTime()
-                val untilDateWithTime = ZonedDateTime.of(untilDate, startTime.toLocalTime(), startTime.zone)
-                return Recur.Builder(recur)
-                    .until(untilDateWithTime.toInstant()) // convert to Instant for UTC with "Z" suffix
-                    .build()
-            } else {
-                // DTSTART is DATE
-                return recur
-            }
-        }
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/util/RecurrenceUtils.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/util/RecurrenceUtils.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.synctools.util
+
+import at.bitfire.synctools.util.AndroidTimeUtils.isUtcTzId
+import at.bitfire.synctools.util.AndroidTimeUtils.toZonedDateTime
+import at.bitfire.synctools.util.TimeApiExtensions.isDateTime
+import at.bitfire.synctools.util.TimeApiExtensions.toLocalDate
+import net.fortuna.ical4j.model.Recur
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.temporal.Temporal
+
+object RecurrenceUtils {
+
+    /**
+     * Aligns the `UNTIL` of the given recurrence info to the VALUE-type (DATE-TIME/DATE) of [startTemporal].
+     *
+     * If the aligned `UNTIL` is a DATE-TIME, this method also makes sure that it's specified in UTC format
+     * as required by RFC 5545 3.3.10.
+     *
+     * @return
+     *
+     * - UNTIL not set -> original recur
+     * - UNTIL and DTSTART are both either DATE or DATE-TIME -> original recur
+     * - UNTIL is DATE, DTSTART is DATE-TIME -> UNTIL is amended to DATE-TIME with time and timezone from DTSTART
+     * - UNTIL is DATE-TIME, DTSTART is DATE -> UNTIL is reduced to its date component
+     *
+     * @see at.bitfire.synctools.mapping.calendar.builder.EndTimeBuilder.alignWithDtStart
+     */
+    fun alignUntil(recur: Recur<Temporal>, startTemporal: Temporal): Recur<Temporal> {
+        val until: Temporal = recur.until ?: return recur
+
+        return when {
+            until.isDateTime() && startTemporal.isDateTime() -> {
+                val untilZoned = until.toZonedDateTime()
+                if (isUtcTzId(untilZoned.zone.id))
+                    recur
+                else
+                    Recur.Builder(recur)
+                        .until(untilZoned.withZoneSameInstant(ZoneOffset.UTC).toInstant())
+                        .build()
+            }
+
+            until.isDateTime() ->
+                Recur.Builder(recur)
+                    .until(until.toLocalDate())
+                    .build()
+
+            startTemporal.isDateTime() -> {
+                val untilDate = until.toLocalDate()
+                val startTime = startTemporal.toZonedDateTime()
+                val untilDateWithTime = ZonedDateTime.of(untilDate, startTime.toLocalTime(), startTime.zone)
+
+                Recur.Builder(recur)
+                    .until(untilDateWithTime.toInstant())
+                    .build()
+            }
+
+            else ->
+                recur
+        }
+    }
+
+}

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/RecurrenceFieldsHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/RecurrenceFieldsHandlerTest.kt
@@ -8,37 +8,28 @@ import android.content.ContentValues
 import android.content.Entity
 import android.provider.CalendarContract.Events
 import androidx.core.content.contentValuesOf
-import at.bitfire.dateTimeValue
 import at.bitfire.dateValue
-import io.mockk.mockk
 import junit.framework.TestCase.assertEquals
 import net.fortuna.ical4j.model.DateList
 import net.fortuna.ical4j.model.Parameter
 import net.fortuna.ical4j.model.ParameterList
 import net.fortuna.ical4j.model.Property
-import net.fortuna.ical4j.model.Recur
 import net.fortuna.ical4j.model.component.VEvent
 import net.fortuna.ical4j.model.parameter.Value
 import net.fortuna.ical4j.model.property.ExDate
 import net.fortuna.ical4j.model.property.ExRule
 import net.fortuna.ical4j.model.property.RDate
 import net.fortuna.ical4j.model.property.RRule
-import net.fortuna.ical4j.transform.recurrence.Frequency
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertSame
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.ZoneId
 import java.time.temporal.Temporal
 import kotlin.jvm.optionals.getOrNull
 
 @RunWith(RobolectricTestRunner::class)
 class RecurrenceFieldsHandlerTest {
-
-    private val tzVienna = ZoneId.of("Europe/Vienna")
 
     private val handler = RecurrenceFieldsHandler()
 
@@ -46,13 +37,15 @@ class RecurrenceFieldsHandlerTest {
     @Test
     fun `Recurring exception`() {
         val result = VEvent()
-        val entity = Entity(contentValuesOf(
-            Events.DTSTART to System.currentTimeMillis(),
-            Events.RRULE to "FREQ=DAILY;COUNT=10",
-            Events.RDATE to "20251010T010203Z",
-            Events.EXRULE to "FREQ=WEEKLY;COUNT=1",
-            Events.EXDATE to "20260201T010203Z"
-        ))
+        val entity = Entity(
+            contentValuesOf(
+                Events.DTSTART to System.currentTimeMillis(),
+                Events.RRULE to "FREQ=DAILY;COUNT=10",
+                Events.RDATE to "20251010T010203Z",
+                Events.EXRULE to "FREQ=WEEKLY;COUNT=1",
+                Events.EXDATE to "20260201T010203Z"
+            )
+        )
         handler.process(entity, Entity(ContentValues()), result)
         // exceptions must never have recurrence properties
         assertNull(result.getProperty<RRule<*>>(Property.RRULE).getOrNull())
@@ -64,11 +57,13 @@ class RecurrenceFieldsHandlerTest {
     @Test
     fun `Non-recurring main event`() {
         val result = VEvent()
-        val entity = Entity(contentValuesOf(
-            Events.DTSTART to System.currentTimeMillis(),
-            Events.EXRULE to "FREQ=WEEKLY;COUNT=1",
-            Events.EXDATE to "20260201T010203Z"
-        ))
+        val entity = Entity(
+            contentValuesOf(
+                Events.DTSTART to System.currentTimeMillis(),
+                Events.EXRULE to "FREQ=WEEKLY;COUNT=1",
+                Events.EXDATE to "20260201T010203Z"
+            )
+        )
         handler.process(entity, entity, result)
         // non-recurring events must never have recurrence properties
         assertNull(result.getProperty<RRule<*>>(Property.RRULE).getOrNull())
@@ -80,14 +75,16 @@ class RecurrenceFieldsHandlerTest {
     @Test
     fun `Recurring main event`() {
         val result = VEvent()
-        val entity = Entity(contentValuesOf(
-            Events.DTSTART to 1759403653000,    // Thu Oct 02 2025 11:14:13 GMT+0000
-            Events.EVENT_TIMEZONE to "UTC",
-            Events.RRULE to "FREQ=DAILY;COUNT=10",      // Oct 02 ... Oct 12
-            Events.RDATE to "20251002T111413Z,20251015T010203Z",    // RDATE at event start as required by Android plus Oct 15
-            Events.EXRULE to "FREQ=WEEKLY;COUNT=1",     // meaningless EXRULE/EXDATE
-            Events.EXDATE to "20260201T010203Z"
-        ))
+        val entity = Entity(
+            contentValuesOf(
+                Events.DTSTART to 1759403653000,    // Thu Oct 02 2025 11:14:13 GMT+0000
+                Events.EVENT_TIMEZONE to "UTC",
+                Events.RRULE to "FREQ=DAILY;COUNT=10",      // Oct 02 ... Oct 12
+                Events.RDATE to "20251002T111413Z,20251015T010203Z",    // RDATE at event start as required by Android plus Oct 15
+                Events.EXRULE to "FREQ=WEEKLY;COUNT=1",     // meaningless EXRULE/EXDATE
+                Events.EXDATE to "20260201T010203Z"
+            )
+        )
         handler.process(entity, entity, result)
         assertEquals(
             listOf(RRule<Temporal>("FREQ=DAILY;COUNT=10")),
@@ -110,14 +107,16 @@ class RecurrenceFieldsHandlerTest {
     @Test
     fun `Recurring main event (all-day)`() {
         val result = VEvent()
-        val entity = Entity(contentValuesOf(
-            Events.ALL_DAY to 1,
-            Events.DTSTART to 1759363200000,    // Thu Oct 02 2025 00:00:00 GMT+0000
-            Events.RRULE to "FREQ=DAILY;COUNT=10",      // Oct 02 ... Oct 12
-            Events.RDATE to "20251002,20251015",        // RDATE at event start as required by Android plus Oct 15
-            Events.EXRULE to "FREQ=WEEKLY;COUNT=1",     // meaningless EXRULE/EXDATE
-            Events.EXDATE to "20260201T010203Z"
-        ))
+        val entity = Entity(
+            contentValuesOf(
+                Events.ALL_DAY to 1,
+                Events.DTSTART to 1759363200000,    // Thu Oct 02 2025 00:00:00 GMT+0000
+                Events.RRULE to "FREQ=DAILY;COUNT=10",      // Oct 02 ... Oct 12
+                Events.RDATE to "20251002,20251015",        // RDATE at event start as required by Android plus Oct 15
+                Events.EXRULE to "FREQ=WEEKLY;COUNT=1",     // meaningless EXRULE/EXDATE
+                Events.EXDATE to "20260201T010203Z"
+            )
+        )
         handler.process(entity, entity, result)
         assertEquals(
             listOf(RRule<Temporal>("FREQ=DAILY;COUNT=10")),
@@ -140,12 +139,14 @@ class RecurrenceFieldsHandlerTest {
     @Test
     fun `RRULE with UNTIL before DTSTART`() {
         val result = VEvent()
-        val entity = Entity(contentValuesOf(
-            Events.DTSTART to 1759403653000,    // Thu Oct 02 2025 11:14:13 GMT+0000
-            Events.RRULE to "FREQ=DAILY;UNTIL=20251002T111300Z",
-            Events.EXDATE to "1759403653000"            // should be removed because the only RRULE is invalid and discarded,
-                                                        // so the whole event isn't recurring anymore
-        ))
+        val entity = Entity(
+            contentValuesOf(
+                Events.DTSTART to 1759403653000,    // Thu Oct 02 2025 11:14:13 GMT+0000
+                Events.RRULE to "FREQ=DAILY;UNTIL=20251002T111300Z",
+                Events.EXDATE to "1759403653000"            // should be removed because the only RRULE is invalid and discarded,
+                // so the whole event isn't recurring anymore
+            )
+        )
         handler.process(entity, entity, result)
         assertNull(result.getProperty<RRule<*>>(Property.RRULE).getOrNull())
         assertNull(result.getProperty<ExDate<*>>(Property.EXDATE).getOrNull())
@@ -154,11 +155,13 @@ class RecurrenceFieldsHandlerTest {
     @Test
     fun `EXRULE with UNTIL before DTSTART`() {
         val result = VEvent()
-        val entity = Entity(contentValuesOf(
-            Events.DTSTART to 1759403653000,    // Thu Oct 02 2025 11:14:13 GMT+0000,
-            Events.RRULE to "FREQ=DAILY;COUNT=10",      // EXRULE is only processed for recurring events
-            Events.EXRULE to "FREQ=DAILY;UNTIL=20251002T111300Z"
-        ))
+        val entity = Entity(
+            contentValuesOf(
+                Events.DTSTART to 1759403653000,    // Thu Oct 02 2025 11:14:13 GMT+0000,
+                Events.RRULE to "FREQ=DAILY;COUNT=10",      // EXRULE is only processed for recurring events
+                Events.EXRULE to "FREQ=DAILY;UNTIL=20251002T111300Z"
+            )
+        )
         handler.process(entity, entity, result)
         assertNull(result.getProperty<ExRule<*>>(Property.EXRULE).getOrNull())
     }
@@ -166,11 +169,13 @@ class RecurrenceFieldsHandlerTest {
     @Test
     fun `EXDATE with explicit UTC timezone`() {
         val result = VEvent()
-        val entity = Entity(contentValuesOf(
-            Events.DTSTART to 1759403653000,    // Thu Oct 02 2025 11:14:13 GMT+0000,
-            Events.RRULE to "FREQ=DAILY;COUNT=10",
-            Events.EXDATE to "UTC;20251003T111413"
-        ))
+        val entity = Entity(
+            contentValuesOf(
+                Events.DTSTART to 1759403653000,    // Thu Oct 02 2025 11:14:13 GMT+0000,
+                Events.RRULE to "FREQ=DAILY;COUNT=10",
+                Events.EXDATE to "UTC;20251003T111413"
+            )
+        )
 
         handler.process(entity, entity, result)
 
@@ -180,84 +185,5 @@ class RecurrenceFieldsHandlerTest {
         )
     }
 
-
-    @Test
-    fun `alignUntil(recurUntil=null)`() {
-        val recur = Recur.Builder<Temporal>()
-            .frequency(Frequency.DAILY)
-            .build()
-        val result = handler.alignUntil(
-            recur = recur,
-            startTemporal = mockk()
-        )
-        assertSame(recur, result)
-    }
-
-    @Test
-    fun `alignUntil(recurUntil=DATE, startDate=DATE)`() {
-        val recur = Recur.Builder<Temporal>()
-            .frequency(Frequency.DAILY)
-            .until(dateValue("20251015"))
-            .build()
-        val result = handler.alignUntil(
-            recur = recur,
-            startTemporal = LocalDate.now()
-        )
-        assertSame(recur, result)
-    }
-
-    @Test
-    fun `alignUntil(recurUntil=DATE, startDate=DATE-TIME)`() {
-        val result = handler.alignUntil(
-            recur = Recur.Builder<Temporal>()
-                .frequency(Frequency.DAILY)
-                .until(dateValue("20251015"))
-                .build(),
-            startTemporal = dateTimeValue("20250101T010203", tzVienna)
-        )
-        assertEquals(
-            Recur.Builder<Temporal>()
-                .frequency(Frequency.DAILY)
-                .until(dateTimeValue("20251014T230203Z"))
-                .build(),
-            result
-        )
-    }
-
-    @Test
-    fun `alignUntil(recurUntil=DATE-TIME, startDate=DATE)`() {
-        val result = handler.alignUntil(
-            recur = Recur.Builder<Temporal>()
-                .frequency(Frequency.DAILY)
-                .until(dateTimeValue("20251015T153118", tzVienna))
-                .build(),
-            startTemporal = LocalDate.now()
-        )
-        assertEquals(
-            Recur.Builder<Temporal>()
-                .frequency(Frequency.DAILY)
-                .until(dateValue("20251015"))
-                .build(),
-            result
-        )
-    }
-
-    @Test
-    fun `alignUntil(recurUntil=DATE-TIME, startDate=DATE-TIME)`() {
-        val result = handler.alignUntil(
-            recur = Recur.Builder<Temporal>()
-                .frequency(Frequency.DAILY)
-                .until(dateTimeValue("20251015T153118", tzVienna))
-                .build(),
-            startTemporal = LocalDateTime.now()
-        )
-        assertEquals(
-            Recur.Builder<Temporal>()
-                .frequency(Frequency.DAILY)
-                .until(dateTimeValue("20251015T133118Z"))
-                .build(),
-            result
-        )
-    }
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/RecurrenceFieldsHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/calendar/handler/RecurrenceFieldsHandlerTest.kt
@@ -36,7 +36,7 @@ import java.time.temporal.Temporal
 import kotlin.jvm.optionals.getOrNull
 
 @RunWith(RobolectricTestRunner::class)
-class RecurrenceFieldHandlerTest {
+class RecurrenceFieldsHandlerTest {
 
     private val tzVienna = ZoneId.of("Europe/Vienna")
 

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/handler/RecurrenceFieldsHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/handler/RecurrenceFieldsHandlerTest.kt
@@ -8,13 +8,10 @@ import android.content.ContentValues
 import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.dateTimeValue
-import at.bitfire.dateValue
 import at.bitfire.synctools.util.AndroidTimeUtils.toTimestamp
 import at.techbee.jtx.JtxContract
-import io.mockk.mockk
 import net.fortuna.ical4j.model.ParameterList
 import net.fortuna.ical4j.model.Property
-import net.fortuna.ical4j.model.Recur
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.parameter.TzId
 import net.fortuna.ical4j.model.parameter.Value
@@ -22,25 +19,18 @@ import net.fortuna.ical4j.model.property.ExDate
 import net.fortuna.ical4j.model.property.RDate
 import net.fortuna.ical4j.model.property.RRule
 import net.fortuna.ical4j.model.property.RecurrenceId
-import net.fortuna.ical4j.transform.recurrence.Frequency
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.temporal.Temporal
 import kotlin.jvm.optionals.getOrNull
 
 @RunWith(RobolectricTestRunner::class)
 class RecurrenceFieldsHandlerTest {
-
-    private val tzVienna = ZoneId.of("Europe/Vienna")
 
     private val handler = RecurrenceFieldsHandler()
 
@@ -350,84 +340,6 @@ class RecurrenceFieldsHandlerTest {
         assertEquals(
             ExDate<Temporal>(ParameterList(), "20260522T120000Z"),
             output.exDates.first()
-        )
-    }
-
-    @Test
-    fun `alignUntil(recurUntil=null)`() {
-        val recur = Recur.Builder<Temporal>()
-            .frequency(Frequency.DAILY)
-            .build()
-        val result = handler.alignUntil(recur, mockk())
-
-        assertSame(recur, result)
-    }
-
-    @Test
-    fun `alignUntil(recurUntil=DATE, startDate=DATE)`() {
-        val recur = Recur.Builder<Temporal>()
-            .frequency(Frequency.DAILY)
-            .until(dateValue("20251015"))
-            .build()
-        val result = handler.alignUntil(recur, LocalDate.now())
-
-        assertSame(recur, result)
-    }
-
-    @Test
-    fun `alignUntil(recurUntil=DATE, startDate=DATE-TIME)`() {
-        val result = handler.alignUntil(
-            recur = Recur.Builder<Temporal>()
-                .frequency(Frequency.DAILY)
-                .until(dateValue("20251015"))
-                .build(),
-            startTemporal = dateTimeValue("20250101T010203", tzVienna)
-        )
-
-        assertEquals(
-            Recur.Builder<Temporal>()
-                .frequency(Frequency.DAILY)
-                .until(dateTimeValue("20251014T230203Z"))
-                .build(),
-            result
-        )
-    }
-
-    @Test
-    fun `alignUntil(recurUntil=DATE-TIME, startDate=DATE)`() {
-        val result = handler.alignUntil(
-            recur = Recur.Builder<Temporal>()
-                .frequency(Frequency.DAILY)
-                .until(dateTimeValue("20251015T153118", tzVienna))
-                .build(),
-            startTemporal = LocalDate.now()
-        )
-
-        assertEquals(
-            Recur.Builder<Temporal>()
-                .frequency(Frequency.DAILY)
-                .until(dateValue("20251015"))
-                .build(),
-            result
-        )
-    }
-
-    @Test
-    fun `alignUntil(recurUntil=DATE-TIME, startDate=DATE-TIME)`() {
-        val result = handler.alignUntil(
-            recur = Recur.Builder<Temporal>()
-                .frequency(Frequency.DAILY)
-                .until(dateTimeValue("20251015T153118", tzVienna))
-                .build(),
-            startTemporal = LocalDateTime.now()
-        )
-
-        assertEquals(
-            Recur.Builder<Temporal>()
-                .frequency(Frequency.DAILY)
-                .until(dateTimeValue("20251015T133118Z"))
-                .build(),
-            result
         )
     }
 

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/RecurrenceFieldsHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/handler/RecurrenceFieldsHandlerTest.kt
@@ -8,28 +8,21 @@ import android.content.ContentValues
 import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.dateTimeValue
-import at.bitfire.dateValue
-import io.mockk.mockk
 import net.fortuna.ical4j.model.DateList
 import net.fortuna.ical4j.model.ParameterList
 import net.fortuna.ical4j.model.Property
-import net.fortuna.ical4j.model.Recur
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.parameter.TzId
 import net.fortuna.ical4j.model.property.ExDate
 import net.fortuna.ical4j.model.property.RDate
 import net.fortuna.ical4j.model.property.RRule
-import net.fortuna.ical4j.transform.recurrence.Frequency
 import org.dmfs.tasks.contract.TaskContract.Tasks
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.time.LocalDate
-import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.temporal.Temporal
 import kotlin.jvm.optionals.getOrNull
@@ -265,81 +258,6 @@ class RecurrenceFieldsHandlerTest {
         assertEquals("Europe/Vienna;20251010T010203", handler.withTzPrefix("Europe/Vienna;20251010T010203", "Europe/Vienna"))
     }
 
-
-    // alignUntil tests
-
-    @Test
-    fun `alignUntil(recurUntil=null)`() {
-        val recur = Recur.Builder<Temporal>()
-            .frequency(Frequency.DAILY)
-            .build()
-        val result = handler.alignUntil(recur, mockk())
-        assertSame(recur, result)
-    }
-
-    @Test
-    fun `alignUntil(recurUntil=DATE, startDate=DATE)`() {
-        val recur = Recur.Builder<Temporal>()
-            .frequency(Frequency.DAILY)
-            .until(dateValue("20251015"))
-            .build()
-        val result = handler.alignUntil(recur, LocalDate.now())
-        assertSame(recur, result)
-    }
-
-    @Test
-    fun `alignUntil(recurUntil=DATE, startDate=DATE-TIME)`() {
-        val result = handler.alignUntil(
-            recur = Recur.Builder<Temporal>()
-                .frequency(Frequency.DAILY)
-                .until(dateValue("20251015"))
-                .build(),
-            startTemporal = dateTimeValue("20250101T010203", tzVienna)
-        )
-        assertEquals(
-            Recur.Builder<Temporal>()
-                .frequency(Frequency.DAILY)
-                .until(dateTimeValue("20251014T230203Z"))
-                .build(),
-            result
-        )
-    }
-
-    @Test
-    fun `alignUntil(recurUntil=DATE-TIME, startDate=DATE)`() {
-        val result = handler.alignUntil(
-            recur = Recur.Builder<Temporal>()
-                .frequency(Frequency.DAILY)
-                .until(dateTimeValue("20251015T153118", tzVienna))
-                .build(),
-            startTemporal = LocalDate.now()
-        )
-        assertEquals(
-            Recur.Builder<Temporal>()
-                .frequency(Frequency.DAILY)
-                .until(dateValue("20251015"))
-                .build(),
-            result
-        )
-    }
-
-    @Test
-    fun `alignUntil(recurUntil=DATE-TIME, startDate=DATE-TIME)`() {
-        val result = handler.alignUntil(
-            recur = Recur.Builder<Temporal>()
-                .frequency(Frequency.DAILY)
-                .until(dateTimeValue("20251015T153118", tzVienna))
-                .build(),
-            startTemporal = LocalDateTime.now()
-        )
-        assertEquals(
-            Recur.Builder<Temporal>()
-                .frequency(Frequency.DAILY)
-                .until(dateTimeValue("20251015T133118Z"))
-                .build(),
-            result
-        )
-    }
 }
 
 private val VToDo.rRule: RRule<*>?

--- a/synctools/src/test/kotlin/at/bitfire/synctools/util/RecurrenceUtilsTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/util/RecurrenceUtilsTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.synctools.util
+
+import at.bitfire.dateTimeValue
+import at.bitfire.dateValue
+import net.fortuna.ical4j.model.Recur
+import net.fortuna.ical4j.transform.recurrence.Frequency
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+import java.time.ZoneId
+import java.time.temporal.Temporal
+
+class RecurrenceUtilsTest {
+
+    private val tzVienna = ZoneId.of("Europe/Vienna")
+
+    @Test
+    fun `alignUntil returns original recur without UNTIL`() {
+        val recur = dailyRecur()
+
+        val result = RecurrenceUtils.alignUntil(
+            recur = recur,
+            startTemporal = dateValue("20250101")
+        )
+
+        assertSame(recur, result)
+    }
+
+    @Test
+    fun `alignUntil returns original recur for DATE UNTIL and DATE DTSTART`() {
+        val recur = dailyRecur(dateValue("20251015"))
+
+        val result = RecurrenceUtils.alignUntil(
+            recur = recur,
+            startTemporal = dateValue("20250101")
+        )
+
+        assertSame(recur, result)
+    }
+
+    @Test
+    fun `alignUntil amends DATE UNTIL with DATE-TIME DTSTART time and timezone`() {
+        val result = RecurrenceUtils.alignUntil(
+            recur = dailyRecur(dateValue("20251015")),
+            startTemporal = dateTimeValue("20250101T010203", tzVienna)
+        )
+
+        assertEquals(
+            dailyRecur(dateTimeValue("20251014T230203Z")),
+            result
+        )
+    }
+
+    @Test
+    fun `alignUntil reduces DATE-TIME UNTIL to DATE for DATE DTSTART`() {
+        val result = RecurrenceUtils.alignUntil(
+            recur = dailyRecur(dateTimeValue("20251015T153118", tzVienna)),
+            startTemporal = dateValue("20250101")
+        )
+
+        assertEquals(
+            dailyRecur(dateValue("20251015")),
+            result
+        )
+    }
+
+    @Test
+    fun `alignUntil converts DATE-TIME UNTIL to UTC for DATE-TIME DTSTART`() {
+        val result = RecurrenceUtils.alignUntil(
+            recur = dailyRecur(dateTimeValue("20251015T153118", tzVienna)),
+            startTemporal = dateTimeValue("20250101T010203Z")
+        )
+
+        assertEquals(
+            dailyRecur(dateTimeValue("20251015T133118Z")),
+            result
+        )
+    }
+
+    @Test
+    fun `alignUntil returns original recur for UTC DATE-TIME UNTIL and DATE-TIME DTSTART`() {
+        val recur = dailyRecur(dateTimeValue("20251015T133118Z"))
+
+        val result = RecurrenceUtils.alignUntil(
+            recur = recur,
+            startTemporal = dateTimeValue("20250101T010203", tzVienna)
+        )
+
+        assertSame(recur, result)
+    }
+
+    private fun dailyRecur(until: Temporal? = null): Recur<Temporal> {
+        val builder = Recur.Builder<Temporal>()
+            .frequency(Frequency.DAILY)
+        until?.let { builder.until(it) }
+        return builder.build()
+    }
+
+}


### PR DESCRIPTION

Changes: 
- Move `alignUntil` to recurrence util (also aligns `TimeFieldsHandler` with `RecurrenceFieldsHandler` by using `AndroidTimeUtils.isUtcTzId()` via `JtxTimeField`, so UTC-like IDs are handled consistently)
- Re-use `JtxTimeField` in `TimeFieldsHandler`