### PR TITLE
[Ktor] Use Ktor for WebDAV mount creation

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/webdav/WebDavUrlCheckerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/webdav/WebDavUrlCheckerTest.kt
@@ -4,6 +4,7 @@
 
 package at.bitfire.davdroid.webdav
 
+import at.bitfire.dav4jvm.HttpUtils.toKtorUrl
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import junit.framework.TestCase.assertEquals
@@ -31,7 +32,7 @@ class WebDavUrlCheckerTest {
     }
 
     val web = MockWebServer()
-    val url = web.url("/")
+    val url = web.url("/").toKtorUrl()
 
     @Test
     fun getWebDavUrl_NoDavHeader() = runTest {

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/webdav/WebDavUrlCheckerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/webdav/WebDavUrlCheckerTest.kt
@@ -17,13 +17,13 @@ import org.junit.Test
 import javax.inject.Inject
 
 @HiltAndroidTest
-class WebDavMountRepositoryTest {
+class WebDavUrlCheckerTest {
 
     @get:Rule
     val hiltRule = HiltAndroidRule(this)
 
     @Inject
-    lateinit var repository: WebDavMountRepository
+    lateinit var webDavUrlChecker: WebDavUrlChecker
 
     @Before
     fun setUp() {
@@ -34,33 +34,44 @@ class WebDavMountRepositoryTest {
     val url = web.url("/")
 
     @Test
-    fun testHasWebDav_NoDavHeader() = runTest {
+    fun getWebDavUrl_NoDavHeader() = runTest {
         web.enqueue(MockResponse().setResponseCode(200))
-        assertNull(repository.hasWebDav(url, null))
+
+        val result = webDavUrlChecker.getWebDavUrl(url = url, credentials = null)
+
+        assertNull(result)
     }
 
     @Test
-    fun testHasWebDav_DavClass1() = runTest {
+    fun getWebDavUrl_DavClass1() = runTest {
         web.enqueue(MockResponse()
             .setResponseCode(200)
             .addHeader("DAV: 1"))
-        assertEquals(url, repository.hasWebDav(url, null))
+
+        val result = webDavUrlChecker.getWebDavUrl(url = url, credentials = null)
+
+        assertEquals(url, result)
     }
 
     @Test
-    fun testHasWebDav_DavClass2() = runTest {
+    fun getWebDavUrl_DavClass2() = runTest {
         web.enqueue(MockResponse()
             .setResponseCode(200)
             .addHeader("DAV: 1, 2"))
-        assertEquals(url,repository.hasWebDav(url, null))
+
+        val result = webDavUrlChecker.getWebDavUrl(url = url, credentials = null)
+
+        assertEquals(url, result)
     }
 
     @Test
-    fun testHasWebDav_DavClass3() = runTest {
+    fun getWebDavUrl_DavClass3() = runTest {
         web.enqueue(MockResponse()
             .setResponseCode(200)
             .addHeader("DAV: 1, 3"))
-        assertEquals(url,repository.hasWebDav(url, null))
-    }
 
+        val result = webDavUrlChecker.getWebDavUrl(url = url, credentials = null)
+
+        assertEquals(url, result)
+    }
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/webdav/AddWebdavMountViewModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/webdav/AddWebdavMountViewModel.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import at.bitfire.dav4jvm.ktor.toUrlOrNull
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.settings.Credentials
@@ -20,7 +21,6 @@ import at.bitfire.synctools.util.trimToNull
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.launch
-import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import javax.inject.Inject
 
 @HiltViewModel
@@ -45,7 +45,7 @@ class AddWebdavMountViewModel @Inject constructor(
                 url
             else
                 "https://$url"
-        val httpUrl = urlWithPrefix.toHttpUrlOrNull()
+        val httpUrl = urlWithPrefix.toUrlOrNull()
         val canContinue = displayName.isNotBlank() && httpUrl != null
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/WebDavMountRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/WebDavMountRepository.kt
@@ -6,15 +6,10 @@ package at.bitfire.davdroid.webdav
 
 import android.content.Context
 import android.provider.DocumentsContract
-import androidx.annotation.VisibleForTesting
-import at.bitfire.dav4jvm.HttpUtils.toHttpUrl
-import at.bitfire.dav4jvm.HttpUtils.toKtorUrl
-import at.bitfire.dav4jvm.ktor.DavResource
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.WebDavMount
 import at.bitfire.davdroid.di.qualifier.IoDispatcher
-import at.bitfire.davdroid.network.HttpClientBuilder
 import at.bitfire.davdroid.settings.Credentials
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
@@ -22,13 +17,12 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl
 import javax.inject.Inject
-import javax.inject.Provider
 
 class WebDavMountRepository @Inject constructor(
     @ApplicationContext private val context: Context,
     private val db: AppDatabase,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
-    private val httpClientBuilder: Provider<HttpClientBuilder>
+    private val webDavUrlChecker: WebDavUrlChecker
 ) {
 
     private val mountDao = db.webDavMountDao()
@@ -51,9 +45,7 @@ class WebDavMountRepository @Inject constructor(
         displayName: String,
         credentials: Credentials?
     ): Boolean {
-        val webdavUrl = hasWebDav(url, credentials)
-        if (webdavUrl == null)
-            return false
+        val webdavUrl = webDavUrlChecker.getWebDavUrl(url, credentials) ?: return false
 
         // create in database
         val mount = WebDavMount(
@@ -108,42 +100,4 @@ class WebDavMountRepository @Inject constructor(
             }
         }
     }
-
-
-    // helpers
-
-    /**
-     * Checks whether WebDAV is supported at given URL with given credentials
-     * and returns the resulting if following a few redirects.
-     *
-     * @param url The URL to check
-     * @param credentials The credentials to use for the request
-     * @return The URL at which WebDAV support was found
-     */
-    @VisibleForTesting
-    internal suspend fun hasWebDav(
-        url: HttpUrl,
-        credentials: Credentials?
-    ): HttpUrl? {
-        val validVersions = arrayOf("1", "2", "3")
-
-        val builder = httpClientBuilder.get()
-        if (credentials != null)
-            builder.authenticate(
-                domain = null,
-                getCredentials = { credentials }
-            )
-
-        var webdavUrl: HttpUrl? = null
-        builder.buildKtor().use { httpClient ->
-            val dav = DavResource(httpClient, url.toKtorUrl())
-            dav.options(followRedirects = true) { davCapabilities, _ ->
-                if (davCapabilities.any { it in validVersions })
-                    webdavUrl = dav.location.toHttpUrl()
-            }
-        }
-
-        return webdavUrl
-    }
-
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/WebDavMountRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/WebDavMountRepository.kt
@@ -6,16 +6,17 @@ package at.bitfire.davdroid.webdav
 
 import android.content.Context
 import android.provider.DocumentsContract
+import at.bitfire.dav4jvm.HttpUtils.toHttpUrl
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.WebDavMount
 import at.bitfire.davdroid.di.qualifier.IoDispatcher
 import at.bitfire.davdroid.settings.Credentials
 import dagger.hilt.android.qualifiers.ApplicationContext
+import io.ktor.http.Url
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
-import okhttp3.HttpUrl
 import javax.inject.Inject
 
 class WebDavMountRepository @Inject constructor(
@@ -41,7 +42,7 @@ class WebDavMountRepository @Inject constructor(
      * @return `true` if the mount was added successfully, `false` if the endpoint doesn't support WebDAV
      */
     suspend fun addMount(
-        url: HttpUrl,
+        url: Url,
         displayName: String,
         credentials: Credentials?
     ): Boolean {
@@ -49,7 +50,7 @@ class WebDavMountRepository @Inject constructor(
 
         // create in database
         val mount = WebDavMount(
-            url = webdavUrl,
+            url = webdavUrl.toHttpUrl(),
             name = displayName
         )
         val id = db.webDavMountDao().insert(mount)

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/WebDavUrlChecker.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/WebDavUrlChecker.kt
@@ -4,12 +4,10 @@
 
 package at.bitfire.davdroid.webdav
 
-import at.bitfire.dav4jvm.HttpUtils.toHttpUrl
-import at.bitfire.dav4jvm.HttpUtils.toKtorUrl
 import at.bitfire.dav4jvm.ktor.DavResource
 import at.bitfire.davdroid.network.HttpClientBuilder
 import at.bitfire.davdroid.settings.Credentials
-import okhttp3.HttpUrl
+import io.ktor.http.Url
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -28,9 +26,9 @@ class WebDavUrlChecker @Inject constructor(
      * @return The URL at which WebDAV support was found
      */
     suspend fun getWebDavUrl(
-        url: HttpUrl,
+        url: Url,
         credentials: Credentials?
-    ): HttpUrl? {
+    ): Url? {
         val validVersions = arrayOf("1", "2", "3")
 
         val builder = httpClientBuilder.get()
@@ -40,12 +38,12 @@ class WebDavUrlChecker @Inject constructor(
                 getCredentials = { credentials }
             )
 
-        var webdavUrl: HttpUrl? = null
+        var webdavUrl: Url? = null
         builder.buildKtor().use { httpClient ->
-            val dav = DavResource(httpClient, url.toKtorUrl())
+            val dav = DavResource(httpClient, url)
             dav.options(followRedirects = true) { davCapabilities, _ ->
                 if (davCapabilities.any { it in validVersions })
-                    webdavUrl = dav.location.toHttpUrl()
+                    webdavUrl = dav.location
             }
         }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/WebDavUrlChecker.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/WebDavUrlChecker.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.webdav
+
+import at.bitfire.dav4jvm.HttpUtils.toHttpUrl
+import at.bitfire.dav4jvm.HttpUtils.toKtorUrl
+import at.bitfire.dav4jvm.ktor.DavResource
+import at.bitfire.davdroid.network.HttpClientBuilder
+import at.bitfire.davdroid.settings.Credentials
+import okhttp3.HttpUrl
+import javax.inject.Inject
+import javax.inject.Provider
+
+/**
+ * Checks if WebDAV is supported at a given URL.
+ */
+class WebDavUrlChecker @Inject constructor(
+    private val httpClientBuilder: Provider<HttpClientBuilder>
+) {
+    /**
+     * Checks whether WebDAV is supported at given URL with given credentials and returns the resulting URL after
+     * following redirects.
+     *
+     * @param url The URL to check
+     * @param credentials The credentials to use for the request
+     * @return The URL at which WebDAV support was found
+     */
+    suspend fun getWebDavUrl(
+        url: HttpUrl,
+        credentials: Credentials?
+    ): HttpUrl? {
+        val validVersions = arrayOf("1", "2", "3")
+
+        val builder = httpClientBuilder.get()
+        if (credentials != null)
+            builder.authenticate(
+                domain = null,
+                getCredentials = { credentials }
+            )
+
+        var webdavUrl: HttpUrl? = null
+        builder.buildKtor().use { httpClient ->
+            val dav = DavResource(httpClient, url.toKtorUrl())
+            dav.options(followRedirects = true) { davCapabilities, _ ->
+                if (davCapabilities.any { it in validVersions })
+                    webdavUrl = dav.location.toHttpUrl()
+            }
+        }
+
+        return webdavUrl
+    }
+}


### PR DESCRIPTION
- Extracts `WebDavUrlChecker` from `WebDavMountRepository`. If the functionality is worth testing in isolation, it should live in it's own class. This way we don't have to use `@VisibleForTesting`.
- Changes `WebDavMountRepository` and associated classes to use ktor's `Url` class instead of okhttp's `HttpUrl`. 
 
Note: I left `WebDavMount` and `WebDavDocument` untouched. That work should be covered by 
- #2542