### PR TITLE
Hide activity intent details

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/push/PushNotificationManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/push/PushNotificationManager.kt
@@ -73,9 +73,7 @@ class PushNotificationManager @Inject constructor(
             title = context.getString(R.string.sync_notification_pending_push_title),
             text = context.getString(R.string.sync_notification_pending_push_message),
             subText = account.name,
-            intent = Intent(context, AccountActivity::class.java).apply {
-                putExtra(AccountActivity.EXTRA_ACCOUNT, account)
-            }
+            intent = AccountActivity.createIntent(context, account)
         )
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/servicedetection/RefreshCollectionsWorker.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/servicedetection/RefreshCollectionsWorker.kt
@@ -183,8 +183,7 @@ class RefreshCollectionsWorker @AssistedInject constructor(
         } catch (e: UnauthorizedException) {
             logger.log(Level.SEVERE, "Not authorized (anymore)", e)
             // notify that we need to re-authenticate in the account settings
-            val settingsIntent = Intent(applicationContext, AccountSettingsActivity::class.java)
-                .putExtra(AccountSettingsActivity.EXTRA_ACCOUNT, account)
+            val settingsIntent = AccountSettingsActivity.createIntent(applicationContext, account)
             notifyRefreshError(
                 applicationContext.getString(R.string.sync_error_authentication_failed),
                 settingsIntent

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncConditions.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncConditions.kt
@@ -51,9 +51,8 @@ class SyncConditions @AssistedInject constructor(
             // check required permissions and location status
             if (!PermissionUtils.canAccessWifiSsid(context)) {
                 // not all permissions granted; show notification
-                val intent = Intent(context, WifiPermissionsActivity::class.java)
-                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                intent.putExtra(WifiPermissionsActivity.EXTRA_ACCOUNT, accountSettings.account)
+                val intent = WifiPermissionsActivity.createIntent(context, accountSettings.account)
+                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                 notificationRegistry.notifyPermissions(intent)
 
                 logger.warning("Can't access WiFi SSID, aborting sync")

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncNotificationManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncNotificationManager.kt
@@ -116,11 +116,7 @@ class SyncNotificationManager @AssistedInject constructor(
     ) = notificationRegistry.notifyIfPossible(NotificationRegistry.NOTIFY_SYNC_ERROR, tag = notificationTag) {
         val contentIntent: Intent
         if (e is UnauthorizedException) {
-            contentIntent = Intent(context, AccountSettingsActivity::class.java)
-            contentIntent.putExtra(
-                AccountSettingsActivity.EXTRA_ACCOUNT,
-                account
-            )
+            contentIntent = AccountSettingsActivity.createIntent(context, account)
         } else {
             contentIntent = buildDebugInfoIntent(syncDataType, e, local, remote)
         }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/AccountsActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/AccountsActivity.kt
@@ -44,8 +44,7 @@ class AccountsActivity: AppCompatActivity() {
                     startActivity(Intent(this, LoginActivity::class.java))
                 },
                 onShowAccount = { account ->
-                    val intent = Intent(this, AccountActivity::class.java)
-                    intent.putExtra(AccountActivity.EXTRA_ACCOUNT, account)
+                    val intent = AccountActivity.createIntent(this, account)
                     startActivity(intent)
                 },
                 onManagePermissions = {

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountActivity.kt
@@ -6,6 +6,7 @@ package at.bitfire.davdroid.ui.account
 
 import AccountScreen
 import android.accounts.Account
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
@@ -75,7 +76,17 @@ class AccountActivity : AppCompatActivity() {
     }
 
     companion object {
-        const val EXTRA_ACCOUNT = "account"
+        private const val EXTRA_ACCOUNT = "account"
+        
+        fun createIntent(context: Context, account: Account): Intent {
+            return Intent(context, AccountActivity::class.java).apply { 
+                putExtra(EXTRA_ACCOUNT, account)
+            }
+        }
+        
+        fun Intent.editAccountActivityIntent(account: Account) {
+            putExtra(EXTRA_ACCOUNT, account)
+        }
     }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountActivity.kt
@@ -53,8 +53,7 @@ class AccountActivity : AppCompatActivity() {
                     startActivity(intent, null)
                 },
                 onCreateAddressBook = {
-                    val intent = Intent(this, CreateAddressBookActivity::class.java)
-                    intent.putExtra(CreateAddressBookActivity.EXTRA_ACCOUNT, account)
+                    val intent = CreateAddressBookActivity.createIntent(this, account)
                     startActivity(intent)
                 },
                 onCreateCalendar = {

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountActivity.kt
@@ -58,8 +58,7 @@ class AccountActivity : AppCompatActivity() {
                     startActivity(intent)
                 },
                 onCreateCalendar = {
-                    val intent = Intent(this, CreateCalendarActivity::class.java)
-                    intent.putExtra(CreateCalendarActivity.EXTRA_ACCOUNT, account)
+                    val intent = CreateCalendarActivity.createIntent(this, account)
                     startActivity(intent)
                 },
                 onCollectionDetails = { collection ->

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountActivity.kt
@@ -63,9 +63,7 @@ class AccountActivity : AppCompatActivity() {
                     startActivity(intent)
                 },
                 onCollectionDetails = { collection ->
-                    val intent = Intent(this, CollectionActivity::class.java)
-                    intent.putExtra(CollectionActivity.EXTRA_ACCOUNT, account)
-                    intent.putExtra(CollectionActivity.EXTRA_COLLECTION_ID, collection.id)
+                    val intent = CollectionActivity.createIntent(this, account, collection.id)
                     startActivity(intent, null)
                 },
                 onNavUp = ::onSupportNavigateUp,

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountActivity.kt
@@ -49,8 +49,7 @@ class AccountActivity : AppCompatActivity() {
             AccountScreen(
                 account = account,
                 onAccountSettings = {
-                    val intent = Intent(this, AccountSettingsActivity::class.java)
-                    intent.putExtra(AccountSettingsActivity.EXTRA_ACCOUNT, account)
+                    val intent = AccountSettingsActivity.createIntent(this, account)
                     startActivity(intent, null)
                 },
                 onCreateAddressBook = {

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsActivity.kt
@@ -11,6 +11,7 @@ import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.TaskStackBuilder
 import androidx.core.content.IntentCompat
+import at.bitfire.davdroid.ui.account.AccountActivity.Companion.editAccountActivityIntent
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -45,7 +46,7 @@ class AccountSettingsActivity: AppCompatActivity() {
     override fun supportShouldUpRecreateTask(targetIntent: Intent) = true
 
     override fun onPrepareSupportNavigateUpTaskStack(builder: TaskStackBuilder) {
-        builder.editIntentAt(builder.intentCount - 1)?.putExtra(AccountActivity.EXTRA_ACCOUNT, account)
+        builder.editIntentAt(builder.intentCount - 1)?.editAccountActivityIntent(account)
     }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsActivity.kt
@@ -5,6 +5,7 @@
 package at.bitfire.davdroid.ui.account
 
 import android.accounts.Account
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
@@ -18,7 +19,17 @@ import dagger.hilt.android.AndroidEntryPoint
 class AccountSettingsActivity: AppCompatActivity() {
 
     companion object {
-        const val EXTRA_ACCOUNT = "account"
+        private const val EXTRA_ACCOUNT = "account"
+        
+        fun createIntent(context: Context, account: Account): Intent {
+            return Intent(context, AccountSettingsActivity::class.java).apply { 
+                putExtra(EXTRA_ACCOUNT, account)
+            }
+        }
+        
+        fun Intent.editAccountSettingsActivityIntent(account: Account) {
+            putExtra(EXTRA_ACCOUNT, account)
+        }
     }
 
     private val account by lazy {

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsActivity.kt
@@ -45,8 +45,7 @@ class AccountSettingsActivity: AppCompatActivity() {
             AccountSettingsScreen(
                 account = account,
                 onNavWifiPermissionsScreen = {
-                    val intent = Intent(this, WifiPermissionsActivity::class.java)
-                    intent.putExtra(WifiPermissionsActivity.EXTRA_ACCOUNT, account)
+                    val intent = WifiPermissionsActivity.createIntent(this, account)
                     startActivity(intent)
                 },
                 onNavUp = ::onSupportNavigateUp,

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionActivity.kt
@@ -11,6 +11,7 @@ import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.TaskStackBuilder
 import androidx.core.content.IntentCompat
+import at.bitfire.davdroid.ui.account.AccountActivity.Companion.editAccountActivityIntent
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -42,7 +43,7 @@ class CollectionActivity: AppCompatActivity() {
     override fun supportShouldUpRecreateTask(targetIntent: Intent) = true
 
     override fun onPrepareSupportNavigateUpTaskStack(builder: TaskStackBuilder) {
-        builder.editIntentAt(builder.intentCount - 1)?.putExtra(AccountActivity.EXTRA_ACCOUNT, account)
+        builder.editIntentAt(builder.intentCount - 1)?.editAccountActivityIntent(account)
     }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionActivity.kt
@@ -5,6 +5,7 @@
 package at.bitfire.davdroid.ui.account
 
 import android.accounts.Account
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
@@ -18,8 +19,15 @@ import dagger.hilt.android.AndroidEntryPoint
 class CollectionActivity: AppCompatActivity() {
 
     companion object {
-        const val EXTRA_ACCOUNT = "account"
-        const val EXTRA_COLLECTION_ID = "collection_id"
+        private const val EXTRA_ACCOUNT = "account"
+        private const val EXTRA_COLLECTION_ID = "collection_id"
+        
+        fun createIntent(context: Context, account: Account, collectionId: Long): Intent {
+            return Intent(context, CollectionActivity::class.java).apply {
+                putExtra(EXTRA_ACCOUNT, account)
+                putExtra(EXTRA_COLLECTION_ID, collectionId)
+            }
+        }
     }
 
     val account by lazy {

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateAddressBookActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateAddressBookActivity.kt
@@ -11,6 +11,7 @@ import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.TaskStackBuilder
 import androidx.core.content.IntentCompat
+import at.bitfire.davdroid.ui.account.AccountActivity.Companion.editAccountActivityIntent
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -40,7 +41,7 @@ class CreateAddressBookActivity: AppCompatActivity() {
     override fun supportShouldUpRecreateTask(targetIntent: Intent) = true
 
     override fun onPrepareSupportNavigateUpTaskStack(builder: TaskStackBuilder) {
-        builder.editIntentAt(builder.intentCount - 1)?.putExtra(AccountActivity.EXTRA_ACCOUNT, account)
+        builder.editIntentAt(builder.intentCount - 1)?.editAccountActivityIntent(account)
     }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateAddressBookActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateAddressBookActivity.kt
@@ -5,6 +5,7 @@
 package at.bitfire.davdroid.ui.account
 
 import android.accounts.Account
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
@@ -18,7 +19,13 @@ import dagger.hilt.android.AndroidEntryPoint
 class CreateAddressBookActivity: AppCompatActivity() {
 
     companion object {
-        const val EXTRA_ACCOUNT = "account"
+        private const val EXTRA_ACCOUNT = "account"
+        
+        fun createIntent(context: Context, account: Account): Intent {
+            return Intent(context, CreateAddressBookActivity::class.java).apply { 
+                putExtra(EXTRA_ACCOUNT, account)
+            }
+        }
     }
 
     val account by lazy {

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateCalendarActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateCalendarActivity.kt
@@ -11,6 +11,7 @@ import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.TaskStackBuilder
 import androidx.core.content.IntentCompat
+import at.bitfire.davdroid.ui.account.AccountActivity.Companion.editAccountActivityIntent
 import at.bitfire.davdroid.ui.composable.AppTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -43,7 +44,7 @@ class CreateCalendarActivity: AppCompatActivity() {
     override fun supportShouldUpRecreateTask(targetIntent: Intent) = true
 
     override fun onPrepareSupportNavigateUpTaskStack(builder: TaskStackBuilder) {
-        builder.editIntentAt(builder.intentCount - 1)?.putExtra(AccountActivity.EXTRA_ACCOUNT, account)
+        builder.editIntentAt(builder.intentCount - 1)?.editAccountActivityIntent(account)
     }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateCalendarActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateCalendarActivity.kt
@@ -5,6 +5,7 @@
 package at.bitfire.davdroid.ui.account
 
 import android.accounts.Account
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
@@ -19,7 +20,13 @@ import dagger.hilt.android.AndroidEntryPoint
 class CreateCalendarActivity: AppCompatActivity() {
 
     companion object {
-        const val EXTRA_ACCOUNT = "account"
+        private const val EXTRA_ACCOUNT = "account"
+        
+        fun createIntent(context: Context, account: Account): Intent {
+            return Intent(context, CreateCalendarActivity::class.java).apply { 
+                putExtra(EXTRA_ACCOUNT, account)
+            }
+        }
     }
 
     val account by lazy {

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/WifiPermissionsActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/WifiPermissionsActivity.kt
@@ -5,6 +5,7 @@
 package at.bitfire.davdroid.ui.account
 
 import android.accounts.Account
+import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
@@ -22,7 +23,13 @@ import dagger.hilt.android.AndroidEntryPoint
 class WifiPermissionsActivity: AppCompatActivity() {
 
     companion object {
-        const val EXTRA_ACCOUNT = "account"
+        private const val EXTRA_ACCOUNT = "account"
+        
+        fun createIntent(context: Context, account: Account): Intent {
+            return Intent(context, WifiPermissionsActivity::class.java).apply { 
+                putExtra(EXTRA_ACCOUNT, account)
+            }
+        }
     }
 
     private val account by lazy { IntentCompat.getParcelableExtra(intent, EXTRA_ACCOUNT, Account::class.java) ?: throw IllegalArgumentException("EXTRA_ACCOUNT must be set") }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/WifiPermissionsActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/WifiPermissionsActivity.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.core.app.TaskStackBuilder
 import androidx.core.content.IntentCompat
 import at.bitfire.davdroid.R
+import at.bitfire.davdroid.ui.account.AccountSettingsActivity.Companion.editAccountSettingsActivityIntent
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -49,7 +50,7 @@ class WifiPermissionsActivity: AppCompatActivity() {
     override fun supportShouldUpRecreateTask(targetIntent: Intent) = true
 
     override fun onPrepareSupportNavigateUpTaskStack(builder: TaskStackBuilder) {
-        builder.editIntentAt(builder.intentCount - 1)?.putExtra(AccountSettingsActivity.EXTRA_ACCOUNT, account)
+        builder.editIntentAt(builder.intentCount - 1)?.editAccountSettingsActivityIntent(account)
     }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginActivity.kt
@@ -41,8 +41,7 @@ class LoginActivity @Inject constructor(): AppCompatActivity() {
                     finish()
 
                     newAccount?.let { newAccount ->
-                        val intent = Intent(this, AccountActivity::class.java)
-                        intent.putExtra(AccountActivity.EXTRA_ACCOUNT, newAccount)
+                        val intent = AccountActivity.createIntent(this, newAccount)
                         startActivity(intent)
                     }
                 }


### PR DESCRIPTION
This changes `Activity` classes that are using an account in `Intent` extras. How arguments are added to the `Intent` is now an implementation detail of the respective `Activity`. 

This will simplify the introduction of our own account classes (see #2033).