### PR TITLE
Make HttpClientBuilder immutable

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -137,7 +137,6 @@ dependencies {
     // third-party libs
     implementation(libs.conscrypt)
     implementation(libs.dnsjava)
-    implementation(libs.error.prone.annotations)
     implementation(libs.guava)
     implementation(libs.ktor.client.auth)
     implementation(libs.ktor.client.content.negotiation)

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -154,6 +154,7 @@ dependencies {
         // See: https://codeberg.org/UnifiedPush/android-connector/src/commit/28cb0d622ed0a972996041ab9cc85b701abc48c6/connector/build.gradle#L56-L59
         exclude(group = "com.google.crypto.tink", module = "tink")
     }
+    implementation(libs.spotbugs.annotations)
     implementation(libs.unifiedpush.fcm)
 
     // force some versions for compatibility with our minSdk level (see version catalog for details)

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -137,6 +137,7 @@ dependencies {
     // third-party libs
     implementation(libs.conscrypt)
     implementation(libs.dnsjava)
+    implementation(libs.error.prone.annotations)
     implementation(libs.guava)
     implementation(libs.ktor.client.auth)
     implementation(libs.ktor.client.content.negotiation)
@@ -154,7 +155,6 @@ dependencies {
         // See: https://codeberg.org/UnifiedPush/android-connector/src/commit/28cb0d622ed0a972996041ab9cc85b701abc48c6/connector/build.gradle#L56-L59
         exclude(group = "com.google.crypto.tink", module = "tink")
     }
-    implementation(libs.spotbugs.annotations)
     implementation(libs.unifiedpush.fcm)
 
     // force some versions for compatibility with our minSdk level (see version catalog for details)

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
@@ -75,14 +75,14 @@ class HttpClientBuilderTest {
 
 
     @Test
-    fun testBuildKtor_CreatesWorkingClient() = runTest {
+    fun testBuild_CreatesWorkingClient() = runTest {
         server.enqueue(
             MockResponse()
                 .setResponseCode(200)
                 .setBody("Some Content")
         )
 
-        httpClientBuilder.buildKtor().use { client ->
+        httpClientBuilder.build().use { client ->
             val response = client.get(server.url("/").toString())
             assertEquals(200, response.status.value)
             assertEquals("Some Content", response.bodyAsText())
@@ -93,7 +93,7 @@ class HttpClientBuilderTest {
     fun testBuildProxy_System() = runTest {
         every { settingsManager.getInt(Settings.PROXY_TYPE) } returns Settings.PROXY_TYPE_SYSTEM
 
-        httpClientBuilder.buildKtor().use { client ->
+        httpClientBuilder.build().use { client ->
             assertNull((client.engine as OkHttpEngine).config.proxy)
         }
     }
@@ -102,7 +102,7 @@ class HttpClientBuilderTest {
     fun testBuildProxy_None() = runTest {
         every { settingsManager.getInt(Settings.PROXY_TYPE) } returns Settings.PROXY_TYPE_NONE
 
-        httpClientBuilder.buildKtor().use { client ->
+        httpClientBuilder.build().use { client ->
             assertEquals(Proxy.NO_PROXY, (client.engine as OkHttpEngine).config.proxy)
         }
     }
@@ -113,7 +113,7 @@ class HttpClientBuilderTest {
         every { settingsManager.getString(Settings.PROXY_HOST) } returns "proxy.example.com"
         every { settingsManager.getInt(Settings.PROXY_PORT) } returns 8080
 
-        httpClientBuilder.buildKtor().use { client ->
+        httpClientBuilder.build().use { client ->
             val proxy = (client.engine as OkHttpEngine).config.proxy
             assertEquals(ProxyBuilder.http(Url("http://proxy.example.com:8080")), proxy)
         }
@@ -125,7 +125,7 @@ class HttpClientBuilderTest {
         every { settingsManager.getString(Settings.PROXY_HOST) } returns "proxy.example.com"
         every { settingsManager.getInt(Settings.PROXY_PORT) } returns 1080
 
-        httpClientBuilder.buildKtor().use { client ->
+        httpClientBuilder.build().use { client ->
             val proxy = (client.engine as OkHttpEngine).config.proxy
             assertEquals(ProxyBuilder.socks("proxy.example.com", 1080), proxy)
         }
@@ -137,7 +137,7 @@ class HttpClientBuilderTest {
         // so they're only stored/sent by the Ktor client, not the raw OkHttp client.
         val url = server.url("/test").toString()
 
-        httpClientBuilder.buildKtor().use { client ->
+        httpClientBuilder.build().use { client ->
             // set cookie for root path (/) and /test path in first response
             server.enqueue(
                 MockResponse()
@@ -178,7 +178,7 @@ class HttpClientBuilderTest {
                 .addHeader(HttpHeaders.Location, server.url("/redirected").toString())
         )
 
-        httpClientBuilder.buildKtor().use { client ->
+        httpClientBuilder.build().use { client ->
             val response = client.get(server.url("/").toString())
             // redirect is not followed, so we get the 302 response directly
             assertEquals(302, response.status.value)
@@ -200,7 +200,7 @@ class HttpClientBuilderTest {
                 .setBody("Target")
         )
 
-        httpClientBuilder.followRedirects(true).buildKtor().use { client ->
+        httpClientBuilder.followRedirects(true).build().use { client ->
             val response = client.get(server.url("/").toString())
             assertEquals(200, response.status.value)
             assertEquals("Target", response.bodyAsText())
@@ -240,7 +240,7 @@ class HttpClientBuilderTest {
         httpClientBuilder
             .logTo(logger)
             .trafficLogLevel(LogLevel.ALL)
-            .buildKtor().use { client ->
+            .build().use { client ->
                 client.get(server.url("/").toString()) {
                     header(HttpHeaders.Authorization, secret)
                 }
@@ -262,7 +262,7 @@ class HttpClientBuilderTest {
         try {
             Locale.setDefault(Locale.GERMANY)
 
-            httpClientBuilder.buildKtor().use { client ->
+            httpClientBuilder.build().use { client ->
                 client.get(server.url("/").toString())
             }
 

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
@@ -90,7 +90,7 @@ class HttpClientBuilderTest {
     }
 
     @Test
-    fun testConfigureProxy_System() = runTest {
+    fun testBuildProxy_System() = runTest {
         every { settingsManager.getInt(Settings.PROXY_TYPE) } returns Settings.PROXY_TYPE_SYSTEM
 
         httpClientBuilder.buildKtor().use { client ->
@@ -99,7 +99,7 @@ class HttpClientBuilderTest {
     }
 
     @Test
-    fun testConfigureProxy_None() = runTest {
+    fun testBuildProxy_None() = runTest {
         every { settingsManager.getInt(Settings.PROXY_TYPE) } returns Settings.PROXY_TYPE_NONE
 
         httpClientBuilder.buildKtor().use { client ->
@@ -108,7 +108,7 @@ class HttpClientBuilderTest {
     }
 
     @Test
-    fun testConfigureProxy_Http() = runTest {
+    fun testBuildProxy_Http() = runTest {
         every { settingsManager.getInt(Settings.PROXY_TYPE) } returns Settings.PROXY_TYPE_HTTP
         every { settingsManager.getString(Settings.PROXY_HOST) } returns "proxy.example.com"
         every { settingsManager.getInt(Settings.PROXY_PORT) } returns 8080
@@ -120,7 +120,7 @@ class HttpClientBuilderTest {
     }
 
     @Test
-    fun testConfigureProxy_Socks() = runTest {
+    fun testBuildProxy_Socks() = runTest {
         every { settingsManager.getInt(Settings.PROXY_TYPE) } returns Settings.PROXY_TYPE_SOCKS
         every { settingsManager.getString(Settings.PROXY_HOST) } returns "proxy.example.com"
         every { settingsManager.getInt(Settings.PROXY_PORT) } returns 1080
@@ -238,8 +238,8 @@ class HttpClientBuilderTest {
         )
 
         httpClientBuilder
-            .setLogger(logger)
-            .loggerInterceptorLevel(LogLevel.ALL)
+            .logTo(logger)
+            .trafficLogLevel(LogLevel.ALL)
             .buildKtor().use { client ->
                 client.get(server.url("/").toString()) {
                     header(HttpHeaders.Authorization, secret)

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
@@ -39,7 +39,6 @@ import java.util.logging.Level
 import java.util.logging.LogRecord
 import java.util.logging.Logger
 import javax.inject.Inject
-import javax.inject.Provider
 
 @HiltAndroidTest
 class HttpClientBuilderTest {
@@ -51,7 +50,7 @@ class HttpClientBuilderTest {
     val mockKRule = MockKRule(this)
 
     @Inject
-    lateinit var httpClientBuilder: Provider<HttpClientBuilder>
+    lateinit var httpClientBuilder: HttpClientBuilder
 
     @Inject
     lateinit var productIds: ProductIds
@@ -83,7 +82,7 @@ class HttpClientBuilderTest {
                 .setBody("Some Content")
         )
 
-        httpClientBuilder.get().buildKtor().use { client ->
+        httpClientBuilder.buildKtor().use { client ->
             val response = client.get(server.url("/").toString())
             assertEquals(200, response.status.value)
             assertEquals("Some Content", response.bodyAsText())
@@ -94,7 +93,7 @@ class HttpClientBuilderTest {
     fun testConfigureProxy_System() = runTest {
         every { settingsManager.getInt(Settings.PROXY_TYPE) } returns Settings.PROXY_TYPE_SYSTEM
 
-        httpClientBuilder.get().buildKtor().use { client ->
+        httpClientBuilder.buildKtor().use { client ->
             assertNull((client.engine as OkHttpEngine).config.proxy)
         }
     }
@@ -103,7 +102,7 @@ class HttpClientBuilderTest {
     fun testConfigureProxy_None() = runTest {
         every { settingsManager.getInt(Settings.PROXY_TYPE) } returns Settings.PROXY_TYPE_NONE
 
-        httpClientBuilder.get().buildKtor().use { client ->
+        httpClientBuilder.buildKtor().use { client ->
             assertEquals(Proxy.NO_PROXY, (client.engine as OkHttpEngine).config.proxy)
         }
     }
@@ -114,7 +113,7 @@ class HttpClientBuilderTest {
         every { settingsManager.getString(Settings.PROXY_HOST) } returns "proxy.example.com"
         every { settingsManager.getInt(Settings.PROXY_PORT) } returns 8080
 
-        httpClientBuilder.get().buildKtor().use { client ->
+        httpClientBuilder.buildKtor().use { client ->
             val proxy = (client.engine as OkHttpEngine).config.proxy
             assertEquals(ProxyBuilder.http(Url("http://proxy.example.com:8080")), proxy)
         }
@@ -126,7 +125,7 @@ class HttpClientBuilderTest {
         every { settingsManager.getString(Settings.PROXY_HOST) } returns "proxy.example.com"
         every { settingsManager.getInt(Settings.PROXY_PORT) } returns 1080
 
-        httpClientBuilder.get().buildKtor().use { client ->
+        httpClientBuilder.buildKtor().use { client ->
             val proxy = (client.engine as OkHttpEngine).config.proxy
             assertEquals(ProxyBuilder.socks("proxy.example.com", 1080), proxy)
         }
@@ -138,7 +137,7 @@ class HttpClientBuilderTest {
         // so they're only stored/sent by the Ktor client, not the raw OkHttp client.
         val url = server.url("/test").toString()
 
-        httpClientBuilder.get().buildKtor().use { client ->
+        httpClientBuilder.buildKtor().use { client ->
             // set cookie for root path (/) and /test path in first response
             server.enqueue(
                 MockResponse()
@@ -179,7 +178,7 @@ class HttpClientBuilderTest {
                 .addHeader(HttpHeaders.Location, server.url("/redirected").toString())
         )
 
-        httpClientBuilder.get().buildKtor().use { client ->
+        httpClientBuilder.buildKtor().use { client ->
             val response = client.get(server.url("/").toString())
             // redirect is not followed, so we get the 302 response directly
             assertEquals(302, response.status.value)
@@ -201,7 +200,7 @@ class HttpClientBuilderTest {
                 .setBody("Target")
         )
 
-        httpClientBuilder.get().followRedirects(true).buildKtor().use { client ->
+        httpClientBuilder.followRedirects(true).buildKtor().use { client ->
             val response = client.get(server.url("/").toString())
             assertEquals(200, response.status.value)
             assertEquals("Target", response.bodyAsText())
@@ -238,7 +237,7 @@ class HttpClientBuilderTest {
                 .setBody("OK")
         )
 
-        httpClientBuilder.get()
+        httpClientBuilder
             .setLogger(logger)
             .loggerInterceptorLevel(LogLevel.ALL)
             .buildKtor().use { client ->
@@ -263,7 +262,7 @@ class HttpClientBuilderTest {
         try {
             Locale.setDefault(Locale.GERMANY)
 
-            httpClientBuilder.get().buildKtor().use { client ->
+            httpClientBuilder.buildKtor().use { client ->
                 client.get(server.url("/").toString())
             }
 

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/servicedetection/DavResourceFinderTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/servicedetection/DavResourceFinderTest.kt
@@ -33,7 +33,6 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.net.URI
 import javax.inject.Inject
-import javax.inject.Provider
 
 @HiltAndroidTest
 class DavResourceFinderTest {
@@ -65,7 +64,7 @@ class DavResourceFinderTest {
     val tempFolder = TemporaryFolder()
 
     @Inject
-    lateinit var httpClientBuilderProvider: Provider<HttpClientBuilder>
+    lateinit var httpClientBuilder: HttpClientBuilder
 
     @Inject
     lateinit var resourceFinderFactory: DavResourceFinder.Factory
@@ -128,7 +127,7 @@ class DavResourceFinderTest {
     fun testFindInitialConfiguration_logsOutput() = runTest {
         val logFile = tempFolder.newFile()
         FileLoggerFactory.forFile(logFile).use { fileLoggerContext ->
-            httpClientBuilderProvider.get()
+            httpClientBuilder
                 .setLogger(fileLoggerContext.logger)
                 .buildKtor()
                 .use { httpClient ->

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/servicedetection/DavResourceFinderTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/servicedetection/DavResourceFinderTest.kt
@@ -128,7 +128,7 @@ class DavResourceFinderTest {
         val logFile = tempFolder.newFile()
         FileLoggerFactory.forFile(logFile).use { fileLoggerContext ->
             httpClientBuilder
-                .setLogger(fileLoggerContext.logger)
+                .logTo(fileLoggerContext.logger)
                 .buildKtor()
                 .use { httpClient ->
                     resourceFinderFactory.create(

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/servicedetection/DavResourceFinderTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/servicedetection/DavResourceFinderTest.kt
@@ -129,7 +129,7 @@ class DavResourceFinderTest {
         FileLoggerFactory.forFile(logFile).use { fileLoggerContext ->
             httpClientBuilder
                 .logTo(fileLoggerContext.logger)
-                .buildKtor()
+                .build()
                 .use { httpClient ->
                     resourceFinderFactory.create(
                         URI("http://localhost"), null, httpClient, fileLoggerContext.logger

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/JtxSyncManagerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/JtxSyncManagerTest.kt
@@ -95,7 +95,7 @@ class JtxSyncManagerTest {
         localJtxCollection = localJtxCollectionStore.create(provider, dbCollection)
         syncManager = jtxSyncManagerFactory.jtxSyncManager(
             account = account,
-            httpClient = httpClientBuilder.buildKtor(),
+            httpClient = httpClientBuilder.build(),
             syncResult = SyncResult(),
             localCollection = localJtxCollection,
             collection = dbCollection,

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/ConnectionSecurityManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/ConnectionSecurityManager.kt
@@ -20,6 +20,8 @@ import kotlin.jvm.optionals.getOrNull
 
 /**
  * Caching provider for [ConnectionSecurityContext].
+ *
+ * When this class is loaded, it makes sure that [ConscryptIntegration] is initialized.
  */
 @Singleton
 class ConnectionSecurityManager @Inject constructor(
@@ -103,6 +105,16 @@ class ConnectionSecurityManager @Inject constructor(
         val factory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
         factory.init(null as KeyStore?)
         return factory.trustManagers.filterIsInstance<X509TrustManager>().first()
+    }
+
+
+    companion object {
+
+        init {
+            // make sure Conscrypt is available
+            ConscryptIntegration().initialize()
+        }
+
     }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/ConscryptIntegration.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/ConscryptIntegration.kt
@@ -20,8 +20,6 @@ class ConscryptIntegration {
     private val logger
         get() = Logger.getLogger(javaClass.name)
 
-    private var initialized = false
-
     /**
      * Loads and initializes Conscrypt (if not already done). Safe to be called multiple times.
      */
@@ -53,5 +51,11 @@ class ConscryptIntegration {
     @VisibleForTesting
     internal fun conscryptInstalled() =
         Security.getProviders().any { Conscrypt.isConscrypt(it) }
+
+
+    companion object {
+        /** whether Conscrypt is already initialized */
+        private var initialized = false
+    }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
@@ -101,6 +101,12 @@ class HttpClientBuilder private constructor(
         val updateAuthStateCallback: ((AuthState) -> Unit)? = null
     )
 
+    /**
+     * Creates a new [HttpClientBuilder] with updated configuration.
+     *
+     * @param update block that takes the current Config and returns a new Config with desired changes
+     * @return new instance with updated config
+     */
     private fun withConfig(update: (Config) -> Config) = HttpClientBuilder(
         accountSettingsFactory,
         connectionSecurityManager,
@@ -110,12 +116,38 @@ class HttpClientBuilder private constructor(
         update(config)
     )
 
+    /**
+     * Sets whether the HTTP client should automatically follow redirects.
+     *
+     * @param follow true to follow redirects, false otherwise
+     * @return new builder with updated config (chainable)
+     */
     fun followRedirects(follow: Boolean): HttpClientBuilder = withConfig { it.copy(followRedirects = follow) }
 
+    /**
+     * Sets the logger for the HTTP client (mainly used to log HTTP traffic).
+     *
+     * @param logger The logger to be used for logging HTTP operations.
+     * @return new builder with updated config (chainable)
+     */
     fun logTo(logger: Logger): HttpClientBuilder = withConfig { it.copy(logger = logger) }
 
+    /**
+     * Sets the log level for HTTP traffic logging.
+     *
+     * @param level The desired log level for traffic logs.
+     * @return new builder with updated config (chainable)
+     */
     fun trafficLogLevel(level: LogLevel): HttpClientBuilder = withConfig { it.copy(trafficLogLevel = level) }
 
+    /**
+     * Configures authentication for the HTTP client.
+     *
+     * @param domain Domain for which the credentials are valid. If null, credentials are sent for all domains.
+     * @param getCredentials Provider function that returns the credentials to use.
+     * @param updateAuthState Optional callback to update the OAuth auth-state.
+     * @return new builder with updated config (chainable)
+     */
     fun authenticate(
         domain: String?,
         getCredentials: () -> Credentials,
@@ -199,6 +231,9 @@ class HttpClientBuilder private constructor(
     // actual client building
 
     private fun buildConnectionSecurity(okBuilder: OkHttpClient.Builder) {
+        // make sure Conscrypt is available
+        ConscryptIntegration().initialize()
+
         // Allow cleartext and TLS 1.2+
         okBuilder.connectionSpecs(
             listOf(
@@ -383,16 +418,6 @@ class HttpClientBuilder private constructor(
         }
 
         return client
-    }
-
-
-    companion object {
-
-        init {
-            // make sure Conscrypt is available when the HttpClientBuilder class is loaded the first time
-            ConscryptIntegration().initialize()
-        }
-
     }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
@@ -157,6 +157,7 @@ class HttpClientBuilder private constructor(
      * @param updateAuthState Optional callback to update the OAuth auth-state.
      * @return new builder with updated config (chainable)
      */
+    @CheckReturnValue
     fun authenticate(
         domain: String?,
         getCredentials: () -> Credentials,

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
@@ -49,60 +49,70 @@ import java.util.logging.Logger
 import javax.inject.Inject
 
 /**
- * Builder for the HTTP client.
+ * Immutable/chainable builder for the HTTP client.
  *
- * **Attention:** If the builder is injected, it shouldn't be used from multiple locations to generate different clients because then
- * there's only one [HttpClientBuilder] object and setting properties from one location would influence the others.
+ * Every configuration method (`setLogger`, `authenticate`, `followRedirects`, ...) returns
+ * a new instance with the change applied.
  *
- * To generate multiple clients, inject and use `Provider<HttpClientBuilder>` instead.
+ * Also makes sure that [ConscryptIntegration] is initialized.
  */
-class HttpClientBuilder @Inject constructor(
+class HttpClientBuilder private constructor(
     private val accountSettingsFactory: AccountSettings.Factory,
     private val connectionSecurityManager: ConnectionSecurityManager,
-    defaultLogger: Logger,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     private val oAuthProviderFactory: OAuthProvider.Factory,
     private val settingsManager: SettingsManager,
-    private val productIds: ProductIds
+    private val productIds: ProductIds,
+    private val config: Config
 ) {
 
-    companion object {
+    @Inject
+    constructor(
+        accountSettingsFactory: AccountSettings.Factory,
+        connectionSecurityManager: ConnectionSecurityManager,
+        defaultLogger: Logger,
+        @IoDispatcher ioDispatcher: CoroutineDispatcher,
+        oAuthProviderFactory: OAuthProvider.Factory,
+        settingsManager: SettingsManager,
+        productIds: ProductIds
+    ) : this(
+        accountSettingsFactory,
+        connectionSecurityManager,
+        ioDispatcher,
+        oAuthProviderFactory,
+        settingsManager,
+        productIds,
+        Config(logger = defaultLogger)
+    )
 
-        init {
-            // make sure Conscrypt is available when the HttpClientBuilder class is loaded the first time
-            ConscryptIntegration().initialize()
-        }
+    private data class Config(
+        val logger: Logger,
+        // LogLevel.ALL logs headers + body (unlike LogLevel.BODY, which omits headers)
+        val loggerInterceptorLevel: LogLevel = LogLevel.ALL,
+        val certificateAlias: String? = null,
+        val authUsername: String? = null,
+        val authPassword: SensitiveString? = null,
+        val authDomain: String? = null,
+        val readAuthStateCallback: (() -> AuthState?)? = null,
+        val updateAuthStateCallback: ((AuthState) -> Unit)? = null,
+        val followRedirects: Boolean = false
+    )
 
-    }
-
-    /**
-     * Flag to prevent multiple [buildKtor] calls
-     */
-    var alreadyBuilt = false
+    private fun copy(newConfig: Config) = HttpClientBuilder(
+        accountSettingsFactory,
+        connectionSecurityManager,
+        ioDispatcher,
+        oAuthProviderFactory,
+        settingsManager,
+        productIds,
+        newConfig
+    )
 
     // property setters/getters
 
-    private var logger: Logger = defaultLogger
-    fun setLogger(logger: Logger): HttpClientBuilder {
-        this.logger = logger
-        return this
-    }
+    fun setLogger(logger: Logger): HttpClientBuilder = copy(config.copy(logger = logger))
 
-    // LogLevel.ALL logs headers + body (unlike LogLevel.BODY, which omits headers)
-    private var loggerInterceptorLevel: LogLevel = LogLevel.ALL
-
-    fun loggerInterceptorLevel(level: LogLevel): HttpClientBuilder {
-        loggerInterceptorLevel = level
-        return this
-    }
-
-    private var certificateAlias: String? = null
-
-    private var authUsername: String? = null
-    private var authPassword: SensitiveString? = null
-    private var authDomain: String? = null
-    private var readAuthStateCallback: (() -> AuthState?)? = null
-    private var updateAuthStateCallback: ((AuthState) -> Unit)? = null
+    fun loggerInterceptorLevel(level: LogLevel): HttpClientBuilder = copy(config.copy(loggerInterceptorLevel = level))
 
     fun authenticate(
         domain: String?,
@@ -110,40 +120,40 @@ class HttpClientBuilder @Inject constructor(
         updateAuthState: ((AuthState) -> Unit)? = null
     ): HttpClientBuilder {
         val credentials = getCredentials()
+        var newConfig = config
         when {
             // OAuth
             credentials.authState != null -> {
-                readAuthStateCallback = {
-                    // We don't use the "credentials" object from above because it may contain an outdated
-                    // access token. Instead, we fetch the up-to-date auth-state on each readAuthState call.
-                    getCredentials().authState
-                }
-                updateAuthStateCallback = updateAuthState
-                authDomain = domain
+                newConfig = newConfig.copy(
+                    readAuthStateCallback = {
+                        // We don't use the "credentials" object from above because it may contain an outdated
+                        // access token. Instead, we fetch the up-to-date auth-state on each readAuthState call.
+                        getCredentials().authState
+                    },
+                    updateAuthStateCallback = updateAuthState,
+                    authDomain = domain
+                )
             }
 
             // basic / digest auth
             credentials.username != null && credentials.password != null -> {
-                authUsername = credentials.username
-                authPassword = credentials.password
-                authDomain = domain
+                newConfig = newConfig.copy(
+                    authUsername = credentials.username,
+                    authPassword = credentials.password,
+                    authDomain = domain
+                )
             }
         }
 
         // client certificate
         if (credentials.certificateAlias != null)
-            certificateAlias = credentials.certificateAlias
+            newConfig = newConfig.copy(certificateAlias = credentials.certificateAlias)
 
-        return this
+        return copy(newConfig)
     }
 
 
-    private var followRedirects = false
-
-    fun followRedirects(follow: Boolean): HttpClientBuilder {
-        followRedirects = follow
-        return this
-    }
+    fun followRedirects(follow: Boolean): HttpClientBuilder = copy(config.copy(followRedirects = follow))
 
 
     // convenience builders from other classes
@@ -165,7 +175,7 @@ class HttpClientBuilder @Inject constructor(
     @WorkerThread
     fun fromAccount(account: Account, authDomain: String? = null): HttpClientBuilder {
         val accountSettings = accountSettingsFactory.create(account)
-        authenticate(
+        return authenticate(
             domain = UrlUtils.hostToDomain(authDomain),
             getCredentials = {
                 accountSettings.credentials()
@@ -174,7 +184,6 @@ class HttpClientBuilder @Inject constructor(
                 accountSettings.updateAuthState(authState)
             }
         )
-        return this
     }
 
     /**
@@ -206,7 +215,7 @@ class HttpClientBuilder @Inject constructor(
          * b. we need to cache the instances because otherwise, HTTPS connection are not used
          *    correctly. okhttp checks the SSLSocketFactory/TrustManager of a connection in the pool
          *    and creates a new connection when they have changed. */
-        val securityContext = connectionSecurityManager.getContext(certificateAlias)
+        val securityContext = connectionSecurityManager.getContext(config.certificateAlias)
 
         if (securityContext.disableHttp2)
             okBuilder.protocols(listOf(Protocol.HTTP_1_1))
@@ -236,7 +245,7 @@ class HttpClientBuilder @Inject constructor(
             else -> /* Invalid proxy type, shouldn't happen */ null
         }
         if (proxy != null) {
-            logger.info("Using non-default proxy setting: $proxy")
+            config.logger.info("Using non-default proxy setting: $proxy")
             engineConfig.proxy = proxy
         }
     }
@@ -247,30 +256,21 @@ class HttpClientBuilder @Inject constructor(
     /**
      * Builds a Ktor [HttpClient] with the configured settings.
      *
-     * [buildKtor] must be called only once because multiple calls indicate this wrong usage pattern:
-     *
-     * ```
-     * val builder = HttpClientBuilder(/*injected*/)
-     * val client1 = builder.configure().buildKtor()
-     * val client2 = builder.configureOtherwise().buildKtor()
-     * ```
-     *
-     * However in this case the configuration of `client1` is still in `builder` and would be reused for `client2`,
-     * which is usually not desired.
+     * Since [HttpClientBuilder] is immutable, this can be called any number of times — on this
+     * builder or on any builder derived from it via the configuration methods — and each call
+     * produces an independent [HttpClient] that only reflects the configuration of the builder
+     * it was called on.
      *
      * @return the new HttpClient (with [OkHttp] engine) which **must be closed by the caller**
      */
     @MustBeClosed
     fun buildKtor(): HttpClient {
-        if (alreadyBuilt)
-            logger.warning("buildKtor() should only be called once; use Provider<HttpClientBuilder> instead")
-
         val client = HttpClient(OkHttp) {
             // Ktor-level configuration here
 
             // don't follow redirects by default because it would break PROPFIND handling;
             // this controls whether Ktor's HttpRedirect plugin is active
-            followRedirects = this@HttpClientBuilder.followRedirects
+            followRedirects = config.followRedirects
 
             installAuthPlugin()
 
@@ -307,14 +307,14 @@ class HttpClientBuilder @Inject constructor(
             }
 
             // add network logging (with redaction of sensitive headers), if requested
-            if (logger.isLoggable(Level.FINEST)) {
+            if (config.logger.isLoggable(Level.FINEST)) {
                 install(Logging) {
                     logger = object : io.ktor.client.plugins.logging.Logger {
                         override fun log(message: String) {
-                            this@HttpClientBuilder.logger.finest(message)
+                            config.logger.finest(message)
                         }
                     }
-                    level = loggerInterceptorLevel
+                    level = config.loggerInterceptorLevel
 
                     // don't log some confidential headers
                     val headersToIgnore = arrayOf(
@@ -345,15 +345,14 @@ class HttpClientBuilder @Inject constructor(
             }
         }
 
-        alreadyBuilt = true
         return client
     }
 
     private fun HttpClientConfig<*>.installAuthPlugin() {
-        val username = authUsername
-        val password = authPassword
-        val readAuthState = readAuthStateCallback
-        val updateAuthState = updateAuthStateCallback
+        val username = config.authUsername
+        val password = config.authPassword
+        val readAuthState = config.readAuthStateCallback
+        val updateAuthState = config.updateAuthStateCallback
         when {
             // prefer OAuth, if available
             readAuthState != null -> {
@@ -362,7 +361,7 @@ class HttpClientBuilder @Inject constructor(
                         oAuthProviderFactory.create(
                             readAuthState = readAuthState,
                             writeAuthState = { authState -> updateAuthState?.invoke(authState) }
-                        ).authProvider(authDomain)
+                        ).authProvider(config.authDomain)
                     )
                 }
             }
@@ -374,7 +373,7 @@ class HttpClientBuilder @Inject constructor(
                         createDomainBasicAuthProvider(
                             username = username,
                             password = password.asString(),
-                            firstLevelDomain = authDomain,
+                            firstLevelDomain = config.authDomain,
                             insecurePreemptive = true
                         )
                     )
@@ -382,11 +381,22 @@ class HttpClientBuilder @Inject constructor(
                         createDomainDigestAuthProvider(
                             username = username,
                             password = password.asString(),
-                            firstLevelDomain = authDomain
+                            firstLevelDomain = config.authDomain
                         )
                     )
                 }
             }
         }
     }
+
+
+    companion object {
+
+        init {
+            // make sure Conscrypt is available when the HttpClientBuilder class is loaded the first time
+            ConscryptIntegration().initialize()
+        }
+
+    }
+
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
@@ -16,8 +16,8 @@ import at.bitfire.davdroid.settings.Credentials
 import at.bitfire.davdroid.settings.Settings
 import at.bitfire.davdroid.settings.SettingsManager
 import at.bitfire.synctools.util.SensitiveString
+import com.google.errorprone.annotations.CheckReturnValue
 import com.google.errorprone.annotations.MustBeClosed
-import edu.umd.cs.findbugs.annotations.CheckReturnValue
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.HttpClientEngineConfig
@@ -54,8 +54,6 @@ import javax.inject.Inject
  *
  * Every configuration method (`logTo`, `authenticate`, `followRedirects`, ...) returns
  * a new instance with the change applied.
- *
- * Also makes sure that [ConscryptIntegration] is initialized.
  */
 class HttpClientBuilder private constructor(
     private val accountSettingsFactory: AccountSettings.Factory,
@@ -169,13 +167,15 @@ class HttpClientBuilder private constructor(
             // OAuth
             credentials.authState != null -> {
                 newConfig = newConfig.copy(
+                    authUsername = null,
+                    authPassword = null,
+                    authDomain = domain,
                     readAuthStateCallback = {
                         // We don't use the "credentials" object from above because it may contain an outdated
                         // access token. Instead, we fetch the up-to-date auth-state on each readAuthState call.
                         getCredentials().authState
                     },
-                    updateAuthStateCallback = updateAuthState,
-                    authDomain = domain
+                    updateAuthStateCallback = updateAuthState
                 )
             }
 
@@ -184,7 +184,9 @@ class HttpClientBuilder private constructor(
                 newConfig = newConfig.copy(
                     authUsername = credentials.username,
                     authPassword = credentials.password,
-                    authDomain = domain
+                    authDomain = domain,
+                    readAuthStateCallback = null,
+                    updateAuthStateCallback = null
                 )
             }
         }
@@ -241,9 +243,6 @@ class HttpClientBuilder private constructor(
     // actual client building
 
     private fun buildConnectionSecurity(okBuilder: OkHttpClient.Builder) {
-        // make sure Conscrypt is available
-        ConscryptIntegration().initialize()
-
         // Allow cleartext and TLS 1.2+
         okBuilder.connectionSpecs(
             listOf(

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
@@ -301,7 +301,7 @@ class HttpClientBuilder private constructor(
      * @return the new HttpClient (with [OkHttp] engine) which **must be closed by the caller**
      */
     @MustBeClosed
-    fun buildKtor(): HttpClient {
+    fun build(): HttpClient {
         val client = HttpClient(OkHttp) {
             // Ktor-level configuration here
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
@@ -353,6 +353,7 @@ class HttpClientBuilder @Inject constructor(
         val username = authUsername
         val password = authPassword
         val readAuthState = readAuthStateCallback
+        val updateAuthState = updateAuthStateCallback
         when {
             // prefer OAuth, if available
             readAuthState != null -> {
@@ -360,7 +361,7 @@ class HttpClientBuilder @Inject constructor(
                     providers.add(
                         oAuthProviderFactory.create(
                             readAuthState = readAuthState,
-                            writeAuthState = { authState -> updateAuthStateCallback?.invoke(authState) }
+                            writeAuthState = { authState -> updateAuthState?.invoke(authState) }
                         ).authProvider(authDomain)
                     )
                 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
@@ -10,12 +10,14 @@ import at.bitfire.dav4jvm.ktor.UrlUtils
 import at.bitfire.dav4jvm.ktor.createDomainBasicAuthProvider
 import at.bitfire.dav4jvm.ktor.createDomainDigestAuthProvider
 import at.bitfire.davdroid.ProductIds
+import at.bitfire.davdroid.di.qualifier.IoDispatcher
 import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.settings.Credentials
 import at.bitfire.davdroid.settings.Settings
 import at.bitfire.davdroid.settings.SettingsManager
 import at.bitfire.synctools.util.SensitiveString
 import com.google.errorprone.annotations.MustBeClosed
+import edu.umd.cs.findbugs.annotations.CheckReturnValue
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.HttpClientEngineConfig
@@ -35,7 +37,7 @@ import io.ktor.http.URLBuilder
 import io.ktor.http.URLProtocol
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.util.appendIfNameAbsent
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import net.openid.appauth.AuthState
 import okhttp3.ConnectionSpec
@@ -50,7 +52,7 @@ import javax.inject.Inject
 /**
  * Immutable/chainable builder for the HTTP client.
  *
- * Every configuration method (`setLogger`, `authenticate`, `followRedirects`, ...) returns
+ * Every configuration method (`logTo`, `authenticate`, `followRedirects`, ...) returns
  * a new instance with the change applied.
  *
  * Also makes sure that [ConscryptIntegration] is initialized.
@@ -58,6 +60,7 @@ import javax.inject.Inject
 class HttpClientBuilder private constructor(
     private val accountSettingsFactory: AccountSettings.Factory,
     private val connectionSecurityManager: ConnectionSecurityManager,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     private val oAuthProviderFactory: OAuthProvider.Factory,
     private val settingsManager: SettingsManager,
     private val productIds: ProductIds,
@@ -71,12 +74,14 @@ class HttpClientBuilder private constructor(
         accountSettingsFactory: AccountSettings.Factory,
         connectionSecurityManager: ConnectionSecurityManager,
         defaultLogger: Logger,
+        ioDispatcher: CoroutineDispatcher,
         oAuthProviderFactory: OAuthProvider.Factory,
         settingsManager: SettingsManager,
         productIds: ProductIds
     ) : this(
         accountSettingsFactory,
         connectionSecurityManager,
+        ioDispatcher,
         oAuthProviderFactory,
         settingsManager,
         productIds,
@@ -110,6 +115,7 @@ class HttpClientBuilder private constructor(
     private fun withConfig(update: (Config) -> Config) = HttpClientBuilder(
         accountSettingsFactory,
         connectionSecurityManager,
+        ioDispatcher,
         oAuthProviderFactory,
         settingsManager,
         productIds,
@@ -122,6 +128,7 @@ class HttpClientBuilder private constructor(
      * @param follow true to follow redirects, false otherwise
      * @return new builder with updated config (chainable)
      */
+    @CheckReturnValue
     fun followRedirects(follow: Boolean): HttpClientBuilder = withConfig { it.copy(followRedirects = follow) }
 
     /**
@@ -130,6 +137,7 @@ class HttpClientBuilder private constructor(
      * @param logger The logger to be used for logging HTTP operations.
      * @return new builder with updated config (chainable)
      */
+    @CheckReturnValue
     fun logTo(logger: Logger): HttpClientBuilder = withConfig { it.copy(logger = logger) }
 
     /**
@@ -138,6 +146,7 @@ class HttpClientBuilder private constructor(
      * @param level The desired log level for traffic logs.
      * @return new builder with updated config (chainable)
      */
+    @CheckReturnValue
     fun trafficLogLevel(level: LogLevel): HttpClientBuilder = withConfig { it.copy(trafficLogLevel = level) }
 
     /**
@@ -223,7 +232,7 @@ class HttpClientBuilder private constructor(
      * @throws at.bitfire.davdroid.sync.account.InvalidAccountException     when the account doesn't exist
      */
     suspend fun fromAccountAsync(account: Account, onlyHost: String? = null): HttpClientBuilder =
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
             fromAccount(account, onlyHost)
         }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
@@ -16,7 +16,6 @@ import at.bitfire.davdroid.settings.Credentials
 import at.bitfire.davdroid.settings.Settings
 import at.bitfire.davdroid.settings.SettingsManager
 import at.bitfire.synctools.util.SensitiveString
-import com.google.errorprone.annotations.CheckReturnValue
 import com.google.errorprone.annotations.MustBeClosed
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
@@ -47,6 +46,7 @@ import java.net.Proxy
 import java.util.Locale
 import java.util.logging.Level
 import java.util.logging.Logger
+import javax.annotation.CheckReturnValue
 import javax.inject.Inject
 
 /**

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
@@ -60,7 +60,7 @@ import javax.inject.Inject
 class HttpClientBuilder private constructor(
     private val accountSettingsFactory: AccountSettings.Factory,
     private val connectionSecurityManager: ConnectionSecurityManager,
-    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+    private val ioDispatcher: CoroutineDispatcher,
     private val oAuthProviderFactory: OAuthProvider.Factory,
     private val settingsManager: SettingsManager,
     private val productIds: ProductIds,
@@ -74,18 +74,18 @@ class HttpClientBuilder private constructor(
         accountSettingsFactory: AccountSettings.Factory,
         connectionSecurityManager: ConnectionSecurityManager,
         defaultLogger: Logger,
-        ioDispatcher: CoroutineDispatcher,
+        @IoDispatcher ioDispatcher: CoroutineDispatcher,
         oAuthProviderFactory: OAuthProvider.Factory,
         settingsManager: SettingsManager,
         productIds: ProductIds
     ) : this(
-        accountSettingsFactory,
-        connectionSecurityManager,
-        ioDispatcher,
-        oAuthProviderFactory,
-        settingsManager,
-        productIds,
-        Config(logger = defaultLogger)
+        accountSettingsFactory = accountSettingsFactory,
+        connectionSecurityManager = connectionSecurityManager,
+        ioDispatcher = ioDispatcher,
+        oAuthProviderFactory = oAuthProviderFactory,
+        settingsManager = settingsManager,
+        productIds = productIds,
+        config = Config(logger = defaultLogger)
     )
 
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
@@ -10,7 +10,6 @@ import at.bitfire.dav4jvm.ktor.UrlUtils
 import at.bitfire.dav4jvm.ktor.createDomainBasicAuthProvider
 import at.bitfire.dav4jvm.ktor.createDomainDigestAuthProvider
 import at.bitfire.davdroid.ProductIds
-import at.bitfire.davdroid.di.qualifier.IoDispatcher
 import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.settings.Credentials
 import at.bitfire.davdroid.settings.Settings
@@ -36,7 +35,7 @@ import io.ktor.http.URLBuilder
 import io.ktor.http.URLProtocol
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.util.appendIfNameAbsent
-import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import net.openid.appauth.AuthState
 import okhttp3.ConnectionSpec
@@ -59,66 +58,69 @@ import javax.inject.Inject
 class HttpClientBuilder private constructor(
     private val accountSettingsFactory: AccountSettings.Factory,
     private val connectionSecurityManager: ConnectionSecurityManager,
-    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     private val oAuthProviderFactory: OAuthProvider.Factory,
     private val settingsManager: SettingsManager,
     private val productIds: ProductIds,
+    /** current configuration of this builder instance (immutable) */
     private val config: Config
 ) {
 
+    // public constructor, delegating to private constructor with empty Config()
     @Inject
     constructor(
         accountSettingsFactory: AccountSettings.Factory,
         connectionSecurityManager: ConnectionSecurityManager,
         defaultLogger: Logger,
-        @IoDispatcher ioDispatcher: CoroutineDispatcher,
         oAuthProviderFactory: OAuthProvider.Factory,
         settingsManager: SettingsManager,
         productIds: ProductIds
     ) : this(
         accountSettingsFactory,
         connectionSecurityManager,
-        ioDispatcher,
         oAuthProviderFactory,
         settingsManager,
         productIds,
         Config(logger = defaultLogger)
     )
 
+
+    // methods to set configuration
+
+    /**
+     * Immutable snapshot of everything that can be configured on a [HttpClientBuilder] plus default config.
+     */
     private data class Config(
+        val followRedirects: Boolean = false,
         val logger: Logger,
-        // LogLevel.ALL logs headers + body (unlike LogLevel.BODY, which omits headers)
-        val loggerInterceptorLevel: LogLevel = LogLevel.ALL,
+        val trafficLogLevel: LogLevel = LogLevel.ALL,
         val certificateAlias: String? = null,
         val authUsername: String? = null,
         val authPassword: SensitiveString? = null,
         val authDomain: String? = null,
         val readAuthStateCallback: (() -> AuthState?)? = null,
-        val updateAuthStateCallback: ((AuthState) -> Unit)? = null,
-        val followRedirects: Boolean = false
+        val updateAuthStateCallback: ((AuthState) -> Unit)? = null
     )
 
-    private fun copy(newConfig: Config) = HttpClientBuilder(
+    private fun withConfig(update: (Config) -> Config) = HttpClientBuilder(
         accountSettingsFactory,
         connectionSecurityManager,
-        ioDispatcher,
         oAuthProviderFactory,
         settingsManager,
         productIds,
-        newConfig
+        update(config)
     )
 
-    // property setters/getters
+    fun followRedirects(follow: Boolean): HttpClientBuilder = withConfig { it.copy(followRedirects = follow) }
 
-    fun setLogger(logger: Logger): HttpClientBuilder = copy(config.copy(logger = logger))
+    fun logTo(logger: Logger): HttpClientBuilder = withConfig { it.copy(logger = logger) }
 
-    fun loggerInterceptorLevel(level: LogLevel): HttpClientBuilder = copy(config.copy(loggerInterceptorLevel = level))
+    fun trafficLogLevel(level: LogLevel): HttpClientBuilder = withConfig { it.copy(trafficLogLevel = level) }
 
     fun authenticate(
         domain: String?,
         getCredentials: () -> Credentials,
         updateAuthState: ((AuthState) -> Unit)? = null
-    ): HttpClientBuilder {
+    ): HttpClientBuilder = withConfig { config ->
         val credentials = getCredentials()
         var newConfig = config
         when {
@@ -149,11 +151,8 @@ class HttpClientBuilder private constructor(
         if (credentials.certificateAlias != null)
             newConfig = newConfig.copy(certificateAlias = credentials.certificateAlias)
 
-        return copy(newConfig)
+        return@withConfig newConfig
     }
-
-
-    fun followRedirects(follow: Boolean): HttpClientBuilder = copy(config.copy(followRedirects = follow))
 
 
     // convenience builders from other classes
@@ -192,14 +191,14 @@ class HttpClientBuilder private constructor(
      * @throws at.bitfire.davdroid.sync.account.InvalidAccountException     when the account doesn't exist
      */
     suspend fun fromAccountAsync(account: Account, onlyHost: String? = null): HttpClientBuilder =
-        withContext(ioDispatcher) {
+        withContext(Dispatchers.IO) {
             fromAccount(account, onlyHost)
         }
 
 
-    // client configuration
+    // actual client building
 
-    private fun configureConnectionSecurity(okBuilder: OkHttpClient.Builder) {
+    private fun buildConnectionSecurity(okBuilder: OkHttpClient.Builder) {
         // Allow cleartext and TLS 1.2+
         okBuilder.connectionSpecs(
             listOf(
@@ -227,7 +226,7 @@ class HttpClientBuilder private constructor(
             okBuilder.hostnameVerifier(securityContext.hostnameVerifier)
     }
 
-    private fun configureProxy(engineConfig: HttpClientEngineConfig) {
+    private fun buildProxy(engineConfig: HttpClientEngineConfig) {
         val proxy = when (settingsManager.getInt(Settings.PROXY_TYPE)) {
             Settings.PROXY_TYPE_SYSTEM -> null
             Settings.PROXY_TYPE_NONE -> Proxy.NO_PROXY
@@ -250,8 +249,46 @@ class HttpClientBuilder private constructor(
         }
     }
 
+    private fun HttpClientConfig<*>.installAuthPlugin() {
+        val username = config.authUsername
+        val password = config.authPassword
+        val readAuthState = config.readAuthStateCallback
+        val updateAuthState = config.updateAuthStateCallback
+        when {
+            // prefer OAuth, if available
+            readAuthState != null -> {
+                install(Auth) {
+                    providers.add(
+                        oAuthProviderFactory.create(
+                            readAuthState = readAuthState,
+                            writeAuthState = { authState -> updateAuthState?.invoke(authState) }
+                        ).authProvider(config.authDomain)
+                    )
+                }
+            }
 
-    // client builder
+            // otherwise use basic / digest, if available
+            username != null && password != null -> {
+                install(Auth) {
+                    providers.add(
+                        createDomainBasicAuthProvider(
+                            username = username,
+                            password = password.asString(),
+                            firstLevelDomain = config.authDomain,
+                            insecurePreemptive = true
+                        )
+                    )
+                    providers.add(
+                        createDomainDigestAuthProvider(
+                            username = username,
+                            password = password.asString(),
+                            firstLevelDomain = config.authDomain
+                        )
+                    )
+                }
+            }
+        }
+    }
 
     /**
      * Builds a Ktor [HttpClient] with the configured settings.
@@ -314,7 +351,7 @@ class HttpClientBuilder private constructor(
                             config.logger.finest(message)
                         }
                     }
-                    level = config.loggerInterceptorLevel
+                    level = config.trafficLogLevel
 
                     // don't log some confidential headers
                     val headersToIgnore = arrayOf(
@@ -333,60 +370,19 @@ class HttpClientBuilder private constructor(
 
             engine {
                 // app-wide custom proxy support
-                configureProxy(this)
+                buildProxy(this)
 
                 // okhttp engine configuration here
                 config {
                     // OkHttpClient.Builder configuration here
 
                     // TLS settings
-                    configureConnectionSecurity(this)
+                    buildConnectionSecurity(this)
                 }
             }
         }
 
         return client
-    }
-
-    private fun HttpClientConfig<*>.installAuthPlugin() {
-        val username = config.authUsername
-        val password = config.authPassword
-        val readAuthState = config.readAuthStateCallback
-        val updateAuthState = config.updateAuthStateCallback
-        when {
-            // prefer OAuth, if available
-            readAuthState != null -> {
-                install(Auth) {
-                    providers.add(
-                        oAuthProviderFactory.create(
-                            readAuthState = readAuthState,
-                            writeAuthState = { authState -> updateAuthState?.invoke(authState) }
-                        ).authProvider(config.authDomain)
-                    )
-                }
-            }
-
-            // otherwise use basic / digest, if available
-            username != null && password != null -> {
-                install(Auth) {
-                    providers.add(
-                        createDomainBasicAuthProvider(
-                            username = username,
-                            password = password.asString(),
-                            firstLevelDomain = config.authDomain,
-                            insecurePreemptive = true
-                        )
-                    )
-                    providers.add(
-                        createDomainDigestAuthProvider(
-                            username = username,
-                            password = password.asString(),
-                            firstLevelDomain = config.authDomain
-                        )
-                    )
-                }
-            }
-        }
     }
 
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/NextcloudLoginFlow.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/NextcloudLoginFlow.kt
@@ -131,7 +131,7 @@ class NextcloudLoginFlow @Inject constructor(
     private fun createClient(): HttpClient =
         httpClientBuilder
             .followRedirects(true)
-            .buildKtor()
+            .build()
 
 
     /**

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/NextcloudLoginFlow.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/NextcloudLoginFlow.kt
@@ -25,7 +25,6 @@ import io.ktor.http.path
 import kotlinx.serialization.Serializable
 import java.net.URI
 import javax.inject.Inject
-import javax.inject.Provider
 
 /**
  * Implements Nextcloud Login Flow v2.
@@ -33,7 +32,7 @@ import javax.inject.Provider
  * See https://docs.nextcloud.com/server/latest/developer_manual/client_apis/LoginFlow/index.html#login-flow-v2
  */
 class NextcloudLoginFlow @Inject constructor(
-    private val httpClientBuilder: Provider<HttpClientBuilder>
+    private val httpClientBuilder: HttpClientBuilder
 ) {
 
     // Login flow state
@@ -130,7 +129,7 @@ class NextcloudLoginFlow @Inject constructor(
      * Creates a Ktor HTTP client that follows redirects.
      */
     private fun createClient(): HttpClient =
-        httpClientBuilder.get()
+        httpClientBuilder
             .followRedirects(true)
             .buildKtor()
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/OAuthProvider.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/OAuthProvider.kt
@@ -81,9 +81,9 @@ class OAuthProvider @AssistedInject constructor(
     }
 
     /**
-     * Requests a fresh access token.
+     * Requests a fresh access token. Ignores whether [AuthState] still considers the current token valid.
      *
-     * Ignores whether [AuthState] still considers the current token valid.
+     * Calls to this method are serialized by the global [refreshMutex].
      *
      * @param oldTokens the tokens Ktor cached and that just got rejected
      */
@@ -93,7 +93,7 @@ class OAuthProvider @AssistedInject constructor(
         val currentAccessToken = authState.accessToken
 
         /* If the persisted access token is already different to the rejected one,
-        another caller refreshed it while we were waiting for the lock, and we can simply return it. */
+        another caller refreshed it while we were waiting for the lock, and we can simply return the new one. */
         if (currentAccessToken != null && currentAccessToken != oldTokens?.accessToken)
             return@withLock BearerTokens(currentAccessToken, authState.refreshToken)
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
@@ -52,7 +52,6 @@ import java.util.concurrent.TimeUnit
 import java.util.logging.Level
 import java.util.logging.Logger
 import javax.inject.Inject
-import javax.inject.Provider
 
 /**
  * Manages push registrations and subscriptions.
@@ -69,7 +68,7 @@ class PushRegistrationManager @Inject constructor(
     private val distributorManager: PushDistributorManager,
     private val notificationManager: PushNotificationManager,
     private val notificationRegistry: NotificationRegistry,
-    private val httpClientBuilder: Provider<HttpClientBuilder>,
+    private val httpClientBuilder: HttpClientBuilder,
     private val logger: Logger,
     private val serviceRepository: DavServiceRepository
 ) {
@@ -199,7 +198,7 @@ class PushRegistrationManager @Inject constructor(
         val nextWorkerRun = Instant.now() + Duration.ofDays(2 * WORKER_INTERVAL_DAYS)
 
         val account = accountRepository.get().fromName(service.accountName)
-        httpClientBuilder.get()
+        httpClientBuilder
             .fromAccountAsync(account)
             .buildKtor()
             .use { httpClient ->
@@ -327,7 +326,7 @@ class PushRegistrationManager @Inject constructor(
             return
 
         val account = accountRepository.get().fromName(service.accountName)
-        httpClientBuilder.get()
+        httpClientBuilder
             .fromAccountAsync(account)
             .buildKtor()
             .use { httpClient ->

--- a/core/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationManager.kt
@@ -200,7 +200,7 @@ class PushRegistrationManager @Inject constructor(
         val account = accountRepository.get().fromName(service.accountName)
         httpClientBuilder
             .fromAccountAsync(account)
-            .buildKtor()
+            .build()
             .use { httpClient ->
             for (collection in subscribeTo) {
                 // update push subscription for the given collection
@@ -328,7 +328,7 @@ class PushRegistrationManager @Inject constructor(
         val account = accountRepository.get().fromName(service.accountName)
         httpClientBuilder
             .fromAccountAsync(account)
-            .buildKtor()
+            .build()
             .use { httpClient ->
             for (collection in from)
                 collection.pushSubscription?.toUrlOrNull()?.let { url ->

--- a/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
@@ -195,7 +195,7 @@ class DavCollectionRepository @Inject constructor(
 
         httpClientBuilder
             .fromAccountAsync(account)
-            .buildKtor()
+            .build()
             .use { httpClient ->
                 try {
                     DavResource(httpClient, collection.url).delete {
@@ -340,7 +340,7 @@ class DavCollectionRepository @Inject constructor(
     private suspend fun createOnServer(account: Account, url: Url, method: String, xmlBody: String) {
         httpClientBuilder
             .fromAccountAsync(account)
-            .buildKtor()
+            .build()
             .use { httpClient ->
                 DavResource(httpClient, url).mkCol(
                     xmlBody = xmlBody,

--- a/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
@@ -43,7 +43,6 @@ import java.util.UUID
 import java.util.logging.Level
 import java.util.logging.Logger
 import javax.inject.Inject
-import javax.inject.Provider
 
 /**
  * Repository for managing collections.
@@ -52,7 +51,7 @@ class DavCollectionRepository @Inject constructor(
     @ApplicationContext private val context: Context,
     private val db: AppDatabase,
     private val logger: Logger,
-    private val httpClientBuilder: Provider<HttpClientBuilder>,
+    private val httpClientBuilder: HttpClientBuilder,
     private val productIds: Lazy<ProductIds>,
     private val serviceRepository: DavServiceRepository
 ) {
@@ -194,7 +193,7 @@ class DavCollectionRepository @Inject constructor(
         val service = serviceRepository.getBlocking(collection.serviceId) ?: throw IllegalArgumentException("Service not found")
         val account = Account(service.accountName, context.getString(R.string.account_type))
 
-        httpClientBuilder.get()
+        httpClientBuilder
             .fromAccountAsync(account)
             .buildKtor()
             .use { httpClient ->
@@ -339,7 +338,7 @@ class DavCollectionRepository @Inject constructor(
      * @param xmlBody XML body containing collection metadata (e.g., display name, properties).
      */
     private suspend fun createOnServer(account: Account, url: Url, method: String, xmlBody: String) {
-        httpClientBuilder.get()
+        httpClientBuilder
             .fromAccountAsync(account)
             .buildKtor()
             .use { httpClient ->

--- a/core/src/main/kotlin/at/bitfire/davdroid/servicedetection/RefreshCollectionsWorker.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/servicedetection/RefreshCollectionsWorker.kt
@@ -154,7 +154,7 @@ class RefreshCollectionsWorker @AssistedInject constructor(
             // create authenticating HttpClient (credentials taken from account settings)
             httpClientBuilder
                 .fromAccount(account)
-                .buildKtor()
+                .build()
                 .use { httpClient ->
                     val refresher = collectionsWithoutHomeSetRefresherFactory.create(service, httpClient)
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/ResourceRetriever.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/ResourceRetriever.kt
@@ -16,7 +16,6 @@ import io.ktor.client.statement.bodyAsBytes
 import io.ktor.http.isSuccess
 import java.util.logging.Level
 import java.util.logging.Logger
-import javax.inject.Provider
 
 /**
  * Downloads a separate resource that is referenced during synchronization, for instance in
@@ -33,7 +32,7 @@ import javax.inject.Provider
 class ResourceRetriever @AssistedInject constructor(
     @Assisted private val account: Account,
     @Assisted private val originalHost: String,
-    private val httpClientBuilder: Provider<HttpClientBuilder>,
+    private val httpClientBuilder: HttpClientBuilder,
     private val logger: Logger
 ) {
 
@@ -76,7 +75,6 @@ class ResourceRetriever @AssistedInject constructor(
      */
     private suspend fun download(url: String): ByteArray? =
         httpClientBuilder
-            .get()
             .fromAccount(account, authDomain = originalHost)  // restricts authentication to original domain
             .followRedirects(true)      // allow redirects
             .buildKtor()

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/ResourceRetriever.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/ResourceRetriever.kt
@@ -77,7 +77,7 @@ class ResourceRetriever @AssistedInject constructor(
         httpClientBuilder
             .fromAccount(account, authDomain = originalHost)  // restricts authentication to original domain
             .followRedirects(true)      // allow redirects
-            .buildKtor()
+            .build()
             .use { httpClient ->
                 val response = httpClient.get(url)
                 if (response.status.isSuccess())

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
@@ -74,7 +74,7 @@ abstract class Syncer<StoreType: LocalDataStore<CollectionType>, CollectionType:
 
     @WillCloseWhenClosed
     val httpClient by lazy {
-        httpClientBuilder.fromAccount(account).buildKtor()
+        httpClientBuilder.fromAccount(account).build()
     }
 
     /**

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenViewModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenViewModel.kt
@@ -265,7 +265,7 @@ class LoginScreenViewModel @AssistedInject constructor(
                     else
                         builder
                 }
-                .buildKtor()
+                .build()
                 .use { httpClient ->
                     val finder = resourceFinderFactory.create(
                         baseUri,

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenViewModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenViewModel.kt
@@ -41,7 +41,6 @@ import java.net.URI
 import java.util.Optional
 import java.util.logging.Level
 import java.util.logging.Logger
-import javax.inject.Provider
 
 @HiltViewModel(assistedFactory = LoginScreenViewModel.Factory::class)
 class LoginScreenViewModel @AssistedInject constructor(
@@ -51,7 +50,7 @@ class LoginScreenViewModel @AssistedInject constructor(
     private val accountRepository: AccountRepository,
     @ApplicationContext val context: Context,
     private val debugDirectory: DebugDirectory,
-    private val httpClientBuilderProvider: Provider<HttpClientBuilder>,
+    private val httpClientBuilder: HttpClientBuilder,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     private val logger: Logger,
     val loginTypesProvider: LoginTypesProvider,
@@ -258,11 +257,13 @@ class LoginScreenViewModel @AssistedInject constructor(
 
         val result = FileLoggerFactory.forFile(logFile).use { fileLoggerContext ->
             val credentials = loginInfo.credentials
-            httpClientBuilderProvider.get()
+            httpClientBuilder
                 .setLogger(fileLoggerContext.logger)    // log HTTP calls to logFile
-                .apply {
+                .let { builder ->
                     if (credentials != null)
-                        authenticate(domain = null, getCredentials = { credentials })
+                        builder.authenticate(domain = null, getCredentials = { credentials })
+                    else
+                        builder
                 }
                 .buildKtor()
                 .use { httpClient ->

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenViewModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenViewModel.kt
@@ -258,7 +258,7 @@ class LoginScreenViewModel @AssistedInject constructor(
         val result = FileLoggerFactory.forFile(logFile).use { fileLoggerContext ->
             val credentials = loginInfo.credentials
             httpClientBuilder
-                .setLogger(fileLoggerContext.logger)    // log HTTP calls to logFile
+                .logTo(fileLoggerContext.logger)    // log HTTP calls to logFile
                 .let { builder ->
                     if (credentials != null)
                         builder.authenticate(domain = null, getCredentials = { credentials })

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/DavHttpClientBuilder.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/DavHttpClientBuilder.kt
@@ -9,11 +9,10 @@ import com.google.errorprone.annotations.MustBeClosed
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.logging.LogLevel
 import javax.inject.Inject
-import javax.inject.Provider
 
 class DavHttpClientBuilder @Inject constructor(
     private val credentialsStore: CredentialsStore,
-    private val httpClientBuilder: Provider<HttpClientBuilder>,
+    private val httpClientBuilder: HttpClientBuilder,
 ) {
 
     /**
@@ -37,12 +36,12 @@ class DavHttpClientBuilder @Inject constructor(
      * @return configured HttpClientBuilder ready for building
      */
     private fun createBuilder(mountId: Long, logBody: Boolean = true): HttpClientBuilder {
-        val builder = httpClientBuilder.get()
+        var builder = httpClientBuilder
             // Ktor's LogLevel.ALL logs headers + body (unlike LogLevel.BODY, which omits headers)
             .loggerInterceptorLevel(if (logBody) LogLevel.ALL else LogLevel.HEADERS)
 
         credentialsStore.getCredentials(mountId)?.let { credentials ->
-            builder.authenticate(
+            builder = builder.authenticate(
                 domain = null,
                 getCredentials = { credentials }
             )

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/DavHttpClientBuilder.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/DavHttpClientBuilder.kt
@@ -38,7 +38,7 @@ class DavHttpClientBuilder @Inject constructor(
     private fun createBuilder(mountId: Long, logBody: Boolean = true): HttpClientBuilder {
         var builder = httpClientBuilder
             // Ktor's LogLevel.ALL logs headers + body (unlike LogLevel.BODY, which omits headers)
-            .loggerInterceptorLevel(if (logBody) LogLevel.ALL else LogLevel.HEADERS)
+            .trafficLogLevel(if (logBody) LogLevel.ALL else LogLevel.HEADERS)
 
         credentialsStore.getCredentials(mountId)?.let { credentials ->
             builder = builder.authenticate(

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/DavHttpClientBuilder.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/DavHttpClientBuilder.kt
@@ -25,7 +25,7 @@ class DavHttpClientBuilder @Inject constructor(
     @MustBeClosed
     fun buildKtor(mountId: Long, logBody: Boolean = true): HttpClient {
         val builder = createBuilder(mountId, logBody)
-        return builder.buildKtor()
+        return builder.build()
     }
 
     /**

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/DavHttpClientBuilder.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/DavHttpClientBuilder.kt
@@ -6,13 +6,12 @@ package at.bitfire.davdroid.webdav
 
 import at.bitfire.davdroid.network.HttpClientBuilder
 import com.google.errorprone.annotations.MustBeClosed
-import io.ktor.client.HttpClient
 import io.ktor.client.plugins.logging.LogLevel
 import javax.inject.Inject
 
 class DavHttpClientBuilder @Inject constructor(
     private val credentialsStore: CredentialsStore,
-    private val httpClientBuilder: HttpClientBuilder,
+    private val httpClientBuilder: HttpClientBuilder
 ) {
 
     /**
@@ -23,10 +22,8 @@ class DavHttpClientBuilder @Inject constructor(
      * @return the new HttpClient which **must be closed by the caller**
      */
     @MustBeClosed
-    fun buildKtor(mountId: Long, logBody: Boolean = true): HttpClient {
-        val builder = createBuilder(mountId, logBody)
-        return builder.build()
-    }
+    fun build(mountId: Long, logBody: Boolean = true) =
+        createBuilder(mountId, logBody).build()
 
     /**
      * Creates and configures an HttpClientBuilder with authentication and cookie store.
@@ -37,7 +34,6 @@ class DavHttpClientBuilder @Inject constructor(
      */
     private fun createBuilder(mountId: Long, logBody: Boolean = true): HttpClientBuilder {
         var builder = httpClientBuilder
-            // Ktor's LogLevel.ALL logs headers + body (unlike LogLevel.BODY, which omits headers)
             .trafficLogLevel(if (logBody) LogLevel.ALL else LogLevel.HEADERS)
 
         credentialsStore.getCredentials(mountId)?.let { credentials ->

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/WebDavUrlChecker.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/WebDavUrlChecker.kt
@@ -9,13 +9,12 @@ import at.bitfire.davdroid.network.HttpClientBuilder
 import at.bitfire.davdroid.settings.Credentials
 import io.ktor.http.Url
 import javax.inject.Inject
-import javax.inject.Provider
 
 /**
  * Checks if WebDAV is supported at a given URL.
  */
 class WebDavUrlChecker @Inject constructor(
-    private val httpClientBuilder: Provider<HttpClientBuilder>
+    private val httpClientBuilder: HttpClientBuilder
 ) {
     /**
      * Checks whether WebDAV is supported at given URL with given credentials and returns the resulting URL after
@@ -31,9 +30,9 @@ class WebDavUrlChecker @Inject constructor(
     ): Url? {
         val validVersions = arrayOf("1", "2", "3")
 
-        val builder = httpClientBuilder.get()
+        var builder = httpClientBuilder
         if (credentials != null)
-            builder.authenticate(
+            builder = builder.authenticate(
                 domain = null,
                 getCredentials = { credentials }
             )

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/WebDavUrlChecker.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/WebDavUrlChecker.kt
@@ -38,7 +38,7 @@ class WebDavUrlChecker @Inject constructor(
             )
 
         var webdavUrl: Url? = null
-        builder.buildKtor().use { httpClient ->
+        builder.build().use { httpClient ->
             val dav = DavResource(httpClient, url)
             dav.options(followRedirects = true) { davCapabilities, _ ->
                 if (davCapabilities.any { it in validVersions })

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/CopyDocumentOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/CopyDocumentOperation.kt
@@ -23,7 +23,7 @@ import javax.inject.Inject
 class CopyDocumentOperation @Inject constructor(
     @ApplicationContext private val context: Context,
     private val db: AppDatabase,
-    private val httpClientBuilder: DavHttpClientBuilder,
+    private val davClientBuilder: DavHttpClientBuilder,
     private val logger: Logger
 ) {
 
@@ -38,7 +38,7 @@ class CopyDocumentOperation @Inject constructor(
         if (srcDoc.mountId != dstFolder.mountId)
             throw UnsupportedOperationException("Can't COPY between WebDAV servers")
 
-        httpClientBuilder
+        davClientBuilder
             .build(srcDoc.mountId)
             .use { httpClient ->
                 val dav = DavResource(httpClient, srcDoc.toKtorUrl(db))

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/CopyDocumentOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/CopyDocumentOperation.kt
@@ -39,7 +39,7 @@ class CopyDocumentOperation @Inject constructor(
             throw UnsupportedOperationException("Can't COPY between WebDAV servers")
 
         httpClientBuilder
-            .buildKtor(srcDoc.mountId)
+            .build(srcDoc.mountId)
             .use { httpClient ->
                 val dav = DavResource(httpClient, srcDoc.toKtorUrl(db))
                 val dstUrl = URLBuilder(dstFolder.toKtorUrl(db))

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/CreateDocumentOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/CreateDocumentOperation.kt
@@ -42,7 +42,7 @@ class CreateDocumentOperation @Inject constructor(
 
         var docId: Long?
         val parentUrl = parent.toKtorUrl(db)
-        httpClientBuilder.buildKtor(parent.mountId).use { client ->
+        httpClientBuilder.build(parent.mountId).use { client ->
             for (attempt in 0..DocumentProviderUtils.MAX_DISPLAYNAME_TO_MEMBERNAME_ATTEMPTS) {
                 val newName = displayNameToMemberName(displayName, attempt)
                 val newLocation = URLBuilder(parentUrl).appendPathSegments(newName).build()

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/CreateDocumentOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/CreateDocumentOperation.kt
@@ -29,7 +29,7 @@ import javax.inject.Inject
 class CreateDocumentOperation @Inject constructor(
     @ApplicationContext private val context: Context,
     private val db: AppDatabase,
-    private val httpClientBuilder: DavHttpClientBuilder,
+    private val davClientBuilder: DavHttpClientBuilder,
     private val logger: Logger
 ) {
 
@@ -42,7 +42,7 @@ class CreateDocumentOperation @Inject constructor(
 
         var docId: Long?
         val parentUrl = parent.toKtorUrl(db)
-        httpClientBuilder.build(parent.mountId).use { client ->
+        davClientBuilder.build(parent.mountId).use { client ->
             for (attempt in 0..DocumentProviderUtils.MAX_DISPLAYNAME_TO_MEMBERNAME_ATTEMPTS) {
                 val newName = displayNameToMemberName(displayName, attempt)
                 val newLocation = URLBuilder(parentUrl).appendPathSegments(newName).build()

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/DeleteDocumentOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/DeleteDocumentOperation.kt
@@ -20,7 +20,7 @@ import javax.inject.Inject
 class DeleteDocumentOperation @Inject constructor(
     @ApplicationContext private val context: Context,
     private val db: AppDatabase,
-    private val httpClientBuilder: DavHttpClientBuilder,
+    private val davClientBuilder: DavHttpClientBuilder,
     private val logger: Logger
 ) {
 
@@ -31,7 +31,7 @@ class DeleteDocumentOperation @Inject constructor(
         val doc = documentDao.get(documentId.toLong()) ?: throw FileNotFoundException()
 
         try {
-            httpClientBuilder.build(doc.mountId).use { client ->
+            davClientBuilder.build(doc.mountId).use { client ->
                 val dav = DavResource(client, doc.toKtorUrl(db))
                 dav.delete {
                     // successfully deleted

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/DeleteDocumentOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/DeleteDocumentOperation.kt
@@ -31,7 +31,7 @@ class DeleteDocumentOperation @Inject constructor(
         val doc = documentDao.get(documentId.toLong()) ?: throw FileNotFoundException()
 
         try {
-            httpClientBuilder.buildKtor(doc.mountId).use { client ->
+            httpClientBuilder.build(doc.mountId).use { client ->
                 val dav = DavResource(client, doc.toKtorUrl(db))
                 dav.delete {
                     // successfully deleted

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/MoveDocumentOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/MoveDocumentOperation.kt
@@ -37,7 +37,7 @@ class MoveDocumentOperation @Inject constructor(
             throw UnsupportedOperationException("Can't MOVE between WebDAV servers")
 
         httpClientBuilder
-            .buildKtor(doc.mountId)
+            .build(doc.mountId)
             .use { httpClient ->
                 val newLocation = URLBuilder(dstParent.toKtorUrl(db))
                     .appendPathSegments(doc.name)

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/MoveDocumentOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/MoveDocumentOperation.kt
@@ -22,7 +22,7 @@ import javax.inject.Inject
 class MoveDocumentOperation @Inject constructor(
     @ApplicationContext private val context: Context,
     private val db: AppDatabase,
-    private val httpClientBuilder: DavHttpClientBuilder,
+    private val davClientBuilder: DavHttpClientBuilder,
     private val logger: Logger
 ) {
 
@@ -36,7 +36,7 @@ class MoveDocumentOperation @Inject constructor(
         if (doc.mountId != dstParent.mountId)
             throw UnsupportedOperationException("Can't MOVE between WebDAV servers")
 
-        httpClientBuilder
+        davClientBuilder
             .build(doc.mountId)
             .use { httpClient ->
                 val newLocation = URLBuilder(dstParent.toKtorUrl(db))

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/OpenDocumentOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/OpenDocumentOperation.kt
@@ -44,7 +44,7 @@ class OpenDocumentOperation @Inject constructor(
 
         val doc = documentDao.get(documentId.toLong()) ?: throw FileNotFoundException()
         val url = doc.toKtorUrl(db)
-        val client = httpClientBuilder.buildKtor(doc.mountId, logBody = false)
+        val client = httpClientBuilder.build(doc.mountId, logBody = false)
 
         val readOnlyMode = when (mode) {
             "r" -> true

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/OpenDocumentOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/OpenDocumentOperation.kt
@@ -31,7 +31,7 @@ import javax.inject.Inject
 class OpenDocumentOperation @Inject constructor(
     @ApplicationContext private val context: Context,
     private val db: AppDatabase,
-    private val httpClientBuilder: DavHttpClientBuilder,
+    private val davClientBuilder: DavHttpClientBuilder,
     private val logger: Logger,
     private val randomAccessCallbackWrapperFactory: RandomAccessCallbackWrapper.Factory,
     private val streamingFileDescriptorFactory: StreamingFileDescriptor.Factory
@@ -44,7 +44,7 @@ class OpenDocumentOperation @Inject constructor(
 
         val doc = documentDao.get(documentId.toLong()) ?: throw FileNotFoundException()
         val url = doc.toKtorUrl(db)
-        val client = httpClientBuilder.build(doc.mountId, logBody = false)
+        val client = davClientBuilder.build(doc.mountId, logBody = false)
 
         val readOnlyMode = when (mode) {
             "r" -> true

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/OpenDocumentThumbnailOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/OpenDocumentThumbnailOperation.kt
@@ -41,7 +41,7 @@ import kotlin.use
 class OpenDocumentThumbnailOperation @Inject constructor(
     @ApplicationContext private val context: Context,
     private val db: AppDatabase,
-    private val httpClientBuilder: DavHttpClientBuilder,
+    private val davClientBuilder: DavHttpClientBuilder,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     private val logger: Logger,
     private val thumbnailCache: ThumbnailCache
@@ -101,7 +101,7 @@ class OpenDocumentThumbnailOperation @Inject constructor(
         }
 
     private suspend fun downloadAndCreateThumbnail(doc: WebDavDocument, db: AppDatabase, sizeHint: Point): ByteArray? =
-        httpClientBuilder
+        davClientBuilder
             .build(doc.mountId, logBody = false)
             .use { httpClient ->
             val url = doc.toKtorUrl(db)

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/OpenDocumentThumbnailOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/OpenDocumentThumbnailOperation.kt
@@ -102,7 +102,7 @@ class OpenDocumentThumbnailOperation @Inject constructor(
 
     private suspend fun downloadAndCreateThumbnail(doc: WebDavDocument, db: AppDatabase, sizeHint: Point): ByteArray? =
         httpClientBuilder
-            .buildKtor(doc.mountId, logBody = false)
+            .build(doc.mountId, logBody = false)
             .use { httpClient ->
             val url = doc.toKtorUrl(db)
             try {

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/QueryChildDocumentsOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/QueryChildDocumentsOperation.kt
@@ -127,7 +127,7 @@ class QueryChildDocumentsOperation @Inject constructor(
 
         val parentUrl = parent.toKtorUrl(db)
         try {
-            httpClientBuilder.buildKtor(parent.mountId).use { client ->
+            httpClientBuilder.build(parent.mountId).use { client ->
                 val folder = DavCollection(client, parentUrl)
                 folder.propfind(1, *DAV_FILE_FIELDS) { response, relation ->
                     logger.fine("$relation $response")

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/QueryChildDocumentsOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/QueryChildDocumentsOperation.kt
@@ -42,7 +42,7 @@ class QueryChildDocumentsOperation @Inject constructor(
     @ApplicationContext private val context: Context,
     private val db: AppDatabase,
     private val documentSortByMapper: Lazy<DocumentSortByMapper>,
-    private val httpClientBuilder: DavHttpClientBuilder,
+    private val davClientBuilder: DavHttpClientBuilder,
     private val logger: Logger
 ) {
 
@@ -127,7 +127,7 @@ class QueryChildDocumentsOperation @Inject constructor(
 
         val parentUrl = parent.toKtorUrl(db)
         try {
-            httpClientBuilder.build(parent.mountId).use { client ->
+            davClientBuilder.build(parent.mountId).use { client ->
                 val folder = DavCollection(client, parentUrl)
                 folder.propfind(1, *DAV_FILE_FIELDS) { response, relation ->
                     logger.fine("$relation $response")

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/RenameDocumentOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/RenameDocumentOperation.kt
@@ -33,7 +33,7 @@ class RenameDocumentOperation @Inject constructor(
         val doc = documentDao.get(documentId.toLong()) ?: throw FileNotFoundException()
 
         httpClientBuilder
-            .buildKtor(doc.mountId)
+            .build(doc.mountId)
             .use { httpClient ->
                 for (attempt in 0..DocumentProviderUtils.MAX_DISPLAYNAME_TO_MEMBERNAME_ATTEMPTS) {
                     val newName = displayNameToMemberName(displayName, attempt)

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/RenameDocumentOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/RenameDocumentOperation.kt
@@ -22,7 +22,7 @@ import javax.inject.Inject
 class RenameDocumentOperation @Inject constructor(
     @ApplicationContext private val context: Context,
     private val db: AppDatabase,
-    private val httpClientBuilder: DavHttpClientBuilder,
+    private val davClientBuilder: DavHttpClientBuilder,
     private val logger: Logger
 ) {
 
@@ -32,7 +32,7 @@ class RenameDocumentOperation @Inject constructor(
         logger.fine("WebDAV renameDocument $documentId $displayName")
         val doc = documentDao.get(documentId.toLong()) ?: throw FileNotFoundException()
 
-        httpClientBuilder
+        davClientBuilder
             .build(doc.mountId)
             .use { httpClient ->
                 for (attempt in 0..DocumentProviderUtils.MAX_DISPLAYNAME_TO_MEMBERNAME_ATTEMPTS) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,6 @@ compose-accompanist = "0.37.3"
 compose-bom = "2026.06.01"
 conscrypt = "2.5.3"
 dnsjava = "3.6.5"
-errorprone-annotations = "2.47.0"
 ezvcard = "0.12.2"
 ical4j = "4.3.0"
 glance = "1.1.1"
@@ -43,6 +42,7 @@ openid-appauth = "0.11.1"
 robolectric = "4.16.1"
 room = "2.8.4"
 slf4j = "2.0.18"
+spotbugs = "4.10.2"
 unifiedpush = "3.3.3"
 unifiedpush-fcm = "3.1.0"
 
@@ -98,7 +98,6 @@ commons-lang = { module = "org.apache.commons:commons-lang3", version.ref = "com
 compose-accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "compose-accompanist" }
 conscrypt = { module = "org.conscrypt:conscrypt-android", version.ref = "conscrypt" }
 dnsjava = { module = "dnsjava:dnsjava", version.ref = "dnsjava" }
-error-prone-annotations = { module = "com.google.errorprone:error_prone_annotations", version.ref = "errorprone-annotations" }
 ezvcard = { module = "com.googlecode.ez-vcard:ez-vcard", version.ref = "ezvcard" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 ical4j = { module = "org.mnode.ical4j:ical4j", version.ref = "ical4j" }
@@ -128,6 +127,7 @@ okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.
 openid-appauth = { module = "net.openid:appauth", version.ref = "openid-appauth" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 slf4j-jdk = { module = "org.slf4j:slf4j-jdk14", version.ref = "slf4j" }
+spotbugs-annotations = { module = "com.github.spotbugs:spotbugs-annotations", version.ref = "spotbugs" }
 unifiedpush = { module = "org.unifiedpush.android:connector", version.ref = "unifiedpush" }
 unifiedpush-fcm = { module = "org.unifiedpush.android:embedded-fcm-distributor", version.ref = "unifiedpush-fcm" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ compose-accompanist = "0.37.3"
 compose-bom = "2026.06.01"
 conscrypt = "2.5.3"
 dnsjava = "3.6.5"
+errorprone-annotations = "2.47.0"
 ezvcard = "0.12.2"
 ical4j = "4.3.0"
 glance = "1.1.1"
@@ -42,7 +43,6 @@ openid-appauth = "0.11.1"
 robolectric = "4.16.1"
 room = "2.8.4"
 slf4j = "2.0.18"
-spotbugs = "4.10.2"
 unifiedpush = "3.3.3"
 unifiedpush-fcm = "3.1.0"
 
@@ -98,6 +98,7 @@ commons-lang = { module = "org.apache.commons:commons-lang3", version.ref = "com
 compose-accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "compose-accompanist" }
 conscrypt = { module = "org.conscrypt:conscrypt-android", version.ref = "conscrypt" }
 dnsjava = { module = "dnsjava:dnsjava", version.ref = "dnsjava" }
+error-prone-annotations = { module = "com.google.errorprone:error_prone_annotations", version.ref = "errorprone-annotations" }
 ezvcard = { module = "com.googlecode.ez-vcard:ez-vcard", version.ref = "ezvcard" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 ical4j = { module = "org.mnode.ical4j:ical4j", version.ref = "ical4j" }
@@ -127,7 +128,6 @@ okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.
 openid-appauth = { module = "net.openid:appauth", version.ref = "openid-appauth" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 slf4j-jdk = { module = "org.slf4j:slf4j-jdk14", version.ref = "slf4j" }
-spotbugs-annotations = { module = "com.github.spotbugs:spotbugs-annotations", version.ref = "spotbugs" }
 unifiedpush = { module = "org.unifiedpush.android:connector", version.ref = "unifiedpush" }
 unifiedpush-fcm = { module = "org.unifiedpush.android:embedded-fcm-distributor", version.ref = "unifiedpush-fcm" }
 

--- a/synctools/build.gradle.kts
+++ b/synctools/build.gradle.kts
@@ -97,6 +97,9 @@ dependencies {
     implementation(libs.slf4j.jdk)       // ical4j uses slf4j, this module uses java.util.Logger
     api(libs.ezvcard)
 
+    // useful annotations
+    compileOnly(libs.spotbugs.annotations)
+
     // force some versions for compatibility with our minSdk level (see version catalog for details)
     implementation(libs.commons.codec)
     implementation(libs.commons.lang)

--- a/synctools/build.gradle.kts
+++ b/synctools/build.gradle.kts
@@ -91,8 +91,7 @@ dependencies {
     implementation(libs.androidx.core)
     implementation(libs.guava)
     implementation(libs.kotlinx.coroutines)
-
-    compileOnly(libs.spotbugs.annotations)
+    implementation(libs.spotbugs.annotations)
 
     // ical4j/ez-vcard
     api(libs.ical4j)
@@ -103,14 +102,10 @@ dependencies {
     implementation(libs.commons.codec)
     implementation(libs.commons.lang)
 
-    // useful annotations
-    api(libs.spotbugs.annotations)
-
     // test fixtures
     testFixturesImplementation(libs.androidx.test.rules)
 
     // instrumented tests
-    androidTestImplementation(libs.androidx.test.rules)
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.kotlinx.coroutines.test)
     androidTestImplementation(libs.mockk.android)

--- a/synctools/build.gradle.kts
+++ b/synctools/build.gradle.kts
@@ -91,7 +91,6 @@ dependencies {
     implementation(libs.androidx.core)
     implementation(libs.guava)
     implementation(libs.kotlinx.coroutines)
-    implementation(libs.spotbugs.annotations)
 
     // ical4j/ez-vcard
     api(libs.ical4j)
@@ -106,6 +105,7 @@ dependencies {
     testFixturesImplementation(libs.androidx.test.rules)
 
     // instrumented tests
+    androidTestImplementation(libs.androidx.test.rules)
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.kotlinx.coroutines.test)
     androidTestImplementation(libs.mockk.android)


### PR DESCRIPTION
> [!NOTE]
> Merge after #2601 

### Purpose

Currently, `HttpClientBuilder` has a bad pattern that requires to inject `Provider<HttpClientBuilder>` when multiple clients are needed and that can cause unexpected behavior, represented by this warning:

https://github.com/bitfireAT/davx5-ose/blob/22f74dc000069702782c8041e8f3377ec6e9ad87/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt#L268-L269

This PR changes the builder to an immutable approach without surprises (exceptions).

### Short description

- Make HttpClientBuilder immutable and remove Hilt `Provider<>` usage
- Rename `buildKtor()` to `build()`
- Rename logger methods to `logTo` and `trafficLogLevel`

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.