### PR TITLE
Replace OkHttp cookie handling with Ktor's HttpCookies plugin

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
@@ -9,7 +9,6 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.test.runTest
-import okhttp3.Request
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
@@ -69,40 +68,42 @@ class HttpClientBuilderTest {
     }
 
     @Test
-    fun testCookies() {
-        val url = server.url("/test")
+    fun testCookies() = runTest {
+        // Cookies are handled by Ktor's HttpCookies plugin (AcceptAllCookiesStorage),
+        // so they're only stored/sent by the Ktor client, not the raw OkHttp client.
+        val url = server.url("/test").toString()
 
-        // set cookie for root path (/) and /test path in first response
-        server.enqueue(MockResponse()
-                .setResponseCode(200)
-                .addHeader("Set-Cookie", "cookie1=1; path=/")
-                .addHeader("Set-Cookie", "cookie2=2")
-                .setBody("Cookie set"))
+        httpClientBuilder.get().buildKtor().use { client ->
+            // set cookie for root path (/) and /test path in first response
+            server.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .addHeader("Set-Cookie", "cookie1=1; path=/")
+                    .addHeader("Set-Cookie", "cookie2=2")
+                    .setBody("Cookie set")
+            )
+            client.get(url)
+            assertNull(server.takeRequest().getHeader("Cookie"))
 
-        val httpClient = httpClientBuilder.get().build()
-        httpClient.newCall(Request.Builder()
-                .get().url(url)
-                .build()).execute()
-        assertNull(server.takeRequest().getHeader("Cookie"))
+            // cookie should be sent with second request
+            // second response lets first cookie expire and overwrites second cookie
+            server.enqueue(
+                MockResponse()
+                    .addHeader("Set-Cookie", "cookie1=1a; path=/; Max-Age=0")
+                    .addHeader("Set-Cookie", "cookie2=2a")
+                    .setResponseCode(200)
+            )
+            client.get(url)
+            val header = server.takeRequest().getHeader("Cookie")
+            assertTrue(header == "cookie1=1; cookie2=2" || header == "cookie2=2; cookie1=1")
 
-        // cookie should be sent with second request
-        // second response lets first cookie expire and overwrites second cookie
-        server.enqueue(MockResponse()
-                .addHeader("Set-Cookie", "cookie1=1a; path=/; Max-Age=0")
-                .addHeader("Set-Cookie", "cookie2=2a")
-                .setResponseCode(200))
-        httpClient.newCall(Request.Builder()
-                .get().url(url)
-                .build()).execute()
-        val header = server.takeRequest().getHeader("Cookie")
-        assertTrue(header == "cookie1=1; cookie2=2" || header == "cookie2=2; cookie1=1")
-
-        server.enqueue(MockResponse()
-                .setResponseCode(200))
-        httpClient.newCall(Request.Builder()
-                .get().url(url)
-                .build()).execute()
-        assertEquals("cookie2=2a", server.takeRequest().getHeader("Cookie"))
+            server.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+            )
+            client.get(url)
+            assertEquals("cookie2=2a", server.takeRequest().getHeader("Cookie"))
+        }
     }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
@@ -18,13 +18,13 @@ import com.google.errorprone.annotations.MustBeClosed
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.cookies.HttpCookies
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import net.openid.appauth.AuthState
 import okhttp3.Authenticator
 import okhttp3.ConnectionSpec
-import okhttp3.CookieJar
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
@@ -103,14 +103,6 @@ class HttpClientBuilder @Inject constructor(
 
     fun loggerInterceptorLevel(level: HttpLoggingInterceptor.Level): HttpClientBuilder {
         loggerInterceptorLevel = level
-        return this
-    }
-
-    // default cookie store for non-persistent cookies (some services like Horde use cookies for session tracking)
-    private var cookieStore: CookieJar = MemoryCookieStore()
-
-    fun setCookieStore(cookieStore: CookieJar): HttpClientBuilder {
-        this.cookieStore = cookieStore
         return this
     }
 
@@ -238,9 +230,6 @@ class HttpClientBuilder @Inject constructor(
         // add User-Agent to every request
         builder.addInterceptor(userAgentInterceptor)
 
-        // connection-private cookie store
-        builder.cookieJar(cookieStore)
-
         // offer Brotli and gzip compression (can be disabled per request with `Accept-Encoding: identity`)
         builder.addInterceptor(BrotliInterceptor)
 
@@ -347,6 +336,9 @@ class HttpClientBuilder @Inject constructor(
 
         val client = HttpClient(OkHttp) {
             // Ktor-level configuration here
+
+            // Uses AcceptAllCookiesStorage, which stores all the cookies in an in-memory map.
+            install(HttpCookies)
 
             // automatically convert JSON from/into data classes (if requested in respective code)
             install(ContentNegotiation) {

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/DavHttpClientBuilder.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/DavHttpClientBuilder.kt
@@ -5,10 +5,8 @@
 package at.bitfire.davdroid.webdav
 
 import at.bitfire.davdroid.network.HttpClientBuilder
-import at.bitfire.davdroid.network.MemoryCookieStore
 import com.google.errorprone.annotations.MustBeClosed
 import io.ktor.client.HttpClient
-import okhttp3.CookieJar
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import javax.inject.Inject
@@ -51,12 +49,8 @@ class DavHttpClientBuilder @Inject constructor(
      * @return configured HttpClientBuilder ready for building
      */
     private fun createBuilder(mountId: Long, logBody: Boolean = true): HttpClientBuilder {
-        val cookieStore = cookieStores.getOrPut(mountId) {
-            MemoryCookieStore()
-        }
         val builder = httpClientBuilder.get()
             .loggerInterceptorLevel(if (logBody) HttpLoggingInterceptor.Level.BODY else HttpLoggingInterceptor.Level.HEADERS)
-            .setCookieStore(cookieStore)
 
         credentialsStore.getCredentials(mountId)?.let { credentials ->
             builder.authenticate(
@@ -66,15 +60,6 @@ class DavHttpClientBuilder @Inject constructor(
         }
 
         return builder
-    }
-
-
-    companion object {
-
-        /** in-memory cookie stores (one per mount ID) that are available until the content
-         * provider (= process) is terminated */
-        private val cookieStores = mutableMapOf<Long, CookieJar>()
-
     }
 
 }


### PR DESCRIPTION
Replaces `setCookieStore(CookieJar)` with a Ktor-facing cookie/session abstraction.

**Note:**

`AcceptAllCookiesStorage` is the ktor default used when only configuring: 

```kotlin
val client = HttpClient(CIO) {
    install(HttpCookies)
}
```
and gives us almost everything we need. In-memory cookies, expiry handling, path/domain matching and no custom code. We could entirely delete our custom cookie-store implementation.

The reason to keep a custom implementation would be "host-only" cookie handling. The previous OkHttp cookies distinguish:

  - Set-Cookie: sid=1; from example.com: **"host-only"** cookie, should only go back to example.com
  - Set-Cookie: sid=1; Domain=example.com: **"domain"** cookie, can also go to sub.example.com

Ktor’s Cookie model doesn’t carry a `hostOnly` flag, and `AcceptAllCookiesStorage` fills a missing domain with the request host. After that, the lookup of cookies to be send, treats it like a domain cookie, so a host-only cookie can effectively become visible to subdomains.

The custom implementation would preserve this distinction and it seems to be closer to RFC 6265 defined cookie behavior (See/search for `host-only-flag`). It is also closer to what OkHttp gave us before. So maybe we should keep the custom implementation?

See also:
- https://ktor.io/docs/client-cookies.html#install_plugin
- https://www.rfc-editor.org/info/rfc6265/#section-5.3