### PR TITLE
Preserve TEL ext= URI parameter when mapping vCard phone numbers to Android

### DIFF
--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/PhoneBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/PhoneBuilder.kt
@@ -22,11 +22,19 @@ class PhoneBuilder(dataRowUri: Uri, rawContactId: Long?, contact: Contact, readO
             val tel = phoneNumber.property
 
             // TEL can have either a TEXT (default for vCard 3 compatibility) or an URI value.
-            val number = tel.uri?.number ?: tel.text
+            val uri = tel.uri
+            val baseNumber = uri?.number ?: tel.text
 
             // Skip empty numbers
-            if (number.isNullOrBlank())
+            if (baseNumber.isNullOrBlank())
                 continue
+
+            val ext = uri?.extension
+            val number =
+                if (uri != null && !ext.isNullOrBlank() && !baseNumber.contains(';') && !baseNumber.contains(','))
+                    "$baseNumber;$ext"
+                else
+                    baseNumber
 
             val types = tel.types
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/PhoneBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/PhoneBuilder.kt
@@ -6,6 +6,7 @@ package at.bitfire.synctools.mapping.contacts.builder
 
 import android.net.Uri
 import android.provider.ContactsContract.CommonDataKinds.Phone
+import android.telephony.PhoneNumberUtils
 import at.bitfire.synctools.mapping.contacts.Contact
 import at.bitfire.synctools.storage.BatchOperation
 import at.bitfire.synctools.vcard.property.CustomType
@@ -23,18 +24,23 @@ class PhoneBuilder(dataRowUri: Uri, rawContactId: Long?, contact: Contact, readO
 
             // TEL can have either a TEXT (default for vCard 3 compatibility) or an URI value.
             val uri = tel.uri
-            val baseNumber = uri?.number ?: tel.text
+            val number: String?
+            if (uri != null) {
+                val baseNumber = uri.number
+                val ext = uri.extension
+                number =
+                    if (!baseNumber.isNullOrBlank() && !ext.isNullOrBlank() &&
+                            !baseNumber.contains(PhoneNumberUtils.WAIT) && !baseNumber.contains(PhoneNumberUtils.PAUSE))
+                        "$baseNumber${PhoneNumberUtils.WAIT}$ext"
+                    else
+                        baseNumber
+            } else {
+                number = tel.text
+            }
 
             // Skip empty numbers
-            if (baseNumber.isNullOrBlank())
+            if (number.isNullOrBlank())
                 continue
-
-            val ext = uri?.extension
-            val number =
-                if (uri != null && !ext.isNullOrBlank() && !baseNumber.contains(';') && !baseNumber.contains(','))
-                    "$baseNumber;$ext"
-                else
-                    baseNumber
 
             val types = tel.types
 

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/builder/PhoneBuilderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/builder/PhoneBuilderTest.kt
@@ -57,6 +57,36 @@ class PhoneBuilderTest {
         }
     }
 
+    @Test
+    fun testNumber_Value_Uri_WithExtension() {
+        PhoneBuilder(Uri.EMPTY, null, Contact().apply {
+            phoneNumbers += LabeledProperty(Telephone(TelUri.Builder("+15551234567").extension("5555").build()))
+        }, false).build().also { result ->
+            assertEquals(1, result.size)
+            assertEquals("+15551234567;5555", result[0].values[CommonDataKinds.Phone.NUMBER])
+        }
+    }
+
+    @Test
+    fun testNumber_Value_Uri_BlankExtension() {
+        PhoneBuilder(Uri.EMPTY, null, Contact().apply {
+            phoneNumbers += LabeledProperty(Telephone(TelUri.Builder("+15551234567").build()))
+        }, false).build().also { result ->
+            assertEquals(1, result.size)
+            assertEquals("+15551234567", result[0].values[CommonDataKinds.Phone.NUMBER])
+        }
+    }
+
+    @Test
+    fun testNumber_Value_Uri_AlreadyHasSeparator() {
+        PhoneBuilder(Uri.EMPTY, null, Contact().apply {
+            phoneNumbers += LabeledProperty(Telephone(TelUri.parse("tel:+15551234567,5555;ext=5555")))
+        }, false).build().also { result ->
+            assertEquals(1, result.size)
+            assertEquals("+15551234567,5555", result[0].values[CommonDataKinds.Phone.NUMBER])
+        }
+    }
+
 
     @Test
     fun testLabel() {


### PR DESCRIPTION
### Purpose

Preserve the phone-number extension carried by RFC 6350 `tel:` URI values when syncing CardDAV contacts down to Android, as reported in issue #2258.

Servers such as Fastmail store extensions per RFC 6350 using a `tel:` URI value with an `ext=` parameter, e.g. `TEL;VALUE=uri:tel:+1-555-555-5555;ext=5555`. Until now `PhoneBuilder` derived the Android `Phone.NUMBER` from `tel.uri.number` only, so the extension was silently dropped and only the base number reached the Android contact.

### Short description

- In `PhoneBuilder.build()`, read the `ext=` parameter (`tel.uri.extension`) in addition to the base number.
- When the value comes from a URI and the extension is non-blank, append it to `Phone.NUMBER` as a `;<ext>` wait suffix, which Android's dialer understands (`<number>;<ext>`).
- Guard against double-appending: if the base number already contains a `;` (wait) or `,` (pause) separator, the extension is not appended again.
- The empty-number skip now checks the base number, and the existing text-form (`tel.text`) fallback path is unchanged, so vCard 3 compatibility and current behavior are preserved.
- Added `PhoneBuilderTest` cases for: a URI with an extension (`+15551234567;5555`), a URI without an extension (no trailing separator), and a URI whose number already embeds a separator (no double-suffix).

Scope note: this covers the URI `ext=` parameter specifically. The text-form wait/pause (`;`/`,`) roundtrip reported as already working in v4.5.13 is intentionally out of scope.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have self-reviewed the PR.
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

Refs #2258
