### PR TITLE
[Ktor] Remove duplicate OkHttp logging and compression interceptors

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -146,7 +146,6 @@ dependencies {
     implementation(libs.ktor.serialization.kotlinx.json)
     implementation(libs.mikepenz.aboutLibraries.m3)
     implementation(libs.okhttp.base)
-    implementation(libs.okhttp.logging)
     implementation(libs.openid.appauth)
     implementation(libs.unifiedpush) {
         // UnifiedPush connector seems to be using a workaround by importing this library.

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -146,7 +146,6 @@ dependencies {
     implementation(libs.ktor.serialization.kotlinx.json)
     implementation(libs.mikepenz.aboutLibraries.m3)
     implementation(libs.okhttp.base)
-    implementation(libs.okhttp.brotli)
     implementation(libs.okhttp.logging)
     implementation(libs.openid.appauth)
     implementation(libs.unifiedpush) {

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
@@ -34,8 +34,6 @@ import okhttp3.ConnectionSpec
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
-import okhttp3.brotli.BrotliInterceptor
-import okhttp3.logging.HttpLoggingInterceptor
 import java.net.InetSocketAddress
 import java.net.Proxy
 import java.util.Locale
@@ -43,7 +41,6 @@ import java.util.concurrent.TimeUnit
 import java.util.logging.Level
 import java.util.logging.Logger
 import javax.inject.Inject
-import com.google.common.net.HttpHeaders as OkHttpHeaders
 
 /**
  * Builder for the HTTP client.
@@ -193,14 +190,8 @@ class HttpClientBuilder @Inject constructor(
     // okhttp configuration (internal: applied to the OkHttp engine of the Ktor client)
 
     private fun configureOkHttp(builder: OkHttpClient.Builder) {
-        // don't allow redirects by default because it would break PROPFIND handling
-        builder.followRedirects(followRedirects)
-
         // add User-Agent to every request
         builder.addInterceptor(userAgentInterceptor)
-
-        // offer Brotli and gzip compression (can be disabled per request with `Accept-Encoding: identity`)
-        builder.addInterceptor(BrotliInterceptor)
 
         // app-wide custom proxy support
         buildProxy(builder)
@@ -208,17 +199,6 @@ class HttpClientBuilder @Inject constructor(
         // add connection security (including client certificates) and authentication
         buildConnectionSecurity(builder)
         buildAuthentication(builder)
-
-        // add network logging, if requested
-        if (logger.isLoggable(Level.FINEST)) {
-            val loggingInterceptor = HttpLoggingInterceptor { message -> logger.finest(message) }
-            loggingInterceptor.redactHeader(OkHttpHeaders.AUTHORIZATION)
-            loggingInterceptor.redactHeader(OkHttpHeaders.COOKIE)
-            loggingInterceptor.redactHeader(OkHttpHeaders.SET_COOKIE)
-            loggingInterceptor.redactHeader(OkHttpHeaders.SET_COOKIE2)
-            loggingInterceptor.level = HttpLoggingInterceptor.Level.BODY
-            builder.addNetworkInterceptor(loggingInterceptor)
-        }
     }
 
     private fun buildAuthentication(okBuilder: OkHttpClient.Builder) {
@@ -348,13 +328,15 @@ class HttpClientBuilder @Inject constructor(
                     }
                     level = loggerInterceptorLevel
                     sanitizeHeader { header ->
-                        header.equals(HttpHeaders.Authorization, ignoreCase = true) ||
-                                header.equals(HttpHeaders.Cookie, ignoreCase = true) ||
-                                header.equals(HttpHeaders.SetCookie, ignoreCase = true) ||
-                                header.equals(
-                                    "Set-Cookie2",
-                                    ignoreCase = true
-                                ) // Obsoleted, but included here for good measure
+                        val ignoreHeaders = arrayOf(
+                            HttpHeaders.Authorization,
+                            HttpHeaders.Cookie,
+                            HttpHeaders.SetCookie,
+                            "Set-Cookie2"       // obsoleted, but included here for good measure
+                        )
+                        ignoreHeaders.any {
+                            header.equals(it, ignoreCase = true)
+                        }
                     }
                 }
             }

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
@@ -327,15 +327,17 @@ class HttpClientBuilder @Inject constructor(
                         }
                     }
                     level = loggerInterceptorLevel
+
+                    // don't log some confidential headers
+                    val headersToIgnore = arrayOf(
+                        HttpHeaders.Authorization,
+                        HttpHeaders.Cookie,
+                        HttpHeaders.SetCookie,
+                        "Set-Cookie2"       // obsoleted, but included here for good measure
+                    )
                     sanitizeHeader { header ->
-                        val ignoreHeaders = arrayOf(
-                            HttpHeaders.Authorization,
-                            HttpHeaders.Cookie,
-                            HttpHeaders.SetCookie,
-                            "Set-Cookie2"       // obsoleted, but included here for good measure
-                        )
-                        ignoreHeaders.any {
-                            header.equals(it, ignoreCase = true)
+                        headersToIgnore.any { headerToIgnore ->
+                            header.equals(headerToIgnore, ignoreCase = true)
                         }
                     }
                 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -122,7 +122,6 @@ mikepenz-aboutLibraries-m3 = { module = "com.mikepenz:aboutlibraries-compose-m3"
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockk" }
 okhttp-base = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
-okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
 openid-appauth = { module = "net.openid:appauth", version.ref = "openid-appauth" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -122,7 +122,6 @@ mikepenz-aboutLibraries-m3 = { module = "com.mikepenz:aboutlibraries-compose-m3"
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockk" }
 okhttp-base = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
-okhttp-brotli = { module = "com.squareup.okhttp3:okhttp-brotli", version.ref = "okhttp" }
 okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
 openid-appauth = { module = "net.openid:appauth", version.ref = "openid-appauth" }


### PR DESCRIPTION
Currently, logging and compression is applied two times: one time over Ktor and one time over okhtttp.

This PR removes OkHttp Brotli and logging interceptors and replaces them with Ktor logging.

### Short description

- Removed OkHttp Brotli and logging interceptors
- Implemented Ktor logging
- Configure `followRedirects` only over Ktor

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.