### PR TITLE
Update DavException and HttpException imports from okhttp to ktor

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoGenerator.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoGenerator.kt
@@ -33,7 +33,7 @@ import androidx.core.content.pm.PackageInfoCompat
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.WorkQuery
-import at.bitfire.dav4jvm.okhttp.exception.DavException
+import at.bitfire.dav4jvm.ktor.exception.DavException
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.repository.AccountRepository

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoScreen.kt
@@ -43,8 +43,8 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import at.bitfire.dav4jvm.okhttp.exception.DavException
-import at.bitfire.dav4jvm.okhttp.exception.HttpException
+import at.bitfire.dav4jvm.ktor.exception.DavException
+import at.bitfire.dav4jvm.ktor.exception.HttpException
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.log.DebugDirectory
 import at.bitfire.davdroid.ui.composable.AppTheme

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/composable/ExceptionInfoDialog.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/composable/ExceptionInfoDialog.kt
@@ -17,7 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import at.bitfire.dav4jvm.okhttp.exception.HttpException
+import at.bitfire.dav4jvm.ktor.exception.HttpException
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.ui.DebugInfoActivity
 import io.ktor.http.Url


### PR DESCRIPTION
### Purpose
PR #2561 migrated the sync layer from OkHttp to Ktor. `SyncManager.kt` and the sync managers now throw `at.bitfire.dav4jvm.ktor.exception.*` (`HttpException`, `DavException`, `ServiceUnavailableException`, …). But the PR did not update the UI/debug code that displays those exceptions.

A Ktor exception thrown by sync code would never match the `is HttpException` / `is DavException` checks in the debug UI, so:                                                                                                                            
  - HTTP failures fall through to the generic "unexpected error" message instead of the specific 403/404/405/5xx text.
  - Debug-info reports silently omit the DAV request/response excerpts.
  
### Changes                                                                                                                                                                                                             
  - ExceptionInfoDialog.kt:20 — HttpException -> ktor
  - DebugInfoScreen.kt:46-47 — DavException + HttpException -> ktor
  - DebugInfoGenerator.kt:36 — DavException -> ktor