### PR TITLE
Migrate many iterate callbacks to Flow

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -179,6 +179,7 @@ dependencies {
 
     testImplementation(libs.bitfire.dav4jvm)
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.mockk)
     testImplementation(libs.okhttp.mockwebserver)
     testImplementation(libs.robolectric)

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookTest.kt
@@ -29,6 +29,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import ezvcard.property.Telephone
+import kotlinx.coroutines.runBlocking
 import org.junit.AfterClass
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -126,7 +127,7 @@ class LocalAddressBookTest {
             assertEquals(newName, addressBook.addressBookAccount.name)
 
             // check whether contact is still here (including data rows) and not dirty
-            val result = addressBook.findContactById(id)
+            val result = runBlocking { addressBook.findContactById(id) }
             assertFalse("Contact is dirty after moving", isContactDirty(addressBook, id))
 
             val contact2 = result.androidContact.getContact()
@@ -156,7 +157,7 @@ class LocalAddressBookTest {
             assertEquals(newName, addressBook.addressBookAccount.name)
 
             // check whether group is still here and not dirty
-            val result = addressBook.findGroupById(id)
+            val result = runBlocking { addressBook.findGroupById(id) }
             assertFalse("Group is dirty after moving", isGroupDirty(addressBook, id))
 
             val group = result.androidGroup.getContact()
@@ -182,7 +183,7 @@ class LocalAddressBookTest {
             )
 
             // pending membership -> contact1 should be added to group
-            localAddressBook.applyPendingMemberships()
+            runBlocking { localAddressBook.applyPendingMemberships() }
 
             // check group membership
             localAddressBook.ab.provider.query(
@@ -231,7 +232,7 @@ class LocalAddressBookTest {
             batch.commit()
 
             // no pending memberships -> membership should be removed
-            localAddressBook.applyPendingMemberships()
+            runBlocking { localAddressBook.applyPendingMemberships() }
 
             // check group membership
             localAddressBook.ab.provider.query(

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookTest.kt
@@ -127,7 +127,7 @@ class LocalAddressBookTest {
             assertEquals(newName, addressBook.addressBookAccount.name)
 
             // check whether contact is still here (including data rows) and not dirty
-            val result = runBlocking { addressBook.findContactById(id) }
+            val result = addressBook.findContactById(id)
             assertFalse("Contact is dirty after moving", isContactDirty(addressBook, id))
 
             val contact2 = result.androidContact.getContact()
@@ -157,7 +157,7 @@ class LocalAddressBookTest {
             assertEquals(newName, addressBook.addressBookAccount.name)
 
             // check whether group is still here and not dirty
-            val result = runBlocking { addressBook.findGroupById(id) }
+            val result = addressBook.findGroupById(id)
             assertFalse("Group is dirty after moving", isGroupDirty(addressBook, id))
 
             val group = result.androidGroup.getContact()

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalCalendarTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalCalendarTest.kt
@@ -20,6 +20,7 @@ import at.bitfire.synctools.storage.calendar.AndroidCalendarProvider
 import at.bitfire.synctools.storage.calendar.EventsContract
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -70,7 +71,7 @@ class LocalCalendarTest {
      * - [Events._ID]
      * - [Events.DIRTY]
      */
-    private fun testRemoveNotDirtyMarked(contentValues: ContentValues) {
+    private fun testRemoveNotDirtyMarked(contentValues: ContentValues) = runTest {
         val entity = Entity(
             contentValuesOf(
                 Events.CALENDAR_ID to androidCalendar.id,

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalGroupTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalGroupTest.kt
@@ -136,8 +136,9 @@ class LocalGroupTest {
     }
 
     @Test
-    fun testMarkMembersDirty() {
-        localTestAddressBook.provide(account, provider, GroupMethod.CATEGORIES) { localAddressBook ->
+    fun testMarkMembersDirty() = runTest {
+        val localAddressBook = localTestAddressBook.create(account, provider, GroupMethod.CATEGORIES)
+        try {
             val group = newGroup(localAddressBook)
 
             val contact1 = localAddressBook.addContact(Contact().apply { displayName = "Test" }, "fn.vcf", null, 0)
@@ -148,9 +149,10 @@ class LocalGroupTest {
 
             assertEquals(0, localAddressBook.countDirty())
             group.markMembersDirty()
-            var dirtyId: Long? = null
-            runTest { dirtyId = localAddressBook.findDirty().first().id }
+            val dirtyId = localAddressBook.findDirty().first().id
             assertEquals(contact1.id, dirtyId)
+        } finally {
+            localTestAddressBook.delete(localAddressBook)
         }
     }
 

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalGroupTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalGroupTest.kt
@@ -22,6 +22,8 @@ import at.bitfire.synctools.vcard.GroupMethod
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -144,9 +146,9 @@ class LocalGroupTest {
             contact1.androidContact.addToGroup(batch, group.id!!)
             batch.commit()
 
-            assertEquals(0, localAddressBook.findDirty().size)
+            assertEquals(0, localAddressBook.countDirty())
             group.markMembersDirty()
-            assertEquals(contact1.id, localAddressBook.findDirty().first().id)
+            assertEquals(contact1.id, runBlocking { localAddressBook.findDirty().first() }.id)
         }
     }
 

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalGroupTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalGroupTest.kt
@@ -23,7 +23,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -148,7 +148,9 @@ class LocalGroupTest {
 
             assertEquals(0, localAddressBook.countDirty())
             group.markMembersDirty()
-            assertEquals(contact1.id, runBlocking { localAddressBook.findDirty().first() }.id)
+            var dirtyId: Long? = null
+            runTest { dirtyId = localAddressBook.findDirty().first().id }
+            assertEquals(contact1.id, dirtyId)
         }
     }
 

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalTestAddressBook.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalTestAddressBook.kt
@@ -19,22 +19,47 @@ class LocalTestAddressBook @Inject constructor(
     private val factory: LocalAddressBook.Factory
 ) {
 
+    private val accountManager = AccountManager.get(context)
+
     fun provide(
         account: Account,
         provider: ContentProviderClient,
         groupMethod: GroupMethod = GroupMethod.GROUP_VCARDS,
         block: (LocalAddressBook) -> Unit
     ) {
-        val accountType = context.getString(R.string.account_type_address_book)
-        val abAccount = Account("Test Address Book ${UUID.randomUUID()}", accountType)
-        AccountManager.get(context).addAccountExplicitly(abAccount, null, null)
-        val ab = factory.create(account, abAccount, provider, groupMethod)
+        val ab = create(account, provider, groupMethod)
         try {
             block(ab)
         } finally {
-            // use ab.addressBookAccount (not abAccount) to handle renames correctly
-            AccountManager.get(context).removeAccountExplicitly(ab.addressBookAccount)
+            delete(ab)
         }
+    }
+
+    /**
+     * Creates a new local address book for testing purposes.
+     *
+     * @param account The account to associate with the new address book.
+     * @param provider The content provider client to use for the new address book.
+     * @param groupMethod The method to use for grouping contacts in the address book.
+     * Defaults to [GroupMethod.GROUP_VCARDS].
+     * @return The newly created local address book.
+     */
+    fun create(
+        account: Account,
+        provider: ContentProviderClient,
+        groupMethod: GroupMethod = GroupMethod.GROUP_VCARDS
+    ): LocalAddressBook {
+        val accountType = context.getString(R.string.account_type_address_book)
+        val abAccount = Account("Test Address Book ${UUID.randomUUID()}", accountType)
+        accountManager.addAccountExplicitly(abAccount, null, null)
+        return factory.create(account, abAccount, provider, groupMethod)
+    }
+
+    /**
+     * Removes a test address book created by [create].
+     */
+    fun delete(addressBook: LocalAddressBook) {
+        accountManager.removeAccountExplicitly(addressBook.addressBookAccount)
     }
 
 }

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/JtxSyncManagerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/JtxSyncManagerTest.kt
@@ -22,6 +22,7 @@ import at.techbee.jtx.JtxContract
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assume.assumeNotNull
@@ -117,7 +118,7 @@ class JtxSyncManagerTest {
 
 
     @Test
-    fun testProcessICalObject_addsVtodo() {
+    fun testProcessICalObject_addsVtodo() = runTest {
         val calendar = "BEGIN:VCALENDAR\n" +
                 "PRODID:-Vivaldi Calendar V1.0//EN\n" +
                 "VERSION:2.0\n" +
@@ -145,7 +146,7 @@ class JtxSyncManagerTest {
     }
 
     @Test
-    fun testProcessICalObject_addsRecurringVtodo_withoutDtStart() {
+    fun testProcessICalObject_addsRecurringVtodo_withoutDtStart() = runTest {
         // Valid calendar example (See bitfireAT/davx5-ose#1265)
         // Note: We don't support starting a recurrence from DUE (RFC 5545  leaves it open to interpretation)
         val calendar = "BEGIN:VCALENDAR\n" +

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/LocalTestCollection.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/LocalTestCollection.kt
@@ -26,7 +26,7 @@ class LocalTestCollection(
 
     override fun findDirty() = entries.filter { it.dirty }.asFlow()
 
-    override fun findByName(name: String) = entries.firstOrNull { it.fileName == name }
+    override suspend fun findByName(name: String) = entries.firstOrNull { it.fileName == name }
 
     override fun markNotDirty(flags: Int): Int {
         var updated = 0
@@ -37,7 +37,7 @@ class LocalTestCollection(
         return updated
     }
 
-    override fun removeNotDirtyMarked(flags: Int): Int {
+    override suspend fun removeNotDirtyMarked(flags: Int): Int {
         val numBefore = entries.size
         entries.removeIf { !it.dirty && it.flags == flags }
         return numBefore - entries.size

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/LocalTestCollection.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/LocalTestCollection.kt
@@ -6,7 +6,6 @@ package at.bitfire.davdroid.sync
 
 import at.bitfire.davdroid.resource.LocalCollection
 import at.bitfire.davdroid.resource.SyncState
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 
 class LocalTestCollection(
@@ -23,17 +22,15 @@ class LocalTestCollection(
     override val readOnly: Boolean
         get() = throw NotImplementedError()
 
-    override fun findDeleted() = entries.filter { it.deleted }
-    override fun deletedFlow() = findDeleted().asFlow()
+    override fun findDeleted() = entries.filter { it.deleted }.asFlow()
 
-    override fun findDirty() = entries.filter { it.dirty }
-    override fun dirtyFlow() = findDirty().asFlow()
+    override fun findDirty() = entries.filter { it.dirty }.asFlow()
 
     override fun findByName(name: String) = entries.firstOrNull { it.fileName == name }
 
     override fun markNotDirty(flags: Int): Int {
         var updated = 0
-        for (dirty in findDirty()) {
+        for (dirty in entries.filter { it.dirty }) {
             dirty.flags = flags
             updated++
         }
@@ -52,5 +49,6 @@ class LocalTestCollection(
     override fun countAll() = entries.size
     override fun countDeleted() = entries.count { it.deleted }
     override fun countModified() = entries.count { it.dirty && !it.deleted }
+    override fun countDirty() = entries.count { it.dirty }
 
 }

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/TestSyncManager.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/TestSyncManager.kt
@@ -120,7 +120,7 @@ class TestSyncManager @AssistedInject constructor(
         }
     }
 
-    override fun postProcess() {
+    override suspend fun postProcess() {
     }
 
     override fun notifyInvalidResourceTitle() =

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/TestSyncManager.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/TestSyncManager.kt
@@ -53,7 +53,7 @@ class TestSyncManager @AssistedInject constructor(
         ): TestSyncManager
     }
 
-    override fun prepare(): Boolean {
+    override suspend fun prepare(): Boolean {
         davCollection = DavCollection(httpClient, collection.url)
         return true
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -116,8 +116,7 @@ open class LocalAddressBook @AssistedInject constructor(
         val batch = ContactsBatchOperation(ab.provider)
         ab.updateRawContactRows(
             contentValuesOf(RawContactColumns.FLAGS to flags),
-            "${RawContacts.DIRTY}=0",
-            null,
+            "${RawContacts.DIRTY}=0", null,
             batch
         )
         if (includeGroups)
@@ -128,8 +127,7 @@ open class LocalAddressBook @AssistedInject constructor(
     override suspend fun removeNotDirtyMarked(flags: Int): Int {
         val batch = ContactsBatchOperation(ab.provider)
         ab.deleteRawContacts(
-            "NOT ${RawContacts.DIRTY} AND ${RawContactColumns.FLAGS}=?",
-            arrayOf(flags.toString()),
+            "NOT ${RawContacts.DIRTY} AND ${RawContactColumns.FLAGS}=?", arrayOf(flags.toString()),
             batch
         )
         if (includeGroups)
@@ -238,14 +236,14 @@ open class LocalAddressBook @AssistedInject constructor(
      * @throws LocalStorageException on content provider errors
      */
     fun findDeletedContacts(): Flow<LocalContact> =
-        ab.rawContactRowsFlow(RawContacts.DELETED, null).map { LocalContact(this, AndroidContact(ab, it)) }
+        ab.queryRawContactRows(RawContacts.DELETED, null).map { LocalContact(this, AndroidContact(ab, it)) }
 
     /**
      * Finds local groups which have been deleted locally. (DELETED != 0).
      * @throws LocalStorageException on content provider errors
      */
     fun findDeletedGroups(): Flow<LocalGroup> =
-        ab.groupsFlow(null, Groups.DELETED, null).map { LocalGroup(AndroidGroup(ab, it)) }
+        ab.queryGroupRows(null, Groups.DELETED, null).map { LocalGroup(AndroidGroup(ab, it)) }
 
     /**
      * Finds local contacts/groups which have been deleted locally. (DELETED != 0).
@@ -262,14 +260,14 @@ open class LocalAddressBook @AssistedInject constructor(
      * @throws LocalStorageException on content provider errors
      */
     fun findDirtyContacts(): Flow<LocalContact> =
-        ab.rawContactRowsFlow(RawContacts.DIRTY, null).map { LocalContact(this, AndroidContact(ab, it)) }
+        ab.queryRawContactRows(RawContacts.DIRTY, null).map { LocalContact(this, AndroidContact(ab, it)) }
 
     /**
      * Finds local groups which have been changed locally (DIRTY != 0).
      * @throws LocalStorageException on content provider errors
      */
     fun findDirtyGroups(): Flow<LocalGroup> =
-        ab.groupsFlow(null, Groups.DIRTY, null).map { LocalGroup(AndroidGroup(ab, it)) }
+        ab.queryGroupRows(null, Groups.DIRTY, null).map { LocalGroup(AndroidGroup(ab, it)) }
 
     /**
      * Finds local contacts/groups which have been changed locally (DIRTY != 0).

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -35,6 +35,7 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.toList
@@ -304,8 +305,8 @@ open class LocalAddressBook @AssistedInject constructor(
     suspend fun queryContacts(where: String?, whereArgs: Array<String>?): List<LocalContact> =
         ab.queryRawContactRows(where, whereArgs).map { LocalContact(this, AndroidContact(ab, it)) }.toList()
 
-    suspend fun queryGroups(where: String?, whereArgs: Array<String>?): List<LocalGroup> =
-        ab.queryGroupRows(null, where, whereArgs).map { LocalGroup(AndroidGroup(ab, it)) }.toList()
+    fun queryGroups(where: String?, whereArgs: Array<String>?): Flow<LocalGroup> =
+        ab.queryGroupRows(null, where, whereArgs).map { LocalGroup(AndroidGroup(ab, it)) }
 
     @Throws(FileNotFoundException::class)
     fun findContactById(id: Long): LocalContact =
@@ -352,7 +353,7 @@ open class LocalAddressBook @AssistedInject constructor(
         queryGroups(
             "${Groups.ACCOUNT_TYPE}=? AND ${Groups.ACCOUNT_NAME}=?",
             arrayOf(addressBookAccount.type, addressBookAccount.name)
-        ).forEach { group ->
+        ).collect { group ->
             val groupId = group.id!!
             val pendingMemberUids = group.androidGroup.pendingMemberships.toMutableSet()
             val batch = ContactsBatchOperation(ab.provider)

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -8,7 +8,6 @@ import android.accounts.AccountManager
 import android.content.ContentProviderClient
 import android.content.ContentValues
 import android.content.Context
-import android.os.RemoteException
 import android.provider.ContactsContract
 import android.provider.ContactsContract.CommonDataKinds.GroupMembership
 import android.provider.ContactsContract.Groups
@@ -20,6 +19,7 @@ import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.sync.SyncDataType
 import at.bitfire.davdroid.sync.adapter.SyncFrameworkIntegration
 import at.bitfire.synctools.mapping.contacts.Contact
+import at.bitfire.synctools.storage.LocalStorageException
 import at.bitfire.synctools.storage.contacts.AddressContract.GroupColumns
 import at.bitfire.synctools.storage.contacts.AddressContract.RawContactColumns
 import at.bitfire.synctools.storage.contacts.AddressContract.asSyncAdapter
@@ -114,7 +114,12 @@ open class LocalAddressBook @AssistedInject constructor(
 
     override fun markNotDirty(flags: Int): Int {
         val batch = ContactsBatchOperation(ab.provider)
-        ab.updateRawContactRows(contentValuesOf(RawContactColumns.FLAGS to flags), "${RawContacts.DIRTY}=0", null, batch)
+        ab.updateRawContactRows(
+            contentValuesOf(RawContactColumns.FLAGS to flags),
+            "${RawContacts.DIRTY}=0",
+            null,
+            batch
+        )
         if (includeGroups)
             ab.updateGroups(contentValuesOf(GroupColumns.FLAGS to flags), "NOT ${Groups.DIRTY}", null, batch)
         return batch.commit()
@@ -122,7 +127,11 @@ open class LocalAddressBook @AssistedInject constructor(
 
     override suspend fun removeNotDirtyMarked(flags: Int): Int {
         val batch = ContactsBatchOperation(ab.provider)
-        ab.deleteRawContacts("NOT ${RawContacts.DIRTY} AND ${RawContactColumns.FLAGS}=?", arrayOf(flags.toString()), batch)
+        ab.deleteRawContacts(
+            "NOT ${RawContacts.DIRTY} AND ${RawContactColumns.FLAGS}=?",
+            arrayOf(flags.toString()),
+            batch
+        )
         if (includeGroups)
             ab.deleteGroups("NOT ${Groups.DIRTY} AND ${GroupColumns.FLAGS}=?", arrayOf(flags.toString()), batch)
         return batch.commit()
@@ -191,14 +200,23 @@ open class LocalAddressBook @AssistedInject constructor(
 
     /* operations on members (contacts/groups) */
 
-    override fun countAll(): Int =
-        ab.countRawContacts(null, null)
+    override fun countAll(): Int {
+        val contacts = ab.countRawContacts(null, null)
+        val groups = if (includeGroups) ab.countGroups(null, null) else 0
+        return contacts + groups
+    }
 
-    override fun countDeleted(): Int =
-        ab.countRawContacts(RawContacts.DELETED, null)
+    override fun countDeleted(): Int {
+        val deletedContacts = ab.countRawContacts(RawContacts.DELETED, null)
+        val deletedGroups = if (includeGroups) ab.countGroups(Groups.DELETED, null) else 0
+        return deletedContacts + deletedGroups
+    }
 
-    override fun countModified(): Int =
-        ab.countRawContacts("${RawContacts.DIRTY} AND NOT ${RawContacts.DELETED}", null)
+    override fun countModified(): Int {
+        val modifiedContacts = ab.countRawContacts("${RawContacts.DIRTY} AND NOT ${RawContacts.DELETED}", null)
+        val modifiedGroups = if (includeGroups) ab.countGroups("${Groups.DIRTY} AND NOT ${Groups.DELETED}", null) else 0
+        return modifiedContacts + modifiedGroups
+    }
 
     override fun countDirty(): Int {
         val dirtyContacts = ab.countRawContacts(RawContacts.DIRTY, null)
@@ -217,21 +235,21 @@ open class LocalAddressBook @AssistedInject constructor(
 
     /**
      * Finds local contacts which have been deleted locally. (DELETED != 0).
-     * @throws RemoteException on content provider errors
+     * @throws LocalStorageException on content provider errors
      */
     fun findDeletedContacts(): Flow<LocalContact> =
         ab.rawContactRowsFlow(RawContacts.DELETED, null).map { LocalContact(this, AndroidContact(ab, it)) }
 
     /**
      * Finds local groups which have been deleted locally. (DELETED != 0).
-     * @throws RemoteException on content provider errors
+     * @throws LocalStorageException on content provider errors
      */
     fun findDeletedGroups(): Flow<LocalGroup> =
         ab.groupsFlow(null, Groups.DELETED, null).map { LocalGroup(AndroidGroup(ab, it)) }
 
     /**
      * Finds local contacts/groups which have been deleted locally. (DELETED != 0).
-     * @throws RemoteException on content provider errors
+     * @throws LocalStorageException on content provider errors
      */
     override fun findDeleted(): Flow<LocalAddress> =
         if (includeGroups)
@@ -241,21 +259,21 @@ open class LocalAddressBook @AssistedInject constructor(
 
     /**
      * Finds local contacts which have been changed locally (DIRTY != 0).
-     * @throws RemoteException on content provider errors
+     * @throws LocalStorageException on content provider errors
      */
     fun findDirtyContacts(): Flow<LocalContact> =
         ab.rawContactRowsFlow(RawContacts.DIRTY, null).map { LocalContact(this, AndroidContact(ab, it)) }
 
     /**
      * Finds local groups which have been changed locally (DIRTY != 0).
-     * @throws RemoteException on content provider errors
+     * @throws LocalStorageException on content provider errors
      */
     fun findDirtyGroups(): Flow<LocalGroup> =
         ab.groupsFlow(null, Groups.DIRTY, null).map { LocalGroup(AndroidGroup(ab, it)) }
 
     /**
      * Finds local contacts/groups which have been changed locally (DIRTY != 0).
-     * @throws RemoteException on content provider errors
+     * @throws LocalStorageException on content provider errors
      */
     override fun findDirty(): Flow<LocalAddress> =
         if (includeGroups)
@@ -340,7 +358,10 @@ open class LocalAddressBook @AssistedInject constructor(
     fun applyPendingMemberships() {
         logger.info("Assigning memberships of contact groups")
 
-        queryGroups("${Groups.ACCOUNT_TYPE}=? AND ${Groups.ACCOUNT_NAME}=?", arrayOf(addressBookAccount.type, addressBookAccount.name)).forEach { group ->
+        queryGroups(
+            "${Groups.ACCOUNT_TYPE}=? AND ${Groups.ACCOUNT_NAME}=?",
+            arrayOf(addressBookAccount.type, addressBookAccount.name)
+        ).forEach { group ->
             val groupId = group.id!!
             val pendingMemberUids = group.androidGroup.pendingMemberships.toMutableSet()
             val batch = ContactsBatchOperation(ab.provider)

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -34,13 +34,9 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.buffer
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
-import kotlinx.coroutines.launch
 import java.io.FileNotFoundException
 import java.util.Optional
 import java.util.logging.Logger
@@ -223,25 +219,15 @@ open class LocalAddressBook @AssistedInject constructor(
      * Finds local contacts which have been deleted locally. (DELETED != 0).
      * @throws RemoteException on content provider errors
      */
-    fun findDeletedContacts(): Flow<LocalContact> = channelFlow {
-        launch(Dispatchers.IO) {
-            ab.iterateRawContactRows(RawContacts.DELETED, null) { values ->
-                trySendBlocking(LocalContact(this@LocalAddressBook, AndroidContact(ab, values)))
-            }
-        }
-    }.buffer(capacity = 1)
+    fun findDeletedContacts(): Flow<LocalContact> =
+        ab.rawContactRowsFlow(RawContacts.DELETED, null).map { LocalContact(this, AndroidContact(ab, it)) }
 
     /**
      * Finds local groups which have been deleted locally. (DELETED != 0).
      * @throws RemoteException on content provider errors
      */
-    fun findDeletedGroups(): Flow<LocalGroup> = channelFlow {
-        launch(Dispatchers.IO) {
-            ab.iterateGroups(null, Groups.DELETED, null) { values ->
-                trySendBlocking(LocalGroup(AndroidGroup(ab, values)))
-            }
-        }
-    }.buffer(capacity = 1)
+    fun findDeletedGroups(): Flow<LocalGroup> =
+        ab.groupsFlow(null, Groups.DELETED, null).map { LocalGroup(AndroidGroup(ab, it)) }
 
     /**
      * Finds local contacts/groups which have been deleted locally. (DELETED != 0).
@@ -257,25 +243,15 @@ open class LocalAddressBook @AssistedInject constructor(
      * Finds local contacts which have been changed locally (DIRTY != 0).
      * @throws RemoteException on content provider errors
      */
-    fun findDirtyContacts(): Flow<LocalContact> = channelFlow {
-        launch(Dispatchers.IO) {
-            ab.iterateRawContactRows(RawContacts.DIRTY, null) { values ->
-                trySendBlocking(LocalContact(this@LocalAddressBook, AndroidContact(ab, values)))
-            }
-        }
-    }.buffer(capacity = 1)
+    fun findDirtyContacts(): Flow<LocalContact> =
+        ab.rawContactRowsFlow(RawContacts.DIRTY, null).map { LocalContact(this, AndroidContact(ab, it)) }
 
     /**
      * Finds local groups which have been changed locally (DIRTY != 0).
      * @throws RemoteException on content provider errors
      */
-    fun findDirtyGroups(): Flow<LocalGroup> = channelFlow {
-        launch(Dispatchers.IO) {
-            ab.iterateGroups(null, Groups.DIRTY, null) { values ->
-                trySendBlocking(LocalGroup(AndroidGroup(ab, values)))
-            }
-        }
-    }.buffer(capacity = 1)
+    fun findDirtyGroups(): Flow<LocalGroup> =
+        ab.groupsFlow(null, Groups.DIRTY, null).map { LocalGroup(AndroidGroup(ab, it)) }
 
     /**
      * Finds local contacts/groups which have been changed locally (DIRTY != 0).

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -38,7 +38,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
-import kotlinx.coroutines.flow.toList
 import java.io.FileNotFoundException
 import java.util.Optional
 import java.util.logging.Logger
@@ -225,7 +224,7 @@ open class LocalAddressBook @AssistedInject constructor(
     }
 
     override suspend fun findByName(name: String): LocalAddress? {
-        val result = queryContacts("${RawContactColumns.FILENAME}=?", arrayOf(name)).firstOrNull()
+        val result = findContact("${RawContactColumns.FILENAME}=?", arrayOf(name))
         return if (includeGroups)
             result ?: queryGroups("${GroupColumns.FILENAME}=?", arrayOf(name)).firstOrNull()
         else
@@ -302,8 +301,10 @@ open class LocalAddressBook @AssistedInject constructor(
         return LocalGroup(androidGroup)
     }
 
-    suspend fun queryContacts(where: String?, whereArgs: Array<String>?): List<LocalContact> =
-        ab.queryRawContactRows(where, whereArgs).map { LocalContact(this, AndroidContact(ab, it)) }.toList()
+    private suspend fun findContact(where: String?, whereArgs: Array<String>?): LocalContact? =
+        ab.queryRawContactRows(where, whereArgs).firstOrNull()?.let {
+            LocalContact(this, AndroidContact(ab, it))
+        }
 
     fun queryGroups(where: String?, whereArgs: Array<String>?): Flow<LocalGroup> =
         ab.queryGroupRows(null, where, whereArgs).map { LocalGroup(AndroidGroup(ab, it)) }

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -308,15 +308,20 @@ open class LocalAddressBook @AssistedInject constructor(
         ab.queryGroupRows(null, where, whereArgs).map { LocalGroup(AndroidGroup(ab, it)) }.toList()
 
     @Throws(FileNotFoundException::class)
-    suspend fun findContactById(id: Long) =
-        queryContacts("${RawContacts._ID}=?", arrayOf(id.toString())).firstOrNull() ?: throw FileNotFoundException()
+    fun findContactById(id: Long): LocalContact =
+        ab.getRawContactRowOrNull("${RawContacts._ID}=?", arrayOf(id.toString()))
+            ?.let { LocalContact(this, AndroidContact(ab, it)) }
+            ?: throw FileNotFoundException()
 
-    suspend fun findContactByUid(uid: String) =
-        queryContacts("${RawContactColumns.UID}=?", arrayOf(uid)).firstOrNull()
+    fun findContactByUid(uid: String): LocalContact? =
+        ab.getRawContactRowOrNull("${RawContactColumns.UID}=?", arrayOf(uid))
+            ?.let { LocalContact(this, AndroidContact(ab, it)) }
 
     @Throws(FileNotFoundException::class)
-    suspend fun findGroupById(id: Long) =
-        queryGroups("${Groups._ID}=?", arrayOf(id.toString())).firstOrNull() ?: throw FileNotFoundException()
+    fun findGroupById(id: Long): LocalGroup =
+        ab.getGroupOrNull("${Groups._ID}=?", arrayOf(id.toString()))
+            ?.let { LocalGroup(AndroidGroup(ab, it)) }
+            ?: throw FileNotFoundException()
 
 
     fun getContactIdsByGroupMembership(groupId: Long): List<Long> = buildList {
@@ -330,16 +335,9 @@ open class LocalAddressBook @AssistedInject constructor(
         }
     }
 
-    fun getContactUidFromId(contactId: Long): String? {
-        ab.provider.query(
-            ab.rawContactsSyncUri(), arrayOf(RawContactColumns.UID),
-            "${RawContacts._ID}=?", arrayOf(contactId.toString()), null
-        )?.use { cursor ->
-            if (cursor.moveToNext())
-                return cursor.getString(0)
-        }
-        return null
-    }
+    fun getContactUidFromId(contactId: Long): String? =
+        ab.getRawContactRowOrNull("${RawContacts._ID}=?", arrayOf(contactId.toString()))
+            ?.getAsString(RawContactColumns.UID)
 
 
     /* special group operations */

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -120,7 +120,7 @@ open class LocalAddressBook @AssistedInject constructor(
         return batch.commit()
     }
 
-    override fun removeNotDirtyMarked(flags: Int): Int {
+    override suspend fun removeNotDirtyMarked(flags: Int): Int {
         val batch = ContactsBatchOperation(ab.provider)
         ab.deleteRawContacts("NOT ${RawContacts.DIRTY} AND ${RawContactColumns.FLAGS}=?", arrayOf(flags.toString()), batch)
         if (includeGroups)
@@ -206,7 +206,7 @@ open class LocalAddressBook @AssistedInject constructor(
         return dirtyContacts + dirtyGroups
     }
 
-    override fun findByName(name: String): LocalAddress? {
+    override suspend fun findByName(name: String): LocalAddress? {
         val result = queryContacts("${RawContactColumns.FILENAME}=?", arrayOf(name)).firstOrNull()
         return if (includeGroups)
             result ?: queryGroups("${GroupColumns.FILENAME}=?", arrayOf(name)).firstOrNull()

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -35,11 +35,11 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.launch
 import java.io.FileNotFoundException
 import java.util.Optional
@@ -204,6 +204,12 @@ open class LocalAddressBook @AssistedInject constructor(
     override fun countModified(): Int =
         ab.countRawContacts("${RawContacts.DIRTY} AND NOT ${RawContacts.DELETED}", null)
 
+    override fun countDirty(): Int {
+        val dirtyContacts = ab.countRawContacts(RawContacts.DIRTY, null)
+        val dirtyGroups = if (includeGroups) ab.countGroups(Groups.DIRTY, null) else 0
+        return dirtyContacts + dirtyGroups
+    }
+
     override fun findByName(name: String): LocalAddress? {
         val result = queryContacts("${RawContactColumns.FILENAME}=?", arrayOf(name)).firstOrNull()
         return if (includeGroups)
@@ -214,76 +220,72 @@ open class LocalAddressBook @AssistedInject constructor(
 
 
     /**
-     * Returns an array of local contacts/groups which have been deleted locally. (DELETED != 0).
+     * Finds local contacts which have been deleted locally. (DELETED != 0).
      * @throws RemoteException on content provider errors
      */
-    override fun findDeleted() =
+    fun findDeletedContacts(): Flow<LocalContact> = channelFlow {
+        launch(Dispatchers.IO) {
+            ab.iterateRawContactRows(RawContacts.DELETED, null) { values ->
+                trySendBlocking(LocalContact(this@LocalAddressBook, AndroidContact(ab, values)))
+            }
+        }
+    }.buffer(capacity = 1)
+
+    /**
+     * Finds local groups which have been deleted locally. (DELETED != 0).
+     * @throws RemoteException on content provider errors
+     */
+    fun findDeletedGroups(): Flow<LocalGroup> = channelFlow {
+        launch(Dispatchers.IO) {
+            ab.iterateGroups(null, Groups.DELETED, null) { values ->
+                trySendBlocking(LocalGroup(AndroidGroup(ab, values)))
+            }
+        }
+    }.buffer(capacity = 1)
+
+    /**
+     * Finds local contacts/groups which have been deleted locally. (DELETED != 0).
+     * @throws RemoteException on content provider errors
+     */
+    override fun findDeleted(): Flow<LocalAddress> =
         if (includeGroups)
-            findDeletedContacts() + findDeletedGroups()
+            merge(findDeletedContacts(), findDeletedGroups())
         else
             findDeletedContacts()
 
-    fun findDeletedContacts() = queryContacts(RawContacts.DELETED, null)
-    fun findDeletedGroups() = queryGroups(Groups.DELETED, null)
-
-    override fun deletedFlow(): Flow<LocalAddress> {
-        return channelFlow {
-            launch(Dispatchers.IO) {
-                sendDeletedContacts()
-                if (includeGroups) {
-                    sendDeletedGroups()
-                }
-            }
-        }.buffer(capacity = 1)
-    }
-
-    private fun ProducerScope<LocalAddress>.sendDeletedContacts() {
-        ab.iterateRawContactRows(RawContacts.DELETED, null) { values ->
-            trySendBlocking(LocalContact(this@LocalAddressBook, AndroidContact(ab, values)))
-        }
-    }
-
-    private fun ProducerScope<LocalAddress>.sendDeletedGroups() {
-        ab.iterateGroups(null, Groups.DELETED, null) { values ->
-            trySendBlocking(LocalGroup(AndroidGroup(ab, values)))
-        }
-    }
-
     /**
-     * Returns an array of local contacts/groups which have been changed locally (DIRTY != 0).
+     * Finds local contacts which have been changed locally (DIRTY != 0).
      * @throws RemoteException on content provider errors
      */
-    override fun findDirty() =
+    fun findDirtyContacts(): Flow<LocalContact> = channelFlow {
+        launch(Dispatchers.IO) {
+            ab.iterateRawContactRows(RawContacts.DIRTY, null) { values ->
+                trySendBlocking(LocalContact(this@LocalAddressBook, AndroidContact(ab, values)))
+            }
+        }
+    }.buffer(capacity = 1)
+
+    /**
+     * Finds local groups which have been changed locally (DIRTY != 0).
+     * @throws RemoteException on content provider errors
+     */
+    fun findDirtyGroups(): Flow<LocalGroup> = channelFlow {
+        launch(Dispatchers.IO) {
+            ab.iterateGroups(null, Groups.DIRTY, null) { values ->
+                trySendBlocking(LocalGroup(AndroidGroup(ab, values)))
+            }
+        }
+    }.buffer(capacity = 1)
+
+    /**
+     * Finds local contacts/groups which have been changed locally (DIRTY != 0).
+     * @throws RemoteException on content provider errors
+     */
+    override fun findDirty(): Flow<LocalAddress> =
         if (includeGroups)
-            findDirtyContacts() + findDirtyGroups()
+            merge(findDirtyContacts(), findDirtyGroups())
         else
             findDirtyContacts()
-
-    fun findDirtyContacts() = queryContacts(RawContacts.DIRTY, null)
-    fun findDirtyGroups() = queryGroups(Groups.DIRTY, null)
-
-    override fun dirtyFlow(): Flow<LocalAddress> {
-        return channelFlow {
-            launch(Dispatchers.IO) {
-                sendDirtyContacts()
-                if (includeGroups) {
-                    sendDirtyGroups()
-                }
-            }
-        }.buffer(capacity = 1)
-    }
-
-    private fun ProducerScope<LocalAddress>.sendDirtyContacts() {
-        ab.iterateRawContactRows(RawContacts.DIRTY, null) { values ->
-            trySendBlocking(LocalContact(this@LocalAddressBook, AndroidContact(ab, values)))
-        }
-    }
-
-    private fun ProducerScope<LocalAddress>.sendDirtyGroups() {
-        ab.iterateGroups(null, Groups.DIRTY, null) { values ->
-            trySendBlocking(LocalGroup(AndroidGroup(ab, values)))
-        }
-    }
 
     override fun forgetETags() {
         val batch = ContactsBatchOperation(ab.provider)

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -37,6 +37,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.toList
 import java.io.FileNotFoundException
 import java.util.Optional
 import java.util.logging.Logger
@@ -300,27 +301,21 @@ open class LocalAddressBook @AssistedInject constructor(
         return LocalGroup(androidGroup)
     }
 
-    fun queryContacts(where: String?, whereArgs: Array<String>?): List<LocalContact> = buildList {
-        ab.iterateRawContactRows(where, whereArgs) { values ->
-            add(LocalContact(this@LocalAddressBook, AndroidContact(ab, values)))
-        }
-    }
+    suspend fun queryContacts(where: String?, whereArgs: Array<String>?): List<LocalContact> =
+        ab.queryRawContactRows(where, whereArgs).map { LocalContact(this, AndroidContact(ab, it)) }.toList()
 
-    fun queryGroups(where: String?, whereArgs: Array<String>?): List<LocalGroup> = buildList {
-        ab.iterateGroups(null, where, whereArgs) { values ->
-            add(LocalGroup(AndroidGroup(ab, values)))
-        }
-    }
+    suspend fun queryGroups(where: String?, whereArgs: Array<String>?): List<LocalGroup> =
+        ab.queryGroupRows(null, where, whereArgs).map { LocalGroup(AndroidGroup(ab, it)) }.toList()
 
     @Throws(FileNotFoundException::class)
-    fun findContactById(id: Long) =
+    suspend fun findContactById(id: Long) =
         queryContacts("${RawContacts._ID}=?", arrayOf(id.toString())).firstOrNull() ?: throw FileNotFoundException()
 
-    fun findContactByUid(uid: String) =
+    suspend fun findContactByUid(uid: String) =
         queryContacts("${RawContactColumns.UID}=?", arrayOf(uid)).firstOrNull()
 
     @Throws(FileNotFoundException::class)
-    fun findGroupById(id: Long) =
+    suspend fun findGroupById(id: Long) =
         queryGroups("${Groups._ID}=?", arrayOf(id.toString())).firstOrNull() ?: throw FileNotFoundException()
 
 
@@ -353,7 +348,7 @@ open class LocalAddressBook @AssistedInject constructor(
      * Processes all groups with pending memberships: applies them (if possible) to keep cached
      * memberships in sync.
      */
-    fun applyPendingMemberships() {
+    suspend fun applyPendingMemberships() {
         logger.info("Assigning memberships of contact groups")
 
         queryGroups(

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
@@ -78,10 +78,10 @@ class LocalCalendar @AssistedInject constructor(
         androidCalendar.countEvents(Events.DIRTY, null)
 
     override fun findDeleted(): Flow<LocalEvent> =
-        recurringCalendar.eventAndExceptionsFlow(Events.DELETED, null).map { LocalEvent(recurringCalendar, it) }
+        recurringCalendar.queryEventsAndExceptions(Events.DELETED, null).map { LocalEvent(recurringCalendar, it) }
 
     override fun findDirty(): Flow<LocalEvent> =
-        recurringCalendar.eventAndExceptionsFlow(Events.DIRTY, null).map { LocalEvent(recurringCalendar, it) }
+        recurringCalendar.queryEventsAndExceptions(Events.DIRTY, null).map { LocalEvent(recurringCalendar, it) }
 
     override suspend fun findByName(name: String) =
         recurringCalendar.findEventAndExceptions("${Events._SYNC_ID}=?", arrayOf(name))?.let {

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
@@ -78,13 +78,10 @@ class LocalCalendar @AssistedInject constructor(
     override fun countModified(): Int =
         androidCalendar.countEvents("${Events.DIRTY} AND NOT ${Events.DELETED}", null)
 
-    override fun findDeleted(): List<LocalEvent> = buildList {
-        recurringCalendar.iterateEventAndExceptions(Events.DELETED, null) { eventAndExceptions ->
-            add(LocalEvent(recurringCalendar, eventAndExceptions))
-        }
-    }
+    override fun countDirty(): Int =
+        androidCalendar.countEvents(Events.DIRTY, null)
 
-    override fun deletedFlow(): Flow<LocalEvent> {
+    override fun findDeleted(): Flow<LocalEvent> {
         return channelFlow {
             launch(Dispatchers.IO) {
                 recurringCalendar.iterateEventAndExceptions(Events.DELETED, null) { eventAndExceptions ->
@@ -94,13 +91,7 @@ class LocalCalendar @AssistedInject constructor(
         }.buffer(capacity = 1)
     }
 
-    override fun findDirty(): List<LocalEvent> = buildList {
-        recurringCalendar.iterateEventAndExceptions(Events.DIRTY, null) { eventAndExceptions ->
-            add(LocalEvent(recurringCalendar, eventAndExceptions))
-        }
-    }
-
-    override fun dirtyFlow(): Flow<LocalEvent> {
+    override fun findDirty(): Flow<LocalEvent> {
         return channelFlow {
             launch(Dispatchers.IO) {
                 recurringCalendar.iterateEventAndExceptions(Events.DIRTY, null) { eventAndExceptions ->

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
@@ -17,12 +17,8 @@ import at.bitfire.synctools.storage.calendar.EventsContract
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.buffer
-import kotlinx.coroutines.flow.channelFlow
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.map
 
 /**
  * Application-specific subclass of [AndroidCalendar] for local calendars.
@@ -81,25 +77,11 @@ class LocalCalendar @AssistedInject constructor(
     override fun countDirty(): Int =
         androidCalendar.countEvents(Events.DIRTY, null)
 
-    override fun findDeleted(): Flow<LocalEvent> {
-        return channelFlow {
-            launch(Dispatchers.IO) {
-                recurringCalendar.iterateEventAndExceptions(Events.DELETED, null) { eventAndExceptions ->
-                    trySendBlocking(LocalEvent(recurringCalendar, eventAndExceptions))
-                }
-            }
-        }.buffer(capacity = 1)
-    }
+    override fun findDeleted(): Flow<LocalEvent> =
+        recurringCalendar.eventAndExceptionsFlow(Events.DELETED, null).map { LocalEvent(recurringCalendar, it) }
 
-    override fun findDirty(): Flow<LocalEvent> {
-        return channelFlow {
-            launch(Dispatchers.IO) {
-                recurringCalendar.iterateEventAndExceptions(Events.DIRTY, null) { eventAndExceptions ->
-                    trySendBlocking(LocalEvent(recurringCalendar, eventAndExceptions))
-                }
-            }
-        }.buffer(capacity = 1)
-    }
+    override fun findDirty(): Flow<LocalEvent> =
+        recurringCalendar.eventAndExceptionsFlow(Events.DIRTY, null).map { LocalEvent(recurringCalendar, it) }
 
     override fun findByName(name: String) =
         recurringCalendar.findEventAndExceptions("${Events._SYNC_ID}=?", arrayOf(name))?.let {

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
@@ -83,7 +83,7 @@ class LocalCalendar @AssistedInject constructor(
     override fun findDirty(): Flow<LocalEvent> =
         recurringCalendar.eventAndExceptionsFlow(Events.DIRTY, null).map { LocalEvent(recurringCalendar, it) }
 
-    override fun findByName(name: String) =
+    override suspend fun findByName(name: String) =
         recurringCalendar.findEventAndExceptions("${Events._SYNC_ID}=?", arrayOf(name))?.let {
             LocalEvent(recurringCalendar, it)
         }
@@ -100,7 +100,7 @@ class LocalCalendar @AssistedInject constructor(
             arrayOf(androidCalendar.id.toString())
         )
 
-    override fun removeNotDirtyMarked(flags: Int): Int {
+    override suspend fun removeNotDirtyMarked(flags: Int): Int {
         // list all non-dirty events with the given flags and delete every row + its exceptions
         val batch = CalendarBatchOperation(androidCalendar.client)
         androidCalendar.iterateEventRows(

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCollection.kt
@@ -53,7 +53,7 @@ interface LocalCollection<out T: LocalResource> {
      * @param name file name to look for
      * @return resource with the given name, or null if none
      */
-    fun findByName(name: String): T?
+    suspend fun findByName(name: String): T?
 
     /**
      * Updates the flags value for entries which are not dirty.
@@ -72,7 +72,7 @@ interface LocalCollection<out T: LocalResource> {
      *
      * @return         number of removed entries
      */
-    fun removeNotDirtyMarked(flags: Int): Int
+    suspend fun removeNotDirtyMarked(flags: Int): Int
 
 
     /**

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCollection.kt
@@ -84,7 +84,6 @@ interface LocalCollection<out T: LocalResource> {
      * Counts all resources in this collection.
      *
      * @return total number of resources
-     * @throws UnsupportedOperationException if the operation is not supported on this collection (jtx Board)
      */
     fun countAll(): Int
 
@@ -92,7 +91,6 @@ interface LocalCollection<out T: LocalResource> {
      * Counts resources in this collection that are locally deleted (pending removal from server).
      *
      * @return number of deleted resources
-     * @throws UnsupportedOperationException if the operation is not supported on this collection (jtx Board)
      */
     fun countDeleted(): Int
 
@@ -101,7 +99,6 @@ interface LocalCollection<out T: LocalResource> {
      * excluding resources already marked as deleted.
      *
      * @return number of modified resources
-     * @throws UnsupportedOperationException if the operation is not supported on this collection (jtx Board)
      */
     fun countModified(): Int
 
@@ -109,7 +106,6 @@ interface LocalCollection<out T: LocalResource> {
      * Counts resources in this collection that are locally marked as *dirty*.
      *
      * @return number of dirty resources
-     * @throws UnsupportedOperationException if the operation is not supported on this collection (jtx Board)
      */
     fun countDirty(): Int
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCollection.kt
@@ -34,25 +34,9 @@ interface LocalCollection<out T: LocalResource> {
      * Finds local resources of this collection which have been marked as *deleted* by the user
      * or an app acting on their behalf.
      *
-     * @return list of resources marked as *deleted*
-     */
-    fun findDeleted(): List<T>
-
-    /**
-     * Finds local resources of this collection which have been marked as *deleted* by the user
-     * or an app acting on their behalf.
-     *
      * @return [Flow] of resources marked as *deleted*
      */
-    fun deletedFlow(): Flow<T>
-
-    /**
-     * Finds local resources of this collection which have been marked as *dirty*, i.e. resources
-     * which have been modified by the user or an app acting on their behalf.
-     *
-     * @return list of resources marked as *dirty*
-     */
-    fun findDirty(): List<T>
+    fun findDeleted(): Flow<T>
 
     /**
      * Finds local resources of this collection which have been marked as *dirty*, i.e. resources
@@ -60,7 +44,7 @@ interface LocalCollection<out T: LocalResource> {
      *
      * @return [Flow] of resources marked as *dirty*
      */
-    fun dirtyFlow(): Flow<T>
+    fun findDirty(): Flow<T>
 
     /**
      * Finds a local resource of this collection with a given file name. (File names are assigned
@@ -120,5 +104,13 @@ interface LocalCollection<out T: LocalResource> {
      * @throws UnsupportedOperationException if the operation is not supported on this collection (jtx Board)
      */
     fun countModified(): Int
+
+    /**
+     * Counts resources in this collection that are locally marked as *dirty*.
+     *
+     * @return number of dirty resources
+     * @throws UnsupportedOperationException if the operation is not supported on this collection (jtx Board)
+     */
+    fun countDirty(): Int
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalDataStore.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalDataStore.kt
@@ -65,7 +65,6 @@ interface LocalDataStore<T: LocalCollection<*>> {
      * @param dbCollectionId The database collection ID which the requested local collection corresponds to.
      *
      * @return The local collection with the specified DB collection ID, or `null` if not found.
-     * @throws UnsupportedOperationException if the operation is not supported on this data store (jtx Board)
      */
     @WorkerThread
     fun getByDbCollectionId(account: Account, client: ContentProviderClient, dbCollectionId: Long): T?

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollection.kt
@@ -73,7 +73,7 @@ class LocalJtxCollection(internal val jtxCollection: JtxCollection) :
         recurringCollection.jtxObjectAndExceptionsFlow(JtxICalObject.DIRTY, null)
             .map { LocalJtxObject(recurringCollection, it) }
 
-    override fun findByName(name: String): LocalJtxObject? {
+    override suspend fun findByName(name: String): LocalJtxObject? {
         return recurringCollection
             .findJtxObjectAndExceptions("${JtxICalObject.FILENAME}=?", arrayOf(name))
             ?.let { jtxObjectAndExceptions ->
@@ -87,12 +87,12 @@ class LocalJtxCollection(internal val jtxCollection: JtxCollection) :
             "NOT ${JtxICalObject.DIRTY}", null
         )
 
-    override fun removeNotDirtyMarked(flags: Int): Int {
+    override suspend fun removeNotDirtyMarked(flags: Int): Int {
         val batch = JtxBatchOperation(jtxCollection.client)
-        recurringCollection.iterateJtxObjectAndExceptions(
+        recurringCollection.jtxObjectAndExceptionsFlow(
             "NOT ${JtxICalObject.DIRTY} AND ${JtxICalObject.FLAGS}=?",
             arrayOf(flags.toString())
-        ) { objectAndExceptions ->
+        ).collect { objectAndExceptions ->
             val id = objectAndExceptions.main.entityValues.getAsLong(JtxICalObject.ID)!!
             recurringCollection.deleteJtxObjectAndExceptions(id, batch)
         }

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollection.kt
@@ -66,13 +66,10 @@ class LocalJtxCollection(internal val jtxCollection: JtxCollection) :
     override fun countModified(): Int =
         jtxCollection.countJtxObjects("${JtxICalObject.DIRTY} AND NOT ${JtxICalObject.DELETED}", null)
 
-    override fun findDeleted(): List<LocalJtxObject> = buildList {
-        recurringCollection.iterateJtxObjectAndExceptions(JtxICalObject.DELETED, null) { jtxObjectAndExceptions ->
-            add(LocalJtxObject(recurringCollection, jtxObjectAndExceptions))
-        }
-    }
+    override fun countDirty(): Int =
+        jtxCollection.countJtxObjects(JtxICalObject.DIRTY, null)
 
-    override fun deletedFlow(): Flow<LocalJtxObject> {
+    override fun findDeleted(): Flow<LocalJtxObject> {
         return channelFlow {
             launch(Dispatchers.IO) {
                 recurringCollection.iterateJtxObjectAndExceptions(JtxICalObject.DELETED, null) { jtxObjectAndExceptions ->
@@ -82,13 +79,7 @@ class LocalJtxCollection(internal val jtxCollection: JtxCollection) :
         }.buffer(capacity = 1)
     }
 
-    override fun findDirty(): List<LocalJtxObject> = buildList {
-        recurringCollection.iterateJtxObjectAndExceptions(JtxICalObject.DIRTY, null) { jtxObjectAndExceptions ->
-            add(LocalJtxObject(recurringCollection, jtxObjectAndExceptions))
-        }
-    }
-
-    override fun dirtyFlow(): Flow<LocalJtxObject> {
+    override fun findDirty(): Flow<LocalJtxObject> {
         return channelFlow {
             launch(Dispatchers.IO) {
                 recurringCollection.iterateJtxObjectAndExceptions(JtxICalObject.DIRTY, null) { jtxObjectAndExceptions ->

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollection.kt
@@ -66,11 +66,11 @@ class LocalJtxCollection(internal val jtxCollection: JtxCollection) :
         jtxCollection.countJtxObjects(JtxICalObject.DIRTY, null)
 
     override fun findDeleted(): Flow<LocalJtxObject> =
-        recurringCollection.jtxObjectAndExceptionsFlow(JtxICalObject.DELETED, null)
+        recurringCollection.queryJtxObjectsAndExceptions(JtxICalObject.DELETED, null)
             .map { LocalJtxObject(recurringCollection, it) }
 
     override fun findDirty(): Flow<LocalJtxObject> =
-        recurringCollection.jtxObjectAndExceptionsFlow(JtxICalObject.DIRTY, null)
+        recurringCollection.queryJtxObjectsAndExceptions(JtxICalObject.DIRTY, null)
             .map { LocalJtxObject(recurringCollection, it) }
 
     override suspend fun findByName(name: String): LocalJtxObject? {
@@ -89,7 +89,7 @@ class LocalJtxCollection(internal val jtxCollection: JtxCollection) :
 
     override suspend fun removeNotDirtyMarked(flags: Int): Int {
         val batch = JtxBatchOperation(jtxCollection.client)
-        recurringCollection.jtxObjectAndExceptionsFlow(
+        recurringCollection.queryJtxObjectsAndExceptions(
             "NOT ${JtxICalObject.DIRTY} AND ${JtxICalObject.FLAGS}=?",
             arrayOf(flags.toString())
         ).collect { objectAndExceptions ->

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollection.kt
@@ -11,12 +11,8 @@ import at.bitfire.synctools.storage.jtx.JtxEntityAndExceptions
 import at.bitfire.synctools.storage.jtx.JtxRecurringCollection
 import at.techbee.jtx.JtxContract
 import at.techbee.jtx.JtxContract.JtxICalObject
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.buffer
-import kotlinx.coroutines.flow.channelFlow
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.map
 
 /**
  * Application-specific implementation for jtx collections.
@@ -69,25 +65,13 @@ class LocalJtxCollection(internal val jtxCollection: JtxCollection) :
     override fun countDirty(): Int =
         jtxCollection.countJtxObjects(JtxICalObject.DIRTY, null)
 
-    override fun findDeleted(): Flow<LocalJtxObject> {
-        return channelFlow {
-            launch(Dispatchers.IO) {
-                recurringCollection.iterateJtxObjectAndExceptions(JtxICalObject.DELETED, null) { jtxObjectAndExceptions ->
-                    trySendBlocking(LocalJtxObject(recurringCollection, jtxObjectAndExceptions))
-                }
-            }
-        }.buffer(capacity = 1)
-    }
+    override fun findDeleted(): Flow<LocalJtxObject> =
+        recurringCollection.jtxObjectAndExceptionsFlow(JtxICalObject.DELETED, null)
+            .map { LocalJtxObject(recurringCollection, it) }
 
-    override fun findDirty(): Flow<LocalJtxObject> {
-        return channelFlow {
-            launch(Dispatchers.IO) {
-                recurringCollection.iterateJtxObjectAndExceptions(JtxICalObject.DIRTY, null) { jtxObjectAndExceptions ->
-                    trySendBlocking(LocalJtxObject(recurringCollection, jtxObjectAndExceptions))
-                }
-            }
-        }.buffer(capacity = 1)
-    }
+    override fun findDirty(): Flow<LocalJtxObject> =
+        recurringCollection.jtxObjectAndExceptionsFlow(JtxICalObject.DIRTY, null)
+            .map { LocalJtxObject(recurringCollection, it) }
 
     override fun findByName(name: String): LocalJtxObject? {
         return recurringCollection

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxObject.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxObject.kt
@@ -41,7 +41,7 @@ class LocalJtxObject(
     override val flags: Int
         get() = mainValues.getAsInteger(JtxContract.JtxICalObject.FLAGS) ?: 0
 
-    fun update(data: JtxEntityAndExceptions) {
+    suspend fun update(data: JtxEntityAndExceptions) {
         recurringCollection.updateJtxObjectAndExceptions(id, data)
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskList.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskList.kt
@@ -82,13 +82,10 @@ class LocalTaskList (
     override fun countModified(): Int =
         dmfsTaskList.countTasks("${Tasks._DIRTY} AND NOT ${Tasks._DELETED}", null)
 
-    override fun findDeleted(): List<LocalTask> = buildList {
-        recurringTaskList.iterateTaskAndExceptions(Tasks._DELETED, null) {
-            add(LocalTask(recurringTaskList, it))
-        }
-    }
+    override fun countDirty(): Int =
+        dmfsTaskList.countTasks(Tasks._DIRTY, null)
 
-    override fun deletedFlow(): Flow<LocalTask> {
+    override fun findDeleted(): Flow<LocalTask> {
         return channelFlow {
             launch(Dispatchers.IO) {
                 recurringTaskList.iterateTaskAndExceptions(Tasks._DELETED, null) {
@@ -98,13 +95,7 @@ class LocalTaskList (
         }.buffer(capacity = 1)
     }
 
-    override fun findDirty(): List<LocalTask> = buildList {
-        recurringTaskList.iterateTaskAndExceptions(Tasks._DIRTY, null) {
-            add(LocalTask(recurringTaskList, it))
-        }
-    }
-
-    override fun dirtyFlow(): Flow<LocalTask> {
+    override fun findDirty(): Flow<LocalTask> {
         return channelFlow {
             launch(Dispatchers.IO) {
                 recurringTaskList.iterateTaskAndExceptions(Tasks._DIRTY, null) {

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskList.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskList.kt
@@ -82,10 +82,10 @@ class LocalTaskList (
         dmfsTaskList.countTasks(Tasks._DIRTY, null)
 
     override fun findDeleted(): Flow<LocalTask> =
-        recurringTaskList.taskAndExceptionsFlow(Tasks._DELETED, null).map { LocalTask(recurringTaskList, it) }
+        recurringTaskList.queryTasksAndExceptions(Tasks._DELETED, null).map { LocalTask(recurringTaskList, it) }
 
     override fun findDirty(): Flow<LocalTask> =
-        recurringTaskList.taskAndExceptionsFlow(Tasks._DIRTY, null).map { LocalTask(recurringTaskList, it) }
+        recurringTaskList.queryTasksAndExceptions(Tasks._DIRTY, null).map { LocalTask(recurringTaskList, it) }
 
     override suspend fun findByName(name: String): LocalTask? {
         val result = recurringTaskList.findTaskAndExceptions("${Tasks._SYNC_ID}=?", arrayOf(name))

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskList.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskList.kt
@@ -10,12 +10,8 @@ import at.bitfire.synctools.storage.tasks.DmfsRecurringTaskList
 import at.bitfire.synctools.storage.tasks.DmfsTaskList
 import at.bitfire.synctools.storage.tasks.DmfsTasksContract
 import at.bitfire.synctools.storage.tasks.TaskAndExceptions
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.buffer
-import kotlinx.coroutines.flow.channelFlow
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.map
 import org.dmfs.tasks.contract.TaskContract
 import org.dmfs.tasks.contract.TaskContract.TaskListColumns
 import org.dmfs.tasks.contract.TaskContract.Tasks
@@ -85,25 +81,11 @@ class LocalTaskList (
     override fun countDirty(): Int =
         dmfsTaskList.countTasks(Tasks._DIRTY, null)
 
-    override fun findDeleted(): Flow<LocalTask> {
-        return channelFlow {
-            launch(Dispatchers.IO) {
-                recurringTaskList.iterateTaskAndExceptions(Tasks._DELETED, null) {
-                    trySendBlocking(LocalTask(recurringTaskList, it))
-                }
-            }
-        }.buffer(capacity = 1)
-    }
+    override fun findDeleted(): Flow<LocalTask> =
+        recurringTaskList.taskAndExceptionsFlow(Tasks._DELETED, null).map { LocalTask(recurringTaskList, it) }
 
-    override fun findDirty(): Flow<LocalTask> {
-        return channelFlow {
-            launch(Dispatchers.IO) {
-                recurringTaskList.iterateTaskAndExceptions(Tasks._DIRTY, null) {
-                    trySendBlocking(LocalTask(recurringTaskList, it))
-                }
-            }
-        }.buffer(capacity = 1)
-    }
+    override fun findDirty(): Flow<LocalTask> =
+        recurringTaskList.taskAndExceptionsFlow(Tasks._DIRTY, null).map { LocalTask(recurringTaskList, it) }
 
     override fun findByName(name: String): LocalTask? {
         val result = recurringTaskList.findTaskAndExceptions("${Tasks._SYNC_ID}=?", arrayOf(name))

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskList.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskList.kt
@@ -87,7 +87,7 @@ class LocalTaskList (
     override fun findDirty(): Flow<LocalTask> =
         recurringTaskList.taskAndExceptionsFlow(Tasks._DIRTY, null).map { LocalTask(recurringTaskList, it) }
 
-    override fun findByName(name: String): LocalTask? {
+    override suspend fun findByName(name: String): LocalTask? {
         val result = recurringTaskList.findTaskAndExceptions("${Tasks._SYNC_ID}=?", arrayOf(name))
         return result?.let {
             LocalTask(recurringTaskList, it)
@@ -101,7 +101,7 @@ class LocalTaskList (
             arrayOf(dmfsTaskList.id.toString())
         )
 
-    override fun removeNotDirtyMarked(flags: Int) =
+    override suspend fun removeNotDirtyMarked(flags: Int) =
         dmfsTaskList.deleteTasks(
             "${Tasks.LIST_ID}=? AND NOT ${Tasks._DIRTY} AND ${DmfsTasksContract.COLUMN_FLAGS}=?",
             arrayOf(dmfsTaskList.id.toString(), flags.toString())

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/workaround/Android7DirtyVerifier.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/workaround/Android7DirtyVerifier.kt
@@ -16,7 +16,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import kotlinx.coroutines.flow.count
+import kotlinx.coroutines.flow.firstOrNull
 import java.util.Optional
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -53,8 +53,8 @@ class Android7DirtyVerifier @Inject constructor(
     override suspend fun prepareAddressBook(addressBook: LocalAddressBook, isUpload: Boolean): Boolean {
         val reallyDirty = verifyDirtyContacts(addressBook)
 
-        val deleted = addressBook.findDeleted().count()
-        if (isUpload && reallyDirty == 0 && deleted == 0) {
+        val anyDeleted = addressBook.findDeleted().firstOrNull() != null
+        if (isUpload && reallyDirty == 0 && !anyDeleted) {
             logger.info("This sync was called to up-sync dirty/deleted contacts, but no contacts have been changed")
             return false
         }

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/workaround/Android7DirtyVerifier.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/workaround/Android7DirtyVerifier.kt
@@ -6,6 +6,7 @@ package at.bitfire.davdroid.resource.workaround
 
 import android.content.ContentValues
 import android.os.Build
+import android.provider.ContactsContract.Groups
 import at.bitfire.davdroid.resource.LocalAddressBook
 import at.bitfire.davdroid.resource.LocalContact
 import at.bitfire.synctools.storage.BatchOperation
@@ -15,6 +16,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.flow.count
 import java.util.Optional
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -48,10 +50,10 @@ class Android7DirtyVerifier @Inject constructor(
 
     // address-book level functions
 
-    override fun prepareAddressBook(addressBook: LocalAddressBook, isUpload: Boolean): Boolean {
+    override suspend fun prepareAddressBook(addressBook: LocalAddressBook, isUpload: Boolean): Boolean {
         val reallyDirty = verifyDirtyContacts(addressBook)
 
-        val deleted = addressBook.findDeleted().size
+        val deleted = addressBook.findDeleted().count()
         if (isUpload && reallyDirty == 0 && deleted == 0) {
             logger.info("This sync was called to up-sync dirty/deleted contacts, but no contacts have been changed")
             return false
@@ -69,9 +71,9 @@ class Android7DirtyVerifier @Inject constructor(
      *
      * @return number of "really dirty" contacts
      */
-    private fun verifyDirtyContacts(addressBook: LocalAddressBook): Int {
+    private suspend fun verifyDirtyContacts(addressBook: LocalAddressBook): Int {
         var reallyDirty = 0
-        for (contact in addressBook.findDirtyContacts()) {
+        addressBook.findDirtyContacts().collect { contact ->
             val lastHash = getLastHashCode(addressBook, contact)
             val currentHash = contactDataHashCode(contact)
             if (lastHash == currentHash) {
@@ -85,7 +87,7 @@ class Android7DirtyVerifier @Inject constructor(
         }
 
         if (addressBook.includeGroups)
-            reallyDirty += addressBook.findDirtyGroups().size
+            reallyDirty += addressBook.ab.countGroups(Groups.DIRTY, null)
 
         return reallyDirty
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/workaround/ContactDirtyVerifier.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/workaround/ContactDirtyVerifier.kt
@@ -28,7 +28,7 @@ interface ContactDirtyVerifier {
      *
      * @return `true` if the address book should be synced, `false` if the sync is an upload and no contacts have been changed
      */
-    fun prepareAddressBook(addressBook: LocalAddressBook, isUpload: Boolean): Boolean
+    suspend fun prepareAddressBook(addressBook: LocalAddressBook, isUpload: Boolean): Boolean
 
 
     // contact level functions

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
@@ -283,7 +283,7 @@ class CalendarSyncManager @AssistedInject constructor(
         }
     }
 
-    override fun postProcess() {}
+    override suspend fun postProcess() {}
 
 
     // helpers

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
@@ -250,7 +250,7 @@ class CalendarSyncManager @AssistedInject constructor(
                  * - ignore responses without requested calendar data (should also ignore collections and hopefully unrelated resources), and
                  * - take the last segment of the href as the file name and assume that it's in the requested collection.
                  */
-                SyncException.wrapWithRemoteResource(response.href) wrapResource@{
+                SyncException.wrapWithRemoteResourceSuspending(response.href) wrapResource@{
                     if (!response.isSuccess()) {
                         logger.warning("Ignoring non-successful multi-get response for ${response.href}")
                         return@wrapResource
@@ -288,7 +288,7 @@ class CalendarSyncManager @AssistedInject constructor(
 
     // helpers
 
-    private fun processICalendar(fileName: String, eTag: String, scheduleTag: String?, reader: Reader) {
+    private suspend fun processICalendar(fileName: String, eTag: String, scheduleTag: String?, reader: Reader) {
         val calendar = ICalendarParser().parse(reader)
 
         val uidsAndEvents = CalendarUidSplitter<VEvent>().associateByUid(calendar, Component.VEVENT)

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
@@ -91,7 +91,7 @@ class CalendarSyncManager @AssistedInject constructor(
     private val accountSettings = accountSettingsFactory.create(account)
 
 
-    override fun prepare(): Boolean {
+    override suspend fun prepare(): Boolean {
         davCollection = DavCalendar(httpClient, collection.url)
 
         // if there are dirty exceptions for events, mark their master events as dirty, too
@@ -140,7 +140,7 @@ class CalendarSyncManager @AssistedInject constructor(
     override suspend fun processLocallyDeleted(): Boolean {
         if (localCollection.readOnly) {
             var modified = false
-            localCollection.deletedFlow().collect { event ->
+            localCollection.findDeleted().collect { event ->
                 logger.warning("Restoring locally deleted event (read-only calendar!)")
                 SyncException.wrapWithLocalResource(event) {
                     event.resetDeleted()
@@ -163,7 +163,7 @@ class CalendarSyncManager @AssistedInject constructor(
     override suspend fun uploadDirty(): Boolean {
         var modified = false
         if (localCollection.readOnly) {
-            localCollection.dirtyFlow().collect { event ->
+            localCollection.findDirty().collect { event ->
                 logger.warning("Resetting locally modified event to ETag=null (read-only calendar!)")
                 SyncException.wrapWithLocalResource(event) {
                     event.clearDirty(Optional.empty(), null, null)

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
@@ -326,7 +326,7 @@ class ContactsSyncManager @AssistedInject constructor(
             }
             davCollection.multiget(bunch, contentType, version) { response, _ ->
                 // See CalendarSyncManager for more information about the multi-get response
-                SyncException.wrapWithRemoteResource(response.href) wrapResource@{
+                SyncException.wrapWithRemoteResourceSuspending(response.href) wrapResource@{
                     if (!response.isSuccess()) {
                         logger.warning("Ignoring non-successful multi-get response for ${response.href}")
                         return@wrapResource
@@ -365,7 +365,7 @@ class ContactsSyncManager @AssistedInject constructor(
 
     // helpers
 
-    private fun processCard(fileName: String, eTag: String, reader: Reader, downloader: Contact.Downloader) {
+    private suspend fun processCard(fileName: String, eTag: String, reader: Reader, downloader: Contact.Downloader) {
         logger.info("Processing CardDAV resource $fileName")
 
         val newData = try {

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
@@ -149,7 +149,7 @@ class ContactsSyncManager @AssistedInject constructor(
     }
 
 
-    override fun prepare(): Boolean {
+    override suspend fun prepare(): Boolean {
         if (dirtyVerifier.isPresent) {
             logger.info("Sync will verify dirty contacts (Android 7.x workaround)")
             if (!dirtyVerifier.get().prepareAddressBook(localCollection, isUpload = syncFrameworkUpload))
@@ -204,7 +204,7 @@ class ContactsSyncManager @AssistedInject constructor(
     override suspend fun processLocallyDeleted() =
             if (localCollection.readOnly) {
                 var modified = false
-                for (group in localCollection.findDeletedGroups()) {
+                localCollection.findDeletedGroups().collect { group ->
                     logger.warning("Restoring locally deleted group (read-only address book!)")
                     SyncException.wrapWithLocalResource(group) {
                         group.resetDeleted()
@@ -212,7 +212,7 @@ class ContactsSyncManager @AssistedInject constructor(
                     modified = true
                 }
 
-                for (contact in localCollection.findDeletedContacts()) {
+                localCollection.findDeletedContacts().collect { contact ->
                     logger.warning("Restoring locally deleted contact (read-only address book!)")
                     SyncException.wrapWithLocalResource(contact) {
                         contact.resetDeleted()
@@ -235,7 +235,7 @@ class ContactsSyncManager @AssistedInject constructor(
         var modified = false
 
         if (localCollection.readOnly) {
-            for (group in localCollection.findDirtyGroups()) {
+            localCollection.findDirtyGroups().collect { group ->
                 logger.warning("Resetting locally modified group to ETag=null (read-only address book!)")
                 SyncException.wrapWithLocalResource(group) {
                     group.clearDirty(Optional.empty(), null)
@@ -243,7 +243,7 @@ class ContactsSyncManager @AssistedInject constructor(
                 modified = true
             }
 
-            for (contact in localCollection.findDirtyContacts()) {
+            localCollection.findDirtyContacts().collect { contact ->
                 logger.warning("Resetting locally modified contact to ETag=null (read-only address book!)")
                 SyncException.wrapWithLocalResource(contact) {
                     contact.clearDirty(Optional.empty(), null)

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
@@ -358,7 +358,7 @@ class ContactsSyncManager @AssistedInject constructor(
         }
     }
 
-    override fun postProcess() {
+    override suspend fun postProcess() {
         groupStrategy.postProcess()
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
@@ -82,7 +82,7 @@ class JtxSyncManager @AssistedInject constructor(
     }
 
 
-    override fun prepare(): Boolean {
+    override suspend fun prepare(): Boolean {
         davCollection = DavCalendar(httpClient, collection.url)
 
         return true

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
@@ -186,7 +186,7 @@ class JtxSyncManager @AssistedInject constructor(
         }
     }
 
-    override fun postProcess() {
+    override suspend fun postProcess() {
         localCollection.updateLastSync()
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
@@ -158,7 +158,7 @@ class JtxSyncManager @AssistedInject constructor(
         SyncException.wrapWithRemoteResourceSuspending(collection.url) {
             davCollection.multiget(bunch) { response, _ ->
                 // See CalendarSyncManager for more information about the multi-get response
-                SyncException.wrapWithRemoteResource(response.href) wrapResource@{
+                SyncException.wrapWithRemoteResourceSuspending(response.href) wrapResource@{
                     if (!response.isSuccess()) {
                         logger.warning("Ignoring non-successful multi-get response for ${response.href}")
                         return@wrapResource
@@ -195,7 +195,7 @@ class JtxSyncManager @AssistedInject constructor(
 
 
     @OpenForTesting
-    internal fun processICalObject(fileName: String, eTag: String, scheduleTag: String?, reader: Reader) {
+    internal suspend fun processICalObject(fileName: String, eTag: String, scheduleTag: String?, reader: Reader) {
         val calendar = ICalendarParser().parse(reader)
 
         val uidsAndJournals = CalendarUidSplitter<CalendarComponent>().associateByUid(calendar, Component.VJOURNAL)
@@ -219,7 +219,7 @@ class JtxSyncManager @AssistedInject constructor(
 
         val local = localCollection.findByName(fileName)
         if (local != null) {
-            SyncException.wrapWithLocalResource(local) {
+            SyncException.wrapWithLocalResourceSuspending(local) {
                 logger.log(Level.INFO, "Updating $fileName in local jtx collection", component)
                 local.update(jtxEntityAndExceptions)
             }

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncException.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncException.kt
@@ -38,11 +38,6 @@ class SyncException(cause: Throwable) : Exception(cause) {
             }
         }
 
-        fun <T> wrapWithRemoteResource(remoteResource: Url?, body: () -> T): T =
-            runBlocking {
-                wrapWithRemoteResourceSuspending(remoteResource, body)
-            }
-
         suspend fun <T> wrapWithRemoteResourceSuspending(remoteResource: Url?, body: suspend () -> T): T {
             try {
                 return body()

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -730,7 +730,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
     /**
      * Post-processing of synchronized entries, for instance contact group membership operations.
      */
-    protected abstract fun postProcess()
+    protected abstract suspend fun postProcess()
 
 
     // sync helpers

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -306,7 +306,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
      *
      * @return whether synchronization shall be performed
      */
-    protected abstract fun prepare(): Boolean
+    protected abstract suspend fun prepare(): Boolean
 
     /**
      * Queries the server for synchronization capabilities like specific report types,
@@ -331,7 +331,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
 
         // Remove locally deleted entries from server (if they have a name, i.e. if they were uploaded before),
         // but only if they don't have changed on the server. Then finally remove them from the local address book.
-        localCollection.deletedFlow().collect { local ->
+        localCollection.findDeleted().collect { local ->
             SyncException.wrapWithLocalResourceSuspending(local) {
                 val fileName = local.fileName
                 if (fileName != null) {
@@ -373,7 +373,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
     protected open suspend fun uploadDirty(): Boolean {
         var numUploaded = 0
 
-        localCollection.dirtyFlow().collect { local ->
+        localCollection.findDirty().collect { local ->
             SyncException.wrapWithLocalResourceSuspending(local) {
                 uploadDirty(local)
                 numUploaded++

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -722,7 +722,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
      * Used together with [resetPresentRemotely] when a full listing has been received from
      * the server to locally delete resources which are not present remotely (anymore).
      */
-    protected open fun deleteNotPresentRemotely() {
+    protected open suspend fun deleteNotPresentRemotely() {
         val removed = localCollection.removeNotDirtyMarked(0)
         logger.info("Removed $removed local resources which are not present on the server anymore")
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
@@ -84,7 +84,7 @@ class TasksSyncManager @AssistedInject constructor(
     }
 
 
-    override fun prepare(): Boolean {
+    override suspend fun prepare(): Boolean {
         davCollection = DavCalendar(httpClient, collection.url)
 
         return true

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
@@ -182,7 +182,7 @@ class TasksSyncManager @AssistedInject constructor(
         }
     }
 
-    override fun postProcess() {
+    override suspend fun postProcess() {
         val touched = localCollection.dmfsTaskList.touchRelations()
         logger.info("Touched $touched relations")
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
@@ -154,7 +154,7 @@ class TasksSyncManager @AssistedInject constructor(
         SyncException.wrapWithRemoteResourceSuspending(collection.url) {
             davCollection.multiget(bunch) { response, _ ->
                 // See CalendarSyncManager for more information about the multi-get response
-                SyncException.wrapWithRemoteResource(response.href) wrapResource@{
+                SyncException.wrapWithRemoteResourceSuspending(response.href) wrapResource@{
                     if (!response.isSuccess()) {
                         logger.warning("Ignoring non-successful multi-get response for ${response.href}")
                         return@wrapResource
@@ -190,7 +190,7 @@ class TasksSyncManager @AssistedInject constructor(
 
     // helpers
 
-    private fun processVTodo(fileName: String, eTag: String, reader: Reader) {
+    private suspend fun processVTodo(fileName: String, eTag: String, reader: Reader) {
         val calendar = ICalendarParser().parse(reader)
 
         val uidsAndTasks = CalendarUidSplitter<VToDo>().associateByUid(calendar, Component.VTODO)

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/groups/CategoriesStrategy.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/groups/CategoriesStrategy.kt
@@ -38,7 +38,7 @@ class CategoriesStrategy(val addressBook: LocalAddressBook): ContactGroupStrateg
         }
     }
 
-    override fun postProcess() {
+    override suspend fun postProcess() {
         logger.info("Removing empty groups")
         addressBook.ab.deleteGroupsWithoutMembers()
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/groups/CategoriesStrategy.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/groups/CategoriesStrategy.kt
@@ -14,16 +14,16 @@ class CategoriesStrategy(val addressBook: LocalAddressBook): ContactGroupStrateg
     private val logger: Logger
         get() = Logger.getGlobal()
 
-    override fun beforeUploadDirty() {
+    override suspend fun beforeUploadDirty() {
         // groups with DELETED=1: set all members to dirty, then remove group
-        for (group in addressBook.findDeletedGroups()) {
+        addressBook.findDeletedGroups().collect { group ->
             logger.fine("Finally removing group $group")
             group.markMembersDirty()
             group.androidGroup.delete()
         }
 
         // groups with DIRTY=1: mark all members as dirty, then clean DIRTY flag of group
-        for (group in addressBook.findDirtyGroups()) {
+        addressBook.findDirtyGroups().collect { group ->
             logger.fine("Marking members of modified group $group as dirty")
             group.markMembersDirty()
             group.clearDirty(Optional.empty(), null)

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/groups/ContactGroupStrategy.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/groups/ContactGroupStrategy.kt
@@ -8,7 +8,7 @@ import at.bitfire.synctools.mapping.contacts.Contact
 
 interface ContactGroupStrategy {
 
-    fun beforeUploadDirty()
+    suspend fun beforeUploadDirty()
     fun verifyContactBeforeSaving(contact: Contact)
     fun postProcess()
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/groups/ContactGroupStrategy.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/groups/ContactGroupStrategy.kt
@@ -10,6 +10,6 @@ interface ContactGroupStrategy {
 
     suspend fun beforeUploadDirty()
     fun verifyContactBeforeSaving(contact: Contact)
-    fun postProcess()
+    suspend fun postProcess()
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/groups/VCard4Strategy.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/groups/VCard4Strategy.kt
@@ -48,7 +48,7 @@ class VCard4Strategy(val addressBook: LocalAddressBook): ContactGroupStrategy {
     override fun verifyContactBeforeSaving(contact: Contact) {
     }
 
-    override fun postProcess() {
+    override suspend fun postProcess() {
         addressBook.applyPendingMemberships()
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/groups/VCard4Strategy.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/groups/VCard4Strategy.kt
@@ -19,8 +19,8 @@ class VCard4Strategy(val addressBook: LocalAddressBook): ContactGroupStrategy {
 
     private val logger: Logger
         get() = Logger.getGlobal()
-    
-    override fun beforeUploadDirty() {
+
+    override suspend fun beforeUploadDirty() {
         /* Mark groups with changed members as dirty:
            1. Iterate over all dirty contacts.
            2. Check whether group memberships have changed by comparing group memberships and cached group memberships.
@@ -28,7 +28,7 @@ class VCard4Strategy(val addressBook: LocalAddressBook): ContactGroupStrategy {
            4. Successful upload will reset dirty flag and update cached group memberships.
          */
         val batch = ContactsBatchOperation(addressBook.ab.provider)
-        for (contact in addressBook.findDirtyContacts())
+        addressBook.findDirtyContacts().collect { contact ->
             try {
                 logger.fine("Looking for changed group memberships of contact ${contact.fileName}")
                 val cachedGroups = contact.androidContact.getCachedGroupMemberships()
@@ -41,6 +41,7 @@ class VCard4Strategy(val addressBook: LocalAddressBook): ContactGroupStrategy {
                 }
             } catch(_: FileNotFoundException) {
             }
+        }
         batch.commit()
     }
 

--- a/core/src/test/kotlin/at/bitfire/davdroid/sync/SyncExceptionTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/sync/SyncExceptionTest.kt
@@ -7,6 +7,7 @@ package at.bitfire.davdroid.sync
 import at.bitfire.davdroid.resource.LocalResource
 import io.ktor.http.Url
 import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -51,14 +52,14 @@ class SyncExceptionTest {
     }
 
     @Test
-    fun testWrapWithLocalResource_RemoteResource_Exception() {
+    fun testWrapWithLocalResource_RemoteResource_Exception() = runTest {
         val local = mockk<LocalResource>()
         val remote = mockk<Url>()
         val e = Exception()
 
-        val result = assertSyncException {
-            SyncException.wrapWithLocalResource(local) {
-                SyncException.wrapWithRemoteResource(remote) {
+        val result = assertSyncExceptionSuspending {
+            SyncException.wrapWithLocalResourceSuspending(local) {
+                SyncException.wrapWithRemoteResourceSuspending(remote) {
                     throw e
                 }
             }
@@ -70,14 +71,14 @@ class SyncExceptionTest {
     }
 
     @Test
-    fun testWrapWithLocalResource_RemoteResource_SyncException() {
+    fun testWrapWithLocalResource_RemoteResource_SyncException() = runTest {
         val local = mockk<LocalResource>()
         val remote = mockk<Url>()
         val e = SyncException(Exception())
 
-        val result = assertSyncException {
-            SyncException.wrapWithLocalResource(local) {
-                SyncException.wrapWithRemoteResource(remote) {
+        val result = assertSyncExceptionSuspending {
+            SyncException.wrapWithLocalResourceSuspending(local) {
+                SyncException.wrapWithRemoteResourceSuspending(remote) {
                     throw e
                 }
             }
@@ -87,17 +88,17 @@ class SyncExceptionTest {
         assertEquals(remote, result.remoteResource)
         assertEquals(e, result)
     }
-    
+
 
     @Test
-    fun testWrapWithRemoteResource_LocalResource_Exception() {
+    fun testWrapWithRemoteResource_LocalResource_Exception() = runTest {
         val remote = mockk<Url>()
         val local = mockk<LocalResource>()
         val e = Exception()
 
-        val result = assertSyncException {
-            SyncException.wrapWithRemoteResource(remote) {
-                SyncException.wrapWithLocalResource(local) {
+        val result = assertSyncExceptionSuspending {
+            SyncException.wrapWithRemoteResourceSuspending(remote) {
+                SyncException.wrapWithLocalResourceSuspending(local) {
                     throw e
                 }
             }
@@ -109,14 +110,14 @@ class SyncExceptionTest {
     }
 
     @Test
-    fun testWrapWithRemoteResource_LocalResource_SyncException() {
+    fun testWrapWithRemoteResource_LocalResource_SyncException() = runTest {
         val remote = mockk<Url>()
         val local = mockk<LocalResource>()
         val e = SyncException(Exception())
 
-        val result = assertSyncException {
-            SyncException.wrapWithRemoteResource(remote) {
-                SyncException.wrapWithLocalResource(local) {
+        val result = assertSyncExceptionSuspending {
+            SyncException.wrapWithRemoteResourceSuspending(remote) {
+                SyncException.wrapWithLocalResourceSuspending(local) {
                     throw e
                 }
             }
@@ -128,14 +129,14 @@ class SyncExceptionTest {
     }
 
     @Test
-    fun testWrapWithRemoteResource_RemoteResource_Exception() {
+    fun testWrapWithRemoteResource_RemoteResource_Exception() = runTest {
         val outer = mockk<Url>()
         val inner = mockk<Url>()
         val e = Exception()
 
-        val result = assertSyncException {
-            SyncException.wrapWithRemoteResource(outer) {
-                SyncException.wrapWithRemoteResource(inner) {
+        val result = assertSyncExceptionSuspending {
+            SyncException.wrapWithRemoteResourceSuspending(outer) {
+                SyncException.wrapWithRemoteResourceSuspending(inner) {
                     throw e
                 }
             }
@@ -146,14 +147,14 @@ class SyncExceptionTest {
     }
 
     @Test
-    fun testWrapWithRemoteResource_RemoteResource_SyncException() {
+    fun testWrapWithRemoteResource_RemoteResource_SyncException() = runTest {
         val outer = mockk<Url>()
         val inner = mockk<Url>()
         val e = SyncException(Exception())
 
-        val result = assertSyncException {
-            SyncException.wrapWithRemoteResource(outer) {
-                SyncException.wrapWithRemoteResource(inner) {
+        val result = assertSyncExceptionSuspending {
+            SyncException.wrapWithRemoteResourceSuspending(outer) {
+                SyncException.wrapWithRemoteResourceSuspending(inner) {
                     throw e
                 }
             }
@@ -197,6 +198,16 @@ class SyncExceptionTest {
         try {
             block()
         } catch(ex: Throwable) {
+            if (ex is SyncException)
+                return ex
+        }
+        throw AssertionError("Expected SyncException")
+    }
+
+    suspend fun assertSyncExceptionSuspending(block: suspend () -> Unit): SyncException {
+        try {
+            block()
+        } catch (ex: Throwable) {
             if (ex is SyncException)
                 return ex
         }

--- a/synctools/build.gradle.kts
+++ b/synctools/build.gradle.kts
@@ -90,6 +90,7 @@ dependencies {
     implementation(libs.androidx.annotation)
     implementation(libs.androidx.core)
     implementation(libs.guava)
+    implementation(libs.kotlinx.coroutines)
 
     compileOnly(libs.spotbugs.annotations)
 

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendarTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendarTest.kt
@@ -206,7 +206,7 @@ class AndroidCalendarTest {
         calendar.addEvent(entity)
 
         // not it finds a result
-        val result = calendar.eventsFlow("${Events.DTSTART}=?", arrayOf(testStartMillis.toString())).toList()
+        val result = calendar.queryEvents("${Events.DTSTART}=?", arrayOf(testStartMillis.toString())).toList()
         assertEquals(1, result.size)
         assertEntitiesEqual(entity, result.first(), onlyFieldsInExpected = true)
     }
@@ -293,7 +293,7 @@ class AndroidCalendarTest {
             Events.TITLE to "Some Event 2"
         )))
 
-        val result = calendar.eventsFlow(null, null).toList()
+        val result = calendar.queryEvents(null, null).toList()
         assertEquals(
             setOf(id1, id2),
             result.map { it.entityValues.getAsLong(Events._ID) }.toSet()

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendarTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendarTest.kt
@@ -19,6 +19,8 @@ import androidx.test.rule.GrantPermissionRule
 import at.bitfire.synctools.storage.BatchOperation
 import at.bitfire.synctools.test.assertContentValuesEqual
 import at.bitfire.synctools.test.assertEntitiesEqual
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.AfterClass
 import org.junit.Assert.assertEquals
@@ -190,7 +192,7 @@ class AndroidCalendarTest {
     }
 
     @Test
-    fun testFindEvent() {
+    fun testFindEvent() = runTest {
         // no result
         assertNull(calendar.findEvent("${Events.DTSTART}=?", arrayOf(testStartMillis.toString())))
 
@@ -204,7 +206,7 @@ class AndroidCalendarTest {
         calendar.addEvent(entity)
 
         // not it finds a result
-        val result = buildList { calendar.iterateEvents("${Events.DTSTART}=?", arrayOf(testStartMillis.toString())) { add(it) } }
+        val result = calendar.eventsFlow("${Events.DTSTART}=?", arrayOf(testStartMillis.toString())).toList()
         assertEquals(1, result.size)
         assertEntitiesEqual(entity, result.first(), onlyFieldsInExpected = true)
     }
@@ -277,7 +279,7 @@ class AndroidCalendarTest {
     }
 
     @Test
-    fun testIterateEvents() {
+    fun testIterateEvents() = runTest {
         val id1 = calendar.addEvent(Entity(contentValuesOf(
             Events.CALENDAR_ID to calendar.id,
             Events.DTSTART to testStartMillis,
@@ -291,10 +293,7 @@ class AndroidCalendarTest {
             Events.TITLE to "Some Event 2"
         )))
 
-        val result = mutableListOf<Entity>()
-        calendar.iterateEvents(null, null) { entity ->
-            result += entity
-        }
+        val result = calendar.eventsFlow(null, null).toList()
         assertEquals(
             setOf(id1, id2),
             result.map { it.entityValues.getAsLong(Events._ID) }.toSet()

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/calendar/AndroidRecurringCalendarTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/calendar/AndroidRecurringCalendarTest.kt
@@ -142,7 +142,7 @@ class AndroidRecurringCalendarTest {
     fun testIterateEventAndExceptions() = runTest {
         val (id1, event1) = insertRecurring(syncId = "testIterateEventAndExceptions1")
         val (id2, event2) = insertRecurring(syncId = "testIterateEventAndExceptions2")
-        val result = recurringCalendar.eventAndExceptionsFlow(
+        val result = recurringCalendar.queryEventsAndExceptions(
             "${Events._SYNC_ID} IN (?, ?)",
             arrayOf("testIterateEventAndExceptions1", "testIterateEventAndExceptions2")
         ).toList()
@@ -156,13 +156,14 @@ class AndroidRecurringCalendarTest {
     fun testIterateEventAndExceptions_IgnoresExceptionMatches() = runTest {
         insertRecurring()
 
-        val result = recurringCalendar.eventAndExceptionsFlow("${Events.TITLE}=?", arrayOf("Exception")).toList()
+        val result = recurringCalendar.queryEventsAndExceptions("${Events.TITLE}=?", arrayOf("Exception")).toList()
         assertTrue(result.isEmpty())
     }
 
     @Test
     fun testIterateEventAndExceptions_NotFound() = runTest {
-        val result = recurringCalendar.eventAndExceptionsFlow("${Events._SYNC_ID}=?", arrayOf("not-existent")).toList()
+        val result =
+            recurringCalendar.queryEventsAndExceptions("${Events._SYNC_ID}=?", arrayOf("not-existent")).toList()
         assertTrue(result.isEmpty())
     }
 

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/calendar/AndroidRecurringCalendarTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/calendar/AndroidRecurringCalendarTest.kt
@@ -81,7 +81,7 @@ class AndroidRecurringCalendarTest {
     // test CRUD
 
     @Test
-    fun testAddEventAndExceptions_and_GetById() {
+    fun testAddEventAndExceptions_and_GetById() = runTest {
         // add event and exceptions
         val (mainEventId, event) = insertRecurring()
         val addedWithId = event.withEventId(mainEventId)
@@ -97,7 +97,7 @@ class AndroidRecurringCalendarTest {
     }
 
     @Test
-    fun testFindEventAndExceptions() {
+    fun testFindEventAndExceptions() = runTest {
         val (mainEventId, event) = insertRecurring(syncId = "testFindEventAndExceptions")
         val addedWithId = event.withEventId(mainEventId)
         val result = recurringCalendar.findEventAndExceptions("${Events._SYNC_ID}=?", arrayOf("testFindEventAndExceptions"))
@@ -105,7 +105,7 @@ class AndroidRecurringCalendarTest {
     }
 
     @Test
-    fun testFindEventAndExceptions_IgnoresExceptionMatches() {
+    fun testFindEventAndExceptions_IgnoresExceptionMatches() = runTest {
         insertRecurring()
 
         val result = recurringCalendar.findEventAndExceptions("${Events.TITLE}=?", arrayOf("Exception"))
@@ -114,12 +114,12 @@ class AndroidRecurringCalendarTest {
     }
 
     @Test
-    fun testFindEventAndExceptions_NotFound() {
+    fun testFindEventAndExceptions_NotFound() = runTest {
         assertNull(recurringCalendar.findEventAndExceptions("${Events._SYNC_ID}=?", arrayOf("not-existent")))
     }
 
     @Test
-    fun testGetById_ExceptionId_ReturnsNull() {
+    fun testGetById_ExceptionId_ReturnsNull() = runTest {
         val (mainEventId, _) = insertRecurring()
         val exceptionId = calendar.findEventRow(
             arrayOf(Events._ID),
@@ -131,7 +131,7 @@ class AndroidRecurringCalendarTest {
     }
 
     @Test
-    fun testGetById_NotFound() {
+    fun testGetById_NotFound() = runTest {
         // make sure there's no event with id=1
         recurringCalendar.deleteEventAndExceptions(1)
 
@@ -167,7 +167,7 @@ class AndroidRecurringCalendarTest {
     }
 
     @Test
-    fun testUpdateEventAndExceptions_NoRebuild() {
+    fun testUpdateEventAndExceptions_NoRebuild() = runTest {
         // Create initial event
         val now = 1754233504000     // Sun Aug 03 2025 15:05:04 GMT+0000
         val initialEvent = Entity(contentValuesOf(
@@ -233,7 +233,7 @@ class AndroidRecurringCalendarTest {
     }
 
     @Test
-    fun testUpdateEventAndExceptions_RebuildNeeded() {
+    fun testUpdateEventAndExceptions_RebuildNeeded() = runTest {
         // Add initial event with STATUS
         val now = 1754233504000     // Sun Aug 03 2025 15:05:04 GMT+0000
         val initialEvent = Entity(contentValuesOf(
@@ -283,7 +283,7 @@ class AndroidRecurringCalendarTest {
     }
 
     @Test
-    fun testDeleteEventAndExceptions() {
+    fun testDeleteEventAndExceptions() = runTest {
         // Add event with exceptions
         val now = 1754233504000     // Sun Aug 03 2025 15:05:04 GMT+0000
         val mainEvent = Entity(contentValuesOf(
@@ -405,7 +405,7 @@ class AndroidRecurringCalendarTest {
     // test processing dirty/deleted events and exceptions
 
     @Test
-    fun testProcessDeletedExceptions() {
+    fun testProcessDeletedExceptions() = runTest {
         val now = System.currentTimeMillis()
         val mainValues = contentValuesOf(
             Events._SYNC_ID to "testProcessDeletedExceptions",
@@ -464,7 +464,7 @@ class AndroidRecurringCalendarTest {
     }
 
     @Test
-    fun testProcessDirtyExceptions() {
+    fun testProcessDirtyExceptions() = runTest {
         val now = System.currentTimeMillis()
         val mainValues = contentValuesOf(
             Events._SYNC_ID to "testProcessDirtyExceptions",

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/calendar/AndroidRecurringCalendarTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/calendar/AndroidRecurringCalendarTest.kt
@@ -139,12 +139,12 @@ class AndroidRecurringCalendarTest {
     }
 
     @Test
-    fun testIterateEventAndExceptions() = runTest {
-        val (id1, event1) = insertRecurring(syncId = "testIterateEventAndExceptions1")
-        val (id2, event2) = insertRecurring(syncId = "testIterateEventAndExceptions2")
+    fun testQueryEventAndExceptions() = runTest {
+        val (id1, event1) = insertRecurring(syncId = "testQueryEventAndExceptions1")
+        val (id2, event2) = insertRecurring(syncId = "testQueryEventAndExceptions2")
         val result = recurringCalendar.queryEventsAndExceptions(
             "${Events._SYNC_ID} IN (?, ?)",
-            arrayOf("testIterateEventAndExceptions1", "testIterateEventAndExceptions2")
+            arrayOf("testQueryEventAndExceptions1", "testQueryEventAndExceptions2")
         ).toList()
         val orderedResult = result.sortedBy { it.main.entityValues.getAsInteger(Events._ID) }
         assertEquals(2, orderedResult.size)
@@ -153,7 +153,7 @@ class AndroidRecurringCalendarTest {
     }
 
     @Test
-    fun testIterateEventAndExceptions_IgnoresExceptionMatches() = runTest {
+    fun testQueryEventAndExceptions_IgnoresExceptionMatches() = runTest {
         insertRecurring()
 
         val result = recurringCalendar.queryEventsAndExceptions("${Events.TITLE}=?", arrayOf("Exception")).toList()
@@ -161,7 +161,7 @@ class AndroidRecurringCalendarTest {
     }
 
     @Test
-    fun testIterateEventAndExceptions_NotFound() = runTest {
+    fun testQueryEventAndExceptions_NotFound() = runTest {
         val result =
             recurringCalendar.queryEventsAndExceptions("${Events._SYNC_ID}=?", arrayOf("not-existent")).toList()
         assertTrue(result.isEmpty())

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/calendar/AndroidRecurringCalendarTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/calendar/AndroidRecurringCalendarTest.kt
@@ -20,6 +20,8 @@ import at.bitfire.synctools.test.withEventId
 import at.bitfire.synctools.verifyCompat
 import io.mockk.junit4.MockKRule
 import io.mockk.spyk
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
 import net.fortuna.ical4j.util.TimeZones
 import org.junit.After
 import org.junit.AfterClass
@@ -27,7 +29,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import org.junit.Assert.fail
 import org.junit.BeforeClass
 import org.junit.ClassRule
 import org.junit.Rule
@@ -138,14 +139,13 @@ class AndroidRecurringCalendarTest {
     }
 
     @Test
-    fun testIterateEventAndExceptions() {
+    fun testIterateEventAndExceptions() = runTest {
         val (id1, event1) = insertRecurring(syncId = "testIterateEventAndExceptions1")
         val (id2, event2) = insertRecurring(syncId = "testIterateEventAndExceptions2")
-        val result = mutableListOf<EventAndExceptions>()
-        recurringCalendar.iterateEventAndExceptions(
+        val result = recurringCalendar.eventAndExceptionsFlow(
             "${Events._SYNC_ID} IN (?, ?)",
             arrayOf("testIterateEventAndExceptions1", "testIterateEventAndExceptions2")
-        ) { result += it }
+        ).toList()
         val orderedResult = result.sortedBy { it.main.entityValues.getAsInteger(Events._ID) }
         assertEquals(2, orderedResult.size)
         assertEventAndExceptionsEqual(event1.withEventId(id1), orderedResult[0], onlyFieldsInExpected = true)
@@ -153,19 +153,17 @@ class AndroidRecurringCalendarTest {
     }
 
     @Test
-    fun testIterateEventAndExceptions_IgnoresExceptionMatches() {
+    fun testIterateEventAndExceptions_IgnoresExceptionMatches() = runTest {
         insertRecurring()
 
-        recurringCalendar.iterateEventAndExceptions("${Events.TITLE}=?", arrayOf("Exception")) {
-            fail("must not be called")
-        }
+        val result = recurringCalendar.eventAndExceptionsFlow("${Events.TITLE}=?", arrayOf("Exception")).toList()
+        assertTrue(result.isEmpty())
     }
 
     @Test
-    fun testIterateEventAndExceptions_NotFound() {
-        recurringCalendar.iterateEventAndExceptions("${Events._SYNC_ID}=?", arrayOf("not-existent")) {
-            fail("must not be called")
-        }
+    fun testIterateEventAndExceptions_NotFound() = runTest {
+        val result = recurringCalendar.eventAndExceptionsFlow("${Events._SYNC_ID}=?", arrayOf("not-existent")).toList()
+        assertTrue(result.isEmpty())
     }
 
     @Test

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBookTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBookTest.kt
@@ -109,61 +109,6 @@ class AndroidAddressBookTest {
     }
 
 
-    // iterateRawContacts
-
-    @Test
-    fun testIterateRawContacts_empty() {
-        val addressBook = TestAddressBook.create(provider)
-        try {
-            var count = 0
-            addressBook.iterateRawContacts { count++ }
-            assertEquals(0, count)
-        } finally {
-            TestAddressBook.remove(addressBook)
-        }
-    }
-
-    @Test
-    fun testIterateRawContacts_all() {
-        val addressBook = TestAddressBook.create(provider)
-        try {
-            val id1 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Iterate Contact 1")))
-            val id2 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Iterate Contact 2")))
-            val ids = mutableListOf<Long>()
-            addressBook.iterateRawContacts { entity ->
-                ids += entity.entityValues.getAsLong(RawContacts._ID)
-            }
-            assertEquals(setOf(id1, id2), ids.toSet())
-        } finally {
-            TestAddressBook.remove(addressBook)
-        }
-    }
-
-    @Test
-    fun testIterateRawContacts_filter() {
-        val addressBook = TestAddressBook.create(provider)
-        try {
-            val id1 = addressBook.addRawContact(Entity(contentValuesOf(
-                RawContacts.DISPLAY_NAME_PRIMARY to "Iterate Filter 1",
-                AddressContract.RawContactColumns.UID to "iter-uid-1"
-            )))
-            addressBook.addRawContact(
-                Entity(
-                    contentValuesOf(
-                RawContacts.DISPLAY_NAME_PRIMARY to "Iterate Filter 2",
-                AddressContract.RawContactColumns.UID to "iter-uid-2"
-            )))
-            val ids = mutableListOf<Long>()
-            addressBook.iterateRawContacts("${AddressContract.RawContactColumns.UID}=?", arrayOf("iter-uid-1")) { entity ->
-                ids += entity.entityValues.getAsLong(RawContacts._ID)
-            }
-            assertEquals(listOf(id1), ids)
-        } finally {
-            TestAddressBook.remove(addressBook)
-        }
-    }
-
-
     // iterateRawContactRows
 
     @Test

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBookTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBookTest.kt
@@ -17,6 +17,8 @@ import androidx.core.content.contentValuesOf
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
 import at.bitfire.synctools.mapping.contacts.TestUtils
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
 import org.junit.AfterClass
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
@@ -109,30 +111,26 @@ class AndroidAddressBookTest {
     }
 
 
-    // iterateRawContactRows
+    // queryRawContactRows
 
     @Test
-    fun testIterateRawContactRows_empty() {
+    fun testQueryRawContactRows_empty() = runTest {
         val addressBook = TestAddressBook.create(provider)
         try {
-            var count = 0
-            addressBook.iterateRawContactRows { count++ }
-            assertEquals(0, count)
+            val rows = addressBook.queryRawContactRows().toList()
+            assertEquals(0, rows.size)
         } finally {
             TestAddressBook.remove(addressBook)
         }
     }
 
     @Test
-    fun testIterateRawContactRows_all() {
+    fun testQueryRawContactRows_all() = runTest {
         val addressBook = TestAddressBook.create(provider)
         try {
             val id1 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Row Contact 1")))
             val id2 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Row Contact 2")))
-            val ids = mutableListOf<Long>()
-            addressBook.iterateRawContactRows { values ->
-                ids += values.getAsLong(RawContacts._ID)
-            }
+            val ids = addressBook.queryRawContactRows().toList().map { it.getAsLong(RawContacts._ID) }
             assertEquals(setOf(id1, id2), ids.toSet())
         } finally {
             TestAddressBook.remove(addressBook)
@@ -140,7 +138,7 @@ class AndroidAddressBookTest {
     }
 
     @Test
-    fun testIterateRawContactRows_filter() {
+    fun testQueryRawContactRows_filter() = runTest {
         val addressBook = TestAddressBook.create(provider)
         try {
             val id1 = addressBook.addRawContact(Entity(contentValuesOf(
@@ -153,10 +151,9 @@ class AndroidAddressBookTest {
                 RawContacts.DISPLAY_NAME_PRIMARY to "Row Filter 2",
                 AddressContract.RawContactColumns.UID to "row-uid-2"
             )))
-            val ids = mutableListOf<Long>()
-            addressBook.iterateRawContactRows("${AddressContract.RawContactColumns.UID}=?", arrayOf("row-uid-1")) { values ->
-                ids += values.getAsLong(RawContacts._ID)
-            }
+            val ids =
+                addressBook.queryRawContactRows("${AddressContract.RawContactColumns.UID}=?", arrayOf("row-uid-1"))
+                    .toList().map { it.getAsLong(RawContacts._ID) }
             assertEquals(listOf(id1), ids)
         } finally {
             TestAddressBook.remove(addressBook)
@@ -167,7 +164,7 @@ class AndroidAddressBookTest {
     // updateRawContactRows
 
     @Test
-    fun testUpdateRawContactRows_all() {
+    fun testUpdateRawContactRows_all() = runTest {
         val addressBook = TestAddressBook.create(provider)
         try {
             addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Update Contact 1")))
@@ -176,10 +173,8 @@ class AndroidAddressBookTest {
             addressBook.updateRawContactRows(contentValuesOf(AddressContract.RawContactColumns.UID to "updated-uid"), null, null, batch)
             batch.commit()
 
-            val uids = mutableListOf<String>()
-            addressBook.iterateRawContactRows { values ->
-                uids += values.getAsString(AddressContract.RawContactColumns.UID)
-            }
+            val uids =
+                addressBook.queryRawContactRows().toList().map { it.getAsString(AddressContract.RawContactColumns.UID) }
             assertEquals(2, uids.count { it == "updated-uid" })
         } finally {
             TestAddressBook.remove(addressBook)
@@ -187,7 +182,7 @@ class AndroidAddressBookTest {
     }
 
     @Test
-    fun testUpdateRawContactRows_filter() {
+    fun testUpdateRawContactRows_filter() = runTest {
         val addressBook = TestAddressBook.create(provider)
         try {
             val id1 = addressBook.addRawContact(Entity(contentValuesOf(RawContacts.DISPLAY_NAME_PRIMARY to "Update Filter 1")))
@@ -202,7 +197,7 @@ class AndroidAddressBookTest {
 
             var uid1: String? = "not-set"
             var uid2: String? = "not-set"
-            addressBook.iterateRawContactRows { values ->
+            addressBook.queryRawContactRows().toList().forEach { values ->
                 when (values.getAsLong(RawContacts._ID)) {
                     id1 -> uid1 = values.getAsString(AddressContract.RawContactColumns.UID)
                     id2 -> uid2 = values.getAsString(AddressContract.RawContactColumns.UID)
@@ -216,30 +211,26 @@ class AndroidAddressBookTest {
     }
 
 
-    // iterateGroups
+    // queryGroupRows
 
     @Test
-    fun testIterateGroups_empty() {
+    fun testQueryGroupRows_empty() = runTest {
         val addressBook = TestAddressBook.create(provider)
         try {
-            var count = 0
-            addressBook.iterateGroups { count++ }
-            assertEquals(0, count)
+            val rows = addressBook.queryGroupRows().toList()
+            assertEquals(0, rows.size)
         } finally {
             TestAddressBook.remove(addressBook)
         }
     }
 
     @Test
-    fun testIterateGroups_all() {
+    fun testQueryGroupRows_all() = runTest {
         val addressBook = TestAddressBook.create(provider)
         try {
             val id1 = addressBook.findOrCreateGroup("Iterate Group 1")
             val id2 = addressBook.findOrCreateGroup("Iterate Group 2")
-            val ids = mutableListOf<Long>()
-            addressBook.iterateGroups { values ->
-                ids += values.getAsLong(Groups._ID)
-            }
+            val ids = addressBook.queryGroupRows().toList().map { it.getAsLong(Groups._ID) }
             assertEquals(setOf(id1, id2), ids.toSet())
         } finally {
             TestAddressBook.remove(addressBook)
@@ -247,15 +238,13 @@ class AndroidAddressBookTest {
     }
 
     @Test
-    fun testIterateGroups_filter() {
+    fun testQueryGroupRows_filter() = runTest {
         val addressBook = TestAddressBook.create(provider)
         try {
             val id1 = addressBook.findOrCreateGroup("Iterate Filter Group 1")
             addressBook.findOrCreateGroup("Iterate Filter Group 2")
-            val ids = mutableListOf<Long>()
-            addressBook.iterateGroups(null, "${Groups._ID}=?", arrayOf(id1.toString())) { values ->
-                ids += values.getAsLong(Groups._ID)
-            }
+            val ids = addressBook.queryGroupRows(null, "${Groups._ID}=?", arrayOf(id1.toString()))
+                .toList().map { it.getAsLong(Groups._ID) }
             assertEquals(listOf(id1), ids)
         } finally {
             TestAddressBook.remove(addressBook)
@@ -535,7 +524,7 @@ class AndroidAddressBookTest {
     // deleteGroupsWithoutMembers
 
     @Test
-    fun testDeleteGroupsWithoutMembers_deletesEmpty() {
+    fun testDeleteGroupsWithoutMembers_deletesEmpty() = runTest {
         val addressBook = TestAddressBook.create(provider)
         try {
             addressBook.findOrCreateGroup("Empty Group")
@@ -551,7 +540,7 @@ class AndroidAddressBookTest {
     }
 
     @Test
-    fun testDeleteGroupsWithoutMembers_keepsNonEmpty() {
+    fun testDeleteGroupsWithoutMembers_keepsNonEmpty() = runTest {
         val addressBook = TestAddressBook.create(provider)
         try {
             val groupId = addressBook.findOrCreateGroup("Group with member")

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/contacts/AndroidGroupTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/contacts/AndroidGroupTest.kt
@@ -10,6 +10,8 @@ import android.provider.ContactsContract
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
 import at.bitfire.synctools.mapping.contacts.Contact
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.AfterClass
 import org.junit.Assert.assertEquals
@@ -59,14 +61,14 @@ class AndroidGroupTest {
         removeGroups()
     }
 
-    private fun removeGroups() {
+    private fun removeGroups() = runBlocking {
         addressBook.provider.delete(addressBook.groupsSyncUri(), null, null)
         assertEquals(0, addressBook.queryGroups(null, null).size)
     }
 
 
     @Test
-    fun testCreateReadDeleteGroup() {
+    fun testCreateReadDeleteGroup() = runTest {
         val contact = Contact()
         contact.displayName = "at.bitfire.vcard4android-AndroidGroupTest"
         contact.note = "(test group)"
@@ -89,7 +91,7 @@ class AndroidGroupTest {
     }
 
     @Test
-    fun testAdd_readOnly() {
+    fun testAdd_readOnly() = runTest {
         addressBook.readOnly = true
 
         val contact = Contact()
@@ -111,7 +113,7 @@ class AndroidGroupTest {
     }
 
     @Test
-    fun testAdd_notReadOnly() {
+    fun testAdd_notReadOnly() = runTest {
         addressBook.readOnly = false
 
         val contact = Contact()

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/contacts/AndroidGroupTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/contacts/AndroidGroupTest.kt
@@ -10,6 +10,7 @@ import android.provider.ContactsContract
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
 import at.bitfire.synctools.mapping.contacts.Contact
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -63,7 +64,7 @@ class AndroidGroupTest {
 
     private fun removeGroups() = runBlocking {
         addressBook.provider.delete(addressBook.groupsSyncUri(), null, null)
-        assertEquals(0, addressBook.queryGroups(null, null).size)
+        assertEquals(0, addressBook.countGroups(null, null))
     }
 
 
@@ -74,12 +75,13 @@ class AndroidGroupTest {
         contact.note = "(test group)"
 
         // ensure we start without this group
-        assertEquals(0, addressBook.queryGroups("${ContactsContract.Groups.TITLE}=?", arrayOf(contact.displayName!!)).size)
+        assertEquals(0, addressBook.countGroups("${ContactsContract.Groups.TITLE}=?", arrayOf(contact.displayName!!)))
 
         // create group
         val group = AndroidGroup(addressBook, contact, null, null)
         group.add()
-        val groups = addressBook.queryGroups("${ContactsContract.Groups.TITLE}=?", arrayOf(contact.displayName!!))
+        val groups =
+            addressBook.queryGroups("${ContactsContract.Groups.TITLE}=?", arrayOf(contact.displayName!!)).toList()
         assertEquals(1, groups.size)
         val contact2 = groups.first().getContact()
         assertEquals(contact.displayName, contact2.displayName)
@@ -87,7 +89,7 @@ class AndroidGroupTest {
 
         // delete group
         group.delete()
-        assertEquals(0, addressBook.queryGroups("${ContactsContract.Groups.TITLE}=?", arrayOf(contact.displayName!!)).size)
+        assertEquals(0, addressBook.countGroups("${ContactsContract.Groups.TITLE}=?", arrayOf(contact.displayName!!)))
     }
 
     @Test
@@ -99,17 +101,16 @@ class AndroidGroupTest {
         contact.note = "(test group)"
 
         // ensure we start without this group
-        assertEquals(0, addressBook.queryGroups("${ContactsContract.Groups.TITLE}=?", arrayOf(contact.displayName!!)).size)
+        assertEquals(0, addressBook.countGroups("${ContactsContract.Groups.TITLE}=?", arrayOf(contact.displayName!!)))
 
         // create group
         val group = AndroidGroup(addressBook, contact, null, null)
         group.add()
-        val groups = addressBook.queryGroups("${ContactsContract.Groups.GROUP_IS_READ_ONLY}=?", arrayOf("1"))
-        assertEquals(1, groups.size)
+        assertEquals(1, addressBook.countGroups("${ContactsContract.Groups.GROUP_IS_READ_ONLY}=?", arrayOf("1")))
 
         // delete group
         group.delete()
-        assertEquals(0, addressBook.queryGroups("${ContactsContract.Groups.TITLE}=?", arrayOf(contact.displayName!!)).size)
+        assertEquals(0, addressBook.countGroups("${ContactsContract.Groups.TITLE}=?", arrayOf(contact.displayName!!)))
     }
 
     @Test
@@ -121,17 +122,16 @@ class AndroidGroupTest {
         contact.note = "(test group)"
 
         // ensure we start without this group
-        assertEquals(0, addressBook.queryGroups("${ContactsContract.Groups.TITLE}=?", arrayOf(contact.displayName!!)).size)
+        assertEquals(0, addressBook.countGroups("${ContactsContract.Groups.TITLE}=?", arrayOf(contact.displayName!!)))
 
         // create group
         val group = AndroidGroup(addressBook, contact, null, null)
         group.add()
-        val groups = addressBook.queryGroups("${ContactsContract.Groups.GROUP_IS_READ_ONLY}=?", arrayOf("0"))
-        assertEquals(1, groups.size)
+        assertEquals(1, addressBook.countGroups("${ContactsContract.Groups.GROUP_IS_READ_ONLY}=?", arrayOf("0")))
 
         // delete group
         group.delete()
-        assertEquals(0, addressBook.queryGroups("${ContactsContract.Groups.TITLE}=?", arrayOf(contact.displayName!!)).size)
+        assertEquals(0, addressBook.countGroups("${ContactsContract.Groups.TITLE}=?", arrayOf(contact.displayName!!)))
     }
 
     @Test

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxCollectionTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxCollectionTest.kt
@@ -19,6 +19,8 @@ import at.bitfire.synctools.test.assertEntitiesEqual
 import at.techbee.jtx.JtxContract
 import at.techbee.jtx.JtxContract.JtxICalObject.Component
 import at.techbee.jtx.JtxContract.asSyncAdapter
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.AfterClass
 import org.junit.Assert.assertEquals
@@ -322,12 +324,11 @@ class JtxCollectionTest {
     }
 
     @Test
-    fun testIterateJtxObjects() {
+    fun testIterateJtxObjects() = runTest {
         val id1 = collection.addJtxObject(sampleEntityWithSubValues("Object 1"))
         val id2 = collection.addJtxObject(sampleEntityWithSubValues("Object 2"))
 
-        val result = mutableListOf<Entity>()
-        collection.iterateJtxObjects(null, null) { result += it }
+        val result = collection.jtxObjectsFlow(null, null).toList()
 
         assertEquals(
             setOf(id1, id2),

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxCollectionTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxCollectionTest.kt
@@ -328,7 +328,7 @@ class JtxCollectionTest {
         val id1 = collection.addJtxObject(sampleEntityWithSubValues("Object 1"))
         val id2 = collection.addJtxObject(sampleEntityWithSubValues("Object 2"))
 
-        val result = collection.jtxObjectsFlow(null, null).toList()
+        val result = collection.queryJtxObjects(null, null).toList()
 
         assertEquals(
             setOf(id1, id2),

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxRecurringCollectionTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxRecurringCollectionTest.kt
@@ -20,6 +20,8 @@ import at.techbee.jtx.JtxContract
 import at.techbee.jtx.JtxContract.JtxICalObject.Component
 import io.mockk.junit4.MockKRule
 import io.mockk.spyk
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.AfterClass
 import org.junit.Assert.assertEquals
@@ -87,7 +89,7 @@ class JtxRecurringCollectionTest {
     // test CRUD
 
     @Test
-    fun testAddJtxEntityAndExceptions_and_GetById() {
+    fun testAddJtxEntityAndExceptions_and_GetById() = runTest {
         val (mainId, obj) = insertRecurring()
         val addedWithId = obj.withJtxId(mainId)
 
@@ -97,7 +99,7 @@ class JtxRecurringCollectionTest {
     }
 
     @Test
-    fun testFindJtxObjectAndExceptions() {
+    fun testFindJtxObjectAndExceptions() = runTest {
         val uid = "testFindJtxObjectAndExceptions"
         val (mainId, obj) = insertRecurring(uid = uid)
         val addedWithId = obj.withJtxId(mainId)
@@ -110,7 +112,7 @@ class JtxRecurringCollectionTest {
     }
 
     @Test
-    fun testFindJtxObjectAndExceptions_NotFound() {
+    fun testFindJtxObjectAndExceptions_NotFound() = runTest {
         assertNull(
             recurringCollection.findJtxObjectAndExceptions(
                 "${JtxContract.JtxICalObject.UID}=?",
@@ -120,13 +122,13 @@ class JtxRecurringCollectionTest {
     }
 
     @Test
-    fun testGetById_NotFound() {
+    fun testGetById_NotFound() = runTest {
         recurringCollection.deleteJtxObjectAndExceptions(Long.MAX_VALUE)
         assertNull(recurringCollection.getById(Long.MAX_VALUE))
     }
 
     @Test
-    fun testGetById_withExceptionId_returnsNull() {
+    fun testGetById_withExceptionId_returnsNull() = runTest {
         val uid = "testGetById_withExceptionId"
         val (mainId, _) = insertRecurring(uid = uid)
 
@@ -144,7 +146,7 @@ class JtxRecurringCollectionTest {
     }
 
     @Test
-    fun testUpdateJtxObjectAndExceptions_withExceptionId_throws() {
+    fun testUpdateJtxObjectAndExceptions_withExceptionId_throws() = runTest {
         val uid = "testUpdateJtxObjectAndExceptions_withExceptionId"
         insertRecurring(uid = uid)
 
@@ -170,17 +172,16 @@ class JtxRecurringCollectionTest {
     }
 
     @Test
-    fun testIterateJtxObjectAndExceptions() {
+    fun testIterateJtxObjectAndExceptions() = runTest {
         val uid1 = "testIterateJtxObjectAndExceptions1"
         val uid2 = "testIterateJtxObjectAndExceptions2"
         val (id1, obj1) = insertRecurring(uid = uid1)
         val (id2, obj2) = insertRecurring(uid = uid2)
 
-        val result = mutableListOf<JtxObjectAndExceptions>()
-        recurringCollection.iterateJtxObjectAndExceptions(
+        val result = recurringCollection.jtxObjectAndExceptionsFlow(
             "${JtxContract.JtxICalObject.UID} IN (?, ?)",
             arrayOf(uid1, uid2)
-        ) { result += it }
+        ).toList()
 
         val orderedResult = result.sortedBy { it.main.entityValues.getAsLong(JtxContract.JtxICalObject.ID) }
         assertEquals(2, orderedResult.size)
@@ -189,17 +190,16 @@ class JtxRecurringCollectionTest {
     }
 
     @Test
-    fun testIterateJtxObjectAndExceptions_NotFound() {
-        recurringCollection.iterateJtxObjectAndExceptions(
+    fun testIterateJtxObjectAndExceptions_NotFound() = runTest {
+        val result = recurringCollection.jtxObjectAndExceptionsFlow(
             "${JtxContract.JtxICalObject.UID}=?",
             arrayOf("does-not-exist")
-        ) {
-            fail("body must not be called, when does not exist")
-        }
+        ).toList()
+        assertTrue("result must be empty, when does not exist", result.isEmpty())
     }
 
     @Test
-    fun testUpdateJtxObjectAndExceptions() {
+    fun testUpdateJtxObjectAndExceptions() = runTest {
         val now = 1754233504000L     // Sun Aug 03 2025 15:05:04 GMT+0000
         val uid = "testUpdateJtxObjectAndExceptions"
         val initialMain = Entity(contentValuesOf(
@@ -266,7 +266,7 @@ class JtxRecurringCollectionTest {
     }
 
     @Test
-    fun testDeleteJtxObjectAndExceptions_batch() {
+    fun testDeleteJtxObjectAndExceptions_batch() = runTest {
         val now = 1754233504000L
         val uid = "testDeleteJtxObjectAndExceptions_batch"
         val mainId = recurringCollection.addJtxEntityAndExceptions(
@@ -312,7 +312,7 @@ class JtxRecurringCollectionTest {
     }
 
     @Test
-    fun testDeleteJtxObjectAndExceptions() {
+    fun testDeleteJtxObjectAndExceptions() = runTest {
         val now = 1754233504000L
         val uid = "testDeleteJtxObjectAndExceptions"
         val mainId = recurringCollection.addJtxEntityAndExceptions(
@@ -486,7 +486,7 @@ class JtxRecurringCollectionTest {
     // test processing dirty/deleted exceptions
 
     @Test
-    fun testProcessDeletedExceptions() {
+    fun testProcessDeletedExceptions() = runTest {
         val now = System.currentTimeMillis()
         val uid = "testProcessDeletedExceptions"
         val mainValues = contentValuesOf(
@@ -550,7 +550,7 @@ class JtxRecurringCollectionTest {
     }
 
     @Test
-    fun testProcessDirtyExceptions() {
+    fun testProcessDirtyExceptions() = runTest {
         val now = System.currentTimeMillis()
         val uid = "testProcessDirtyExceptions"
         val mainValues = contentValuesOf(

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxRecurringCollectionTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxRecurringCollectionTest.kt
@@ -178,7 +178,7 @@ class JtxRecurringCollectionTest {
         val (id1, obj1) = insertRecurring(uid = uid1)
         val (id2, obj2) = insertRecurring(uid = uid2)
 
-        val result = recurringCollection.jtxObjectAndExceptionsFlow(
+        val result = recurringCollection.queryJtxObjectsAndExceptions(
             "${JtxContract.JtxICalObject.UID} IN (?, ?)",
             arrayOf(uid1, uid2)
         ).toList()
@@ -191,7 +191,7 @@ class JtxRecurringCollectionTest {
 
     @Test
     fun testIterateJtxObjectAndExceptions_NotFound() = runTest {
-        val result = recurringCollection.jtxObjectAndExceptionsFlow(
+        val result = recurringCollection.queryJtxObjectsAndExceptions(
             "${JtxContract.JtxICalObject.UID}=?",
             arrayOf("does-not-exist")
         ).toList()

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsRecurringTaskListTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsRecurringTaskListTest.kt
@@ -16,6 +16,8 @@ import at.bitfire.synctools.test.assertExceptionsEqual
 import at.bitfire.synctools.verifyCompat
 import io.mockk.junit4.MockKRule
 import io.mockk.spyk
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
 import net.fortuna.ical4j.util.TimeZones
 import org.dmfs.tasks.contract.TaskContract
 import org.dmfs.tasks.contract.TaskContract.Tasks
@@ -26,7 +28,6 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Rule
@@ -141,14 +142,13 @@ class DmfsRecurringTaskListTest(providerName: TaskProvider.ProviderName) :
     }
 
     @Test
-    fun testIterateTaskAndExceptions() {
+    fun testIterateTaskAndExceptions() = runTest {
         val task1 = insertRecurring(syncId = "testIterateTaskAndExceptions1")
         val task2 = insertRecurring(syncId = "testIterateTaskAndExceptions2")
-        val result = mutableListOf<TaskAndExceptions>()
-        recurringTaskList.iterateTaskAndExceptions(
+        val result = recurringTaskList.taskAndExceptionsFlow(
             "${Tasks._SYNC_ID} IN (?, ?)",
             arrayOf("testIterateTaskAndExceptions1", "testIterateTaskAndExceptions2")
-        ) { result += it }
+        ).toList()
         val orderedResult = result.sortedBy { it.main.entityValues.getAsInteger(Tasks._ID) }
         assertEquals(2, orderedResult.size)
         assertTaskAndExceptionsEqual(task1, orderedResult[0], onlyFieldsInExpected = true)
@@ -156,19 +156,17 @@ class DmfsRecurringTaskListTest(providerName: TaskProvider.ProviderName) :
     }
 
     @Test
-    fun testIterateTaskAndExceptions_IgnoresExceptionMatches() {
+    fun testIterateTaskAndExceptions_IgnoresExceptionMatches() = runTest {
         insertRecurring()
 
-        recurringTaskList.iterateTaskAndExceptions("${Tasks.TITLE}=?", arrayOf("Exception")) {
-            fail("must not be called")
-        }
+        val result = recurringTaskList.taskAndExceptionsFlow("${Tasks.TITLE}=?", arrayOf("Exception")).toList()
+        assertTrue(result.isEmpty())
     }
 
     @Test
-    fun testIterateTaskAndExceptions_NotFound() {
-        recurringTaskList.iterateTaskAndExceptions("${Tasks._SYNC_ID}=?", arrayOf("not-existent")) {
-            fail("must not be called")
-        }
+    fun testIterateTaskAndExceptions_NotFound() = runTest {
+        val result = recurringTaskList.taskAndExceptionsFlow("${Tasks._SYNC_ID}=?", arrayOf("not-existent")).toList()
+        assertTrue(result.isEmpty())
     }
 
     @Test

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsRecurringTaskListTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsRecurringTaskListTest.kt
@@ -90,7 +90,7 @@ class DmfsRecurringTaskListTest(providerName: TaskProvider.ProviderName) :
     // test CRUD
 
     @Test
-    fun testAddTaskAndExceptions_and_GetById() {
+    fun testAddTaskAndExceptions_and_GetById() = runTest {
         // add task and exceptions
         val task = insertRecurring()
 
@@ -100,14 +100,14 @@ class DmfsRecurringTaskListTest(providerName: TaskProvider.ProviderName) :
     }
 
     @Test
-    fun testFindTaskAndExceptions() {
+    fun testFindTaskAndExceptions() = runTest {
         val task = insertRecurring(syncId = "testFindTaskAndExceptions")
         val result = recurringTaskList.findTaskAndExceptions("${Tasks._SYNC_ID}=?", arrayOf("testFindTaskAndExceptions"))
         assertTaskAndExceptionsEqual(task, result!!, onlyFieldsInExpected = true)
     }
 
     @Test
-    fun testFindTaskAndExceptions_IgnoresExceptionMatches() {
+    fun testFindTaskAndExceptions_IgnoresExceptionMatches() = runTest {
         insertRecurring()
 
         val result = recurringTaskList.findTaskAndExceptions("${Tasks.TITLE}=?", arrayOf("Exception"))
@@ -116,12 +116,12 @@ class DmfsRecurringTaskListTest(providerName: TaskProvider.ProviderName) :
     }
 
     @Test
-    fun testFindTaskAndExceptions_NotFound() {
+    fun testFindTaskAndExceptions_NotFound() = runTest {
         assertNull(recurringTaskList.findTaskAndExceptions("${Tasks._SYNC_ID}=?", arrayOf("not-existent")))
     }
 
     @Test
-    fun testGetById_ExceptionId_ReturnsNull() {
+    fun testGetById_ExceptionId_ReturnsNull() = runTest {
         val task = insertRecurring()
         val mainTaskId = task.main.entityValues.getAsLong(Tasks._ID)!!
         val exceptionId = taskList.findTaskRow(
@@ -134,7 +134,7 @@ class DmfsRecurringTaskListTest(providerName: TaskProvider.ProviderName) :
     }
 
     @Test
-    fun testGetById_NotFound() {
+    fun testGetById_NotFound() = runTest {
         // make sure there's no task with id=1
         recurringTaskList.deleteTaskAndExceptions(1)
 
@@ -170,7 +170,7 @@ class DmfsRecurringTaskListTest(providerName: TaskProvider.ProviderName) :
     }
 
     @Test
-    fun testUpdateTaskAndExceptions() {
+    fun testUpdateTaskAndExceptions() = runTest {
         // Create initial task
         val now = 1754233504000L    // Sun Aug 03 2025 15:05:04 GMT+0000
         val initialTask = Entity(
@@ -242,7 +242,7 @@ class DmfsRecurringTaskListTest(providerName: TaskProvider.ProviderName) :
     }
 
     @Test
-    fun testDeleteTaskAndExceptions() {
+    fun testDeleteTaskAndExceptions() = runTest {
         // Add task with exceptions
         val now = 1754233504000L    // Sun Aug 03 2025 15:05:04 GMT+0000
         val mainTaskId = recurringTaskList.addTaskAndExceptions(
@@ -396,7 +396,7 @@ class DmfsRecurringTaskListTest(providerName: TaskProvider.ProviderName) :
      * because then the tasks provider directly deletes tasks and doesn't mark them as [Tasks._DELETED].
      */
     @Test
-    fun testProcessDeletedExceptions() {
+    fun testProcessDeletedExceptions() = runTest {
         // Insert a recurring task with an exception
         val taskAndExceptions = insertRecurring()
         val mainTaskId = taskAndExceptions.main.entityValues.getAsLong(Tasks._ID)!!
@@ -426,7 +426,7 @@ class DmfsRecurringTaskListTest(providerName: TaskProvider.ProviderName) :
     }
 
     @Test
-    fun testProcessDirtyExceptions() {
+    fun testProcessDirtyExceptions() = runTest {
         // Insert a recurring task with an exception
         val taskAndExceptions = insertRecurring()
         val mainTaskId = taskAndExceptions.main.entityValues.getAsLong(Tasks._ID)!!

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsRecurringTaskListTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsRecurringTaskListTest.kt
@@ -145,7 +145,7 @@ class DmfsRecurringTaskListTest(providerName: TaskProvider.ProviderName) :
     fun testIterateTaskAndExceptions() = runTest {
         val task1 = insertRecurring(syncId = "testIterateTaskAndExceptions1")
         val task2 = insertRecurring(syncId = "testIterateTaskAndExceptions2")
-        val result = recurringTaskList.taskAndExceptionsFlow(
+        val result = recurringTaskList.queryTasksAndExceptions(
             "${Tasks._SYNC_ID} IN (?, ?)",
             arrayOf("testIterateTaskAndExceptions1", "testIterateTaskAndExceptions2")
         ).toList()
@@ -159,13 +159,13 @@ class DmfsRecurringTaskListTest(providerName: TaskProvider.ProviderName) :
     fun testIterateTaskAndExceptions_IgnoresExceptionMatches() = runTest {
         insertRecurring()
 
-        val result = recurringTaskList.taskAndExceptionsFlow("${Tasks.TITLE}=?", arrayOf("Exception")).toList()
+        val result = recurringTaskList.queryTasksAndExceptions("${Tasks.TITLE}=?", arrayOf("Exception")).toList()
         assertTrue(result.isEmpty())
     }
 
     @Test
     fun testIterateTaskAndExceptions_NotFound() = runTest {
-        val result = recurringTaskList.taskAndExceptionsFlow("${Tasks._SYNC_ID}=?", arrayOf("not-existent")).toList()
+        val result = recurringTaskList.queryTasksAndExceptions("${Tasks._SYNC_ID}=?", arrayOf("not-existent")).toList()
         assertTrue(result.isEmpty())
     }
 

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
@@ -11,6 +11,8 @@ import android.content.Entity
 import android.database.DatabaseUtils
 import androidx.core.content.contentValuesOf
 import at.bitfire.synctools.storage.TaskProvider
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
 import org.dmfs.tasks.contract.TaskContract
 import org.dmfs.tasks.contract.TaskContract.Property
 import org.dmfs.tasks.contract.TaskContract.TaskLists
@@ -371,7 +373,7 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName) :
     }
 
     @Test
-    fun testIterateTasks() {
+    fun testIterateTasks() = runTest {
         val taskList = createTaskList()
         try {
             // Add tasks directly via Entity
@@ -404,10 +406,7 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName) :
                 )
             )
 
-            val result = mutableListOf<Entity>()
-            taskList.iterateTasks(null, null) { entity ->
-                result += entity
-            }
+            val result = taskList.tasksFlow(null, null).toList()
 
             assertEquals(2, result.size)
             val uids = result.mapNotNull { it.entityValues.getAsString(Tasks._UID) }.toSet()
@@ -580,7 +579,7 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName) :
     }
 
     @Test
-    fun testUpdateTasks() {
+    fun testUpdateTasks() = runTest {
         val taskList = createTaskList()
         try {
             // Add tasks
@@ -614,7 +613,7 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName) :
             assertEquals(2, updatedCount)
 
             // Verify updates
-            val tasks = buildList { taskList.iterateTasks(null, null) { add(it) } }
+            val tasks = taskList.tasksFlow(null, null).toList()
             assertEquals(2, tasks.size)
             for (task in tasks) {
                 assertEquals("Updated Title", task.entityValues.getAsString(Tasks.TITLE))

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
@@ -406,7 +406,7 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName) :
                 )
             )
 
-            val result = taskList.tasksFlow(null, null).toList()
+            val result = taskList.queryTasks(null, null).toList()
 
             assertEquals(2, result.size)
             val uids = result.mapNotNull { it.entityValues.getAsString(Tasks._UID) }.toSet()
@@ -613,7 +613,7 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName) :
             assertEquals(2, updatedCount)
 
             // Verify updates
-            val tasks = taskList.tasksFlow(null, null).toList()
+            val tasks = taskList.queryTasks(null, null).toList()
             assertEquals(2, tasks.size)
             for (task in tasks) {
                 assertEquals("Updated Title", task.entityValues.getAsString(Tasks.TITLE))

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/QueryFlow.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/QueryFlow.kt
@@ -19,6 +19,13 @@ import kotlinx.coroutines.flow.flowOn
  *
  * Runs on [Dispatchers.IO]. Chained blocking work (e.g. a nested query in `.map { }`) needs its
  * own trailing [kotlinx.coroutines.flow.flowOn] — this one only covers the query itself.
+ *
+ * @param uri           content URI to query
+ * @param projection    columns to return
+ * @param where         selection
+ * @param whereArgs     arguments for selection
+ * @param sortOrder     sort order
+ * @param transformRow  maps a cursor row (positioned by the query) to the emitted value
  */
 fun <T> ContentProviderClient.queryFlow(
     uri: Uri,
@@ -26,17 +33,24 @@ fun <T> ContentProviderClient.queryFlow(
     where: String? = null,
     whereArgs: Array<String>? = null,
     sortOrder: String? = null,
-    transform: (Cursor) -> T
+    transformRow: (Cursor) -> T
 ): Flow<T> = flow {
     query(uri, projection, where, whereArgs, sortOrder)?.use { cursor ->
         while (cursor.moveToNext())
-            emit(transform(cursor))
+            emit(transformRow(cursor))
     }
 }.flowOn(Dispatchers.IO)
 
 /**
  * Like [queryFlow], but for providers that expose rows via an [EntityIterator] (e.g. raw contacts,
  * calendar events), built from the cursor by [newIterator].
+ *
+ * @param uri           content URI to query
+ * @param projection    columns to return
+ * @param where         selection
+ * @param whereArgs     arguments for selection
+ * @param newIterator   builds the [EntityIterator] from the query's cursor
+ * @param transformRow  maps an entity produced by [newIterator] to the emitted value
  */
 fun <T> ContentProviderClient.queryEntityFlow(
     uri: Uri,
@@ -44,10 +58,10 @@ fun <T> ContentProviderClient.queryEntityFlow(
     where: String? = null,
     whereArgs: Array<String>? = null,
     newIterator: (Cursor) -> EntityIterator,
-    transform: (Entity) -> T
+    transformRow: (Entity) -> T
 ): Flow<T> = flow {
     query(uri, projection, where, whereArgs, null)?.use { cursor ->
         for (entity in newIterator(cursor))
-            emit(transform(entity))
+            emit(transformRow(entity))
     }
 }.flowOn(Dispatchers.IO)

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/QueryFlow.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/QueryFlow.kt
@@ -9,16 +9,16 @@ import android.content.Entity
 import android.content.EntityIterator
 import android.database.Cursor
 import android.net.Uri
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 
 /**
- * Runs a content provider query and emits each row as a cold [Flow], transformed by [transform].
- * The query is executed and the cursor is iterated lazily, only when the flow is collected; the
- * cursor is closed once the flow completes or is cancelled. No producer coroutine/thread is used.
+ * Cold [Flow] over a content provider query, one row per emission.
  *
- * Doesn't switch dispatchers itself — callers should apply [kotlinx.coroutines.flow.flowOn] as
- * needed, since content provider access is blocking.
+ * Runs on [Dispatchers.IO]. Chained blocking work (e.g. a nested query in `.map { }`) needs its
+ * own trailing [kotlinx.coroutines.flow.flowOn] — this one only covers the query itself.
  */
 fun <T> ContentProviderClient.queryFlow(
     uri: Uri,
@@ -32,11 +32,11 @@ fun <T> ContentProviderClient.queryFlow(
         while (cursor.moveToNext())
             emit(transform(cursor))
     }
-}
+}.flowOn(Dispatchers.IO)
 
 /**
- * Like [queryFlow], but iterates rows as [Entity] via [newIterator], for content providers that
- * expose their rows through an [EntityIterator] (e.g. raw contacts and calendar events).
+ * Like [queryFlow], but for providers that expose rows via an [EntityIterator] (e.g. raw contacts,
+ * calendar events), built from the cursor by [newIterator].
  */
 fun <T> ContentProviderClient.queryEntityFlow(
     uri: Uri,
@@ -50,4 +50,4 @@ fun <T> ContentProviderClient.queryEntityFlow(
         for (entity in newIterator(cursor))
             emit(transform(entity))
     }
-}
+}.flowOn(Dispatchers.IO)

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/QueryFlow.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/QueryFlow.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.synctools.storage
+
+import android.content.ContentProviderClient
+import android.content.Entity
+import android.content.EntityIterator
+import android.database.Cursor
+import android.net.Uri
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+/**
+ * Runs a content provider query and emits each row as a cold [Flow], transformed by [transform].
+ * The query is executed and the cursor is iterated lazily, only when the flow is collected; the
+ * cursor is closed once the flow completes or is cancelled. No producer coroutine/thread is used.
+ *
+ * Doesn't switch dispatchers itself — callers should apply [kotlinx.coroutines.flow.flowOn] as
+ * needed, since content provider access is blocking.
+ */
+fun <T> ContentProviderClient.queryFlow(
+    uri: Uri,
+    projection: Array<String>? = null,
+    where: String? = null,
+    whereArgs: Array<String>? = null,
+    sortOrder: String? = null,
+    transform: (Cursor) -> T
+): Flow<T> = flow {
+    query(uri, projection, where, whereArgs, sortOrder)?.use { cursor ->
+        while (cursor.moveToNext())
+            emit(transform(cursor))
+    }
+}
+
+/**
+ * Like [queryFlow], but iterates rows as [Entity] via [newIterator], for content providers that
+ * expose their rows through an [EntityIterator] (e.g. raw contacts and calendar events).
+ */
+fun <T> ContentProviderClient.queryEntityFlow(
+    uri: Uri,
+    projection: Array<String>? = null,
+    where: String? = null,
+    whereArgs: Array<String>? = null,
+    newIterator: (Cursor) -> EntityIterator,
+    transform: (Entity) -> T
+): Flow<T> = flow {
+    query(uri, projection, where, whereArgs, null)?.use { cursor ->
+        for (entity in newIterator(cursor))
+            emit(transform(entity))
+    }
+}

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/QueryFlow.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/QueryFlow.kt
@@ -24,7 +24,6 @@ import kotlinx.coroutines.flow.flowOn
  * @param projection    columns to return
  * @param where         selection
  * @param whereArgs     arguments for selection
- * @param sortOrder     sort order
  * @param transformRow  maps a cursor row (positioned by the query) to the emitted value
  */
 fun <T> ContentProviderClient.queryFlow(
@@ -32,25 +31,25 @@ fun <T> ContentProviderClient.queryFlow(
     projection: Array<String>? = null,
     where: String? = null,
     whereArgs: Array<String>? = null,
-    sortOrder: String? = null,
     transformRow: (Cursor) -> T
-): Flow<T> = flow {
-    query(uri, projection, where, whereArgs, sortOrder)?.use { cursor ->
-        while (cursor.moveToNext())
-            emit(transformRow(cursor))
-    }
-}.flowOn(Dispatchers.IO)
+): Flow<T> =
+    flow {
+        query(uri, projection, where, whereArgs, null)?.use { cursor ->
+            while (cursor.moveToNext())
+                emit(transformRow(cursor))
+        }
+    }.flowOn(Dispatchers.IO)
 
 /**
  * Like [queryFlow], but for providers that expose rows via an [EntityIterator] (e.g. raw contacts,
  * calendar events), built from the cursor by [newIterator].
  *
- * @param uri           content URI to query
- * @param projection    columns to return
- * @param where         selection
- * @param whereArgs     arguments for selection
- * @param newIterator   builds the [EntityIterator] from the query's cursor
- * @param transformRow  maps an entity produced by [newIterator] to the emitted value
+ * @param uri              content URI to query
+ * @param projection       columns to return
+ * @param where            selection
+ * @param whereArgs        arguments for selection
+ * @param newIterator      builds the [EntityIterator] from the query's cursor
+ * @param transformEntity  maps an entity produced by [newIterator] to the emitted value
  */
 fun <T> ContentProviderClient.queryEntityFlow(
     uri: Uri,
@@ -58,10 +57,11 @@ fun <T> ContentProviderClient.queryEntityFlow(
     where: String? = null,
     whereArgs: Array<String>? = null,
     newIterator: (Cursor) -> EntityIterator,
-    transformRow: (Entity) -> T
-): Flow<T> = flow {
-    query(uri, projection, where, whereArgs, null)?.use { cursor ->
-        for (entity in newIterator(cursor))
-            emit(transformRow(entity))
-    }
-}.flowOn(Dispatchers.IO)
+    transformEntity: (Entity) -> T
+): Flow<T> =
+    flow {
+        query(uri, projection, where, whereArgs, null)?.use { cursor ->
+            for (entity in newIterator(cursor))
+                emit(transformEntity(entity))
+        }
+    }.flowOn(Dispatchers.IO)

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/QueryFlow.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/QueryFlow.kt
@@ -45,7 +45,7 @@ fun ContentProviderClient.queryFlow(
         } catch (e: RemoteException) {
             throw LocalStorageException("Couldn't query $uri", e)
         }
-    }.flowOn(Dispatchers.IO).buffer(capacity = Channel.RENDEZVOUS)
+    }.flowOn(Dispatchers.IO)    // buffers by default – but main rows are not big enough to worry
 
 /**
  * Like [queryFlow], but for providers that expose rows via an [EntityIterator] (e.g. raw contacts,
@@ -74,4 +74,5 @@ fun ContentProviderClient.queryEntityFlow(
         } catch (e: RemoteException) {
             throw LocalStorageException("Couldn't query $uri", e)
         }
-    }.flowOn(Dispatchers.IO).buffer(capacity = Channel.RENDEZVOUS)
+    }.flowOn(Dispatchers.IO)            // buffers by default
+        .buffer(capacity = Channel.RENDEZVOUS)   // Entity-s could be big → reduce buffer size to 1

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/QueryFlow.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/QueryFlow.kt
@@ -9,6 +9,7 @@ import android.content.Entity
 import android.content.EntityIterator
 import android.database.Cursor
 import android.net.Uri
+import android.os.RemoteException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -25,6 +26,7 @@ import kotlinx.coroutines.flow.flowOn
  * @param where         selection
  * @param whereArgs     arguments for selection
  * @param transformRow  maps a cursor row (positioned by the query) to the emitted value
+ * @throws LocalStorageException when the content provider returns an error
  */
 fun <T> ContentProviderClient.queryFlow(
     uri: Uri,
@@ -34,9 +36,13 @@ fun <T> ContentProviderClient.queryFlow(
     transformRow: (Cursor) -> T
 ): Flow<T> =
     flow {
-        query(uri, projection, where, whereArgs, null)?.use { cursor ->
-            while (cursor.moveToNext())
-                emit(transformRow(cursor))
+        try {
+            query(uri, projection, where, whereArgs, null)?.use { cursor ->
+                while (cursor.moveToNext())
+                    emit(transformRow(cursor))
+            }
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't query $uri", e)
         }
     }.flowOn(Dispatchers.IO)
 
@@ -50,6 +56,7 @@ fun <T> ContentProviderClient.queryFlow(
  * @param whereArgs        arguments for selection
  * @param newIterator      builds the [EntityIterator] from the query's cursor
  * @param transformEntity  maps an entity produced by [newIterator] to the emitted value
+ * @throws LocalStorageException when the content provider returns an error
  */
 fun <T> ContentProviderClient.queryEntityFlow(
     uri: Uri,
@@ -60,8 +67,12 @@ fun <T> ContentProviderClient.queryEntityFlow(
     transformEntity: (Entity) -> T
 ): Flow<T> =
     flow {
-        query(uri, projection, where, whereArgs, null)?.use { cursor ->
-            for (entity in newIterator(cursor))
-                emit(transformEntity(entity))
+        try {
+            query(uri, projection, where, whereArgs, null)?.use { cursor ->
+                for (entity in newIterator(cursor))
+                    emit(transformEntity(entity))
+            }
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't query $uri", e)
         }
     }.flowOn(Dispatchers.IO)

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/QueryFlow.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/QueryFlow.kt
@@ -5,6 +5,7 @@
 package at.bitfire.synctools.storage
 
 import android.content.ContentProviderClient
+import android.content.ContentValues
 import android.content.Entity
 import android.content.EntityIterator
 import android.database.Cursor
@@ -25,21 +26,19 @@ import kotlinx.coroutines.flow.flowOn
  * @param projection    columns to return
  * @param where         selection
  * @param whereArgs     arguments for selection
- * @param transformRow  maps a cursor row (positioned by the query) to the emitted value
  * @throws LocalStorageException when the content provider returns an error
  */
-fun <T> ContentProviderClient.queryFlow(
+fun ContentProviderClient.queryFlow(
     uri: Uri,
     projection: Array<String>? = null,
     where: String? = null,
-    whereArgs: Array<String>? = null,
-    transformRow: (Cursor) -> T
-): Flow<T> =
+    whereArgs: Array<String>? = null
+): Flow<ContentValues> =
     flow {
         try {
             query(uri, projection, where, whereArgs, null)?.use { cursor ->
                 while (cursor.moveToNext())
-                    emit(transformRow(cursor))
+                    emit(cursor.toContentValues())
             }
         } catch (e: RemoteException) {
             throw LocalStorageException("Couldn't query $uri", e)
@@ -55,22 +54,20 @@ fun <T> ContentProviderClient.queryFlow(
  * @param where            selection
  * @param whereArgs        arguments for selection
  * @param buildIterator    builds the [EntityIterator] from the query's cursor
- * @param transformEntity  maps an entity produced by [buildIterator] to the emitted value
  * @throws LocalStorageException when the content provider returns an error
  */
-fun <T> ContentProviderClient.queryEntityFlow(
+fun ContentProviderClient.queryEntityFlow(
     uri: Uri,
     projection: Array<String>? = null,
     where: String? = null,
     whereArgs: Array<String>? = null,
-    buildIterator: (Cursor) -> EntityIterator,
-    transformEntity: (Entity) -> T
-): Flow<T> =
+    buildIterator: (Cursor) -> EntityIterator
+): Flow<Entity> =
     flow {
         try {
             query(uri, projection, where, whereArgs, null)?.use { cursor ->
                 for (entity in buildIterator(cursor))
-                    emit(transformEntity(entity))
+                    emit(entity)
             }
         } catch (e: RemoteException) {
             throw LocalStorageException("Couldn't query $uri", e)

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/QueryFlow.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/QueryFlow.kt
@@ -37,7 +37,6 @@ fun <T> ContentProviderClient.queryFlow(
 ): Flow<T> =
     flow {
         try {
-            // Flow cancellation causes the next emit to throw a CancellationException, so the cursor is still closed.
             query(uri, projection, where, whereArgs, null)?.use { cursor ->
                 while (cursor.moveToNext())
                     emit(transformRow(cursor))
@@ -69,7 +68,6 @@ fun <T> ContentProviderClient.queryEntityFlow(
 ): Flow<T> =
     flow {
         try {
-            // Flow cancellation causes the next emit to throw a CancellationException, so the cursor is still closed.
             query(uri, projection, where, whereArgs, null)?.use { cursor ->
                 for (entity in newIterator(cursor))
                     emit(transformEntity(entity))

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/QueryFlow.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/QueryFlow.kt
@@ -48,14 +48,14 @@ fun <T> ContentProviderClient.queryFlow(
 
 /**
  * Like [queryFlow], but for providers that expose rows via an [EntityIterator] (e.g. raw contacts,
- * calendar events), built from the cursor by [newIterator].
+ * calendar events), built from the cursor by [buildIterator].
  *
  * @param uri              content URI to query
  * @param projection       columns to return
  * @param where            selection
  * @param whereArgs        arguments for selection
- * @param newIterator      builds the [EntityIterator] from the query's cursor
- * @param transformEntity  maps an entity produced by [newIterator] to the emitted value
+ * @param buildIterator    builds the [EntityIterator] from the query's cursor
+ * @param transformEntity  maps an entity produced by [buildIterator] to the emitted value
  * @throws LocalStorageException when the content provider returns an error
  */
 fun <T> ContentProviderClient.queryEntityFlow(
@@ -63,13 +63,13 @@ fun <T> ContentProviderClient.queryEntityFlow(
     projection: Array<String>? = null,
     where: String? = null,
     whereArgs: Array<String>? = null,
-    newIterator: (Cursor) -> EntityIterator,
+    buildIterator: (Cursor) -> EntityIterator,
     transformEntity: (Entity) -> T
 ): Flow<T> =
     flow {
         try {
             query(uri, projection, where, whereArgs, null)?.use { cursor ->
-                for (entity in newIterator(cursor))
+                for (entity in buildIterator(cursor))
                     emit(transformEntity(entity))
             }
         } catch (e: RemoteException) {

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/QueryFlow.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/QueryFlow.kt
@@ -12,7 +12,9 @@ import android.database.Cursor
 import android.net.Uri
 import android.os.RemoteException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 
@@ -43,7 +45,7 @@ fun ContentProviderClient.queryFlow(
         } catch (e: RemoteException) {
             throw LocalStorageException("Couldn't query $uri", e)
         }
-    }.flowOn(Dispatchers.IO)
+    }.flowOn(Dispatchers.IO).buffer(capacity = Channel.RENDEZVOUS)
 
 /**
  * Like [queryFlow], but for providers that expose rows via an [EntityIterator] (e.g. raw contacts,
@@ -72,4 +74,4 @@ fun ContentProviderClient.queryEntityFlow(
         } catch (e: RemoteException) {
             throw LocalStorageException("Couldn't query $uri", e)
         }
-    }.flowOn(Dispatchers.IO)
+    }.flowOn(Dispatchers.IO).buffer(capacity = Channel.RENDEZVOUS)

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/QueryFlow.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/QueryFlow.kt
@@ -37,6 +37,7 @@ fun <T> ContentProviderClient.queryFlow(
 ): Flow<T> =
     flow {
         try {
+            // Flow cancellation causes the next emit to throw a CancellationException, so the cursor is still closed.
             query(uri, projection, where, whereArgs, null)?.use { cursor ->
                 while (cursor.moveToNext())
                     emit(transformRow(cursor))
@@ -68,6 +69,7 @@ fun <T> ContentProviderClient.queryEntityFlow(
 ): Flow<T> =
     flow {
         try {
+            // Flow cancellation causes the next emit to throw a CancellationException, so the cursor is still closed.
             query(uri, projection, where, whereArgs, null)?.use { cursor ->
                 for (entity in newIterator(cursor))
                     emit(transformEntity(entity))

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendar.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendar.kt
@@ -124,8 +124,10 @@ class AndroidCalendar(
     fun countEvents(where: String?, whereArgs: Array<String>?): Int {
         try {
             val (protectedWhere, protectedWhereArgs) = whereWithCalendarId(where, whereArgs)
-            client.query(eventsUri, arrayOf(Events._ID),
-                protectedWhere, protectedWhereArgs, null)?.use { cursor ->
+            client.query(
+                eventsUri, arrayOf(Events._ID),
+                protectedWhere, protectedWhereArgs, null
+            )?.use { cursor ->
                 return cursor.count
             }
         } catch (e: RemoteException) {
@@ -213,7 +215,12 @@ class AndroidCalendar(
      *
      * @throws LocalStorageException when the content provider returns an error
      */
-    fun getEventRow(id: Long, projection: Array<String>? = null, where: String? = null, whereArgs: Array<String>? = null): ContentValues? {
+    fun getEventRow(
+        id: Long,
+        projection: Array<String>? = null,
+        where: String? = null,
+        whereArgs: Array<String>? = null
+    ): ContentValues? {
         try {
             client.query(eventUri(id), projection, where, whereArgs, null)?.use { cursor ->
                 if (cursor.moveToNext())
@@ -237,7 +244,12 @@ class AndroidCalendar(
      *
      * @throws LocalStorageException when the content provider returns an error
      */
-    fun iterateEventRows(projection: Array<String>?, where: String?, whereArgs: Array<String>?, body: (ContentValues) -> Unit) {
+    fun iterateEventRows(
+        projection: Array<String>?,
+        where: String?,
+        whereArgs: Array<String>?,
+        body: (ContentValues) -> Unit
+    ) {
         try {
             val (protectedWhere, protectedWhereArgs) = whereWithCalendarId(where, whereArgs)
             client.query(eventsUri, projection, protectedWhere, protectedWhereArgs, null)?.use { cursor ->
@@ -260,11 +272,9 @@ class AndroidCalendar(
      */
     fun queryEvents(where: String?, whereArgs: Array<String>?): Flow<Entity> {
         val (protectedWhere, protectedWhereArgs) = whereWithCalendarId(where, whereArgs)
-        return client.queryEntityFlow(
-            eventEntitiesUri, null, protectedWhere, protectedWhereArgs,
-            buildIterator = { cursor -> EventsEntity.newEntityIterator(cursor, client) },
-            transformEntity = { it }
-        )
+        return client.queryEntityFlow(eventEntitiesUri, null, protectedWhere, protectedWhereArgs) {
+            EventsEntity.newEntityIterator(it, client)
+        }
     }
 
     /**
@@ -320,7 +330,7 @@ class AndroidCalendar(
             batch.commit()
 
             if (newEventIdIdx == null)
-                // event was updated
+            // event was updated
                 return id
             else {
                 // event was re-built
@@ -646,8 +656,10 @@ class AndroidCalendar(
     enum class StatusUpdateWorkaround {
         /** no workaround needed */
         NO_WORKAROUND,
+
         /** don't update eventStatus (no need to change value) */
         DONT_UPDATE_STATUS,
+
         /** rebuild event (delete+insert instead of update) */
         REBUILD_EVENT
     }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendar.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendar.kt
@@ -258,7 +258,7 @@ class AndroidCalendar(
      * @param where         selection
      * @param whereArgs     arguments for selection
      */
-    fun eventsFlow(where: String?, whereArgs: Array<String>?): Flow<Entity> {
+    fun queryEvents(where: String?, whereArgs: Array<String>?): Flow<Entity> {
         val (protectedWhere, protectedWhereArgs) = whereWithCalendarId(where, whereArgs)
         return client.queryEntityFlow(
             eventEntitiesUri, null, protectedWhere, protectedWhereArgs,

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendar.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendar.kt
@@ -265,7 +265,7 @@ class AndroidCalendar(
         return client.queryEntityFlow(
             eventEntitiesUri, null, protectedWhere, protectedWhereArgs,
             newIterator = { cursor -> EventsEntity.newEntityIterator(cursor, client) },
-            transformRow = { it }
+            transformEntity = { it }
         )
     }
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendar.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendar.kt
@@ -329,10 +329,10 @@ class AndroidCalendar(
             val newEventIdIdx = updateEvent(id, entity, batch)
             batch.commit()
 
-            if (newEventIdIdx == null)
-            // event was updated
+            if (newEventIdIdx == null) {
+                // event was updated
                 return id
-            else {
+            } else {
                 // event was re-built
                 val result = batch.getResult(newEventIdIdx)
                 val newEventUri = result?.uri ?: throw LocalStorageException("Content provider returned null on insert")

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendar.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendar.kt
@@ -22,7 +22,11 @@ import at.bitfire.synctools.mapping.UnknownProperty
 import at.bitfire.synctools.storage.BatchOperation.CpoBuilder
 import at.bitfire.synctools.storage.LocalStorageException
 import at.bitfire.synctools.storage.calendar.EventsContract.asSyncAdapter
+import at.bitfire.synctools.storage.queryEntityFlow
 import at.bitfire.synctools.storage.toContentValues
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
 import org.jetbrains.annotations.TestOnly
 import java.util.logging.Logger
 
@@ -270,6 +274,24 @@ class AndroidCalendar(
         } catch (e: RemoteException) {
             throw LocalStorageException("Couldn't iterate events", e)
         }
+    }
+
+    /**
+     * Like [iterateEvents], but returns a cold [Flow] instead of using a callback.
+     * Runs on [Dispatchers.IO], since content provider access is blocking.
+     *
+     * Adds a WHERE clause that restricts the query to [CalendarContract.EventsColumns.CALENDAR_ID] = [id].
+     *
+     * @param where         selection
+     * @param whereArgs     arguments for selection
+     */
+    fun eventsFlow(where: String?, whereArgs: Array<String>?): Flow<Entity> {
+        val (protectedWhere, protectedWhereArgs) = whereWithCalendarId(where, whereArgs)
+        return client.queryEntityFlow(
+            eventEntitiesUri, null, protectedWhere, protectedWhereArgs,
+            newIterator = { cursor -> EventsEntity.newEntityIterator(cursor, client) },
+            transform = { it }
+        ).flowOn(Dispatchers.IO)
     }
 
     /**

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendar.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendar.kt
@@ -37,7 +37,7 @@ import java.util.logging.Logger
  * Methods that use [Entity] operate on [EventsEntity] URIs to access the [Events] rows together with
  * associated data rows (reminders, attendees etc.)
  *
- * @param client    calendar provider
+ * @param provider  calendar provider
  * @param values    content values as read from the calendar provider; [android.provider.BaseColumns._ID] must be set
  *
  * @throws IllegalArgumentException when [Calendars._ID] is not set
@@ -265,7 +265,7 @@ class AndroidCalendar(
         return client.queryEntityFlow(
             eventEntitiesUri, null, protectedWhere, protectedWhereArgs,
             newIterator = { cursor -> EventsEntity.newEntityIterator(cursor, client) },
-            transform = { it }
+            transformRow = { it }
         )
     }
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendar.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendar.kt
@@ -26,7 +26,6 @@ import at.bitfire.synctools.storage.queryEntityFlow
 import at.bitfire.synctools.storage.toContentValues
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOn
 import org.jetbrains.annotations.TestOnly
 import java.util.logging.Logger
 
@@ -253,32 +252,8 @@ class AndroidCalendar(
     }
 
     /**
-     * Iterates event entities from this calendar.
-     *
-     * Adds a WHERE clause that restricts the query to [CalendarContract.EventsColumns.CALENDAR_ID] = [id].
-     *
-     * @param where         selection
-     * @param whereArgs     arguments for selection
-     * @param body          callback that is called for each entity
-     *
-     * @throws LocalStorageException when the content provider returns an error
-     */
-    fun iterateEvents(where: String?, whereArgs: Array<String>?, body: (Entity) -> Unit) {
-        try {
-            val (protectedWhere, protectedWhereArgs) = whereWithCalendarId(where, whereArgs)
-            client.query(eventEntitiesUri, null, protectedWhere, protectedWhereArgs, null)?.use { cursor ->
-                val iterator = EventsEntity.newEntityIterator(cursor, client)
-                for (entity in iterator)
-                    body(entity)
-            }
-        } catch (e: RemoteException) {
-            throw LocalStorageException("Couldn't iterate events", e)
-        }
-    }
-
-    /**
-     * Like [iterateEvents], but returns a cold [Flow] instead of using a callback.
-     * Runs on [Dispatchers.IO], since content provider access is blocking.
+     * Cold [Flow] of event entities from this calendar. Runs on [Dispatchers.IO], since content
+     * provider access is blocking.
      *
      * Adds a WHERE clause that restricts the query to [CalendarContract.EventsColumns.CALENDAR_ID] = [id].
      *
@@ -291,7 +266,7 @@ class AndroidCalendar(
             eventEntitiesUri, null, protectedWhere, protectedWhereArgs,
             newIterator = { cursor -> EventsEntity.newEntityIterator(cursor, client) },
             transform = { it }
-        ).flowOn(Dispatchers.IO)
+        )
     }
 
     /**

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendar.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendar.kt
@@ -262,7 +262,7 @@ class AndroidCalendar(
         val (protectedWhere, protectedWhereArgs) = whereWithCalendarId(where, whereArgs)
         return client.queryEntityFlow(
             eventEntitiesUri, null, protectedWhere, protectedWhereArgs,
-            newIterator = { cursor -> EventsEntity.newEntityIterator(cursor, client) },
+            buildIterator = { cursor -> EventsEntity.newEntityIterator(cursor, client) },
             transformEntity = { it }
         )
     }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendar.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendar.kt
@@ -24,7 +24,6 @@ import at.bitfire.synctools.storage.LocalStorageException
 import at.bitfire.synctools.storage.calendar.EventsContract.asSyncAdapter
 import at.bitfire.synctools.storage.queryEntityFlow
 import at.bitfire.synctools.storage.toContentValues
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import org.jetbrains.annotations.TestOnly
 import java.util.logging.Logger
@@ -252,8 +251,7 @@ class AndroidCalendar(
     }
 
     /**
-     * Cold [Flow] of event entities from this calendar. Runs on [Dispatchers.IO], since content
-     * provider access is blocking.
+     * Cold [Flow] of event entities from this calendar.
      *
      * Adds a WHERE clause that restricts the query to [CalendarContract.EventsColumns.CALENDAR_ID] = [id].
      *

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidRecurringCalendar.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidRecurringCalendar.kt
@@ -90,7 +90,7 @@ class AndroidRecurringCalendar(
      * @param whereArgs     arguments for selection
      */
     suspend fun findEventAndExceptions(where: String?, whereArgs: Array<String>?): EventAndExceptions? =
-        eventAndExceptionsFlow(where, whereArgs).firstOrNull()
+        queryEventsAndExceptions(where, whereArgs).firstOrNull()
 
     /**
      * Retrieves a main event and its exceptions from the content provider (associated by [Events.ORIGINAL_ID]).
@@ -111,15 +111,15 @@ class AndroidRecurringCalendar(
      * @param where         selection
      * @param whereArgs     arguments for selection
      */
-    fun eventAndExceptionsFlow(where: String?, whereArgs: Array<String>?): Flow<EventAndExceptions> {
+    fun queryEventsAndExceptions(where: String?, whereArgs: Array<String>?): Flow<EventAndExceptions> {
         val (mainWhere, mainWhereArgs) = whereWithMainEventsOnly(where, whereArgs)
         return calendar
-            .eventsFlow(mainWhere, mainWhereArgs)
+            .queryEvents(mainWhere, mainWhereArgs)
             .map { main ->
                 val mainEventId = main.entityValues.getAsLong(Events._ID)
                 EventAndExceptions(
                     main = main,
-                    exceptions = calendar.eventsFlow("${Events.ORIGINAL_ID}=?", arrayOf(mainEventId.toString()))
+                    exceptions = calendar.queryEvents("${Events.ORIGINAL_ID}=?", arrayOf(mainEventId.toString()))
                         .toList()
                 )
             }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidRecurringCalendar.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidRecurringCalendar.kt
@@ -14,10 +14,8 @@ import androidx.core.content.contentValuesOf
 import at.bitfire.synctools.storage.BatchOperation.CpoBuilder
 import at.bitfire.synctools.storage.LocalStorageException
 import at.bitfire.synctools.storage.containsNotNull
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
 import java.util.logging.Level
@@ -123,7 +121,6 @@ class AndroidRecurringCalendar(
                         .toList()
                 )
             }
-            .flowOn(Dispatchers.IO)
     }
 
     /**

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidRecurringCalendar.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidRecurringCalendar.kt
@@ -103,9 +103,8 @@ class AndroidRecurringCalendar(
         findEventAndExceptions("${Events._ID}=?", arrayOf(mainEventId.toString()))
 
     /**
-     * Cold [Flow] of main events together with their exceptions. Runs on [Dispatchers.IO] as a
-     * whole, since content provider access is blocking; the per-main exceptions lookup stays a
-     * small bounded query (exceptions of a single event are not streamed).
+     * Cold [Flow] of main events together with their exceptions; the per-main exceptions lookup
+     * stays a small bounded query (exceptions of a single event are not streamed).
      *
      * Note that the exceptions may contain deleted events.
      *
@@ -114,7 +113,8 @@ class AndroidRecurringCalendar(
      */
     fun eventAndExceptionsFlow(where: String?, whereArgs: Array<String>?): Flow<EventAndExceptions> {
         val (mainWhere, mainWhereArgs) = whereWithMainEventsOnly(where, whereArgs)
-        return calendar.eventsFlow(mainWhere, mainWhereArgs)
+        return calendar
+            .eventsFlow(mainWhere, mainWhereArgs)
             .map { main ->
                 val mainEventId = main.entityValues.getAsLong(Events._ID)
                 EventAndExceptions(

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidRecurringCalendar.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidRecurringCalendar.kt
@@ -16,8 +16,10 @@ import at.bitfire.synctools.storage.LocalStorageException
 import at.bitfire.synctools.storage.containsNotNull
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
 import java.util.logging.Level
 import java.util.logging.Logger
 
@@ -87,17 +89,8 @@ class AndroidRecurringCalendar(
      * @param where         selection
      * @param whereArgs     arguments for selection
      */
-    fun findEventAndExceptions(where: String?, whereArgs: Array<String>?): EventAndExceptions? {
-        val (mainWhere, mainWhereArgs) = whereWithMainEventsOnly(where, whereArgs)
-        val main = calendar.findEvent(mainWhere, mainWhereArgs) ?: return null
-
-        // attach exceptions
-        val mainEventId = main.entityValues.getAsLong(Events._ID)
-        return EventAndExceptions(
-            main = main,
-            exceptions = buildList { calendar.iterateEvents("${Events.ORIGINAL_ID}=?", arrayOf(mainEventId.toString())) { add(it) } }
-        )
-    }
+    suspend fun findEventAndExceptions(where: String?, whereArgs: Array<String>?): EventAndExceptions? =
+        eventAndExceptionsFlow(where, whereArgs).firstOrNull()
 
     /**
      * Retrieves a main event and its exceptions from the content provider (associated by [Events.ORIGINAL_ID]).
@@ -106,14 +99,13 @@ class AndroidRecurringCalendar(
      *
      * @return event and exceptions
      */
-    fun getById(mainEventId: Long): EventAndExceptions? =
+    suspend fun getById(mainEventId: Long): EventAndExceptions? =
         findEventAndExceptions("${Events._ID}=?", arrayOf(mainEventId.toString()))
 
     /**
-     * Like the callback-based iteration through main events together with their exceptions,
-     * but returns a cold [Flow] instead. Runs on [Dispatchers.IO] as a whole, since content
-     * provider access is blocking; the per-main exceptions lookup stays a small bounded
-     * synchronous query (exceptions of a single event are not streamed).
+     * Cold [Flow] of main events together with their exceptions. Runs on [Dispatchers.IO] as a
+     * whole, since content provider access is blocking; the per-main exceptions lookup stays a
+     * small bounded query (exceptions of a single event are not streamed).
      *
      * Note that the exceptions may contain deleted events.
      *
@@ -127,12 +119,8 @@ class AndroidRecurringCalendar(
                 val mainEventId = main.entityValues.getAsLong(Events._ID)
                 EventAndExceptions(
                     main = main,
-                    exceptions = buildList {
-                        calendar.iterateEvents(
-                            "${Events.ORIGINAL_ID}=?",
-                            arrayOf(mainEventId.toString())
-                        ) { add(it) }
-                    }
+                    exceptions = calendar.eventsFlow("${Events.ORIGINAL_ID}=?", arrayOf(mainEventId.toString()))
+                        .toList()
                 )
             }
             .flowOn(Dispatchers.IO)

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidRecurringCalendar.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidRecurringCalendar.kt
@@ -14,6 +14,10 @@ import androidx.core.content.contentValuesOf
 import at.bitfire.synctools.storage.BatchOperation.CpoBuilder
 import at.bitfire.synctools.storage.LocalStorageException
 import at.bitfire.synctools.storage.containsNotNull
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import java.util.logging.Level
 import java.util.logging.Logger
 
@@ -106,24 +110,32 @@ class AndroidRecurringCalendar(
         findEventAndExceptions("${Events._ID}=?", arrayOf(mainEventId.toString()))
 
     /**
-     * Iterates through main events together with their exceptions from the content provider.
+     * Like the callback-based iteration through main events together with their exceptions,
+     * but returns a cold [Flow] instead. Runs on [Dispatchers.IO] as a whole, since content
+     * provider access is blocking; the per-main exceptions lookup stays a small bounded
+     * synchronous query (exceptions of a single event are not streamed).
      *
      * Note that the exceptions may contain deleted events.
      *
      * @param where         selection
      * @param whereArgs     arguments for selection
-     * @param body          callback that is called for each event (including exceptions)
      */
-    fun iterateEventAndExceptions(where: String?, whereArgs: Array<String>?, body: (EventAndExceptions) -> Unit) {
-        // iterate through main events and attach exceptions
+    fun eventAndExceptionsFlow(where: String?, whereArgs: Array<String>?): Flow<EventAndExceptions> {
         val (mainWhere, mainWhereArgs) = whereWithMainEventsOnly(where, whereArgs)
-        calendar.iterateEvents(mainWhere, mainWhereArgs) { main ->
-            val mainEventId = main.entityValues.getAsLong(Events._ID)
-            body(EventAndExceptions(
-                main = main,
-                exceptions = buildList { calendar.iterateEvents("${Events.ORIGINAL_ID}=?", arrayOf(mainEventId.toString())) { add(it) } }
-            ))
-        }
+        return calendar.eventsFlow(mainWhere, mainWhereArgs)
+            .map { main ->
+                val mainEventId = main.entityValues.getAsLong(Events._ID)
+                EventAndExceptions(
+                    main = main,
+                    exceptions = buildList {
+                        calendar.iterateEvents(
+                            "${Events.ORIGINAL_ID}=?",
+                            arrayOf(mainEventId.toString())
+                        ) { add(it) }
+                    }
+                )
+            }
+            .flowOn(Dispatchers.IO)
     }
 
     /**

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
@@ -29,8 +29,8 @@ import at.bitfire.synctools.storage.toContentValues
 import at.bitfire.synctools.util.setAndVerifyUserData
 import at.bitfire.synctools.vcard.GroupMethod
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.toList
 import org.jetbrains.annotations.TestOnly
 import org.jetbrains.annotations.VisibleForTesting
 import java.io.FileNotFoundException
@@ -370,7 +370,7 @@ class AndroidAddressBook(
     }
 
     suspend fun deleteGroupsWithoutMembers() {
-        queryGroups(null, null).filter { it.getMembers().isEmpty() }.forEach { group ->
+        queryGroups(null, null).filter { it.getMembers().isEmpty() }.collect { group ->
             logger.log(Level.FINE, "Deleting empty group", group)
             group.delete()
         }
@@ -479,8 +479,8 @@ class AndroidAddressBook(
     // region legacy AndroidContact/AndroidGroup CRUD
 
     @VisibleForTesting
-    internal suspend fun queryGroups(where: String?, whereArgs: Array<String>?): List<AndroidGroup> =
-        queryGroupRows(null, where, whereArgs).map { AndroidGroup(this, it) }.toList()
+    internal suspend fun queryGroups(where: String?, whereArgs: Array<String>?): Flow<AndroidGroup> =
+        queryGroupRows(null, where, whereArgs).map { AndroidGroup(this, it) }
 
     @TestOnly
     @Throws(FileNotFoundException::class)

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
@@ -35,7 +35,6 @@ import org.jetbrains.annotations.TestOnly
 import org.jetbrains.annotations.VisibleForTesting
 import java.io.FileNotFoundException
 import java.io.IOException
-import java.util.LinkedList
 import java.util.logging.Level
 import java.util.logging.Logger
 
@@ -198,6 +197,24 @@ class AndroidAddressBook(
         provider.queryFlow(rawContactsSyncUri(), null, where, whereArgs) { it.toContentValues() }
 
     /**
+     * Finds the first raw contact row matching the given selection, without collecting
+     * the full result set.
+     *
+     * This method operates "as sync adapter" on [addressBookAccount] and doesn't take the [readOnly] flag into account.
+     *
+     * @param where      optional selection
+     * @param whereArgs  optional arguments for [where]
+     * @return the matching row, or `null` if none matches
+     */
+    fun getRawContactRowOrNull(where: String?, whereArgs: Array<String>?): ContentValues? {
+        provider.query(rawContactsSyncUri(), null, where, whereArgs, null)?.use { cursor ->
+            if (cursor.moveToNext())
+                return cursor.toContentValues()
+        }
+        return null
+    }
+
+    /**
      * Enqueues an update of raw contact rows in this address book to the given batch.
      *
      * This method operates "as sync adapter" on [addressBookAccount] and doesn't take the [readOnly] flag into account.
@@ -240,14 +257,11 @@ class AndroidAddressBook(
     // region ContactsContract.Groups CRUD
 
     @Throws(FileNotFoundException::class)
-    fun findGroupById(id: Long): AndroidGroup {
+    fun findGroupById(id: Long): AndroidGroup =
         // account is implicitly restricted via the URI (asSyncAdapter appends ACCOUNT_NAME/ACCOUNT_TYPE)
-        provider.query(groupsSyncUri(), null, "${Groups._ID}=?", arrayOf(id.toString()), null)?.use { cursor ->
-            if (cursor.moveToNext())
-                return AndroidGroup(this, cursor.toContentValues())
-        }
-        throw FileNotFoundException()
-    }
+        getGroupOrNull("${Groups._ID}=?", arrayOf(id.toString()))
+            ?.let { AndroidGroup(this, it) }
+            ?: throw FileNotFoundException()
 
     fun findOrCreateGroup(title: String): Long {
         provider.query(
@@ -279,6 +293,24 @@ class AndroidAddressBook(
         whereArgs: Array<String>? = null
     ): Flow<ContentValues> =
         provider.queryFlow(groupsSyncUri(), projection, where, whereArgs) { it.toContentValues() }
+
+    /**
+     * Finds the first group row matching the given selection, without collecting
+     * the full result set.
+     *
+     * This method operates "as sync adapter" on [addressBookAccount] and doesn't take the [readOnly] flag into account.
+     *
+     * @param where      optional selection
+     * @param whereArgs  optional arguments for [where]
+     * @return the matching row, or `null` if none matches
+     */
+    fun getGroupOrNull(where: String?, whereArgs: Array<String>?): ContentValues? {
+        provider.query(groupsSyncUri(), null, where, whereArgs, null)?.use { cursor ->
+            if (cursor.moveToNext())
+                return cursor.toContentValues()
+        }
+        return null
+    }
 
     /**
      * Counts the number of groups in the address book that match the given selection criteria.
@@ -448,19 +480,6 @@ class AndroidAddressBook(
 
     // region legacy AndroidContact/AndroidGroup CRUD
 
-    @Deprecated("Use queryRawContactRows instead")
-    fun queryContacts(where: String?, whereArgs: Array<String>?): List<AndroidContact> {
-        val contacts = LinkedList<AndroidContact>()
-        provider.query(
-            rawContactsSyncUri(), null,
-            where, whereArgs, null
-        )?.use { cursor ->
-            while (cursor.moveToNext())
-                contacts += AndroidContact(this, cursor.toContentValues())
-        }
-        return contacts
-    }
-
     @VisibleForTesting
     internal suspend fun queryGroups(where: String?, whereArgs: Array<String>?): List<AndroidGroup> =
         queryGroupRows(null, where, whereArgs).map { AndroidGroup(this, it) }.toList()
@@ -468,7 +487,9 @@ class AndroidAddressBook(
     @TestOnly
     @Throws(FileNotFoundException::class)
     fun findContactById(id: Long) =
-        queryContacts("${RawContacts._ID}=?", arrayOf(id.toString())).firstOrNull() ?: throw FileNotFoundException()
+        getRawContactRowOrNull("${RawContacts._ID}=?", arrayOf(id.toString()))
+            ?.let { AndroidContact(this, it) }
+            ?: throw FileNotFoundException()
 
     // endregion
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
@@ -24,9 +24,13 @@ import at.bitfire.synctools.storage.BatchOperation
 import at.bitfire.synctools.storage.LocalStorageException
 import at.bitfire.synctools.storage.contacts.AddressContract.asSyncAdapter
 import at.bitfire.synctools.storage.contacts.AndroidAddressBook.Companion.USER_DATA_READ_ONLY
+import at.bitfire.synctools.storage.queryFlow
 import at.bitfire.synctools.storage.toContentValues
 import at.bitfire.synctools.util.setAndVerifyUserData
 import at.bitfire.synctools.vcard.GroupMethod
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
 import org.jetbrains.annotations.TestOnly
 import org.jetbrains.annotations.VisibleForTesting
 import java.io.FileNotFoundException
@@ -231,6 +235,19 @@ class AndroidAddressBook(
     }
 
     /**
+     * Like [iterateRawContactRows], but returns a cold [Flow] instead of using a callback.
+     * Runs on [Dispatchers.IO], since content provider access is blocking.
+     *
+     * This method operates "as sync adapter" on [addressBookAccount] and doesn't take the [readOnly] flag into account.
+     *
+     * @param where      optional selection
+     * @param whereArgs  optional arguments for [where]
+     */
+    fun rawContactRowsFlow(where: String? = null, whereArgs: Array<String>? = null): Flow<ContentValues> =
+        provider.queryFlow(rawContactsSyncUri(), null, where, whereArgs) { it.toContentValues() }
+            .flowOn(Dispatchers.IO)
+
+    /**
      * Enqueues an update of raw contact rows in this address book to the given batch.
      *
      * This method operates "as sync adapter" on [addressBookAccount] and doesn't take the [readOnly] flag into account.
@@ -313,6 +330,24 @@ class AndroidAddressBook(
             throw LocalStorageException("Couldn't iterate groups", e)
         }
     }
+
+    /**
+     * Like [iterateGroups], but returns a cold [Flow] instead of using a callback.
+     * Runs on [Dispatchers.IO], since content provider access is blocking.
+     *
+     * This method operates "as sync adapter" on [addressBookAccount] and doesn't take the [readOnly] flag into account.
+     *
+     * @param projection optional column projection
+     * @param where      optional selection
+     * @param whereArgs  optional arguments for [where]
+     */
+    fun groupsFlow(
+        projection: Array<String>? = null,
+        where: String? = null,
+        whereArgs: Array<String>? = null
+    ): Flow<ContentValues> =
+        provider.queryFlow(groupsSyncUri(), projection, where, whereArgs) { it.toContentValues() }
+            .flowOn(Dispatchers.IO)
 
     /**
      * Counts the number of groups in the address book that match the given selection criteria.

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
@@ -181,8 +181,7 @@ class AndroidAddressBook(
         )?.use { cursor ->
             return cursor.count
         }
-        // If the query was invalid, an exception should have been thrown. So this should never be reached:
-        return 0
+        throw LocalStorageException("Couldn't count raw contacts")
     }
 
     /**
@@ -329,8 +328,7 @@ class AndroidAddressBook(
         )?.use { cursor ->
             return cursor.count
         }
-        // If the query was invalid, an exception should have been thrown. So this should never be reached:
-        return 0
+        throw LocalStorageException("Couldn't count groups")
     }
 
     /**

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
@@ -240,7 +240,7 @@ class AndroidAddressBook(
      * @param where      optional selection
      * @param whereArgs  optional arguments for [where]
      */
-    fun rawContactRowsFlow(where: String? = null, whereArgs: Array<String>? = null): Flow<ContentValues> =
+    fun queryRawContactRows(where: String? = null, whereArgs: Array<String>? = null): Flow<ContentValues> =
         provider.queryFlow(rawContactsSyncUri(), null, where, whereArgs) { it.toContentValues() }
 
     /**
@@ -336,7 +336,7 @@ class AndroidAddressBook(
      * @param where      optional selection
      * @param whereArgs  optional arguments for [where]
      */
-    fun groupsFlow(
+    fun queryGroupRows(
         projection: Array<String>? = null,
         where: String? = null,
         whereArgs: Array<String>? = null

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
@@ -28,7 +28,6 @@ import at.bitfire.synctools.storage.queryFlow
 import at.bitfire.synctools.storage.toContentValues
 import at.bitfire.synctools.util.setAndVerifyUserData
 import at.bitfire.synctools.vcard.GroupMethod
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import org.jetbrains.annotations.TestOnly
 import org.jetbrains.annotations.VisibleForTesting
@@ -235,7 +234,6 @@ class AndroidAddressBook(
 
     /**
      * Like [iterateRawContactRows], but returns a cold [Flow] instead of using a callback.
-     * Runs on [Dispatchers.IO], since content provider access is blocking.
      *
      * This method operates "as sync adapter" on [addressBookAccount] and doesn't take the [readOnly] flag into account.
      *
@@ -331,7 +329,6 @@ class AndroidAddressBook(
 
     /**
      * Like [iterateGroups], but returns a cold [Flow] instead of using a callback.
-     * Runs on [Dispatchers.IO], since content provider access is blocking.
      *
      * This method operates "as sync adapter" on [addressBookAccount] and doesn't take the [readOnly] flag into account.
      *

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
@@ -315,6 +315,27 @@ class AndroidAddressBook(
     }
 
     /**
+     * Counts the number of groups in the address book that match the given selection criteria.
+     *
+     * This method operates "as sync adapter" on [addressBookAccount] and doesn't take the [readOnly] flag into account.
+     *
+     * @param where An optional filter declaring which rows to return.
+     * @param whereArgs Optional arguments for [where].
+     * @return The number of groups matching the selection criteria.
+     */
+    fun countGroups(where: String?, whereArgs: Array<String>?): Int {
+        // account is implicitly restricted via the URI (asSyncAdapter appends ACCOUNT_NAME/ACCOUNT_TYPE)
+        provider.query(
+            groupsSyncUri(), arrayOf(Groups._ID),
+            where, whereArgs, null
+        )?.use { cursor ->
+            return cursor.count
+        }
+        // If the query was invalid, an exception should have been thrown. So this should never be reached:
+        return 0
+    }
+
+    /**
      * Enqueues an update of group rows in this address book to the given batch.
      *
      * This method operates "as sync adapter" on [addressBookAccount] and doesn't take the [readOnly] flag into account.

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
@@ -29,6 +29,8 @@ import at.bitfire.synctools.storage.toContentValues
 import at.bitfire.synctools.util.setAndVerifyUserData
 import at.bitfire.synctools.vcard.GroupMethod
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
 import org.jetbrains.annotations.TestOnly
 import org.jetbrains.annotations.VisibleForTesting
 import java.io.FileNotFoundException
@@ -185,29 +187,7 @@ class AndroidAddressBook(
     }
 
     /**
-     * Iterates raw contact rows (without associated data rows) from this address book.
-     *
-     * This method operates "as sync adapter" on [addressBookAccount] and doesn't take the [readOnly] flag into account.
-     *
-     * @param where      optional selection
-     * @param whereArgs  optional arguments for [where]
-     * @param block      callback invoked for each raw contact row
-     * @throws LocalStorageException on content provider errors
-     */
-    fun iterateRawContactRows(where: String? = null, whereArgs: Array<String>? = null, block: (ContentValues) -> Unit) {
-        // account is implicitly restricted via the URI (asSyncAdapter appends ACCOUNT_NAME/ACCOUNT_TYPE)
-        try {
-            provider.query(rawContactsSyncUri(), null, where, whereArgs, null)?.use { cursor ->
-                while (cursor.moveToNext())
-                    block(cursor.toContentValues())
-            }
-        } catch (e: RemoteException) {
-            throw LocalStorageException("Couldn't iterate raw contact rows", e)
-        }
-    }
-
-    /**
-     * Like [iterateRawContactRows], but returns a cold [Flow] instead of using a callback.
+     * Cold [Flow] of raw contact rows (without associated data rows) from this address book.
      *
      * This method operates "as sync adapter" on [addressBookAccount] and doesn't take the [readOnly] flag into account.
      *
@@ -260,8 +240,14 @@ class AndroidAddressBook(
     // region ContactsContract.Groups CRUD
 
     @Throws(FileNotFoundException::class)
-    fun findGroupById(id: Long) =
-        queryGroups("${Groups._ID}=?", arrayOf(id.toString())).firstOrNull() ?: throw FileNotFoundException()
+    fun findGroupById(id: Long): AndroidGroup {
+        // account is implicitly restricted via the URI (asSyncAdapter appends ACCOUNT_NAME/ACCOUNT_TYPE)
+        provider.query(groupsSyncUri(), null, "${Groups._ID}=?", arrayOf(id.toString()), null)?.use { cursor ->
+            if (cursor.moveToNext())
+                return AndroidGroup(this, cursor.toContentValues())
+        }
+        throw FileNotFoundException()
+    }
 
     fun findOrCreateGroup(title: String): Long {
         provider.query(
@@ -279,30 +265,7 @@ class AndroidAddressBook(
     }
 
     /**
-     * Iterates group rows in this address book.
-     *
-     * This method operates "as sync adapter" on [addressBookAccount] and doesn't take the [readOnly] flag into account.
-     *
-     * @param projection optional column projection
-     * @param where      optional selection
-     * @param whereArgs  optional arguments for [where]
-     * @param block      callback invoked for each group row
-     * @throws LocalStorageException on content provider errors
-     */
-    fun iterateGroups(projection: Array<String>? = null, where: String? = null, whereArgs: Array<String>? = null, block: (ContentValues) -> Unit) {
-        // account is implicitly restricted via the URI (asSyncAdapter appends ACCOUNT_NAME/ACCOUNT_TYPE)
-        try {
-            provider.query(groupsSyncUri(), projection, where, whereArgs, null)?.use { cursor ->
-                while (cursor.moveToNext())
-                    block(cursor.toContentValues())
-            }
-        } catch (e: RemoteException) {
-            throw LocalStorageException("Couldn't iterate groups", e)
-        }
-    }
-
-    /**
-     * Like [iterateGroups], but returns a cold [Flow] instead of using a callback.
+     * Cold [Flow] of group rows in this address book.
      *
      * This method operates "as sync adapter" on [addressBookAccount] and doesn't take the [readOnly] flag into account.
      *
@@ -376,7 +339,7 @@ class AndroidAddressBook(
         batch += builder
     }
 
-    fun deleteGroupsWithoutMembers() {
+    suspend fun deleteGroupsWithoutMembers() {
         queryGroups(null, null).filter { it.getMembers().isEmpty() }.forEach { group ->
             logger.log(Level.FINE, "Deleting empty group", group)
             group.delete()
@@ -499,11 +462,8 @@ class AndroidAddressBook(
     }
 
     @VisibleForTesting
-    internal fun queryGroups(where: String?, whereArgs: Array<String>?): List<AndroidGroup> = buildList {
-        iterateGroups(null, where, whereArgs) { values ->
-            add(AndroidGroup(this@AndroidAddressBook, values))
-        }
-    }
+    internal suspend fun queryGroups(where: String?, whereArgs: Array<String>?): List<AndroidGroup> =
+        queryGroupRows(null, where, whereArgs).map { AndroidGroup(this, it) }.toList()
 
     @TestOnly
     @Throws(FileNotFoundException::class)

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
@@ -194,7 +194,7 @@ class AndroidAddressBook(
      * @param whereArgs  optional arguments for [where]
      */
     fun queryRawContactRows(where: String? = null, whereArgs: Array<String>? = null): Flow<ContentValues> =
-        provider.queryFlow(rawContactsSyncUri(), null, where, whereArgs) { it.toContentValues() }
+        provider.queryFlow(rawContactsSyncUri(), null, where, whereArgs)
 
     /**
      * Finds the first raw contact row matching the given selection, without collecting
@@ -292,7 +292,7 @@ class AndroidAddressBook(
         where: String? = null,
         whereArgs: Array<String>? = null
     ): Flow<ContentValues> =
-        provider.queryFlow(groupsSyncUri(), projection, where, whereArgs) { it.toContentValues() }
+        provider.queryFlow(groupsSyncUri(), projection, where, whereArgs)
 
     /**
      * Finds the first group row matching the given selection, without collecting

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
@@ -30,7 +30,6 @@ import at.bitfire.synctools.util.setAndVerifyUserData
 import at.bitfire.synctools.vcard.GroupMethod
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOn
 import org.jetbrains.annotations.TestOnly
 import org.jetbrains.annotations.VisibleForTesting
 import java.io.FileNotFoundException
@@ -245,7 +244,6 @@ class AndroidAddressBook(
      */
     fun rawContactRowsFlow(where: String? = null, whereArgs: Array<String>? = null): Flow<ContentValues> =
         provider.queryFlow(rawContactsSyncUri(), null, where, whereArgs) { it.toContentValues() }
-            .flowOn(Dispatchers.IO)
 
     /**
      * Enqueues an update of raw contact rows in this address book to the given batch.
@@ -347,7 +345,6 @@ class AndroidAddressBook(
         whereArgs: Array<String>? = null
     ): Flow<ContentValues> =
         provider.queryFlow(groupsSyncUri(), projection, where, whereArgs) { it.toContentValues() }
-            .flowOn(Dispatchers.IO)
 
     /**
      * Counts the number of groups in the address book that match the given selection criteria.

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
@@ -185,32 +185,6 @@ class AndroidAddressBook(
     }
 
     /**
-     * Iterates raw contacts with their associated data rows (as [Entity]) from this address book.
-     *
-     * This method operates "as sync adapter" on [addressBookAccount] and doesn't take the [readOnly] flag into account.
-     *
-     * @param where     optional selection (only applied to raw contact rows, not data rows)
-     * @param whereArgs optional arguments for [where]
-     * @param block     callback invoked for each raw contact entity
-     * @throws LocalStorageException on content provider errors
-     */
-    fun iterateRawContacts(where: String? = null, whereArgs: Array<String>? = null, block: (Entity) -> Unit) {
-        // account is implicitly restricted via the URI (asSyncAdapter appends ACCOUNT_NAME/ACCOUNT_TYPE)
-        try {
-            provider.query(
-                ContactsContract.RawContactsEntity.CONTENT_URI.asSyncAdapter(addressBookAccount),
-                null, where, whereArgs, null
-            )?.use { cursor ->
-                val iterator = RawContacts.newEntityIterator(cursor)
-                for (entity in iterator)
-                    block(entity)
-            }
-        } catch (e: RemoteException) {
-            throw LocalStorageException("Couldn't iterate raw contacts", e)
-        }
-    }
-
-    /**
      * Iterates raw contact rows (without associated data rows) from this address book.
      *
      * This method operates "as sync adapter" on [addressBookAccount] and doesn't take the [readOnly] flag into account.
@@ -511,7 +485,7 @@ class AndroidAddressBook(
 
     // region legacy AndroidContact/AndroidGroup CRUD
 
-    @Deprecated("Use iterateRawContacts instead")
+    @Deprecated("Use queryRawContactRows instead")
     fun queryContacts(where: String?, whereArgs: Array<String>?): List<AndroidContact> {
         val contacts = LinkedList<AndroidContact>()
         provider.query(

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollection.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollection.kt
@@ -330,7 +330,7 @@ class JtxCollection(
      * @param where         selection
      * @param whereArgs     arguments for selection
      */
-    fun jtxObjectsFlow(where: String?, whereArgs: Array<String>?): Flow<Entity> {
+    fun queryJtxObjects(where: String?, whereArgs: Array<String>?): Flow<Entity> {
         val (protectedWhere, protectedWhereArgs) = whereWithCollectionId(where, whereArgs)
         return client.queryFlow(
             jtxObjectsUri,

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollection.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollection.kt
@@ -17,6 +17,7 @@ import at.bitfire.synctools.storage.toContentValues
 import at.techbee.jtx.JtxContract
 import at.techbee.jtx.JtxContract.asSyncAdapter
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import org.jetbrains.annotations.TestOnly
 import java.nio.channels.Channels
 
@@ -336,7 +337,7 @@ class JtxCollection(
             jtxObjectsUri,
             null,
             protectedWhere, protectedWhereArgs
-        ) { readEntity(it.toContentValues()) }
+        ).map { readEntity(it) }
     }
 
     /**

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollection.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollection.kt
@@ -16,7 +16,6 @@ import at.bitfire.synctools.storage.queryFlow
 import at.bitfire.synctools.storage.toContentValues
 import at.techbee.jtx.JtxContract
 import at.techbee.jtx.JtxContract.asSyncAdapter
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import org.jetbrains.annotations.TestOnly
 import java.nio.channels.Channels
@@ -324,8 +323,7 @@ class JtxCollection(
     }
 
     /**
-     * Cold [Flow] of jtx objects (with sub-rows) from this collection. Runs on [Dispatchers.IO],
-     * since content provider access is blocking.
+     * Cold [Flow] of jtx objects (with sub-rows) from this collection.
      *
      * Adds a WHERE clause that restricts the query to [JtxContract.JtxICalObject.ICALOBJECT_COLLECTIONID] = [id].
      *

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollection.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollection.kt
@@ -18,7 +18,6 @@ import at.techbee.jtx.JtxContract
 import at.techbee.jtx.JtxContract.asSyncAdapter
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOn
 import org.jetbrains.annotations.TestOnly
 import java.nio.channels.Channels
 
@@ -325,31 +324,8 @@ class JtxCollection(
     }
 
     /**
-     * Iterates jtx objects (with sub-rows) from this collection.
-     *
-     * Adds a WHERE clause that restricts the query to [JtxContract.JtxICalObject.ICALOBJECT_COLLECTIONID] = [id].
-     *
-     * @param where         selection
-     * @param whereArgs     arguments for selection
-     * @param body          callback that is called for each jtx object entity
-     *
-     * @throws LocalStorageException when the content provider returns an error
-     */
-    fun iterateJtxObjects(where: String?, whereArgs: Array<String>?, body: (Entity) -> Unit) {
-        try {
-            val (protectedWhere, protectedWhereArgs) = whereWithCollectionId(where, whereArgs)
-            client.query(jtxObjectsUri, null, protectedWhere, protectedWhereArgs, null)?.use { cursor ->
-                while (cursor.moveToNext())
-                    body(readEntity(cursor.toContentValues()))
-            }
-        } catch (e: RemoteException) {
-            throw LocalStorageException("Couldn't iterate jtx objects", e)
-        }
-    }
-
-    /**
-     * Like [iterateJtxObjects], but returns a cold [Flow] instead of using a callback.
-     * Runs on [Dispatchers.IO], since content provider access is blocking.
+     * Cold [Flow] of jtx objects (with sub-rows) from this collection. Runs on [Dispatchers.IO],
+     * since content provider access is blocking.
      *
      * Adds a WHERE clause that restricts the query to [JtxContract.JtxICalObject.ICALOBJECT_COLLECTIONID] = [id].
      *
@@ -364,7 +340,6 @@ class JtxCollection(
             protectedWhere,
             protectedWhereArgs
         ) { readEntity(it.toContentValues()) }
-            .flowOn(Dispatchers.IO)
     }
 
     /**

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollection.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollection.kt
@@ -337,12 +337,14 @@ class JtxCollection(
      */
     fun queryJtxObjects(where: String?, whereArgs: Array<String>?): Flow<Entity> {
         val (protectedWhere, protectedWhereArgs) = whereWithCollectionId(where, whereArgs)
-        return client.queryFlow(
-            jtxObjectsUri,
-            null,
-            protectedWhere, protectedWhereArgs
-        ).map { readEntity(it) }
-            .flowOn(Dispatchers.IO).buffer(Channel.RENDEZVOUS)
+        return client
+            .queryFlow(
+                jtxObjectsUri,
+                null,
+                protectedWhere, protectedWhereArgs
+            ).map { readEntity(it) }
+            .flowOn(Dispatchers.IO)         // buffers by default
+            .buffer(Channel.RENDEZVOUS)     // Entity-s could be big → reduce buffer size to 1
     }
 
     /**

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollection.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollection.kt
@@ -335,8 +335,7 @@ class JtxCollection(
         return client.queryFlow(
             jtxObjectsUri,
             null,
-            protectedWhere,
-            protectedWhereArgs
+            protectedWhere, protectedWhereArgs
         ) { readEntity(it.toContentValues()) }
     }
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollection.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollection.kt
@@ -16,7 +16,11 @@ import at.bitfire.synctools.storage.queryFlow
 import at.bitfire.synctools.storage.toContentValues
 import at.techbee.jtx.JtxContract
 import at.techbee.jtx.JtxContract.asSyncAdapter
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import org.jetbrains.annotations.TestOnly
 import java.nio.channels.Channels
@@ -338,6 +342,7 @@ class JtxCollection(
             null,
             protectedWhere, protectedWhereArgs
         ).map { readEntity(it) }
+            .flowOn(Dispatchers.IO).buffer(Channel.RENDEZVOUS)
     }
 
     /**

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollection.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollection.kt
@@ -12,9 +12,13 @@ import android.os.ParcelFileDescriptor
 import android.os.RemoteException
 import at.bitfire.synctools.storage.BatchOperation.CpoBuilder
 import at.bitfire.synctools.storage.LocalStorageException
+import at.bitfire.synctools.storage.queryFlow
 import at.bitfire.synctools.storage.toContentValues
 import at.techbee.jtx.JtxContract
 import at.techbee.jtx.JtxContract.asSyncAdapter
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
 import org.jetbrains.annotations.TestOnly
 import java.nio.channels.Channels
 
@@ -341,6 +345,26 @@ class JtxCollection(
         } catch (e: RemoteException) {
             throw LocalStorageException("Couldn't iterate jtx objects", e)
         }
+    }
+
+    /**
+     * Like [iterateJtxObjects], but returns a cold [Flow] instead of using a callback.
+     * Runs on [Dispatchers.IO], since content provider access is blocking.
+     *
+     * Adds a WHERE clause that restricts the query to [JtxContract.JtxICalObject.ICALOBJECT_COLLECTIONID] = [id].
+     *
+     * @param where         selection
+     * @param whereArgs     arguments for selection
+     */
+    fun jtxObjectsFlow(where: String?, whereArgs: Array<String>?): Flow<Entity> {
+        val (protectedWhere, protectedWhereArgs) = whereWithCollectionId(where, whereArgs)
+        return client.queryFlow(
+            jtxObjectsUri,
+            null,
+            protectedWhere,
+            protectedWhereArgs
+        ) { readEntity(it.toContentValues()) }
+            .flowOn(Dispatchers.IO)
     }
 
     /**

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxRecurringCollection.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxRecurringCollection.kt
@@ -101,16 +101,16 @@ class JtxRecurringCollection(
     }
 
     /**
-     * Cold [Flow] of main jtx objects together with their exceptions. Runs on [Dispatchers.IO] as
-     * a whole, since content provider access is blocking; the per-main exceptions lookup stays a
-     * small bounded query (exceptions of a single object are not streamed).
+     * Cold [Flow] of main jtx objects together with their exceptions; the per-main exceptions
+     * lookup stays a small bounded query (exceptions of a single object are not streamed).
      *
      * @param where         selection (applied to main objects only; [JtxContract.JtxICalObject.RECURID] IS NULL is added automatically)
      * @param whereArgs     arguments for selection
      */
     fun jtxObjectAndExceptionsFlow(where: String?, whereArgs: Array<String>?): Flow<JtxObjectAndExceptions> {
         val mainWhere = mainJtxObjectOnlyWhere(where)
-        return collection.jtxObjectsFlow(mainWhere, whereArgs)
+        return collection
+            .jtxObjectsFlow(mainWhere, whereArgs)
             .map { main ->
                 val uid = main.entityValues.getAsString(JtxContract.JtxICalObject.UID)
                 JtxObjectAndExceptions(

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxRecurringCollection.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxRecurringCollection.kt
@@ -12,6 +12,10 @@ import androidx.core.content.contentValuesOf
 import at.bitfire.synctools.storage.LocalStorageException
 import at.bitfire.synctools.storage.containsNotNull
 import at.techbee.jtx.JtxContract
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import java.util.logging.Level
 import java.util.logging.Logger
 
@@ -112,6 +116,28 @@ class JtxRecurringCollection(
                 exceptions = if (uid != null) findExceptionsByUid(uid) else emptyList()
             ))
         }
+    }
+
+    /**
+     * Like [iterateJtxObjectAndExceptions], but returns a cold [Flow] instead of using a callback.
+     * Runs on [Dispatchers.IO] as a whole, since content provider access is blocking; the
+     * per-main exceptions lookup stays a small bounded synchronous query (exceptions of a single
+     * object are not streamed).
+     *
+     * @param where         selection (applied to main objects only; [JtxContract.JtxICalObject.RECURID] IS NULL is added automatically)
+     * @param whereArgs     arguments for selection
+     */
+    fun jtxObjectAndExceptionsFlow(where: String?, whereArgs: Array<String>?): Flow<JtxObjectAndExceptions> {
+        val mainWhere = mainJtxObjectOnlyWhere(where)
+        return collection.jtxObjectsFlow(mainWhere, whereArgs)
+            .map { main ->
+                val uid = main.entityValues.getAsString(JtxContract.JtxICalObject.UID)
+                JtxObjectAndExceptions(
+                    main = main,
+                    exceptions = if (uid != null) findExceptionsByUid(uid) else emptyList()
+                )
+            }
+            .flowOn(Dispatchers.IO)
     }
 
     /**

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxRecurringCollection.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxRecurringCollection.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
 import java.util.logging.Level
 import java.util.logging.Logger
 
@@ -60,7 +61,7 @@ class JtxRecurringCollection(
      * @param where         selection (applied to main objects only; [JtxContract.JtxICalObject.RECURID] IS NULL is added automatically)
      * @param whereArgs     arguments for selection
      */
-    fun findJtxObjectAndExceptions(where: String?, whereArgs: Array<String>?): JtxObjectAndExceptions? {
+    suspend fun findJtxObjectAndExceptions(where: String?, whereArgs: Array<String>?): JtxObjectAndExceptions? {
         val mainWhere = mainJtxObjectOnlyWhere(where)
 
         // attach exceptions
@@ -85,7 +86,7 @@ class JtxRecurringCollection(
      *
      * @return jtx object and exceptions, or `null` if not found or [mainId] is an exception
      */
-    fun getById(mainId: Long): JtxObjectAndExceptions? {
+    suspend fun getById(mainId: Long): JtxObjectAndExceptions? {
         val main = collection.getJtxObject(mainId) ?: return null
         if (main.entityValues.getAsString(JtxContract.JtxICalObject.RECURID) != null) {
             logger.warning("getById called with exception ID $mainId (RECURID IS NOT NULL) – returning null")
@@ -100,29 +101,9 @@ class JtxRecurringCollection(
     }
 
     /**
-     * Iterates through main jtx objects together with their exceptions from the content provider.
-     *
-     * @param where         selection (applied to main objects only; [JtxContract.JtxICalObject.RECURID] IS NULL is added automatically)
-     * @param whereArgs     arguments for selection
-     * @param body          callback that is called for each main object (with exceptions attached)
-     */
-    fun iterateJtxObjectAndExceptions(where: String?, whereArgs: Array<String>?, body: (JtxObjectAndExceptions) -> Unit) {
-        val mainWhere = mainJtxObjectOnlyWhere(where)
-        // iterate through main events and attach exceptions
-        collection.iterateJtxObjects(mainWhere, whereArgs) { main ->
-            val uid = main.entityValues.getAsString(JtxContract.JtxICalObject.UID)
-            body(JtxObjectAndExceptions(
-                main = main,
-                exceptions = if (uid != null) findExceptionsByUid(uid) else emptyList()
-            ))
-        }
-    }
-
-    /**
-     * Like [iterateJtxObjectAndExceptions], but returns a cold [Flow] instead of using a callback.
-     * Runs on [Dispatchers.IO] as a whole, since content provider access is blocking; the
-     * per-main exceptions lookup stays a small bounded synchronous query (exceptions of a single
-     * object are not streamed).
+     * Cold [Flow] of main jtx objects together with their exceptions. Runs on [Dispatchers.IO] as
+     * a whole, since content provider access is blocking; the per-main exceptions lookup stays a
+     * small bounded query (exceptions of a single object are not streamed).
      *
      * @param where         selection (applied to main objects only; [JtxContract.JtxICalObject.RECURID] IS NULL is added automatically)
      * @param whereArgs     arguments for selection
@@ -151,7 +132,7 @@ class JtxRecurringCollection(
      *
      * @throws LocalStorageException when [id] refers to an exception row instead of a main object
      */
-    fun updateJtxObjectAndExceptions(id: Long, jtxEntityAndExceptions: JtxEntityAndExceptions): Long {
+    suspend fun updateJtxObjectAndExceptions(id: Long, jtxEntityAndExceptions: JtxEntityAndExceptions): Long {
         try {
             // validate / clean up input
             val cleaned = cleanUp(jtxEntityAndExceptions)
@@ -458,12 +439,11 @@ class JtxRecurringCollection(
      * exceptions and must not be treated as such. The provider sets SEQUENCE to at least 1 for any
      * sync-adapter-inserted exception.
      */
-    private fun findExceptionsByUid(uid: String): List<Entity> = buildList {
-        collection.iterateJtxObjects(
+    private suspend fun findExceptionsByUid(uid: String): List<Entity> =
+        collection.jtxObjectsFlow(
             "${JtxContract.JtxICalObject.UID}=? AND ${JtxContract.JtxICalObject.RECURID} IS NOT NULL AND ${JtxContract.JtxICalObject.SEQUENCE} > 0",
             arrayOf(uid)
-        ) { add(it) }
-    }
+        ).toList()
 
     /**
      * Adds [JtxContract.JtxICalObject.RECURID] IS NULL to [where] to restrict queries to main objects only.

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxRecurringCollection.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxRecurringCollection.kt
@@ -107,10 +107,10 @@ class JtxRecurringCollection(
      * @param where         selection (applied to main objects only; [JtxContract.JtxICalObject.RECURID] IS NULL is added automatically)
      * @param whereArgs     arguments for selection
      */
-    fun jtxObjectAndExceptionsFlow(where: String?, whereArgs: Array<String>?): Flow<JtxObjectAndExceptions> {
+    fun queryJtxObjectsAndExceptions(where: String?, whereArgs: Array<String>?): Flow<JtxObjectAndExceptions> {
         val mainWhere = mainJtxObjectOnlyWhere(where)
         return collection
-            .jtxObjectsFlow(mainWhere, whereArgs)
+            .queryJtxObjects(mainWhere, whereArgs)
             .map { main ->
                 val uid = main.entityValues.getAsString(JtxContract.JtxICalObject.UID)
                 JtxObjectAndExceptions(
@@ -440,7 +440,7 @@ class JtxRecurringCollection(
      * sync-adapter-inserted exception.
      */
     private suspend fun findExceptionsByUid(uid: String): List<Entity> =
-        collection.jtxObjectsFlow(
+        collection.queryJtxObjects(
             "${JtxContract.JtxICalObject.UID}=? AND ${JtxContract.JtxICalObject.RECURID} IS NOT NULL AND ${JtxContract.JtxICalObject.SEQUENCE} > 0",
             arrayOf(uid)
         ).toList()

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxRecurringCollection.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxRecurringCollection.kt
@@ -12,9 +12,7 @@ import androidx.core.content.contentValuesOf
 import at.bitfire.synctools.storage.LocalStorageException
 import at.bitfire.synctools.storage.containsNotNull
 import at.techbee.jtx.JtxContract
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
 import java.util.logging.Level
@@ -118,7 +116,6 @@ class JtxRecurringCollection(
                     exceptions = if (uid != null) findExceptionsByUid(uid) else emptyList()
                 )
             }
-            .flowOn(Dispatchers.IO)
     }
 
     /**

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsRecurringTaskList.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsRecurringTaskList.kt
@@ -15,8 +15,10 @@ import at.bitfire.synctools.storage.LocalStorageException
 import at.bitfire.synctools.storage.containsNotNull
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
 import org.dmfs.tasks.contract.TaskContract
 import org.dmfs.tasks.contract.TaskContract.Tasks
 import java.util.logging.Level
@@ -79,17 +81,8 @@ class DmfsRecurringTaskList(
      * @param where         selection
      * @param whereArgs     arguments for selection
      */
-    fun findTaskAndExceptions(where: String?, whereArgs: Array<String>?): TaskAndExceptions? {
-        val (mainWhere, mainWhereArgs) = whereWithMainTasksOnly(where, whereArgs)
-        val main = taskList.findTask(mainWhere, mainWhereArgs) ?: return null
-
-        // attach exceptions
-        val mainTaskId = main.entityValues.getAsLong(Tasks._ID)
-        return TaskAndExceptions(
-            main = main,
-            exceptions = findExceptions(mainTaskId)
-        )
-    }
+    suspend fun findTaskAndExceptions(where: String?, whereArgs: Array<String>?): TaskAndExceptions? =
+        taskAndExceptionsFlow(where, whereArgs).firstOrNull()
 
     /**
      * Retrieves a main task and its exceptions from the content provider.
@@ -98,14 +91,13 @@ class DmfsRecurringTaskList(
      *
      * @return the task and its exceptions, or _null_ if no task with the given id was found
      */
-    fun getById(mainTaskId: Long): TaskAndExceptions? =
+    suspend fun getById(mainTaskId: Long): TaskAndExceptions? =
         findTaskAndExceptions("${Tasks._ID}=?", arrayOf(mainTaskId.toString()))
 
     /**
-     * Like the callback-based iteration through main tasks together with their exceptions,
-     * but returns a cold [Flow] instead. Runs on [Dispatchers.IO] as a whole, since content
-     * provider access is blocking; the per-main exceptions lookup stays a small bounded
-     * synchronous query (exceptions of a single task are not streamed).
+     * Cold [Flow] of main tasks together with their exceptions. Runs on [Dispatchers.IO] as a
+     * whole, since content provider access is blocking; the per-main exceptions lookup stays a
+     * small bounded query (exceptions of a single task are not streamed).
      *
      * Note that the exceptions may contain deleted tasks.
      *
@@ -367,9 +359,8 @@ class DmfsRecurringTaskList(
      * @param mainTaskId   The [Tasks._ID] of the main task
      * @return List of exception entities linked to the main task
      */
-    private fun findExceptions(mainTaskId: Long): List<Entity> = buildList {
-        taskList.iterateTasks("${Tasks.ORIGINAL_INSTANCE_ID}=?", arrayOf(mainTaskId.toString())) { add(it) }
-    }
+    private suspend fun findExceptions(mainTaskId: Long): List<Entity> =
+        taskList.tasksFlow("${Tasks.ORIGINAL_INSTANCE_ID}=?", arrayOf(mainTaskId.toString())).toList()
 
     private fun whereWithMainTasksOnly(where: String?, whereArgs: Array<String>?): Pair<String, Array<String>> {
         val protectedWhere = "(${where ?: "1"}) AND ${Tasks.ORIGINAL_INSTANCE_ID} IS NULL"

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsRecurringTaskList.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsRecurringTaskList.kt
@@ -13,6 +13,10 @@ import androidx.core.content.contentValuesOf
 import at.bitfire.synctools.storage.BatchOperation.CpoBuilder
 import at.bitfire.synctools.storage.LocalStorageException
 import at.bitfire.synctools.storage.containsNotNull
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import org.dmfs.tasks.contract.TaskContract
 import org.dmfs.tasks.contract.TaskContract.Tasks
 import java.util.logging.Level
@@ -98,25 +102,24 @@ class DmfsRecurringTaskList(
         findTaskAndExceptions("${Tasks._ID}=?", arrayOf(mainTaskId.toString()))
 
     /**
-     * Iterates through main tasks in [taskList] together with their exceptions.
+     * Like the callback-based iteration through main tasks together with their exceptions,
+     * but returns a cold [Flow] instead. Runs on [Dispatchers.IO] as a whole, since content
+     * provider access is blocking; the per-main exceptions lookup stays a small bounded
+     * synchronous query (exceptions of a single task are not streamed).
      *
      * Note that the exceptions may contain deleted tasks.
      *
      * @param where         selection
      * @param whereArgs     arguments for selection
-     * @param body          callback that is called for each task (including exceptions)
      */
-    fun iterateTaskAndExceptions(where: String?, whereArgs: Array<String>?, body: (TaskAndExceptions) -> Unit) {
+    fun taskAndExceptionsFlow(where: String?, whereArgs: Array<String>?): Flow<TaskAndExceptions> {
         val (mainWhere, mainWhereArgs) = whereWithMainTasksOnly(where, whereArgs)
-        taskList.iterateTasks(mainWhere, mainWhereArgs) { main ->
-            val mainTaskId = main.entityValues.getAsLong(Tasks._ID)
-            body(
-                TaskAndExceptions(
-                    main = main,
-                    exceptions = findExceptions(mainTaskId)
-                )
-            )
-        }
+        return taskList.tasksFlow(mainWhere, mainWhereArgs)
+            .map { main ->
+                val mainTaskId = main.entityValues.getAsLong(Tasks._ID)
+                TaskAndExceptions(main = main, exceptions = findExceptions(mainTaskId))
+            }
+            .flowOn(Dispatchers.IO)
     }
 
     /**

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsRecurringTaskList.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsRecurringTaskList.kt
@@ -95,9 +95,8 @@ class DmfsRecurringTaskList(
         findTaskAndExceptions("${Tasks._ID}=?", arrayOf(mainTaskId.toString()))
 
     /**
-     * Cold [Flow] of main tasks together with their exceptions. Runs on [Dispatchers.IO] as a
-     * whole, since content provider access is blocking; the per-main exceptions lookup stays a
-     * small bounded query (exceptions of a single task are not streamed).
+     * Cold [Flow] of main tasks together with their exceptions; the per-main exceptions lookup
+     * stays a small bounded query (exceptions of a single task are not streamed).
      *
      * Note that the exceptions may contain deleted tasks.
      *
@@ -106,7 +105,8 @@ class DmfsRecurringTaskList(
      */
     fun taskAndExceptionsFlow(where: String?, whereArgs: Array<String>?): Flow<TaskAndExceptions> {
         val (mainWhere, mainWhereArgs) = whereWithMainTasksOnly(where, whereArgs)
-        return taskList.tasksFlow(mainWhere, mainWhereArgs)
+        return taskList
+            .tasksFlow(mainWhere, mainWhereArgs)
             .map { main ->
                 val mainTaskId = main.entityValues.getAsLong(Tasks._ID)
                 TaskAndExceptions(main = main, exceptions = findExceptions(mainTaskId))

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsRecurringTaskList.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsRecurringTaskList.kt
@@ -13,10 +13,8 @@ import androidx.core.content.contentValuesOf
 import at.bitfire.synctools.storage.BatchOperation.CpoBuilder
 import at.bitfire.synctools.storage.LocalStorageException
 import at.bitfire.synctools.storage.containsNotNull
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
 import org.dmfs.tasks.contract.TaskContract
@@ -111,7 +109,6 @@ class DmfsRecurringTaskList(
                 val mainTaskId = main.entityValues.getAsLong(Tasks._ID)
                 TaskAndExceptions(main = main, exceptions = findExceptions(mainTaskId))
             }
-            .flowOn(Dispatchers.IO)
     }
 
     /**

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsRecurringTaskList.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsRecurringTaskList.kt
@@ -82,7 +82,7 @@ class DmfsRecurringTaskList(
      * @param whereArgs     arguments for selection
      */
     suspend fun findTaskAndExceptions(where: String?, whereArgs: Array<String>?): TaskAndExceptions? =
-        taskAndExceptionsFlow(where, whereArgs).firstOrNull()
+        queryTasksAndExceptions(where, whereArgs).firstOrNull()
 
     /**
      * Retrieves a main task and its exceptions from the content provider.
@@ -103,10 +103,10 @@ class DmfsRecurringTaskList(
      * @param where         selection
      * @param whereArgs     arguments for selection
      */
-    fun taskAndExceptionsFlow(where: String?, whereArgs: Array<String>?): Flow<TaskAndExceptions> {
+    fun queryTasksAndExceptions(where: String?, whereArgs: Array<String>?): Flow<TaskAndExceptions> {
         val (mainWhere, mainWhereArgs) = whereWithMainTasksOnly(where, whereArgs)
         return taskList
-            .tasksFlow(mainWhere, mainWhereArgs)
+            .queryTasks(mainWhere, mainWhereArgs)
             .map { main ->
                 val mainTaskId = main.entityValues.getAsLong(Tasks._ID)
                 TaskAndExceptions(main = main, exceptions = findExceptions(mainTaskId))
@@ -360,7 +360,7 @@ class DmfsRecurringTaskList(
      * @return List of exception entities linked to the main task
      */
     private suspend fun findExceptions(mainTaskId: Long): List<Entity> =
-        taskList.tasksFlow("${Tasks.ORIGINAL_INSTANCE_ID}=?", arrayOf(mainTaskId.toString())).toList()
+        taskList.queryTasks("${Tasks.ORIGINAL_INSTANCE_ID}=?", arrayOf(mainTaskId.toString())).toList()
 
     private fun whereWithMainTasksOnly(where: String?, whereArgs: Array<String>?): Pair<String, Array<String>> {
         val protectedWhere = "(${where ?: "1"}) AND ${Tasks.ORIGINAL_INSTANCE_ID} IS NULL"

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
@@ -243,7 +243,12 @@ class DmfsTaskList(
      *
      * @throws LocalStorageException when the content provider returns an error
      */
-    fun getTaskRow(id: Long, projection: Array<String>? = null, where: String? = null, whereArgs: Array<String>? = null): ContentValues? {
+    fun getTaskRow(
+        id: Long,
+        projection: Array<String>? = null,
+        where: String? = null,
+        whereArgs: Array<String>? = null
+    ): ContentValues? {
         try {
             client.query(taskUri(id), projection, where, whereArgs, null)?.use { cursor ->
                 if (cursor.moveToNext())
@@ -265,7 +270,12 @@ class DmfsTaskList(
      *
      * @throws LocalStorageException when the content provider returns an error
      */
-    fun iterateTaskRows(projection: Array<String>?, where: String?, whereArgs: Array<String>?, body: (ContentValues) -> Unit) {
+    fun iterateTaskRows(
+        projection: Array<String>?,
+        where: String?,
+        whereArgs: Array<String>?,
+        body: (ContentValues) -> Unit
+    ) {
         try {
             val (protectedWhere, protectedWhereArgs) = whereWithTaskListId(where, whereArgs)
             client.query(tasksUri(), projection, protectedWhere, protectedWhereArgs, null)?.use { cursor ->
@@ -280,15 +290,15 @@ class DmfsTaskList(
     }
 
     /**
-     * Cold [Flow] of tasks (with properties) from this task list. Runs on [Dispatchers.IO],
-     * since content provider access is blocking.
+     * Cold [Flow] of tasks (with properties) from this task list.
      *
      * @param where         selection
      * @param whereArgs     arguments for selection
      */
     fun tasksFlow(where: String?, whereArgs: Array<String>?): Flow<Entity> {
         val (protectedWhere, protectedWhereArgs) = whereWithTaskListId(where, whereArgs)
-        return client.queryFlow(tasksUri(), null, protectedWhere, protectedWhereArgs) { it.toContentValues() }
+        return client
+            .queryFlow(tasksUri(), null, protectedWhere, protectedWhereArgs) { it.toContentValues() }
             .mapNotNull { row -> row.getAsLong(Tasks._ID)?.let { getTask(it) } }
             .flowOn(Dispatchers.IO)
     }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
@@ -298,7 +298,7 @@ class DmfsTaskList(
     fun queryTasks(where: String?, whereArgs: Array<String>?): Flow<Entity> {
         val (protectedWhere, protectedWhereArgs) = whereWithTaskListId(where, whereArgs)
         return client
-            .queryFlow(tasksUri(), null, protectedWhere, protectedWhereArgs) { it.toContentValues() }
+            .queryFlow(tasksUri(), null, protectedWhere, protectedWhereArgs)
             .mapNotNull { row -> row.getAsLong(Tasks._ID)?.let { getTask(it) } }
             .flowOn(Dispatchers.IO)
     }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
@@ -16,7 +16,9 @@ import at.bitfire.synctools.storage.queryFlow
 import at.bitfire.synctools.storage.tasks.DmfsTasksContract.asSyncAdapter
 import at.bitfire.synctools.storage.toContentValues
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.mapNotNull
 import org.dmfs.tasks.contract.TaskContract
@@ -303,7 +305,8 @@ class DmfsTaskList(
                 val id = mainRow.getAsLong(Tasks._ID) ?: return@mapNotNull null
                 getTask(id)
             }
-            .flowOn(Dispatchers.IO)
+            .flowOn(Dispatchers.IO)      // buffers by default
+            .buffer(Channel.RENDEZVOUS)  // Entity-s could be big → reduce buffer size to 1
     }
 
     /**

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
@@ -280,29 +280,8 @@ class DmfsTaskList(
     }
 
     /**
-     * Iterates tasks (with properties) from this task list.
-     *
-     * @param where         selection
-     * @param whereArgs     arguments for selection
-     * @param body          callback that is called for each task entity
-     *
-     * @throws LocalStorageException when the content provider returns an error
-     */
-    fun iterateTasks(where: String?, whereArgs: Array<String>?, body: (Entity) -> Unit) {
-        try {
-            iterateTaskRows(null, where, whereArgs) { row ->
-                val id = row.getAsLong(Tasks._ID) ?: return@iterateTaskRows
-                val entity = getTask(id) ?: return@iterateTaskRows
-                body(entity)
-            }
-        } catch (e: RemoteException) {
-            throw LocalStorageException("Couldn't iterate tasks", e)
-        }
-    }
-
-    /**
-     * Like [iterateTasks], but returns a cold [Flow] instead of using a callback.
-     * Runs on [Dispatchers.IO], since content provider access is blocking.
+     * Cold [Flow] of tasks (with properties) from this task list. Runs on [Dispatchers.IO],
+     * since content provider access is blocking.
      *
      * @param where         selection
      * @param whereArgs     arguments for selection

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
@@ -299,7 +299,10 @@ class DmfsTaskList(
         val (protectedWhere, protectedWhereArgs) = whereWithTaskListId(where, whereArgs)
         return client
             .queryFlow(tasksUri(), null, protectedWhere, protectedWhereArgs)
-            .mapNotNull { row -> row.getAsLong(Tasks._ID)?.let { getTask(it) } }
+            .mapNotNull { mainRow ->
+                val id = mainRow.getAsLong(Tasks._ID) ?: return@mapNotNull null
+                getTask(id)
+            }
             .flowOn(Dispatchers.IO)
     }
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
@@ -295,7 +295,7 @@ class DmfsTaskList(
      * @param where         selection
      * @param whereArgs     arguments for selection
      */
-    fun tasksFlow(where: String?, whereArgs: Array<String>?): Flow<Entity> {
+    fun queryTasks(where: String?, whereArgs: Array<String>?): Flow<Entity> {
         val (protectedWhere, protectedWhereArgs) = whereWithTaskListId(where, whereArgs)
         return client
             .queryFlow(tasksUri(), null, protectedWhere, protectedWhereArgs) { it.toContentValues() }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
@@ -12,8 +12,13 @@ import android.os.RemoteException
 import at.bitfire.synctools.storage.BatchOperation
 import at.bitfire.synctools.storage.LocalStorageException
 import at.bitfire.synctools.storage.TaskProvider
+import at.bitfire.synctools.storage.queryFlow
 import at.bitfire.synctools.storage.tasks.DmfsTasksContract.asSyncAdapter
 import at.bitfire.synctools.storage.toContentValues
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.mapNotNull
 import org.dmfs.tasks.contract.TaskContract
 import org.dmfs.tasks.contract.TaskContract.Tasks
 import org.jetbrains.annotations.TestOnly
@@ -293,6 +298,20 @@ class DmfsTaskList(
         } catch (e: RemoteException) {
             throw LocalStorageException("Couldn't iterate tasks", e)
         }
+    }
+
+    /**
+     * Like [iterateTasks], but returns a cold [Flow] instead of using a callback.
+     * Runs on [Dispatchers.IO], since content provider access is blocking.
+     *
+     * @param where         selection
+     * @param whereArgs     arguments for selection
+     */
+    fun tasksFlow(where: String?, whereArgs: Array<String>?): Flow<Entity> {
+        val (protectedWhere, protectedWhereArgs) = whereWithTaskListId(where, whereArgs)
+        return client.queryFlow(tasksUri(), null, protectedWhere, protectedWhereArgs) { it.toContentValues() }
+            .mapNotNull { row -> row.getAsLong(Tasks._ID)?.let { getTask(it) } }
+            .flowOn(Dispatchers.IO)
     }
 
     /**


### PR DESCRIPTION
### Purpose

Finishes migrating `synctools` storage access from callback-based `iterate...(where, whereArgs) { row -> ... }` methods to cold-`Flow`-based `query...(): Flow<T>` methods, and cleans up single-row lookups along the way.

### Short description

- **New synctools extension methods: `queryFlow`/`queryEntityFlow` always emit `ContentValues`/`Entity` directly** as Flow (a simple `flow {}`, no `channelFlow` needed anymore); callers map further with `.map { }` if needed.
- Replaced callback-based iteration (`iterate...`) with `Flow`-returning `query...` methods across contacts, calendars, tasks, and jtx storage; many call sites became `suspend fun`.
- Added non-suspending single-row lookups (`getRawContactRowOrNull`, `getGroupOrNull`) so `LocalAddressBook.findContactById`/`findContactByUid`/`findGroupById` no longer need to be `suspend`, removing `runBlocking {}` from their test callers.
- Removed now-dead code (`iterateRawContactRows`, `iterateGroups`, deprecated `AndroidAddressBook.queryContacts`).

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
