### PR TITLE
Fix java.util.Logger parameter formatting in synctools

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/HiltTestRunner.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/HiltTestRunner.kt
@@ -27,8 +27,7 @@ class HiltTestRunner : AndroidJUnitRunner() {
         // set root logger to adb Logcat
         val rootLogger = Logger.getLogger("")
         rootLogger.level = Level.ALL
-        rootLogger.handlers.forEach { rootLogger.removeHandler(it) }
-        rootLogger.addHandler(LogcatHandler(javaClass.name))
+        rootLogger.addHandler(LogcatHandler())
 
         // MockK requirements
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P)

--- a/core/src/main/kotlin/at/bitfire/davdroid/log/FileLoggerFactory.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/log/FileLoggerFactory.kt
@@ -39,7 +39,7 @@ object FileLoggerFactory {
     @MustBeClosed
     fun forFile(file: File): FileLoggerContext {
         val fileHandler = FileHandler(file.absolutePath, 1_000_000, 1, false).apply {
-            formatter = PlainTextFormatter.DEFAULT
+            formatter = PlainTextFormatter.FOR_FILE
         }
         val logger = Logger.getAnonymousLogger().apply {
             level = Level.ALL

--- a/core/src/main/kotlin/at/bitfire/davdroid/log/LogFileHandler.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/log/LogFileHandler.kt
@@ -36,27 +36,29 @@ import javax.inject.Inject
 class LogFileHandler @Inject constructor(
     @ApplicationContext val context: Context,
     private val debugDirectory: DebugDirectory,
-    private val logger: Logger,
+    logger: Logger,
     private val notificationRegistry: NotificationRegistry
 ): Handler(), Closeable {
 
-    companion object {
-        val LOG_FILE_NAME = DebugDirectory.FileName("davx5-log.txt")
-    }
-
+    /**
+     * file handler we're delegating actual file access to
+     */
     private var fileHandler: FileHandler? = null
     private val notificationManager = NotificationManagerCompat.from(context)
 
     private val logFile = debugDirectory.resolve(LOG_FILE_NAME)
 
     init {
+        // use PlainTextFormatter by default
+        formatter = PlainTextFormatter.FOR_FILE
+
         if (logFile != null) {
             if (logFile.createNewFile())
                 logFile.writeText("Log file created at ${Date()}; PID ${Process.myPid()}; UID ${Process.myUid()}\n")
 
             // actual logging is handled by a FileHandler
-            fileHandler = FileHandler(logFile.toString(), true).apply {
-                formatter = PlainTextFormatter.DEFAULT
+            fileHandler = FileHandler(logFile.toString(), true).also { fh ->
+                fh.formatter = formatter
             }
 
             showNotification()
@@ -142,6 +144,10 @@ class LogFileHandler @Inject constructor(
 
     private fun removeNotification() {
         notificationManager.cancel(NotificationRegistry.NOTIFY_VERBOSE_LOGGING)
+    }
+
+    companion object {
+        val LOG_FILE_NAME = DebugDirectory.FileName("davx5-log.txt")
     }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/log/LogManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/log/LogManager.kt
@@ -87,7 +87,7 @@ class LogManager @Inject constructor(
             Level.ALL       // include everything (including HTTP interceptor logs) in verbose logs
         else
             Level.FINE      // include detailed information like content provider operations in non-verbose logs
-        rootLogger.addHandler(LogcatHandler(context.packageName))
+        rootLogger.addHandler(LogcatHandler())
 
         // log to file, if requested
         if (logToFile)

--- a/synctools/build.gradle.kts
+++ b/synctools/build.gradle.kts
@@ -133,6 +133,9 @@ dependencies {
 }
 
 tasks.withType<Test>().configureEach {
+    // activate verbose logging for tests
+    systemProperty("java.util.logging.config.file", "$projectDir/src/test/resources/logging.properties")
+
     options {
         // Prevent Robolectric from instrumenting ical4j classes to avoid problems with registering
         // ical4j's ZoneRulesProviderImpl more than once with Java's ZoneRulesProvider.

--- a/synctools/src/androidTest/assets/logging.properties
+++ b/synctools/src/androidTest/assets/logging.properties
@@ -1,6 +1,5 @@
-# log unit test output to stderr
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=ALL
+# log instrumented test output to logcat
+handlers=at.bitfire.synctools.log.LogcatHandler
 .level=ALL
 # reduce verbose of some otherwise annoying ical4j messages
 net.fortuna.ical4j.data.level=INFO

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/LoggingTestRunner.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/LoggingTestRunner.kt
@@ -26,7 +26,7 @@ class LoggingTestRunner: AndroidJUnitRunner() {
         rootLogger.level = Level.ALL
 
         // log to logcat
-        rootLogger.addHandler(LogcatHandler(BuildConfig.LIBRARY_PACKAGE_NAME))
+        rootLogger.addHandler(LogcatHandler())
     }
 
 }

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/LoggingTestRunner.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/LoggingTestRunner.kt
@@ -6,9 +6,7 @@ package at.bitfire.synctools
 
 import android.os.Bundle
 import androidx.test.runner.AndroidJUnitRunner
-import at.bitfire.synctools.log.LogcatHandler
-import java.util.logging.Level
-import java.util.logging.Logger
+import java.util.logging.LogManager
 
 /**
  * Custom test runner that enables verbose logging to Android logcat during tests.
@@ -19,14 +17,11 @@ class LoggingTestRunner: AndroidJUnitRunner() {
     override fun onCreate(arguments: Bundle?) {
         super.onCreate(arguments)
 
-        // enable verbose logging during tests
-        val rootLogger = Logger.getLogger("")
-
-        // verbose logging
-        rootLogger.level = Level.ALL
-
-        // log to logcat
-        rootLogger.addHandler(LogcatHandler())
+        // reset existing loggers and initialize from assets/logging.properties
+        context.assets.open("logging.properties").use {
+            val javaLogManager = LogManager.getLogManager()
+            javaLogManager.readConfiguration(it)
+        }
     }
 
 }

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/LoggingTestRunner.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/LoggingTestRunner.kt
@@ -10,6 +10,10 @@ import at.bitfire.synctools.log.LogcatHandler
 import java.util.logging.Level
 import java.util.logging.Logger
 
+/**
+ * Custom test runner that enables verbose logging to Android logcat during tests.
+ */
+@Suppress("unused")
 class LoggingTestRunner: AndroidJUnitRunner() {
 
     override fun onCreate(arguments: Bundle?) {
@@ -17,8 +21,11 @@ class LoggingTestRunner: AndroidJUnitRunner() {
 
         // enable verbose logging during tests
         val rootLogger = Logger.getLogger("")
+
+        // verbose logging
         rootLogger.level = Level.ALL
-        rootLogger.handlers.forEach { rootLogger.removeHandler(it) }
+
+        // log to logcat
         rootLogger.addHandler(LogcatHandler(BuildConfig.LIBRARY_PACKAGE_NAME))
     }
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/DatePropertyTzMapper.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/DatePropertyTzMapper.kt
@@ -136,15 +136,14 @@ object DatePropertyTzMapper {
             val origDateInstant = origDate.toInstant()
             val resultInstant = result.toInstant()
             if (origDateInstant != resultInstant)
-                logger.log(Level.WARNING, "Different timestamps of normalized $result (${resultInstant.toEpochMilli()}) " +
-                        "and original $origDate (${origDateInstant.toEpochMilli()}) ZonedDateTime")
+                logger.warning("Different timestamps of normalized $result (${resultInstant.toEpochMilli()}) and original $origDate (${origDateInstant.toEpochMilli()}) ZonedDateTime")
 
             return result
 
         } else {
             // Timezone ID unknown or timezone not known by system, fall back to same timestamp, but
             // with system default timezone.
-            logger.log(Level.WARNING, "ZonedDateTime ($origDate) with unknown timezone ($tzId), using calculated timestamp in system default timezone")
+            logger.warning("ZonedDateTime ($origDate) with unknown timezone ($tzId), using calculated timestamp in system default timezone")
             return origDate.withZoneSameInstant(ZoneId.systemDefault())
         }
     }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/validation/FixInvalidUtcOffsetPreprocessor.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/validation/FixInvalidUtcOffsetPreprocessor.kt
@@ -5,7 +5,6 @@
 package at.bitfire.synctools.icalendar.validation
 
 import androidx.annotation.VisibleForTesting
-import java.util.logging.Level
 import java.util.logging.Logger
 
 
@@ -26,7 +25,7 @@ class FixInvalidUtcOffsetPreprocessor: StreamPreprocessor {
 
     override fun repairLine(line: String) =
         line.replace(regexpForProblem) {
-            logger.log(Level.FINE, "Applying Synology WebDAV fix to invalid utc-offset", it.value)
+            logger.fine("Applying Synology WebDAV fix to invalid utc-offset: ${it.value}")
             "${it.groupValues[1]}00${it.groupValues[3]}"
         }
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/log/ClassNameUtils.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/log/ClassNameUtils.kt
@@ -6,6 +6,20 @@ package at.bitfire.synctools.log
 
 object ClassNameUtils {
 
+    /**
+     * Shortens a fully qualified class name by
+     *
+     * - removing the `at.bitfire` package prefix,
+     * - removing the `$...` suffix for anonymous classes,
+     * - optionally placing the class name first (useful when the shortened class name can still be truncated).
+     *
+     * @param fullClassName The fully qualified class name to shorten.
+     * @param classNameFirst If true, the class name is placed before the package name, separated by a slash.
+     * @return The shortened class name, like
+     *
+     * - `.subpkg.SomeClass` when [classNameFirst] is false
+     * - `SomeClass/.subpkg` when [classNameFirst] is true
+     */
     fun shortenClassName(fullClassName: String, classNameFirst: Boolean): String {
         // remove $... that is appended for anonymous classes
         val withoutSuffix = fullClassName.replace(Regex("\\$.*$"), "")

--- a/synctools/src/main/kotlin/at/bitfire/synctools/log/LogcatHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/log/LogcatHandler.kt
@@ -12,15 +12,14 @@ import java.util.logging.Level
 import java.util.logging.LogRecord
 
 /**
- * Logging handler that logs to Android logcat.
+ * Logging handler that logs to Android logcat ([Log]).
  *
- * Log level mapping: https://source.android.com/docs/core/tests/debug/understanding-logging#log-standards
+ * Maps log level according to [Android docs](https://source.android.com/docs/core/tests/debug/understanding-logging#log-standards).
  *
- * @param fallbackTag   adb tag to use if class name can't be determined
+ * Logs source class and exception natively over logcat, so the formatter is configured
+ * to omit those.
  */
-class LogcatHandler(
-    private val fallbackTag: String
-): Handler() {
+class LogcatHandler : Handler() {
 
     init {
         formatter = PlainTextFormatter.LOGCAT
@@ -30,11 +29,11 @@ class LogcatHandler(
         val level = r.level.intValue()
         val text = formatter.format(r)
 
-        // get class name that calls the logger (or fall back to package name)
+        // use class name (or fallbackTag, if not available) as logcat tag
         val tag = if (r.sourceClassName != null)
             ClassNameUtils.shortenClassName(r.sourceClassName, classNameFirst = tagLengthRestricted)
         else
-            fallbackTag
+            FALLBACK_TAG
 
         val tagOrTruncated = if (tagLengthRestricted)
             Ascii.truncate(tag, 23, "")
@@ -64,6 +63,8 @@ class LogcatHandler(
 
 
     companion object {
+
+        private const val FALLBACK_TAG: String = "at.bitfire"
 
         /** log tag has to be truncated to 23 characters on Android <8, see Log documentation */
         val tagLengthRestricted = Build.VERSION.SDK_INT < Build.VERSION_CODES.O

--- a/synctools/src/main/kotlin/at/bitfire/synctools/log/LogcatHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/log/LogcatHandler.kt
@@ -22,26 +22,21 @@ class LogcatHandler(
     private val fallbackTag: String
 ): Handler() {
 
-    val logcatFormatter = PlainTextFormatter.LOGCAT
-
     init {
-        setFormatter(logcatFormatter)
+        formatter = PlainTextFormatter.LOGCAT
     }
 
     override fun publish(r: LogRecord) {
         val level = r.level.intValue()
-        val text = logcatFormatter.format(r)
-
-        // log tag has to be truncated to 23 characters on Android <8, see Log documentation
-        val tagLimited = Build.VERSION.SDK_INT < Build.VERSION_CODES.O
+        val text = formatter.format(r)
 
         // get class name that calls the logger (or fall back to package name)
         val tag = if (r.sourceClassName != null)
-            ClassNameUtils.shortenClassName(r.sourceClassName, classNameFirst = tagLimited)
+            ClassNameUtils.shortenClassName(r.sourceClassName, classNameFirst = tagLengthRestricted)
         else
             fallbackTag
 
-        val tagOrTruncated = if (tagLimited)
+        val tagOrTruncated = if (tagLengthRestricted)
             Ascii.truncate(tag, 23, "")
         else
             tag
@@ -66,5 +61,13 @@ class LogcatHandler(
 
     override fun flush() {}
     override fun close() {}
+
+
+    companion object {
+
+        /** log tag has to be truncated to 23 characters on Android <8, see Log documentation */
+        val tagLengthRestricted = Build.VERSION.SDK_INT < Build.VERSION_CODES.O
+
+    }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/log/LogcatHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/log/LogcatHandler.kt
@@ -22,7 +22,8 @@ import java.util.logging.LogRecord
 class LogcatHandler : Handler() {
 
     init {
-        formatter = PlainTextFormatter.LOGCAT
+        // use PlainTextFormatter by default
+        formatter = PlainTextFormatter.FOR_LOGCAT
     }
 
     override fun publish(r: LogRecord) {

--- a/synctools/src/main/kotlin/at/bitfire/synctools/log/PlainTextFormatter.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/log/PlainTextFormatter.kt
@@ -77,7 +77,12 @@ class PlainTextFormatter(
             if (r.parameters == null)
                 r.message
             else
-                MessageFormat.format(r.message, *r.parameters)
+                try {
+                    MessageFormat.format(r.message, *r.parameters)
+                } catch (_: IllegalArgumentException) {
+                    // fall back to message when it couldn't be parsed
+                    r.message
+                }
         builder.append(truncate(formattedMessage))
 
         if (withException && r.thrown != null) {

--- a/synctools/src/main/kotlin/at/bitfire/synctools/log/PlainTextFormatter.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/log/PlainTextFormatter.kt
@@ -19,9 +19,9 @@ import java.util.logging.LogRecord
 class PlainTextFormatter(
     private val withTime: Boolean,
     private val withSource: Boolean,
-    private val padSource: Int = 0,
     private val withException: Boolean,
-    private val lineSeparator: String?
+    private val padSource: Int = 0,
+    private val lineSeparator: String? = System.lineSeparator()
 ): Formatter() {
 
     companion object {
@@ -30,10 +30,10 @@ class PlainTextFormatter(
          * Formatter intended for logcat output.
          */
         val LOGCAT = PlainTextFormatter(
-            withTime = false,
-            withSource = false,
-            withException = false,
-            lineSeparator = null
+            withTime = false,       // logged by logcat, not needed in text
+            withSource = false,     // source class is used as tag in LogcatHandler, not needed in text
+            withException = false,  // exception is attached natively by LogcatHandler, not needed in text
+            lineSeparator = null    // omit line separators for logcat
         )
 
         /**
@@ -42,9 +42,8 @@ class PlainTextFormatter(
         val DEFAULT = PlainTextFormatter(
             withTime = true,
             withSource = true,
-            padSource = 35,
             withException = true,
-            lineSeparator = System.lineSeparator()
+            padSource = 35
         )
 
         /**
@@ -97,28 +96,6 @@ class PlainTextFormatter(
             builder.append(lineSeparator)
 
         return builder.toString()
-    }
-
-    fun shortClassName(className: String): String {
-        // remove $... that is appended for anonymous classes
-        val withoutSuffix = className.replace(Regex("\\$.*$"), "")
-
-        // shorten all but the last part of the package name
-        val parts = withoutSuffix.split('.')
-        val shortened =
-            if (parts.isNotEmpty()) {
-                val lastIdx = parts.size - 1
-                val shortenedParts = parts.mapIndexed { idx, part ->
-                    if (idx == lastIdx)
-                        part
-                    else
-                        part[0]
-                }
-                shortenedParts.joinToString(".")
-            } else
-                ""
-
-        return shortened
     }
 
     private fun stackTrace(ex: Throwable): String {

--- a/synctools/src/main/kotlin/at/bitfire/synctools/log/PlainTextFormatter.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/log/PlainTextFormatter.kt
@@ -7,6 +7,7 @@ package at.bitfire.synctools.log
 import com.google.common.base.Ascii
 import java.io.PrintWriter
 import java.io.StringWriter
+import java.text.MessageFormat
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -17,30 +18,30 @@ import java.util.logging.LogRecord
  * Logging formatter for logging as formatted plain text.
  */
 class PlainTextFormatter(
-    private val withTime: Boolean,
+    private val withTimeAndThreadId: Boolean,
     private val withSource: Boolean,
     private val withException: Boolean,
     private val padSource: Int = 0,
     private val lineSeparator: String? = System.lineSeparator()
-): Formatter() {
+) : Formatter() {
 
     companion object {
 
         /**
          * Formatter intended for logcat output.
          */
-        val LOGCAT = PlainTextFormatter(
-            withTime = false,       // logged by logcat, not needed in text
-            withSource = false,     // source class is used as tag in LogcatHandler, not needed in text
-            withException = false,  // exception is attached natively by LogcatHandler, not needed in text
-            lineSeparator = null    // omit line separators for logcat
+        val FOR_LOGCAT = PlainTextFormatter(
+            withTimeAndThreadId = false,    // logged by logcat, not needed in text
+            withSource = false,             // source class is used as tag in LogcatHandler, not needed in text
+            withException = false,          // exception is attached natively by LogcatHandler, not needed in text
+            lineSeparator = null            // omit line separators for logcat
         )
 
         /**
-         * Formatter intended for file output.
+         * Formatter intended for custom log file output.
          */
-        val DEFAULT = PlainTextFormatter(
-            withTime = true,
+        val FOR_FILE = PlainTextFormatter(
+            withTimeAndThreadId = true,
             withSource = true,
             withException = true,
             padSource = 35
@@ -59,9 +60,10 @@ class PlainTextFormatter(
     override fun format(r: LogRecord): String {
         val builder = StringBuilder()
 
-        if (withTime)
-            builder .append(timeFormat.format(Date(r.millis)))
-                    .append(" ").append(r.threadID).append(" ")
+        if (withTimeAndThreadId)
+            builder
+                .append(timeFormat.format(Date(r.millis)))
+                .append(" ").append(r.threadID).append(" ")
 
         if (withSource && r.sourceClassName != null) {
             val className = ClassNameUtils.shortenClassName(r.sourceClassName, classNameFirst = false)
@@ -71,7 +73,12 @@ class PlainTextFormatter(
             }
         }
 
-        builder.append(truncate(r.message))
+        val formattedMessage =
+            if (r.parameters == null)
+                r.message
+            else
+                MessageFormat.format(r.message, *r.parameters)
+        builder.append(truncate(formattedMessage))
 
         if (withException && r.thrown != null) {
             val indentedStackTrace = stackTrace(r.thrown)
@@ -80,29 +87,17 @@ class PlainTextFormatter(
             builder.append("\n\tEXCEPTION ").append(indentedStackTrace)
         }
 
-        r.parameters?.let {
-            for ((idx, param) in it.withIndex()) {
-                builder.append("\n\tPARAMETER #").append(idx + 1).append(" = ")
-
-                val valStr = if (param == null)
-                    "(null)"
-                else
-                    truncate(param.toString())
-                builder.append(valStr)
-            }
-        }
-
         if (lineSeparator != null)
             builder.append(lineSeparator)
 
         return builder.toString()
     }
 
-    private fun stackTrace(ex: Throwable): String {
-        val writer = StringWriter()
-        ex.printStackTrace(PrintWriter(writer))
-        return writer.toString()
-    }
+    private fun stackTrace(ex: Throwable): String =
+        StringWriter().run {
+            ex.printStackTrace(PrintWriter(this))
+            toString()
+        }
 
     private fun truncate(s: String) =
         Ascii.truncate(s, MAX_LENGTH, "[…]")

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/OrganizerBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/builder/OrganizerBuilder.kt
@@ -13,7 +13,6 @@ import net.fortuna.ical4j.model.parameter.Email
 import net.fortuna.ical4j.model.property.Attendee
 import net.fortuna.ical4j.model.property.Organizer
 import java.net.URI
-import java.util.logging.Level
 import java.util.logging.Logger
 import kotlin.jvm.optionals.getOrNull
 
@@ -54,7 +53,7 @@ class OrganizerBuilder(
         if (email != null)
             return email
 
-        logger.log(Level.WARNING, "Ignoring ORGANIZER without email address (not supported by Android)", organizer)
+        logger.warning("Ignoring ORGANIZER without email address (not supported by Android): $organizer")
         return null
     }
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/AttendeesHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/AttendeesHandler.kt
@@ -31,7 +31,7 @@ class AttendeesHandler : AndroidEventEntityHandler {
     }
 
     private fun populateAttendee(row: ContentValues, to: VEvent) {
-        logger.log(Level.FINE, "Read event attendee from calendar provider", row)
+        logger.fine("Read event attendee from calendar provider: $row")
 
         try {
             val attendee: Attendee

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/RemindersHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/calendar/handler/RemindersHandler.kt
@@ -18,7 +18,6 @@ import net.fortuna.ical4j.model.property.Summary
 import net.fortuna.ical4j.model.property.immutable.ImmutableAction
 import java.net.URI
 import java.time.Duration
-import java.util.logging.Level
 import java.util.logging.Logger
 
 class RemindersHandler(
@@ -34,7 +33,7 @@ class RemindersHandler(
     }
 
     private fun populateReminder(row: ContentValues, event: Entity, to: VEvent) {
-        logger.log(Level.FINE, "Read event reminder from calendar provider", row)
+        logger.fine("Read event reminder from calendar provider: $row")
 
         val eventTitle = event.entityValues.getAsString(Events.TITLE) ?: "Calendar Event Reminder"
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/ContactReader.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/ContactReader.kt
@@ -104,7 +104,7 @@ class ContactReader internal constructor(val vCard: VCard, val downloader: Conta
             val date: Temporal? = prop.date
 
             if (arrayOf(ChronoField.YEAR, ChronoField.MONTH_OF_YEAR, ChronoField.DAY_OF_MONTH).any { date?.isSupported(it) == false }) {
-                logger.log(Level.WARNING, "checkPartialDate: unsupported DateOrTimeProperty", prop)
+                logger.warning("checkPartialDate: unsupported DateOrTimeProperty $prop")
                 return
             }
 
@@ -242,8 +242,7 @@ class ContactReader internal constructor(val vCard: VCard, val downloader: Conta
                     val relation = Related()
                     relation.text = prop.value
 
-                    val labelStr = findAndRemoveLabel(prop.group)
-                    when (labelStr) {
+                    when (val labelStr = findAndRemoveLabel(prop.group)) {
                         XAbRelatedNames.APPLE_ASSISTANT -> {
                             relation.types.add(CustomType.Related.ASSISTANT)
                             relation.types.add(RelatedType.CO_WORKER)

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/ContactWriter.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/ContactWriter.kt
@@ -365,7 +365,7 @@ class ContactWriter(
             val msgs = LinkedList<String>()
             for ((key, warnings) in validation)
                 msgs += "  * " + key?.javaClass?.simpleName + " - " + warnings?.joinToString(" | ")
-            logger.log(Level.WARNING, "vCard validation warnings", msgs.joinToString(","))
+            logger.warning("vCard validation warnings: ${msgs.joinToString(",")}")
         }
     }
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/RawContactHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/RawContactHandler.kt
@@ -25,7 +25,6 @@ import at.bitfire.synctools.mapping.contacts.handler.UnknownPropertiesHandler
 import at.bitfire.synctools.mapping.contacts.handler.WebsiteHandler
 import at.bitfire.synctools.storage.contacts.AddressContract
 import at.bitfire.synctools.storage.contacts.AndroidContact
-import java.util.logging.Level
 import java.util.logging.Logger
 
 class RawContactHandler(
@@ -81,7 +80,7 @@ class RawContactHandler(
                 handler.handle(values, contact)
         else {
             val logger = Logger.getLogger(javaClass.name)
-            logger.log(Level.WARNING, "No registered handler for $mimeType", values)
+            logger.warning("No registered handler for $mimeType: $values")
         }
     }
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/EventBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/contacts/builder/EventBuilder.kt
@@ -19,7 +19,6 @@ import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.LinkedList
 import java.util.Locale
-import java.util.logging.Level
 
 class EventBuilder(dataRowUri: Uri, rawContactId: Long?, contact: Contact, readOnly: Boolean)
     : DataRowBuilder(Factory.mimeType(), dataRowUri, rawContactId, contact, readOnly) {
@@ -87,7 +86,7 @@ class EventBuilder(dataRowUri: Uri, rawContactId: Long?, contact: Contact, readO
                     null
             }
         if (androidStr == null) {
-            logger.log(Level.WARNING, "Ignoring date/time without supported (partial) date", dateOrTime)
+            logger.warning("Ignoring date/time without supported (partial) date: $dateOrTime")
             return null
         }
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/OrganizerBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/builder/OrganizerBuilder.kt
@@ -10,7 +10,6 @@ import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.parameter.Email
 import net.fortuna.ical4j.model.property.Organizer
 import org.dmfs.tasks.contract.TaskContract.Tasks
-import java.util.logging.Level
 import java.util.logging.Logger
 import kotlin.jvm.optionals.getOrNull
 
@@ -35,7 +34,7 @@ class OrganizerBuilder : DmfsTaskEntityBuilder {
         if (email != null)
             to.entityValues.put(Tasks.ORGANIZER, email)
         else {
-            logger.log(Level.WARNING, "Ignoring ORGANIZER without email address (not supported by Android)", organizer)
+            logger.warning("Ignoring ORGANIZER without email address (not supported by Android): $organizer")
             to.entityValues.putNull(Tasks.ORGANIZER)
         }
     }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/BatchOperation.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/BatchOperation.kt
@@ -79,8 +79,7 @@ open class BatchOperation internal constructor(
             if (logger.isLoggable(Level.FINE))
                 logger.log(
                     Level.FINE, "Committing {0} operation(s): {1}",
-                    queue.size,
-                    queue.mapIndexed { idx, op -> "[$idx] ${op.build()}" }.joinToString(", ")
+                    arrayOf<Any>(queue.size, queue.mapIndexed { idx, op -> "[$idx] ${op.build()}" }.joinToString(", "))
                 )
 
             results = arrayOfNulls(queue.size)

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/BatchOperation.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/BatchOperation.kt
@@ -77,10 +77,11 @@ open class BatchOperation internal constructor(
         var affected = 0
         if (!queue.isEmpty()) {
             if (logger.isLoggable(Level.FINE))
-                logger.log(Level.FINE, "Committing ${queue.size} operation(s)",
-                    queue.mapIndexed { idx, op ->
-                        "[$idx] ${op.build()}"
-                    }.toTypedArray())
+                logger.log(
+                    Level.FINE, "Committing {0} operation(s): {1}",
+                    queue.size,
+                    queue.mapIndexed { idx, op -> "[$idx] ${op.build()}" }.joinToString(", ")
+                )
 
             results = arrayOfNulls(queue.size)
             runBatch(0, queue.size)

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendarProvider.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidCalendarProvider.kt
@@ -21,7 +21,6 @@ import at.bitfire.synctools.storage.calendar.AndroidCalendarProvider.Companion.C
 import at.bitfire.synctools.storage.calendar.EventsContract.asSyncAdapter
 import at.bitfire.synctools.storage.toContentValues
 import java.util.LinkedList
-import java.util.logging.Level
 import java.util.logging.Logger
 
 /**
@@ -49,7 +48,7 @@ class AndroidCalendarProvider(
      * @throws LocalStorageException when the content provider returns nothing or an error
      */
     fun createCalendar(values: ContentValues): Long {
-        logger.log(Level.FINE, "Creating local calendar", values)
+        logger.fine("Creating local calendar with $values")
 
         values.put(Calendars.ACCOUNT_NAME, account.name)
         values.put(Calendars.ACCOUNT_TYPE, account.type)
@@ -155,7 +154,7 @@ class AndroidCalendarProvider(
      * @throws LocalStorageException when the content provider returns an error
      */
     fun updateCalendar(id: Long, values: ContentValues, where: String? = null, whereArgs: Array<String>? = null): Int {
-        logger.log(Level.FINE, "Updating local calendar #$id", values)
+        logger.fine("Updating local calendar #$id with $values")
         try {
             return client.update(calendarUri(id), values, where, whereArgs)
         } catch (e: RemoteException) {

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidRecurringCalendar.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/calendar/AndroidRecurringCalendar.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
-import java.util.logging.Level
 import java.util.logging.Logger
 
 /**
@@ -215,7 +214,7 @@ class AndroidRecurringCalendar(
             // 2. main event not recurring → exceptions are useless, ignore them
 
             if (original.exceptions.isNotEmpty())
-                logger.log(Level.WARNING, "Dropping exceptions of event because event is not recurring or _SYNC_ID is not set", main)
+                logger.warning("Dropping exceptions of event because event is not recurring or _SYNC_ID is not set: $main")
 
             return EventAndExceptions(main = main, exceptions = emptyList())
         }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
@@ -371,7 +371,7 @@ class AndroidAddressBook(
 
     suspend fun deleteGroupsWithoutMembers() {
         queryGroups(null, null).filter { it.getMembers().isEmpty() }.collect { group ->
-            logger.log(Level.FINE, "Deleting empty group", group)
+            logger.fine("Deleting empty group $group")
             group.delete()
         }
     }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollectionProvider.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollectionProvider.kt
@@ -15,7 +15,6 @@ import at.bitfire.synctools.storage.toContentValues
 import at.techbee.jtx.JtxContract
 import at.techbee.jtx.JtxContract.asSyncAdapter
 import java.util.LinkedList
-import java.util.logging.Level
 import java.util.logging.Logger
 
 /**
@@ -43,7 +42,7 @@ class JtxCollectionProvider(
      * @throws LocalStorageException when the content provider returns nothing or an error
      */
     fun createCollection(values: ContentValues): Long {
-        logger.log(Level.FINE, "Creating jtx collection", values)
+        logger.fine("Creating jtx collection with $values")
 
         values.put(JtxContract.JtxCollection.ACCOUNT_NAME, account.name)
         values.put(JtxContract.JtxCollection.ACCOUNT_TYPE, account.type)
@@ -142,7 +141,7 @@ class JtxCollectionProvider(
      * @throws LocalStorageException when the content provider returns an error
      */
     fun updateCollection(id: Long, values: ContentValues): Int {
-        logger.log(Level.FINE, "Updating jtx collection #$id", values)
+        logger.fine("Updating jtx collection #$id with $values")
         try {
             return client.update(collectionUri(id), values, null, null)
         } catch (e: RemoteException) {

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxRecurringCollection.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxRecurringCollection.kt
@@ -15,7 +15,6 @@ import at.techbee.jtx.JtxContract
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
-import java.util.logging.Level
 import java.util.logging.Logger
 
 /**
@@ -237,7 +236,7 @@ class JtxRecurringCollection(
             // without a UID, exceptions cannot be associated to the main object in the jtx provider
             // and without recurrence fields, exceptions are meaningless
             if (original.exceptions.isNotEmpty())
-                logger.log(Level.WARNING, "Dropping exceptions of jtx object because it is not recurring or UID is not set", main)
+                logger.warning("Dropping exceptions of jtx object because it is not recurring or UID is not set: $main")
 
             return JtxEntityAndExceptions(main = main, exceptions = emptyList())
         }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsRecurringTaskList.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsRecurringTaskList.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
 import org.dmfs.tasks.contract.TaskContract
 import org.dmfs.tasks.contract.TaskContract.Tasks
-import java.util.logging.Level
 import java.util.logging.Logger
 
 /**
@@ -188,7 +187,7 @@ class DmfsRecurringTaskList(
 
         if (!recurring) {
             if (original.exceptions.isNotEmpty())
-                logger.log(Level.WARNING, "Dropping exceptions of task because task is not recurring", main)
+                logger.warning("Dropping exceptions of task because task is not recurring: $main")
             return TaskAndExceptions(main = main, exceptions = emptyList())
         }
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListProvider.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListProvider.kt
@@ -15,7 +15,6 @@ import at.bitfire.synctools.storage.tasks.DmfsTasksContract.asSyncAdapter
 import at.bitfire.synctools.storage.toContentValues
 import org.dmfs.tasks.contract.TaskContract
 import java.util.LinkedList
-import java.util.logging.Level
 import java.util.logging.Logger
 
 /**
@@ -38,7 +37,7 @@ class DmfsTaskListProvider(
     // DmfsTaskList CRUD
 
     fun createTaskList(values: ContentValues): Long {
-        logger.log(Level.FINE, "Creating ${providerName.authority} local task list", values)
+        logger.fine("Creating ${providerName.authority} local task list with $values")
 
         values.put(TaskContract.ACCOUNT_NAME, account.name)
         values.put(TaskContract.ACCOUNT_TYPE, account.type)
@@ -145,7 +144,7 @@ class DmfsTaskListProvider(
         }
 
     fun updateTaskList(id: Long, info: ContentValues): Int {
-        logger.log(Level.FINE, "Updating ${providerName.authority} task list (#$id)", info)
+        logger.fine("Updating ${providerName.authority} task list (#$id) with $info")
         try {
             return client.update(taskListUri(id), info, null, null)
         } catch (e: RemoteException) {
@@ -159,7 +158,7 @@ class DmfsTaskListProvider(
      * @return `true` if the task list was deleted, `false` otherwise (like it was not there before the call)
      */
     fun deleteTaskList(id: Long): Boolean {
-        logger.log(Level.FINE, "Deleting ${providerName.authority} task list (#$id)")
+        logger.fine("Deleting ${providerName.authority} task list (#$id)")
         try {
             return client.delete(taskListUri(id), null, null) > 0
         } catch (e: RemoteException) {

--- a/synctools/src/main/kotlin/at/bitfire/synctools/util/AlarmTriggerCalculator.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/util/AlarmTriggerCalculator.kt
@@ -17,7 +17,6 @@ import net.fortuna.ical4j.model.property.Trigger
 import java.time.Duration
 import java.time.Instant
 import java.time.temporal.TemporalAmount
-import java.util.logging.Level
 import java.util.logging.Logger
 import kotlin.jvm.optionals.getOrNull
 
@@ -69,8 +68,7 @@ object AlarmTriggerCalculator {
                 refStart
             )
         } else {
-            logger.log(Level.WARNING, "VALARM TRIGGER type is not DURATION or DATE-TIME " +
-                    "(requires event DTSTART for Android), ignoring alarm", alarm)
+            logger.warning("VALARM TRIGGER type is not DURATION or DATE-TIME (requires event DTSTART for Android), ignoring alarm: $alarm")
             null
         }
     }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/log/PlainTextFormatterTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/log/PlainTextFormatterTest.kt
@@ -20,7 +20,15 @@ class PlainTextFormatterTest {
     )
 
     @Test
-    fun test_format_param_null() {
+    fun `format with invalid message formatting`() {
+        val result = minimum.format(LogRecord(Level.INFO, "Message {!}").apply {
+            parameters = arrayOf(null)
+        })
+        assertEquals("Message {!}", result)
+    }
+
+    @Test
+    fun `format with null parameter`() {
         val result = minimum.format(LogRecord(Level.INFO, "Message {0}").apply {
             parameters = arrayOf(null)
         })
@@ -28,7 +36,7 @@ class PlainTextFormatterTest {
     }
 
     @Test
-    fun test_format_param_object() {
+    fun `format with Object parameter`() {
         val result = minimum.format(LogRecord(Level.INFO, "Message {0}").apply {
             parameters = arrayOf(object {
                 override fun toString() = "SomeObject[]"
@@ -38,7 +46,7 @@ class PlainTextFormatterTest {
     }
 
     @Test
-    fun test_format_truncatesMessage() {
+    fun `format truncates long line`() {
         val result = minimum.format(LogRecord(Level.INFO, "a".repeat(50000)))
         // PlainTextFormatter.MAX_LENGTH is 10,000
         assertEquals(10000, result.length)

--- a/synctools/src/test/kotlin/at/bitfire/synctools/log/PlainTextFormatterTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/log/PlainTextFormatterTest.kt
@@ -21,20 +21,20 @@ class PlainTextFormatterTest {
 
     @Test
     fun test_format_param_null() {
-        val result = minimum.format(LogRecord(Level.INFO, "Message").apply {
+        val result = minimum.format(LogRecord(Level.INFO, "Message {0}").apply {
             parameters = arrayOf(null)
         })
-        assertEquals("Message\n\tPARAMETER #1 = (null)", result)
+        assertEquals("Message null", result)
     }
 
     @Test
     fun test_format_param_object() {
-        val result = minimum.format(LogRecord(Level.INFO, "Message").apply {
+        val result = minimum.format(LogRecord(Level.INFO, "Message {0}").apply {
             parameters = arrayOf(object {
                 override fun toString() = "SomeObject[]"
             })
         })
-        assertEquals("Message\n\tPARAMETER #1 = SomeObject[]", result)
+        assertEquals("Message SomeObject[]", result)
     }
 
     @Test

--- a/synctools/src/test/kotlin/at/bitfire/synctools/log/PlainTextFormatterTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/log/PlainTextFormatterTest.kt
@@ -44,20 +44,4 @@ class PlainTextFormatterTest {
         assertEquals(10000, result.length)
     }
 
-
-    @Test
-    fun test_shortClassName_Empty() {
-        assertEquals("", PlainTextFormatter.DEFAULT.shortClassName(""))
-    }
-
-    @Test
-    fun test_shortClassName_NoDot_Anonymous() {
-        assertEquals("NoDot", PlainTextFormatter.DEFAULT.shortClassName("NoDot\$Anonymous"))
-    }
-
-    @Test
-    fun test_shortClassName_MultipleParts() {
-        assertEquals("a.b.s.l.PlainTextFormatterTest", PlainTextFormatter.DEFAULT.shortClassName(javaClass.name))
-    }
-
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/log/PlainTextFormatterTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/log/PlainTextFormatterTest.kt
@@ -12,7 +12,7 @@ import java.util.logging.LogRecord
 class PlainTextFormatterTest {
 
     private val minimum = PlainTextFormatter(
-        withTime = false,
+        withTimeAndThreadId = false,
         withSource = false,
         padSource = 0,
         withException = false,

--- a/synctools/src/test/resources/logging.properties
+++ b/synctools/src/test/resources/logging.properties
@@ -1,0 +1,3 @@
+handlers=java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.level=ALL
+.level=ALL


### PR DESCRIPTION
### Purpose
Fix java.util.Logger calls in synctools that pass non-Throwable parameters without proper formatting.

### Short description
- Fix logger.log() calls that took non-Throwable parameters without MessageFormat placeholders
- Convert to convenience methods (logger.fine(), logger.warning() etc.) where appropriate
- Restore complete object logging instead of extracting single fields
- Use MessageFormat for complex expressions

### Checklist
- [x] The PR has a proper title, description and label.
- [x] I have self-reviewed the PR.
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.