### PR TITLE
Run garbage collection when ical4j's `ZoneIdPool` runs empty

### DIFF
--- a/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/TimeZoneRegistryFactoryWorkaround.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/TimeZoneRegistryFactoryWorkaround.kt
@@ -8,6 +8,7 @@ import net.fortuna.ical4j.model.DefaultTimeZoneRegistryFactory
 import net.fortuna.ical4j.model.TimeZone
 import net.fortuna.ical4j.model.TimeZoneRegistry
 import net.fortuna.ical4j.model.TimeZoneRegistryFactory
+import net.fortuna.ical4j.model.ZoneRulesProviderImpl
 import net.fortuna.ical4j.model.component.Observance
 import java.util.logging.Logger
 
@@ -18,7 +19,9 @@ class TimeZoneRegistryFactoryWorkaround : TimeZoneRegistryFactory() {
 }
 
 /**
- * Work around https://github.com/bitfireAT/davx5-ose/issues/2248
+ * Work around
+ * - https://github.com/bitfireAT/davx5-ose/issues/2248
+ * - https://github.com/bitfireAT/davx5/issues/914
  */
 class TimeZoneRegistryWorkaround(
     private val timeZoneRegistry: TimeZoneRegistry = DefaultTimeZoneRegistryFactory().createRegistry()
@@ -39,8 +42,15 @@ class TimeZoneRegistryWorkaround(
 
         if (standardObservances.isEmpty() && daylightObservances.isEmpty()) {
             logger.info("Ignoring invalid VTIMEZONE with TZID: ${timeZone.id}")
-        } else {
-            timeZoneRegistry.register(timeZone, update)
+            return
         }
+
+        if (ZoneRulesProviderImpl.INSTANCE.zoneIdPool.availableZoneIds() == 0) {
+            // Trigger garbage collection in the hope that old TimeZoneRegistry instances will be freed and in turn
+            // ZoneIdPool.cleanup() will be able to reclaim zone IDs that are no longer used.
+            Runtime.getRuntime().gc()
+        }
+
+        timeZoneRegistry.register(timeZone, update)
     }
 }

--- a/synctools/src/main/resources/ical4j.properties
+++ b/synctools/src/main/resources/ical4j.properties
@@ -2,6 +2,7 @@ net.fortuna.ical4j.timezone.registry=at.bitfire.synctools.icalendar.TimeZoneRegi
 net.fortuna.ical4j.timezone.cache.impl=net.fortuna.ical4j.util.MapTimeZoneCache
 net.fortuna.ical4j.timezone.offset.negative_dst_supported=true
 net.fortuna.ical4j.timezone.update.enabled=false
+net.fortuna.ical4j.timezone.id.pool.size=2000
 ical4j.unfolding.relaxed=true
 ical4j.parsing.relaxed=true
 ical4j.validation.relaxed=true

--- a/synctools/src/main/resources/ical4j.properties
+++ b/synctools/src/main/resources/ical4j.properties
@@ -2,7 +2,6 @@ net.fortuna.ical4j.timezone.registry=at.bitfire.synctools.icalendar.TimeZoneRegi
 net.fortuna.ical4j.timezone.cache.impl=net.fortuna.ical4j.util.MapTimeZoneCache
 net.fortuna.ical4j.timezone.offset.negative_dst_supported=true
 net.fortuna.ical4j.timezone.update.enabled=false
-net.fortuna.ical4j.timezone.id.pool.size=2000
 ical4j.unfolding.relaxed=true
 ical4j.parsing.relaxed=true
 ical4j.validation.relaxed=true


### PR DESCRIPTION
### Steps to test

1. Set `net.fortuna.ical4j.timezone.id.pool.size=1` in `ical4j.properties`
2. Run the following test on a device/emulator

```kotlin
class ZoneIdPoolTest {
    @Test
    fun zoneIdTest() {
        val data = """
            BEGIN:VCALENDAR
            CALSCALE:GREGORIAN
            VERSION:2.0
            PRODID:-//K Desktop Environment//NONSGML KOrganizer 6.5.0 (25.08.0)//EN
            BEGIN:VTIMEZONE
            TZID:America/Asuncion
            BEGIN:STANDARD
            TZNAME:-03
            TZOFFSETFROM:-0300
            TZOFFSETTO:-0300
            DTSTART:19700101T000000
            END:STANDARD
            END:VTIMEZONE
            BEGIN:VEVENT
            DTSTAMP:20250828T233827Z
            CREATED:20250828T233750Z
            UID:e5d424b9-d3f6-4ee0-bf95-da7537fca1fe
            LAST-MODIFIED:20250828T233827Z
            SUMMARY:Test Timezones
            RRULE:FREQ=WEEKLY;COUNT=3;BYDAY=TH
            DTSTART;TZID=America/Asuncion:20250828T130000
            DTEND;TZID=America/Asuncion:20250828T133000
            TRANSP:OPAQUE
            END:VEVENT
            END:VCALENDAR
            """.trimIndent()

        parseCalendarAndCreateZonedDateTime(data)

        assertEquals(0, ZoneRulesProviderImpl.INSTANCE.zoneIdPool.availableZoneIds())

        parseCalendarAndCreateZonedDateTime(data)
    }

    // This code is in a separate function so we don't retain any references to TimeZoneRegistry when triggering
    // the garbage collection.
    private fun parseCalendarAndCreateZonedDateTime(data: String) {
        val tzRegistry = TimeZoneRegistryFactory.getInstance().createRegistry()
        val calendar = CalendarBuilder(tzRegistry).build(StringReader(data))
        val event = calendar.getComponent<VEvent>(Component.VEVENT).get()
        val dtStart = event.requireDtStart<ZonedDateTime>()
        assertEquals(ZoneOffset.ofHours(-3), ZoneOffset.from(dtStart.date))
    }
}
```

Without the change to `TimeZoneRegistryWorkaround`, the test should fail. With the change applied, it should pass.

Fixes https://github.com/bitfireAT/davx5/issues/914