### PR TITLE
Introduce `AccountId` type

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/accounts/AccountId.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/accounts/AccountId.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.accounts
+
+import android.accounts.Account as AndroidAccount
+
+/**
+ * Uniquely identifies an app account.
+ */
+sealed interface AccountId
+
+/**
+ * A legacy account that is backed by Android's AccountManager.
+ */
+class LegacyAccount(val androidAccount: AndroidAccount) : AccountId {
+    override fun toString(): String {
+        return "${androidAccount.type}/${androidAccount.name}"
+    }
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/accounts/AccountIdIntentSerializer.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/accounts/AccountIdIntentSerializer.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.accounts
+
+import android.content.Intent
+import androidx.core.content.IntentCompat
+import android.accounts.Account as AndroidAccount
+
+object AccountIdIntentSerializer {
+    fun addExtra(intent: Intent, key: String, accountId: AccountId) {
+        val value = when (accountId) {
+            is LegacyAccount -> accountId.androidAccount
+        }
+        intent.putExtra(key, value)
+    }
+    
+    fun fromIntent(intent: Intent, key: String): AccountId? {
+        return IntentCompat.getParcelableExtra(intent, key, AndroidAccount::class.java)?.let { androidAccount ->
+            LegacyAccount(androidAccount)
+        }
+    }
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/accounts/TemporaryHelpers.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/accounts/TemporaryHelpers.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.accounts
+
+import android.accounts.Account as AndroidAccount
+
+@Deprecated("Only used during conversion from android.accounts.Account to AccountId")
+fun AccountId.toAndroidAccount(): AndroidAccount {
+    require(this is LegacyAccount) { 
+        "Account instance must be a LegacyAccount, but was ${this.javaClass.canonicalName}" 
+    }
+    
+    return androidAccount
+}
+
+@Deprecated("Only used during conversion from android.accounts.Account to AccountId")
+fun AndroidAccount.toAccountId(): AccountId {
+    return LegacyAccount(this)
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/db/HomeSetDao.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/HomeSetDao.kt
@@ -10,6 +10,8 @@ import androidx.room.Insert
 import androidx.room.Query
 import androidx.room.Transaction
 import androidx.room.Update
+import at.bitfire.davdroid.accounts.AccountId
+import at.bitfire.davdroid.accounts.LegacyAccount
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -26,6 +28,17 @@ interface HomeSetDao {
 
     @Query("SELECT * FROM homeset WHERE serviceId=(SELECT id FROM service WHERE accountName=:accountName AND type=:serviceType) AND privBind ORDER BY displayName, url COLLATE NOCASE")
     fun getBindableByAccountAndServiceTypeFlow(accountName: String, @ServiceType serviceType: String): Flow<List<HomeSet>>
+
+    fun getBindableByAccountAndServiceTypeFlow(
+        accountId: AccountId,
+        @ServiceType serviceType: String
+    ): Flow<List<HomeSet>> {
+        return when (accountId) {
+            is LegacyAccount -> {
+                getBindableByAccountAndServiceTypeFlow(accountId.androidAccount.name, serviceType)
+            }
+        }
+    }
 
     @Query("SELECT * FROM homeset WHERE serviceId=:serviceId AND privBind")
     fun getBindableByServiceFlow(serviceId: Long): Flow<List<HomeSet>>

--- a/core/src/main/kotlin/at/bitfire/davdroid/repository/DavHomeSetRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/repository/DavHomeSetRepository.kt
@@ -5,6 +5,7 @@
 package at.bitfire.davdroid.repository
 
 import android.accounts.Account
+import at.bitfire.davdroid.accounts.AccountId
 import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.HomeSet
 import at.bitfire.davdroid.db.Service
@@ -25,8 +26,8 @@ class DavHomeSetRepository @Inject constructor(
 
     fun getByServiceBlocking(serviceId: Long) = dao.getByService(serviceId)
 
-    fun getCalendarHomeSetsFlow(account: Account) =
-        dao.getBindableByAccountAndServiceTypeFlow(account.name, Service.TYPE_CALDAV)
+    fun getCalendarHomeSetsFlow(accountId: AccountId) =
+        dao.getBindableByAccountAndServiceTypeFlow(accountId, Service.TYPE_CALDAV)
 
     fun insertOrUpdateByUrlBlocking(homeSet: HomeSet): Long =
         dao.insertOrUpdateByUrlBlocking(homeSet)

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountActivity.kt
@@ -58,7 +58,7 @@ class AccountActivity : AppCompatActivity() {
                     startActivity(intent)
                 },
                 onCreateCalendar = {
-                    val intent = CreateCalendarActivity.createIntent(this, account)
+                    val intent = CreateCalendarActivity.createIntent(this, account.toAccountId())
                     startActivity(intent)
                 },
                 onCollectionDetails = { collection ->

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountActivity.kt
@@ -13,6 +13,7 @@ import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.IntentCompat
 import at.bitfire.davdroid.R
+import at.bitfire.davdroid.accounts.toAccountId
 import at.bitfire.davdroid.ui.AccountsActivity
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.logging.Logger
@@ -61,7 +62,7 @@ class AccountActivity : AppCompatActivity() {
                     startActivity(intent)
                 },
                 onCollectionDetails = { collection ->
-                    val intent = CollectionActivity.createIntent(this, account, collection.id)
+                    val intent = CollectionActivity.createIntent(this, account.toAccountId(), collection.id)
                     startActivity(intent, null)
                 },
                 onNavUp = ::onSupportNavigateUp,

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionActivity.kt
@@ -4,14 +4,15 @@
 
 package at.bitfire.davdroid.ui.account
 
-import android.accounts.Account
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.TaskStackBuilder
-import androidx.core.content.IntentCompat
+import at.bitfire.davdroid.accounts.AccountId
+import at.bitfire.davdroid.accounts.AccountIdIntentSerializer
+import at.bitfire.davdroid.accounts.toAndroidAccount
 import at.bitfire.davdroid.ui.account.AccountActivity.Companion.editAccountActivityIntent
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -22,16 +23,17 @@ class CollectionActivity: AppCompatActivity() {
         private const val EXTRA_ACCOUNT = "account"
         private const val EXTRA_COLLECTION_ID = "collection_id"
         
-        fun createIntent(context: Context, account: Account, collectionId: Long): Intent {
+        fun createIntent(context: Context, accountId: AccountId, collectionId: Long): Intent {
             return Intent(context, CollectionActivity::class.java).apply {
-                putExtra(EXTRA_ACCOUNT, account)
+                AccountIdIntentSerializer.addExtra(this, EXTRA_ACCOUNT, accountId)
                 putExtra(EXTRA_COLLECTION_ID, collectionId)
             }
         }
     }
 
-    val account by lazy {
-        IntentCompat.getParcelableExtra(intent, EXTRA_ACCOUNT, Account::class.java) ?: throw IllegalArgumentException("EXTRA_ACCOUNT must be set")
+    val accountId by lazy {
+        AccountIdIntentSerializer.fromIntent(intent, EXTRA_ACCOUNT) 
+            ?: throw IllegalArgumentException("EXTRA_ACCOUNT must be set")
     }
     val collectionId by lazy { intent.getLongExtra(EXTRA_COLLECTION_ID, -1) }
 
@@ -51,7 +53,7 @@ class CollectionActivity: AppCompatActivity() {
     override fun supportShouldUpRecreateTask(targetIntent: Intent) = true
 
     override fun onPrepareSupportNavigateUpTaskStack(builder: TaskStackBuilder) {
-        builder.editIntentAt(builder.intentCount - 1)?.editAccountActivityIntent(account)
+        builder.editIntentAt(builder.intentCount - 1)?.editAccountActivityIntent(accountId.toAndroidAccount())
     }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateCalendarActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateCalendarActivity.kt
@@ -4,14 +4,15 @@
 
 package at.bitfire.davdroid.ui.account
 
-import android.accounts.Account
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.TaskStackBuilder
-import androidx.core.content.IntentCompat
+import at.bitfire.davdroid.accounts.AccountId
+import at.bitfire.davdroid.accounts.AccountIdIntentSerializer
+import at.bitfire.davdroid.accounts.toAndroidAccount
 import at.bitfire.davdroid.ui.account.AccountActivity.Companion.editAccountActivityIntent
 import at.bitfire.davdroid.ui.composable.AppTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -22,15 +23,16 @@ class CreateCalendarActivity: AppCompatActivity() {
     companion object {
         private const val EXTRA_ACCOUNT = "account"
         
-        fun createIntent(context: Context, account: Account): Intent {
-            return Intent(context, CreateCalendarActivity::class.java).apply { 
-                putExtra(EXTRA_ACCOUNT, account)
+        fun createIntent(context: Context, accountId: AccountId): Intent {
+            return Intent(context, CreateCalendarActivity::class.java).apply {
+                AccountIdIntentSerializer.addExtra(this, EXTRA_ACCOUNT, accountId)
             }
         }
     }
 
-    val account by lazy {
-        IntentCompat.getParcelableExtra(intent, EXTRA_ACCOUNT, Account::class.java) ?: throw IllegalArgumentException("EXTRA_ACCOUNT must be set")
+    val accountId by lazy {
+        AccountIdIntentSerializer.fromIntent(intent, EXTRA_ACCOUNT) 
+            ?: throw IllegalArgumentException("EXTRA_ACCOUNT must be set")
     }
 
 
@@ -40,7 +42,7 @@ class CreateCalendarActivity: AppCompatActivity() {
         setContent {
             AppTheme {
                 CreateCalendarScreen(
-                    account = account,
+                    accountId = accountId,
                     onNavUp = ::onSupportNavigateUp,
                     onFinish = ::finish
                 )
@@ -51,7 +53,7 @@ class CreateCalendarActivity: AppCompatActivity() {
     override fun supportShouldUpRecreateTask(targetIntent: Intent) = true
 
     override fun onPrepareSupportNavigateUpTaskStack(builder: TaskStackBuilder) {
-        builder.editIntentAt(builder.intentCount - 1)?.editAccountActivityIntent(account)
+        builder.editIntentAt(builder.intentCount - 1)?.editAccountActivityIntent(accountId.toAndroidAccount())
     }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateCalendarScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateCalendarScreen.kt
@@ -4,7 +4,6 @@
 
 package at.bitfire.davdroid.ui.account
 
-import android.accounts.Account
 import android.annotation.SuppressLint
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -59,6 +58,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import at.bitfire.dav4jvm.ktor.toUrlOrNull
 import at.bitfire.davdroid.R
+import at.bitfire.davdroid.accounts.AccountId
 import at.bitfire.davdroid.db.HomeSet
 import at.bitfire.davdroid.ui.composable.AppTheme
 import at.bitfire.davdroid.ui.composable.ExceptionInfoDialog
@@ -68,13 +68,13 @@ import at.bitfire.synctools.icalendar.Css3Color
 
 @Composable
 fun CreateCalendarScreen(
-    account: Account,
+    accountId: AccountId,
     onFinish: () -> Unit,
     onNavUp: () -> Unit
 ) {
     val model: CreateCalendarViewModel = hiltViewModel(
         creationCallback = { factory: CreateCalendarViewModel.Factory ->
-            factory.create(account)
+            factory.create(accountId)
         }
     )
     val uiState = model.uiState

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateCalendarViewModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateCalendarViewModel.kt
@@ -4,11 +4,12 @@
 
 package at.bitfire.davdroid.ui.account
 
-import android.accounts.Account
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import at.bitfire.davdroid.accounts.AccountId
+import at.bitfire.davdroid.accounts.toAndroidAccount
 import at.bitfire.davdroid.db.HomeSet
 import at.bitfire.davdroid.repository.DavCollectionRepository
 import at.bitfire.davdroid.repository.DavHomeSetRepository
@@ -31,17 +32,17 @@ import java.util.Locale
 
 @HiltViewModel(assistedFactory = CreateCalendarViewModel.Factory::class)
 class CreateCalendarViewModel @AssistedInject constructor(
-    @Assisted val account: Account,
+    @Assisted val accountId: AccountId,
     private val collectionRepository: DavCollectionRepository,
     homeSetRepository: DavHomeSetRepository
 ): ViewModel() {
 
     @AssistedFactory
     interface Factory {
-        fun create(account: Account): CreateCalendarViewModel
+        fun create(accountId: AccountId): CreateCalendarViewModel
     }
 
-    val calendarHomeSets = homeSetRepository.getCalendarHomeSetsFlow(account)
+    val calendarHomeSets = homeSetRepository.getCalendarHomeSetsFlow(accountId)
 
     data class TimeZoneInfo(
         val id: String,
@@ -137,7 +138,7 @@ class CreateCalendarViewModel @AssistedInject constructor(
         createCollectionScope.launch {
             uiState = try {
                 collectionRepository.createCalendar(
-                    account = account,
+                    account = accountId.toAndroidAccount(),
                     homeSet = homeSet,
                     color = uiState.color,
                     displayName = uiState.displayName,


### PR DESCRIPTION
This is a first small step towards switching from `android.accounts.Account` to `AccountId`.

`android.accounts.Account` is part of the documented [DAVx⁵ Integration / API](https://manual.davx5.com/integration.html#open-davx5-for-a-specific-account). So I decided not to change the Intent extras for now and instead introduced `AccountIntentSerializer` as an abstraction layer.

Part of #2033