### PR TITLE
Add `HttpUrl.toKtorUrl()` helper for tests

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/MockWebServerUtils.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/MockWebServerUtils.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid
+
+import io.ktor.http.Url
+import okhttp3.HttpUrl
+
+/**
+ * Converts an okhttp [HttpUrl] to a Ktor [Url].
+ */
+fun HttpUrl.toKtorUrl() = Url(toString())

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/webdav/WebDavUrlCheckerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/webdav/WebDavUrlCheckerTest.kt
@@ -4,7 +4,7 @@
 
 package at.bitfire.davdroid.webdav
 
-import at.bitfire.dav4jvm.HttpUtils.toKtorUrl
+import at.bitfire.davdroid.toKtorUrl
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import junit.framework.TestCase.assertEquals

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/webdav/operation/MoveDocumentOperationTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/webdav/operation/MoveDocumentOperationTest.kt
@@ -5,12 +5,12 @@
 package at.bitfire.davdroid.webdav.operation
 
 import android.security.NetworkSecurityPolicy
-import at.bitfire.dav4jvm.HttpUtils.toKtorUrl
 import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.WebDavDocument
 import at.bitfire.davdroid.db.WebDavDocumentDao
 import at.bitfire.davdroid.db.WebDavMount
 import at.bitfire.davdroid.db.WebDavMountDao
+import at.bitfire.davdroid.toKtorUrl
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.runBlocking

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/webdav/operation/QueryChildDocumentsOperationTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/webdav/operation/QueryChildDocumentsOperationTest.kt
@@ -6,10 +6,10 @@ package at.bitfire.davdroid.webdav.operation
 
 import android.content.Context
 import android.security.NetworkSecurityPolicy
-import at.bitfire.dav4jvm.HttpUtils.toKtorUrl
 import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.WebDavDocument
 import at.bitfire.davdroid.db.WebDavMount
+import at.bitfire.davdroid.toKtorUrl
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest

--- a/core/src/main/kotlin/at/bitfire/davdroid/servicedetection/CollectionsWithoutHomeSetRefresher.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/servicedetection/CollectionsWithoutHomeSetRefresher.kt
@@ -4,7 +4,6 @@
 
 package at.bitfire.davdroid.servicedetection
 
-import at.bitfire.dav4jvm.HttpUtils.toKtorUrl
 import at.bitfire.dav4jvm.ktor.DavResource
 import at.bitfire.dav4jvm.ktor.exception.HttpException
 import at.bitfire.dav4jvm.ktor.resolve


### PR DESCRIPTION
Stop depending on dav4jvm's `HttpUtils.toKtorUrl()`. Instead, add a `HttpUrl.toKtorUrl()` helper for tests that are using `MockWebServer`.
