### PR TITLE
Remove duplicate ez-vcard version from product ID

### DIFF
--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/ContactWriter.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/ContactWriter.kt
@@ -71,7 +71,7 @@ class ContactWriter(
     }
 
     private fun addProperties() {
-        vCard.productId = ProductId("$productId (ez-vcard/${Ezvcard.VERSION})")
+        vCard.productId = ProductId(productId)
         contact.uid?.let { vCard.uid = Uid(it) }
 
         addKindAndMembers()


### PR DESCRIPTION

### Purpose

Remove duplicate ez-vcard version declaration in product ID to avoid redundancy.

### Short description

- Removed the duplicate version specification for ez-vcard in the product ID configuration.

Currently (before PR) it's defined with ez-vcard version at

https://github.com/bitfireAT/davx5-ose/blob/7cb03926577d77ff6d6a8e5b8f19b7f202636a83/core/src/main/kotlin/at/bitfire/davdroid/ProductIds.kt#L30

and then the version is appended another time at

https://github.com/bitfireAT/davx5-ose/blob/7cb03926577d77ff6d6a8e5b8f19b7f202636a83/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/ContactWriter.kt#L74

→ duplicate ez-vcard version


### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.