### PR TITLE
Ignore unsupported recurring task exceptions

### DIFF
--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskBuilder.kt
@@ -43,6 +43,7 @@ import at.bitfire.synctools.mapping.tasks.builder.UrlBuilder
 import at.bitfire.synctools.storage.tasks.DmfsTaskList
 import at.bitfire.synctools.storage.tasks.TaskAndExceptions
 import net.fortuna.ical4j.model.component.VToDo
+import java.util.logging.Logger
 
 class DmfsTaskBuilder(
     taskList: DmfsTaskList,
@@ -93,14 +94,21 @@ class DmfsTaskBuilder(
         UnknownPropertiesBuilder(taskList),
     )
 
+    private val logger
+        get() = Logger.getLogger(javaClass.name)
+
     fun build(associatedTasks: AssociatedTasks): TaskAndExceptions {
-        // TODO: when recurrence is supported on tasks, no exception should be thrown, but instead a reference should be created for exceptions. See AndroidEventBuilder
-        val mainVToDo = associatedTasks.main ?: throw ResourceMappingException("Main task is missing in associated tasks")
+        val mainVToDo = associatedTasks.main
+            ?: throw ResourceMappingException("Main task is missing in associated tasks")
+
+        /* Recurring task exceptions are not yet supported. Passing them to OpenTasks
+        without ORIGINAL_INSTANCE_TIME causes problems, so drop them. */
+        if (associatedTasks.exceptions.isNotEmpty())
+            logger.warning("Ignoring ${associatedTasks.exceptions.size} exception(s) of recurring task (not yet supported, see #2357)")
+
         return TaskAndExceptions(
             main = buildTask(from = mainVToDo, main = mainVToDo),
-            exceptions = associatedTasks.exceptions.map { exception ->
-                buildTask(from = exception, main = mainVToDo)
-            }
+            exceptions = emptyList()
         )
     }
 

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskBuilderTest.kt
@@ -12,6 +12,7 @@ import at.bitfire.synctools.storage.tasks.DmfsTaskList
 import io.mockk.every
 import io.mockk.mockk
 import net.fortuna.ical4j.model.property.DtStart
+import net.fortuna.ical4j.model.property.RRule
 import net.fortuna.ical4j.model.property.RecurrenceId
 import net.fortuna.ical4j.model.property.Uid
 import org.dmfs.tasks.contract.TaskContract.Tasks
@@ -20,6 +21,7 @@ import org.junit.Assert.assertNotNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.time.temporal.Temporal
 
 @RunWith(RobolectricTestRunner::class)
 class DmfsTaskBuilderTest {
@@ -55,5 +57,26 @@ class DmfsTaskBuilderTest {
         assertNotNull(result.main.entityValues.getAsString(Tasks.RDATE))
         assertEquals(null, result.exceptions.first().entityValues.getAsString(Tasks.RRULE))
         assertEquals(null, result.exceptions.first().entityValues.getAsString(Tasks.RDATE))
+    }
+
+    // Drop this test once recurring task exception support is implemented (#2357)
+    @Test
+    fun `build with main task and exceptions drops exceptions`() {
+        val main = VToDoUtil.build(
+            Uid("uid-1"),
+            DtStart(dateTimeValue("20250101T000000Z")),
+            RRule<Temporal>("FREQ=YEARLY")
+        )
+        val exception = VToDoUtil.build(
+            Uid("uid-1"),
+            DtStart(dateTimeValue("20260101T000000Z")),
+            RecurrenceId(dateTimeValue("20260101T000000Z"))
+        )
+
+        val result = builder.build(
+            AssociatedTasks(main = main, exceptions = listOf(exception))
+        )
+
+        assertEquals(0, result.exceptions.size)
     }
 }


### PR DESCRIPTION
### Purpose

Ignores recurring task exceptions as they are not yet fully supported (see #2357).

When we don't ignore them, it causes problems, see https://github.com/bitfireAT/davx5-ose/issues/2552 ("1. Local storage error - Content provider threw a runtime exception").

### Short description

- Removed recurring task exceptions for now.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.