### PR TITLE
Add RAM info to debug info

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoGenerator.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoGenerator.kt
@@ -6,6 +6,7 @@ package at.bitfire.davdroid.ui
 
 import android.accounts.Account
 import android.accounts.AccountManager
+import android.app.ActivityManager
 import android.app.usage.UsageStatsManager
 import android.content.ContentUris
 import android.content.Context
@@ -15,6 +16,7 @@ import android.content.pm.PackageManager
 import android.net.ConnectivityManager
 import android.net.Uri
 import android.os.Build
+import android.os.Debug
 import android.os.Environment
 import android.os.LocaleList
 import android.os.PowerManager
@@ -54,6 +56,7 @@ import java.time.Instant
 import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
+import java.util.Locale
 import java.util.TimeZone
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -192,10 +195,12 @@ class DebugInfoGenerator @Inject constructor(
         val filesPath = Environment.getDataDirectory()
         val statFs = StatFs(filesPath.path)
         writer.append("Internal memory ($filesPath): ")
-            .append(Formatter.formatFileSize(context, statFs.availableBytes))
+            .append(formatFileSize(statFs.availableBytes))
             .append(" free of ")
-            .append(Formatter.formatFileSize(context, statFs.totalBytes))
-            .append("\n\n")
+            .append(formatFileSize(statFs.totalBytes))
+            .append('\n')
+        dumpRamInfo(writer)
+        writer.append('\n')
 
         // power saving
         if (Build.VERSION.SDK_INT >= 28)
@@ -333,6 +338,86 @@ class DebugInfoGenerator @Inject constructor(
 
         writer.append("--- END DEBUG INFO ---\n")
     }
+
+    /**
+     * Appends current system and process memory information.
+     */
+    private fun dumpRamInfo(writer: Writer) {
+        context.getSystemService<ActivityManager>()?.let { activityManager ->
+            val memoryInfo = ActivityManager.MemoryInfo()
+            activityManager.getMemoryInfo(memoryInfo)
+
+            writer.append("System RAM: ")
+                .append(formatFileSize(memoryInfo.availMem))
+                .append(" available of ")
+                .append(formatFileSize(memoryInfo.totalMem))
+                .append(" total (")
+                .append(formatPercent(memoryInfo.availMem, memoryInfo.totalMem))
+                .append(")\n")
+                .append("System RAM threshold: ")
+                .append(formatFileSize(memoryInfo.threshold))
+                .append("; low memory: ")
+                .append(if (memoryInfo.lowMemory) "yes" else "no")
+                .append("; low-RAM device: ")
+                .append(if (activityManager.isLowRamDevice) "yes" else "no")
+                .append('\n')
+            if (Build.VERSION.SDK_INT >= 34 && memoryInfo.advertisedMem > 0)
+                writer.append("System advertised RAM: ")
+                    .append(formatFileSize(memoryInfo.advertisedMem))
+                    .append('\n')
+            if (Build.VERSION.SDK_INT >= 37)
+                writer.append("System free RAM: ")
+                    .append(formatFileSize(memoryInfo.freeMem))
+                    .append('\n')
+
+            writer.append("App heap class: ")
+                .append(activityManager.memoryClass.toString())
+                .append(" MB; large heap class: ")
+                .append(activityManager.largeMemoryClass.toString())
+                .append(" MB\n")
+        }
+
+        val runtime = Runtime.getRuntime()
+        val allocatedHeap = runtime.totalMemory()
+        val freeHeap = runtime.freeMemory()
+        val maxHeap = runtime.maxMemory()
+        val usedHeap = allocatedHeap - freeHeap
+        writer.append("App heap: ")
+            .append(formatFileSize(usedHeap))
+            .append(" used; ")
+            .append(formatFileSize(freeHeap))
+            .append(" free of ")
+            .append(formatFileSize(allocatedHeap))
+            .append(" allocated; ")
+            .append(formatFileSize(maxHeap))
+            .append(" max (")
+            .append(formatPercent(usedHeap, maxHeap))
+            .append(" used)\n")
+
+        val processMemoryInfo = Debug.MemoryInfo()
+        Debug.getMemoryInfo(processMemoryInfo)
+        writer.append("App PSS: ")
+            .append(formatKib(processMemoryInfo.totalPss))
+            .append(" total (Dalvik ")
+            .append(formatKib(processMemoryInfo.dalvikPss))
+            .append(", native ")
+            .append(formatKib(processMemoryInfo.nativePss))
+            .append(", other ")
+            .append(formatKib(processMemoryInfo.otherPss))
+            .append(")\n")
+    }
+
+    private fun formatFileSize(bytes: Long): String =
+        Formatter.formatFileSize(context, bytes)
+
+    private fun formatKib(kib: Int): String =
+        formatFileSize(kib.toLong() * 1024)
+
+    private fun formatPercent(part: Long, total: Long): String =
+        if (total > 0)
+            String.format(Locale.ROOT, "%.1f%%", part.toDouble() / total.toDouble() * 100)
+        else
+            "n/a"
 
     /**
      * Appends relevant android account information the given writer.

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoGenerator.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoGenerator.kt
@@ -353,7 +353,7 @@ class DebugInfoGenerator @Inject constructor(
                 .append(formatFileSize(memoryInfo.totalMem))
                 .append(" total (")
                 .append(formatPercent(memoryInfo.availMem, memoryInfo.totalMem))
-                .append(")\n")
+                .append(" available)\n")
                 .append("System RAM threshold: ")
                 .append(formatFileSize(memoryInfo.threshold))
                 .append("; low memory: ")


### PR DESCRIPTION


Added RAM details under "SYSTEM INFORMATION" to Debug info:

  - System RAM: available/total, percentage, low-memory threshold/status, low-RAM device flag, guarded advertisedMem and freeMem
  - App heap limits: memoryClass, largeMemoryClass, Runtime.maxMemory()
  - Current app heap: used/free/allocated/max
  - Current process RAM footprint: total PSS split into Dalvik/native/other

For understanding GC we are mostly interested in: App heap used, App heap free, App heap allocated, and App heap max, but I think the other informations might come in handy at some point.

<img width="706" height="708" alt="image" src="https://github.com/user-attachments/assets/37fdc937-281c-4ae7-9228-023ba28b8a0c" />
