### PR TITLE
[WIP] Add OpenID Connect login

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/network/OAuthOidc.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/OAuthOidc.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.network
+
+import at.bitfire.dav4jvm.ktor.exception.HttpException
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.URLBuilder
+import io.ktor.http.Url
+import io.ktor.http.appendPathSegments
+import io.ktor.http.auth.HttpAuthHeader
+import io.ktor.http.auth.parseAuthorizationHeader
+import io.ktor.http.isSuccess
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import net.openid.appauth.AuthorizationRequest
+import net.openid.appauth.AuthorizationServiceConfiguration
+import net.openid.appauth.AuthorizationServiceDiscovery
+import net.openid.appauth.ResponseTypeValues
+import org.json.JSONObject
+import javax.inject.Inject
+import javax.inject.Provider
+
+
+class OAuthOidc @Inject constructor(
+    private val httpClientBuilder: Provider<HttpClientBuilder>,
+    private val oAuthIntegration: OAuthIntegration
+) {
+    private var serviceConfig: AuthorizationServiceConfiguration? = null
+
+    suspend fun fetchServiceConfig(baseUrl: Url) {
+        serviceConfig = null
+
+        createClient().use { client ->
+            var discoveryBaseUrl = baseUrl
+
+            val baseResponse = client.get(baseUrl)
+            val resourceMetadata = baseResponse.headers
+                .getAll(HttpHeaders.WWWAuthenticate)
+                // TODO: this is not fully spec compliant because it doesn't parse multiple challenges in one header
+                // the `parseAuthorizationHeaders` function would do that, but it's marked as InternalApi
+                ?.mapNotNull { parseAuthorizationHeader(it) }
+                ?.firstNotNullOfOrNull { header ->
+                    if (header is HttpAuthHeader.Parameterized &&
+                        header.authScheme.equals("Bearer", ignoreCase = true)
+                    ) {
+                        header.parameter("resource_metadata")
+                    } else null
+                }
+
+            if (resourceMetadata != null) {
+                val resourceResponse = client.get(resourceMetadata)
+                if (!resourceResponse.status.isSuccess())
+                    throw HttpException.fromResponse(resourceResponse)
+
+                val resourceObject: ResourceMetadata = resourceResponse.body()
+
+                discoveryBaseUrl = resourceObject.authorizationServers.first()
+            }
+
+            val discoveryUrl = URLBuilder(discoveryBaseUrl)
+                .appendPathSegments(
+                    AuthorizationServiceConfiguration.WELL_KNOWN_PATH,
+                    AuthorizationServiceConfiguration.OPENID_CONFIGURATION_RESOURCE
+                )
+                .build()
+            val discoveryResponse = client.get(discoveryUrl)
+            if (!discoveryResponse.status.isSuccess())
+                throw HttpException.fromResponse(discoveryResponse)
+
+            val discoveryJson = JSONObject(discoveryResponse.bodyAsText())
+            val discovery = AuthorizationServiceDiscovery(discoveryJson)
+            serviceConfig = AuthorizationServiceConfiguration(discovery)
+        }
+    }
+
+    fun signIn(clientId: String, scope: String, locale: String?): AuthorizationRequest {
+        val serviceConfig = serviceConfig ?: throw IllegalArgumentException("Missing serviceConfig")
+
+        val builder = AuthorizationRequest.Builder(
+            serviceConfig,
+            clientId,
+            ResponseTypeValues.CODE,
+            oAuthIntegration.redirectUri
+        )
+        return builder
+            .setScope(scope)
+            .setUiLocales(locale)
+            .build()
+    }
+
+    private fun createClient() = httpClientBuilder.get().buildKtor()
+
+    @Serializable
+    private data class ResourceMetadata(
+        @SerialName("authorization_servers") val authorizationServers: List<Url>
+    )
+
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/OidcLogin.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/OidcLogin.kt
@@ -1,0 +1,210 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.ui.setup
+
+import android.content.ActivityNotFoundException
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.core.text.HtmlCompat
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import at.bitfire.davdroid.R
+import at.bitfire.davdroid.ui.ExternalUris
+import at.bitfire.davdroid.ui.UiUtils.toAnnotatedString
+import at.bitfire.davdroid.ui.composable.Assistant
+import java.util.logging.Level
+import java.util.logging.Logger
+
+object OidcLogin : LoginType {
+
+    override val title
+        get() = R.string.login_type_oidc
+
+    override val helpUrl: Uri?
+        get() = null
+
+    @Composable
+    override fun LoginScreen(
+        snackbarHostState: SnackbarHostState,
+        initialLoginInfo: LoginInfo,
+        onLogin: (LoginInfo) -> Unit
+    ) {
+        val model: OidcLoginViewModel = hiltViewModel(
+            creationCallback = { factory: OidcLoginViewModel.Factory ->
+                factory.create(loginInfo = initialLoginInfo)
+            }
+        )
+
+        // contract to open the browser for authentication
+        val authRequestContract = rememberLauncherForActivityResult(model.authorizationContract()) { authResponse ->
+            if (authResponse != null)
+                model.authenticate(authResponse)
+            else
+                model.authCodeFailed()
+        }
+
+        val uiState = model.uiState
+        LaunchedEffect(uiState.authorizationRequest) {
+            if (uiState.authorizationRequest != null) {
+                try {
+                    authRequestContract.launch(uiState.authorizationRequest)
+                } catch (e: ActivityNotFoundException) {
+                    Logger.getGlobal().log(Level.WARNING, "Couldn't start OAuth intent", e)
+                    model.signInFailed()
+                }
+                model.resetResult()
+            }
+        }
+
+        LaunchedEffect(uiState.result) {
+            if (uiState.result != null) {
+                onLogin(uiState.result)
+                model.resetResult()
+            }
+        }
+
+        LaunchedEffect(uiState.error) {
+            if (uiState.error != null)
+                snackbarHostState.showSnackbar(uiState.error)
+        }
+
+        OidcLoginScreen(
+            url = uiState.url,
+            onSetUrl = model::setUrl,
+            clientId = uiState.clientId,
+            onSetClientId = model::setClientId,
+            scope = uiState.scope,
+            onSetScope = model::setScope,
+            canContinue = uiState.canContinue,
+            onLogin = {
+                if (uiState.canContinue) model.signIn()
+            }
+        )
+    }
+
+}
+
+@Composable
+fun OidcLoginScreen(
+    url: String,
+    onSetUrl: (String) -> Unit = {},
+    clientId: String,
+    onSetClientId: (String) -> Unit = {},
+    scope: String,
+    onSetScope: (String) -> Unit = {},
+    canContinue: Boolean,
+    onLogin: () -> Unit = {}
+) {
+    val focusRequester = remember { FocusRequester() }
+
+    Assistant(
+        nextLabel = stringResource(R.string.login_login),
+        nextEnabled = canContinue,
+        onNext = onLogin
+    ) {
+        Column(modifier = Modifier.padding(8.dp)) {
+            Text(
+                stringResource(R.string.login_type_oidc),
+                style = MaterialTheme.typography.headlineMedium,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp)
+            )
+
+            val manualUrl = ExternalUris.Manual.baseUrl.buildUpon()
+                .appendPath(ExternalUris.Manual.PATH_ACCOUNTS_COLLECTIONS)
+                .fragment(ExternalUris.Manual.FRAGMENT_SERVICE_DISCOVERY)
+                .build()
+            val urlInfo = HtmlCompat.fromHtml(
+                stringResource(R.string.login_base_url_info, manualUrl),
+                HtmlCompat.FROM_HTML_MODE_COMPACT
+            )
+            Text(
+                text = urlInfo.toAnnotatedString(),
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp, bottom = 16.dp)
+            )
+
+            OutlinedTextField(
+                value = url,
+                onValueChange = onSetUrl,
+                label = { Text(stringResource(R.string.login_base_url)) },
+                placeholder = { Text("dav.example.com/path") },
+                singleLine = true,
+                leadingIcon = {
+                    Icon(Icons.Default.Folder, null)
+                },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Uri,
+                    imeAction = ImeAction.Next
+                ),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(focusRequester)
+            )
+
+            OutlinedTextField(
+                value = clientId,
+                onValueChange = onSetClientId,
+                label = { Text(stringResource(R.string.login_oidc_client_id)) },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(
+                    imeAction = ImeAction.Next
+                ),
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            OutlinedTextField(
+                value = scope,
+                onValueChange = onSetScope,
+                label = { Text(stringResource(R.string.login_oidc_scope)) },
+                placeholder = { Text("openid profile") },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(
+                    imeAction = ImeAction.Next
+                ),
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+}
+
+@Composable
+@Preview
+fun OidcLoginScreen_Preview() {
+    OidcLoginScreen(
+        url = "https://example.com",
+        clientId = "a1b2c3",
+        scope = "openid profile",
+        canContinue = false
+    )
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/OidcLoginViewModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/OidcLoginViewModel.kt
@@ -1,0 +1,187 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.ui.setup
+
+import android.content.Context
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import at.bitfire.dav4jvm.ktor.toUrlOrNull
+import at.bitfire.davdroid.R
+import at.bitfire.davdroid.network.OAuthIntegration
+import at.bitfire.davdroid.network.OAuthOidc
+import at.bitfire.davdroid.settings.Credentials
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.ktor.http.toURI
+import kotlinx.coroutines.launch
+import net.openid.appauth.AuthorizationRequest
+import net.openid.appauth.AuthorizationResponse
+import net.openid.appauth.AuthorizationService
+import java.util.Locale
+import java.util.logging.Level
+import java.util.logging.Logger
+
+@HiltViewModel(assistedFactory = OidcLoginViewModel.Factory::class)
+class OidcLoginViewModel @AssistedInject constructor(
+    @Assisted val initialLoginInfo: LoginInfo,
+    private val authService: AuthorizationService,
+    @ApplicationContext val context: Context,
+    private val logger: Logger,
+    private val oAuthOidc: OAuthOidc,
+    private val oAuthIntegration: OAuthIntegration
+) : ViewModel() {
+
+    @AssistedFactory
+    interface Factory {
+        fun create(loginInfo: LoginInfo): OidcLoginViewModel
+    }
+
+    override fun onCleared() {
+        authService.dispose()
+    }
+
+    data class UiState(
+        val url: String = "",
+        val clientId: String = "",
+        val scope: String = "openid profile email",
+
+        val inProgress: Boolean = false,
+
+        val error: String? = null,
+
+        val authorizationRequest: AuthorizationRequest? = null,
+        /** login info (set after successful login) */
+        val result: LoginInfo? = null
+    ) {
+        val urlWithPrefix =
+            if (url.startsWith("http://") || url.startsWith("https://"))
+                url
+            else
+                "https://$url"
+        val ktorUrl = urlWithPrefix.toUrlOrNull()
+
+        val canContinue = !inProgress && ktorUrl != null && clientId.isNotEmpty()
+    }
+
+    var uiState by mutableStateOf(UiState())
+        private set
+
+    init {
+        uiState = UiState(
+            url = initialLoginInfo.baseUri?.toString()?.removePrefix("https://") ?: "",
+            clientId = initialLoginInfo.credentials?.username ?: "",
+        )
+        initialLoginInfo.credentials?.authState?.scope?.let {
+            uiState = uiState.copy(scope = it)
+        }
+    }
+
+    fun setUrl(url: String) {
+        uiState = uiState.copy(url = url)
+    }
+
+    fun setClientId(clientId: String) {
+        uiState = uiState.copy(clientId = clientId)
+    }
+
+    fun setScope(scope: String) {
+        uiState = uiState.copy(scope = scope)
+    }
+
+
+    fun authorizationContract() = OAuthIntegration.AuthorizationContract(authService)
+
+    fun signInFailed() {
+        uiState = uiState.copy(error = context.getString(R.string.install_browser))
+    }
+
+    fun signIn() {
+        val url = uiState.ktorUrl
+        if (uiState.inProgress || url == null)
+            return
+
+        uiState = uiState.copy(
+            inProgress = true,
+            error = null
+        )
+
+        viewModelScope.launch {
+            try {
+                oAuthOidc.fetchServiceConfig(url)
+
+                val request = oAuthOidc.signIn(
+                    clientId = uiState.clientId,
+                    scope = uiState.scope,
+                    locale = Locale.getDefault().toLanguageTag()
+                )
+
+                uiState = uiState.copy(
+                    inProgress = false,
+                    authorizationRequest = request
+                )
+            } catch (e: Exception) {
+                logger.log(Level.WARNING, "OIDC authentication failed", e)
+
+                uiState = uiState.copy(
+                    inProgress = false,
+                    error = e.message
+                )
+            }
+        }
+    }
+
+    fun authenticate(authResponse: AuthorizationResponse) {
+        val url = uiState.ktorUrl
+        if (uiState.inProgress || url == null)
+            return
+
+        uiState = uiState.copy(
+            inProgress = true,
+            error = null
+        )
+
+        viewModelScope.launch {
+            try {
+                val credentials = Credentials(authState = oAuthIntegration.authenticate(authService, authResponse))
+
+                // success, provide login info to continue
+                uiState = uiState.copy(
+                    inProgress = false,
+                    result = LoginInfo(
+                        baseUri = url.toURI(),
+                        credentials = credentials,
+                        // TODO: this could be queried from the ID Token but requires a JWT parser
+                        suggestedAccountName = null
+                    )
+                )
+            } catch (e: Exception) {
+                logger.log(Level.WARNING, "OIDC authentication failed", e)
+
+                uiState = uiState.copy(
+                    inProgress = false,
+                    error = e.message
+                )
+            }
+        }
+    }
+
+    fun authCodeFailed() {
+        uiState = uiState.copy(error = context.getString(R.string.login_oauth_couldnt_obtain_auth_code))
+    }
+
+    fun resetResult() {
+        uiState = uiState.copy(
+            authorizationRequest = null,
+            result = null
+        )
+    }
+
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/StandardLoginTypesProvider.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/StandardLoginTypesProvider.kt
@@ -19,6 +19,7 @@ class StandardLoginTypesProvider @Inject constructor(
         val genericLoginTypes = listOf(
             UrlLogin,
             EmailLogin,
+            OidcLogin,
             AdvancedLogin
         )
 

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -340,6 +340,9 @@
     <string name="login_nextcloud_login_flow_sign_in">Sign in</string>
     <string name="login_nextcloud_login_flow_no_login_url">Couldn\'t obtain login URL</string>
     <string name="login_nextcloud_login_flow_no_login_data">Couldn\'t obtain login data</string>
+    <string name="login_type_oidc">Login with OpenID Connect</string>
+    <string name="login_oidc_client_id">Client ID</string>
+    <string name="login_oidc_scope">Scope</string>
 
     <string name="login_configuration_detection">Configuration detection</string>
     <string name="login_querying_server">Please wait, querying server…</string>


### PR DESCRIPTION
### Purpose

Adds an OpenID Connect login type, which is useful particularly for setups that rely on SSO. Discussions around this have been made in #189 and #1620.

### Short description

- Added OAuthOidc based on OAuthGoogle and OAuthFastmail
- Added OidcLogin/OidcLoginViewModel based on the other login types, particularly Google, Fastmail, and Nextcloud

Currently, this is an OpenID Connect only login method - no support for raw OAuth2. If wanted, adding individual fields for the required URLs (as mentioned [here](https://github.com/bitfireAT/davx5-ose/discussions/1620#discussioncomment-15794041)) is a possible alternative.

Using this login type requires a client id of a public client. Capturing cookies has been proposed as an alternative [here](https://github.com/bitfireAT/davx5-ose/discussions/1620#discussioncomment-13960013), but it isn't OAuth/OIDC-compliant so it is generally better to avoid it.
Dynamic client registration could also be utilised, but it is rather rare for IdPs to support it which reduces its viability as an alternative.

Open questions:
- resource metadata parsing should use `parseAuthorizationHeaders` but it is marked as an InternalApi. This can be solved by either opting in, or writing a mini parser ourselves
- the `suggestedAccountName` isn't filled in because there isn't a JWT parser in any libraries. Should a dependency be added, or perhaps should we just handroll a parser for the payload?

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [ ] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

