### PR TITLE
SyncManager: Don't load all changed objects into memory at once

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/LocalTestCollection.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/LocalTestCollection.kt
@@ -24,6 +24,7 @@ class LocalTestCollection(
         get() = throw NotImplementedError()
 
     override fun findDeleted() = entries.filter { it.deleted }
+    override fun deletedFlow() = findDeleted().asFlow()
 
     override fun findDirty() = entries.filter { it.dirty }
     override fun dirtyFlow() = findDirty().asFlow()

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/LocalTestCollection.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/LocalTestCollection.kt
@@ -6,6 +6,8 @@ package at.bitfire.davdroid.sync
 
 import at.bitfire.davdroid.resource.LocalCollection
 import at.bitfire.davdroid.resource.SyncState
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
 
 class LocalTestCollection(
     override val dbCollectionId: Long = 0L
@@ -22,7 +24,9 @@ class LocalTestCollection(
         get() = throw NotImplementedError()
 
     override fun findDeleted() = entries.filter { it.deleted }
+
     override fun findDirty() = entries.filter { it.dirty }
+    override fun dirtyFlow() = findDirty().asFlow()
 
     override fun findByName(name: String) = entries.firstOrNull { it.fileName == name }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -226,6 +226,29 @@ open class LocalAddressBook @AssistedInject constructor(
     fun findDeletedContacts() = queryContacts(RawContacts.DELETED, null)
     fun findDeletedGroups() = queryGroups(Groups.DELETED, null)
 
+    override fun deletedFlow(): Flow<LocalAddress> {
+        return channelFlow {
+            launch(Dispatchers.IO) {
+                sendDeletedContacts()
+                if (includeGroups) {
+                    sendDeletedGroups()
+                }
+            }
+        }.buffer(capacity = 1)
+    }
+
+    private fun ProducerScope<LocalAddress>.sendDeletedContacts() {
+        ab.iterateRawContactRows(RawContacts.DELETED, null) { values ->
+            trySendBlocking(LocalContact(this@LocalAddressBook, AndroidContact(ab, values)))
+        }
+    }
+
+    private fun ProducerScope<LocalAddress>.sendDeletedGroups() {
+        ab.iterateGroups(null, Groups.DELETED, null) { values ->
+            trySendBlocking(LocalGroup(AndroidGroup(ab, values)))
+        }
+    }
+
     /**
      * Returns an array of local contacts/groups which have been changed locally (DIRTY != 0).
      * @throws RemoteException on content provider errors

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -34,6 +34,13 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.ProducerScope
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.launch
 import java.io.FileNotFoundException
 import java.util.Optional
 import java.util.logging.Logger
@@ -231,6 +238,29 @@ open class LocalAddressBook @AssistedInject constructor(
 
     fun findDirtyContacts() = queryContacts(RawContacts.DIRTY, null)
     fun findDirtyGroups() = queryGroups(Groups.DIRTY, null)
+
+    override fun dirtyFlow(): Flow<LocalAddress> {
+        return channelFlow {
+            launch(Dispatchers.IO) {
+                sendDirtyContacts()
+                if (includeGroups) {
+                    sendDirtyGroups()
+                }
+            }
+        }.buffer(capacity = 1)
+    }
+
+    private fun ProducerScope<LocalAddress>.sendDirtyContacts() {
+        ab.iterateRawContactRows(RawContacts.DIRTY, null) { values ->
+            trySendBlocking(LocalContact(this@LocalAddressBook, AndroidContact(ab, values)))
+        }
+    }
+
+    private fun ProducerScope<LocalAddress>.sendDirtyGroups() {
+        ab.iterateGroups(null, Groups.DIRTY, null) { values ->
+            trySendBlocking(LocalGroup(AndroidGroup(ab, values)))
+        }
+    }
 
     override fun forgetETags() {
         val batch = ContactsBatchOperation(ab.provider)

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
@@ -84,6 +84,16 @@ class LocalCalendar @AssistedInject constructor(
         }
     }
 
+    override fun deletedFlow(): Flow<LocalEvent> {
+        return channelFlow {
+            launch(Dispatchers.IO) {
+                recurringCalendar.iterateEventAndExceptions(Events.DELETED, null) { eventAndExceptions ->
+                    trySendBlocking(LocalEvent(recurringCalendar, eventAndExceptions))
+                }
+            }
+        }.buffer(capacity = 1)
+    }
+
     override fun findDirty(): List<LocalEvent> = buildList {
         recurringCalendar.iterateEventAndExceptions(Events.DIRTY, null) { eventAndExceptions ->
             add(LocalEvent(recurringCalendar, eventAndExceptions))

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
@@ -17,6 +17,12 @@ import at.bitfire.synctools.storage.calendar.EventsContract
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.launch
 
 /**
  * Application-specific subclass of [AndroidCalendar] for local calendars.
@@ -82,6 +88,16 @@ class LocalCalendar @AssistedInject constructor(
         recurringCalendar.iterateEventAndExceptions(Events.DIRTY, null) { eventAndExceptions ->
             add(LocalEvent(recurringCalendar, eventAndExceptions))
         }
+    }
+
+    override fun dirtyFlow(): Flow<LocalEvent> {
+        return channelFlow {
+            launch(Dispatchers.IO) {
+                recurringCalendar.iterateEventAndExceptions(Events.DIRTY, null) { eventAndExceptions ->
+                    trySendBlocking(LocalEvent(recurringCalendar, eventAndExceptions))
+                }
+            }
+        }.buffer(capacity = 1)
     }
 
     override fun findByName(name: String) =

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCollection.kt
@@ -4,6 +4,8 @@
 
 package at.bitfire.davdroid.resource
 
+import kotlinx.coroutines.flow.Flow
+
 /**
  * This is an interface between the Syncer/SyncManager and a collection in the local storage.
  *
@@ -43,6 +45,14 @@ interface LocalCollection<out T: LocalResource> {
      * @return list of resources marked as *dirty*
      */
     fun findDirty(): List<T>
+
+    /**
+     * Finds local resources of this collection which have been marked as *dirty*, i.e. resources
+     * which have been modified by the user or an app acting on their behalf.
+     *
+     * @return [Flow] of resources marked as *dirty*
+     */
+    fun dirtyFlow(): Flow<T>
 
     /**
      * Finds a local resource of this collection with a given file name. (File names are assigned

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCollection.kt
@@ -39,6 +39,14 @@ interface LocalCollection<out T: LocalResource> {
     fun findDeleted(): List<T>
 
     /**
+     * Finds local resources of this collection which have been marked as *deleted* by the user
+     * or an app acting on their behalf.
+     *
+     * @return [Flow] of resources marked as *deleted*
+     */
+    fun deletedFlow(): Flow<T>
+
+    /**
      * Finds local resources of this collection which have been marked as *dirty*, i.e. resources
      * which have been modified by the user or an app acting on their behalf.
      *

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollection.kt
@@ -11,6 +11,12 @@ import at.bitfire.synctools.storage.jtx.JtxEntityAndExceptions
 import at.bitfire.synctools.storage.jtx.JtxRecurringCollection
 import at.techbee.jtx.JtxContract
 import at.techbee.jtx.JtxContract.JtxICalObject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.launch
 
 /**
  * Application-specific implementation for jtx collections.
@@ -70,6 +76,16 @@ class LocalJtxCollection(internal val jtxCollection: JtxCollection) :
         recurringCollection.iterateJtxObjectAndExceptions(JtxICalObject.DIRTY, null) { jtxObjectAndExceptions ->
             add(LocalJtxObject(recurringCollection, jtxObjectAndExceptions))
         }
+    }
+
+    override fun dirtyFlow(): Flow<LocalJtxObject> {
+        return channelFlow {
+            launch(Dispatchers.IO) {
+                recurringCollection.iterateJtxObjectAndExceptions(JtxICalObject.DIRTY, null) { jtxObjectAndExceptions ->
+                    trySendBlocking(LocalJtxObject(recurringCollection, jtxObjectAndExceptions))
+                }
+            }
+        }.buffer(capacity = 1)
     }
 
     override fun findByName(name: String): LocalJtxObject? {

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollection.kt
@@ -72,6 +72,16 @@ class LocalJtxCollection(internal val jtxCollection: JtxCollection) :
         }
     }
 
+    override fun deletedFlow(): Flow<LocalJtxObject> {
+        return channelFlow {
+            launch(Dispatchers.IO) {
+                recurringCollection.iterateJtxObjectAndExceptions(JtxICalObject.DELETED, null) { jtxObjectAndExceptions ->
+                    trySendBlocking(LocalJtxObject(recurringCollection, jtxObjectAndExceptions))
+                }
+            }
+        }.buffer(capacity = 1)
+    }
+
     override fun findDirty(): List<LocalJtxObject> = buildList {
         recurringCollection.iterateJtxObjectAndExceptions(JtxICalObject.DIRTY, null) { jtxObjectAndExceptions ->
             add(LocalJtxObject(recurringCollection, jtxObjectAndExceptions))

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskList.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskList.kt
@@ -88,6 +88,16 @@ class LocalTaskList (
         }
     }
 
+    override fun deletedFlow(): Flow<LocalTask> {
+        return channelFlow {
+            launch(Dispatchers.IO) {
+                recurringTaskList.iterateTaskAndExceptions(Tasks._DELETED, null) {
+                    trySendBlocking(LocalTask(recurringTaskList, it))
+                }
+            }
+        }.buffer(capacity = 1)
+    }
+
     override fun findDirty(): List<LocalTask> = buildList {
         recurringTaskList.iterateTaskAndExceptions(Tasks._DIRTY, null) {
             add(LocalTask(recurringTaskList, it))

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskList.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskList.kt
@@ -10,6 +10,12 @@ import at.bitfire.synctools.storage.tasks.DmfsRecurringTaskList
 import at.bitfire.synctools.storage.tasks.DmfsTaskList
 import at.bitfire.synctools.storage.tasks.DmfsTasksContract
 import at.bitfire.synctools.storage.tasks.TaskAndExceptions
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.launch
 import org.dmfs.tasks.contract.TaskContract
 import org.dmfs.tasks.contract.TaskContract.TaskListColumns
 import org.dmfs.tasks.contract.TaskContract.Tasks
@@ -86,6 +92,16 @@ class LocalTaskList (
         recurringTaskList.iterateTaskAndExceptions(Tasks._DIRTY, null) {
             add(LocalTask(recurringTaskList, it))
         }
+    }
+
+    override fun dirtyFlow(): Flow<LocalTask> {
+        return channelFlow {
+            launch(Dispatchers.IO) {
+                recurringTaskList.iterateTaskAndExceptions(Tasks._DIRTY, null) {
+                    trySendBlocking(LocalTask(recurringTaskList, it))
+                }
+            }
+        }.buffer(capacity = 1)
     }
 
     override fun findByName(name: String): LocalTask? {

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
@@ -140,7 +140,7 @@ class CalendarSyncManager @AssistedInject constructor(
     override suspend fun processLocallyDeleted(): Boolean {
         if (localCollection.readOnly) {
             var modified = false
-            for (event in localCollection.findDeleted()) {
+            localCollection.deletedFlow().collect { event ->
                 logger.warning("Restoring locally deleted event (read-only calendar!)")
                 SyncException.wrapWithLocalResource(event) {
                     event.resetDeleted()

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
@@ -163,7 +163,7 @@ class CalendarSyncManager @AssistedInject constructor(
     override suspend fun uploadDirty(): Boolean {
         var modified = false
         if (localCollection.readOnly) {
-            for (event in localCollection.findDirty()) {
+            localCollection.dirtyFlow().collect { event ->
                 logger.warning("Resetting locally modified event to ETag=null (read-only calendar!)")
                 SyncException.wrapWithLocalResource(event) {
                     event.clearDirty(Optional.empty(), null, null)

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -331,8 +331,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
 
         // Remove locally deleted entries from server (if they have a name, i.e. if they were uploaded before),
         // but only if they don't have changed on the server. Then finally remove them from the local address book.
-        val localList = localCollection.findDeleted()
-        for (local in localList) {
+        localCollection.deletedFlow().collect { local ->
             SyncException.wrapWithLocalResourceSuspending(local) {
                 val fileName = local.fileName
                 if (fileName != null) {

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -374,14 +374,11 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
     protected open suspend fun uploadDirty(): Boolean {
         var numUploaded = 0
 
-        coroutineScope {    // structured concurrency
-            for (local in localCollection.findDirty())
-                launch {
-                    SyncException.wrapWithLocalResourceSuspending(local) {
-                        uploadDirty(local)
-                        numUploaded++
-                    }
-                }
+        localCollection.dirtyFlow().collect { local ->
+            SyncException.wrapWithLocalResourceSuspending(local) {
+                uploadDirty(local)
+                numUploaded++
+            }
         }
         logger.info("Sent $numUploaded record(s) to server")
         return numUploaded > 0


### PR DESCRIPTION
This uses the mechanism suggested in <https://github.com/bitfireAT/davx5-ose/issues/2520#issuecomment-4789552003>.

The code changes are fairly minimal compared to 8a01a5ec10771e59a77fb67b6cc79366c07e99c9. The downside is that it requires a thread context switch between producing and consuming a single item. If this turns out to be a performance problem, we can adjust the buffer capacity and e.g. load 5 objects into memory at the same time.