### PR TITLE
[SyncManager] Replace `SyncDispatcher` by explicit concurrency control; make batch-downloading testable

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/di/TestCoroutineDispatchersModule.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/di/TestCoroutineDispatchersModule.kt
@@ -7,7 +7,6 @@ package at.bitfire.davdroid.di
 import at.bitfire.davdroid.di.qualifier.DefaultDispatcher
 import at.bitfire.davdroid.di.qualifier.IoDispatcher
 import at.bitfire.davdroid.di.qualifier.MainDispatcher
-import at.bitfire.davdroid.di.qualifier.SyncTransferSemaphore
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.components.SingletonComponent
@@ -15,7 +14,6 @@ import dagger.hilt.testing.TestInstallIn
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -47,10 +45,6 @@ object TestCoroutineDispatchersModule {
     @Provides
     @MainDispatcher
     fun mainDispatcher(): CoroutineDispatcher = StandardTestDispatcher(testScheduler)
-
-    @Provides
-    @SyncTransferSemaphore
-    fun syncTransferSemaphore(): Semaphore = Semaphore(Runtime.getRuntime().availableProcessors())
 
     @OptIn(ExperimentalCoroutinesApi::class)
     fun initMainDispatcher() {

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/di/TestCoroutineDispatchersModule.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/di/TestCoroutineDispatchersModule.kt
@@ -7,7 +7,7 @@ package at.bitfire.davdroid.di
 import at.bitfire.davdroid.di.qualifier.DefaultDispatcher
 import at.bitfire.davdroid.di.qualifier.IoDispatcher
 import at.bitfire.davdroid.di.qualifier.MainDispatcher
-import at.bitfire.davdroid.di.qualifier.SyncDispatcher
+import at.bitfire.davdroid.di.qualifier.SyncTransferSemaphore
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.components.SingletonComponent
@@ -15,6 +15,7 @@ import dagger.hilt.testing.TestInstallIn
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -48,8 +49,8 @@ object TestCoroutineDispatchersModule {
     fun mainDispatcher(): CoroutineDispatcher = StandardTestDispatcher(testScheduler)
 
     @Provides
-    @SyncDispatcher
-    fun syncDispatcher(): CoroutineDispatcher = StandardTestDispatcher(testScheduler)
+    @SyncTransferSemaphore
+    fun syncTransferSemaphore(): Semaphore = Semaphore(Runtime.getRuntime().availableProcessors())
 
     @OptIn(ExperimentalCoroutinesApi::class)
     fun initMainDispatcher() {

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/TestSyncManager.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/TestSyncManager.kt
@@ -11,7 +11,8 @@ import at.bitfire.dav4jvm.ktor.Response
 import at.bitfire.dav4jvm.property.caldav.CalDAV
 import at.bitfire.dav4jvm.property.caldav.GetCTag
 import at.bitfire.davdroid.db.Collection
-import at.bitfire.davdroid.di.qualifier.SyncDispatcher
+import at.bitfire.davdroid.di.qualifier.IoDispatcher
+import at.bitfire.davdroid.di.qualifier.SyncTransferSemaphore
 import at.bitfire.davdroid.resource.LocalResource
 import at.bitfire.davdroid.resource.SyncState
 import at.bitfire.davdroid.util.DavUtils.lastSegment
@@ -22,6 +23,7 @@ import io.ktor.client.HttpClient
 import io.ktor.http.Url
 import io.ktor.http.content.ByteArrayContent
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.sync.Semaphore
 import org.junit.Assert.assertEquals
 
 class TestSyncManager @AssistedInject constructor(
@@ -30,7 +32,8 @@ class TestSyncManager @AssistedInject constructor(
     @Assisted syncResult: SyncResult,
     @Assisted localCollection: LocalTestCollection,
     @Assisted collection: Collection,
-    @SyncDispatcher syncDispatcher: CoroutineDispatcher
+    @IoDispatcher ioDispatcher: CoroutineDispatcher,
+    @SyncTransferSemaphore syncTransferSemaphore: Semaphore
 ): SyncManager<LocalTestResource, LocalTestCollection, DavCollection>(
     account,
     httpClient,
@@ -39,7 +42,8 @@ class TestSyncManager @AssistedInject constructor(
     localCollection,
     collection,
     resync = null,
-    syncDispatcher
+    ioDispatcher,
+    syncTransferSemaphore
 ) {
 
     @AssistedFactory

--- a/core/src/main/kotlin/at/bitfire/davdroid/di/CoroutineDispatchersModule.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/di/CoroutineDispatchersModule.kt
@@ -7,15 +7,12 @@ package at.bitfire.davdroid.di
 import at.bitfire.davdroid.di.qualifier.DefaultDispatcher
 import at.bitfire.davdroid.di.qualifier.IoDispatcher
 import at.bitfire.davdroid.di.qualifier.MainDispatcher
-import at.bitfire.davdroid.di.qualifier.SyncTransferSemaphore
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.sync.Semaphore
-import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -32,17 +29,5 @@ class CoroutineDispatchersModule {
     @Provides
     @MainDispatcher
     fun mainDispatcher(): CoroutineDispatcher = Dispatchers.Main
-
-    /**
-     * Limits how many sync uploads/downloads may run at the same time, app-wide, so that a sync
-     * of a huge collection doesn't open an unbounded number of concurrent HTTP requests / local
-     * storage writes. Only meant to be acquired around the actual network transfer of a resource
-     * (upload or download) — not around unrelated sync work like listing or local lookups, so
-     * that a slow/blocking transfer can't starve unrelated sync operations.
-     */
-    @Provides
-    @SyncTransferSemaphore
-    @Singleton
-    fun syncTransferSemaphore(): Semaphore = Semaphore(Runtime.getRuntime().availableProcessors())
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/di/CoroutineDispatchersModule.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/di/CoroutineDispatchersModule.kt
@@ -7,13 +7,14 @@ package at.bitfire.davdroid.di
 import at.bitfire.davdroid.di.qualifier.DefaultDispatcher
 import at.bitfire.davdroid.di.qualifier.IoDispatcher
 import at.bitfire.davdroid.di.qualifier.MainDispatcher
-import at.bitfire.davdroid.di.qualifier.SyncDispatcher
+import at.bitfire.davdroid.di.qualifier.SyncTransferSemaphore
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Semaphore
 import javax.inject.Singleton
 
 @Module
@@ -33,19 +34,15 @@ class CoroutineDispatchersModule {
     fun mainDispatcher(): CoroutineDispatcher = Dispatchers.Main
 
     /**
-     * A dispatcher for background sync operations. They're not run on [ioDispatcher] because there can
-     * be many long-blocking operations at the same time which should never block other I/O operations
-     * like database access for the UI.
-     *
-     * It uses the I/O dispatcher and limits the number of parallel operations to the number of available processors.
-     *
-     * **Never use the syncDispatcher outside the SyncManager because this can cause deadlocks!**
-     * For instance don't use it for sync-related I/O.
+     * Limits how many sync uploads/downloads may run at the same time, app-wide, so that a sync
+     * of a huge collection doesn't open an unbounded number of concurrent HTTP requests / local
+     * storage writes. Only meant to be acquired around the actual network transfer of a resource
+     * (upload or download) — not around unrelated sync work like listing or local lookups, so
+     * that a slow/blocking transfer can't starve unrelated sync operations.
      */
     @Provides
-    @SyncDispatcher
+    @SyncTransferSemaphore
     @Singleton
-    fun syncDispatcher(): CoroutineDispatcher =
-        Dispatchers.IO.limitedParallelism(Runtime.getRuntime().availableProcessors())
+    fun syncTransferSemaphore(): Semaphore = Semaphore(Runtime.getRuntime().availableProcessors())
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/di/SyncModule.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/di/SyncModule.kt
@@ -17,15 +17,11 @@ import javax.inject.Singleton
 class SyncModule {
 
     /**
-     * Limits how many sync uploads/downloads may run at the same time, app-wide, so that a sync
-     * of a huge collection doesn't open an unbounded number of concurrent HTTP requests / local
-     * storage writes. Only meant to be acquired around the actual network transfer of a resource
-     * (upload or download) — not around unrelated sync work like listing or local lookups, so
-     * that a slow/blocking transfer can't starve unrelated sync operations.
+     * Semaphore to limit concurrent sync downloads/uploads, app-wide. (Currently only used for downloads.)
      *
-     * Sized to the number of available processors, but at least 2 (so single-core devices still
-     * get some overlap between transfers) and at most 8 (to avoid opening too many concurrent
-     * requests/local writes on very high-core-count devices).
+     * Sized to the number of available processors, clamped to
+     * - 2 (some overlap even on single-core devices) to
+     * - 8 (avoid too many concurrent requests/local writes on high-core-count devices).
      */
     @Provides
     @SyncTransferSemaphore

--- a/core/src/main/kotlin/at/bitfire/davdroid/di/SyncModule.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/di/SyncModule.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.di
+
+import at.bitfire.davdroid.di.qualifier.SyncTransferSemaphore
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.sync.Semaphore
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+class SyncModule {
+
+    /**
+     * Limits how many sync uploads/downloads may run at the same time, app-wide, so that a sync
+     * of a huge collection doesn't open an unbounded number of concurrent HTTP requests / local
+     * storage writes. Only meant to be acquired around the actual network transfer of a resource
+     * (upload or download) — not around unrelated sync work like listing or local lookups, so
+     * that a slow/blocking transfer can't starve unrelated sync operations.
+     *
+     * Sized to the number of available processors, but at least 2 (so single-core devices still
+     * get some overlap between transfers) and at most 8 (to avoid opening too many concurrent
+     * requests/local writes on very high-core-count devices).
+     */
+    @Provides
+    @SyncTransferSemaphore
+    @Singleton
+    fun syncTransferSemaphore(): Semaphore =
+        Semaphore(Runtime.getRuntime().availableProcessors().coerceIn(2, 8))
+
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/di/qualifier/CoroutineQualifiers.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/di/qualifier/CoroutineQualifiers.kt
@@ -27,10 +27,3 @@ annotation class IoDispatcher
 @Retention(AnnotationRetention.RUNTIME)
 @Qualifier
 annotation class MainDispatcher
-
-
-// other sync-related qualifiers
-
-@Retention(AnnotationRetention.RUNTIME)
-@Qualifier
-annotation class SyncTransferSemaphore

--- a/core/src/main/kotlin/at/bitfire/davdroid/di/qualifier/CoroutineQualifiers.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/di/qualifier/CoroutineQualifiers.kt
@@ -28,6 +28,9 @@ annotation class IoDispatcher
 @Qualifier
 annotation class MainDispatcher
 
+
+// other sync-related qualifiers
+
 @Retention(AnnotationRetention.RUNTIME)
 @Qualifier
-annotation class SyncDispatcher
+annotation class SyncTransferSemaphore

--- a/core/src/main/kotlin/at/bitfire/davdroid/di/qualifier/SyncQualifiers.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/di/qualifier/SyncQualifiers.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.di.qualifier
+
+import javax.inject.Qualifier
+
+@Retention(AnnotationRetention.RUNTIME)
+@Qualifier
+annotation class SyncTransferSemaphore

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/BatchDownloader.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/BatchDownloader.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.sync
+
+import io.ktor.http.Url
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Collects [Url]s and calls [downloadBatch] once [batchSize] of them have been enqueued
+ * (and once more, with the remainder, on [flush]).
+ */
+class BatchDownloader(
+    private val batchSize: Int = 10,
+    private val downloadBatch: (List<Url>) -> Unit
+) {
+
+    private val mutex = Mutex()
+    private val queue = mutableListOf<Url>()
+
+    suspend fun enqueue(url: Url) {
+        // protect queue operation with lock
+        val toDownload: List<Url>? = mutex.withLock {
+            // enqueue next download
+            queue += url
+
+            // download batch if needed
+            if (queue.size >= batchSize)
+                queue.toList().also {
+                    queue.clear()
+                }
+            else
+                null
+        }
+
+        // download batch queue became too large
+        if (toDownload != null)
+            downloadBatch(toDownload)
+    }
+
+    suspend operator fun plusAssign(url: Url) = enqueue(url)
+
+    suspend fun flush() {
+        // protect queue operation with lock
+        val toDownload = mutex.withLock {
+            queue.toList().also {
+                queue.clear()
+            }
+        }
+
+        // download remaining items as batch
+        if (toDownload.isNotEmpty())
+            downloadBatch(toDownload)
+    }
+
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/BatchDownloader.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/BatchDownloader.kt
@@ -11,15 +11,26 @@ import kotlinx.coroutines.sync.withLock
 /**
  * Collects [Url]s and calls [downloadBatch] once [batchSize] of them have been enqueued
  * (and once more, with the remainder, on [flush]).
+ *
+ * @param batchSize The number of URLs to accumulate before triggering a batch download. Default is 10.
+ * @param downloadBatch The function to call with a batch of URLs to download (typically uses CalDAV/CardDAV multiget).
  */
 class BatchDownloader(
     private val batchSize: Int = 10,
     private val downloadBatch: (List<Url>) -> Unit
 ) {
 
+    /** used to synchronize [queue] access */
     private val mutex = Mutex()
+
+    /** currently enqueued URLs */
     private val queue = mutableListOf<Url>()
 
+    /**
+     * Adds a URL to the download queue and triggers a batch download if the queue has reached [batchSize].
+     *
+     * @param url The URL to be added to the download queue.
+     */
     suspend fun enqueue(url: Url) {
         // protect queue operation with lock
         val toDownload: List<Url>? = mutex.withLock {
@@ -28,31 +39,41 @@ class BatchDownloader(
 
             // download batch if needed
             if (queue.size >= batchSize)
-                queue.toList().also {
-                    queue.clear()
-                }
+                queue.clearToList()
             else
                 null
         }
 
-        // download batch queue became too large
+        // perform actual download outside the lock
         if (toDownload != null)
             downloadBatch(toDownload)
     }
 
-    suspend operator fun plusAssign(url: Url) = enqueue(url)
-
+    /**
+     * Downloads all remaining items in the queue as a single batch.
+     */
     suspend fun flush() {
         // protect queue operation with lock
         val toDownload = mutex.withLock {
-            queue.toList().also {
-                queue.clear()
-            }
+            queue.clearToList()
         }
 
-        // download remaining items as batch
+        // download remaining items as batch outside the lock
         if (toDownload.isNotEmpty())
             downloadBatch(toDownload)
     }
+
+
+    /**
+     * Returns a copy of this list as a new read-only list and clears the original list.
+     *
+     * Not thread-safe, access must be synchronized by caller.
+     *
+     * @return A new read-only list containing all elements of the original list.
+     */
+    private fun <T> MutableList<T>.clearToList(): List<T> =
+        toList().also {
+            clear()
+        }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
@@ -20,7 +20,8 @@ import at.bitfire.dav4jvm.property.webdav.WebDAV
 import at.bitfire.davdroid.ProductIds
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.Collection
-import at.bitfire.davdroid.di.qualifier.SyncDispatcher
+import at.bitfire.davdroid.di.qualifier.IoDispatcher
+import at.bitfire.davdroid.di.qualifier.SyncTransferSemaphore
 import at.bitfire.davdroid.resource.LocalCalendar
 import at.bitfire.davdroid.resource.LocalEvent
 import at.bitfire.davdroid.resource.LocalResource
@@ -43,6 +44,7 @@ import io.ktor.client.HttpClient
 import io.ktor.http.Url
 import io.ktor.http.content.TextContent
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.sync.Semaphore
 import net.fortuna.ical4j.model.Component
 import net.fortuna.ical4j.model.component.VEvent
 import java.io.Reader
@@ -63,8 +65,9 @@ class CalendarSyncManager @AssistedInject constructor(
     @Assisted collection: Collection,
     @Assisted resync: ResyncType?,
     accountSettingsFactory: AccountSettings.Factory,
+    @IoDispatcher ioDispatcher: CoroutineDispatcher,
     private val productIds: ProductIds,
-    @SyncDispatcher syncDispatcher: CoroutineDispatcher
+    @SyncTransferSemaphore syncTransferSemaphore: Semaphore
 ) : SyncManager<LocalEvent, LocalCalendar, DavCalendar>(
     account,
     httpClient,
@@ -73,7 +76,8 @@ class CalendarSyncManager @AssistedInject constructor(
     localCalendar,
     collection,
     resync,
-    syncDispatcher
+    ioDispatcher,
+    syncTransferSemaphore
 ) {
 
     @AssistedFactory

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
@@ -22,7 +22,8 @@ import at.bitfire.dav4jvm.property.webdav.WebDAV
 import at.bitfire.davdroid.ProductIds
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.Collection
-import at.bitfire.davdroid.di.qualifier.SyncDispatcher
+import at.bitfire.davdroid.di.qualifier.IoDispatcher
+import at.bitfire.davdroid.di.qualifier.SyncTransferSemaphore
 import at.bitfire.davdroid.resource.LocalAddress
 import at.bitfire.davdroid.resource.LocalAddressBook
 import at.bitfire.davdroid.resource.LocalContact
@@ -50,6 +51,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.Url
 import io.ktor.http.content.TextContent
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.sync.Semaphore
 import java.io.Reader
 import java.io.StringReader
 import java.io.StringWriter
@@ -105,9 +107,10 @@ class ContactsSyncManager @AssistedInject constructor(
     @Assisted val syncFrameworkUpload: Boolean,
     accountSettingsFactory: AccountSettings.Factory,
     val dirtyVerifier: Optional<ContactDirtyVerifier>,
+    @IoDispatcher ioDispatcher: CoroutineDispatcher,
     private val productIds: ProductIds,
     private val resourceRetrieverFactory: ResourceRetriever.Factory,
-    @SyncDispatcher syncDispatcher: CoroutineDispatcher
+    @SyncTransferSemaphore syncTransferSemaphore: Semaphore
 ): SyncManager<LocalAddress, LocalAddressBook, DavAddressBook>(
     account,
     httpClient,
@@ -116,7 +119,8 @@ class ContactsSyncManager @AssistedInject constructor(
     localAddressBook,
     collection,
     resync,
-    syncDispatcher
+    ioDispatcher,
+    syncTransferSemaphore
 ) {
 
     @AssistedFactory

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
@@ -20,7 +20,8 @@ import at.bitfire.dav4jvm.property.webdav.WebDAV
 import at.bitfire.davdroid.ProductIds
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.Collection
-import at.bitfire.davdroid.di.qualifier.SyncDispatcher
+import at.bitfire.davdroid.di.qualifier.IoDispatcher
+import at.bitfire.davdroid.di.qualifier.SyncTransferSemaphore
 import at.bitfire.davdroid.resource.LocalJtxCollection
 import at.bitfire.davdroid.resource.LocalJtxObject
 import at.bitfire.davdroid.resource.LocalResource
@@ -41,6 +42,7 @@ import io.ktor.client.HttpClient
 import io.ktor.http.Url
 import io.ktor.http.content.TextContent
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.sync.Semaphore
 import net.fortuna.ical4j.model.Component
 import net.fortuna.ical4j.model.component.CalendarComponent
 import net.fortuna.ical4j.model.property.ProdId
@@ -56,8 +58,9 @@ class JtxSyncManager @AssistedInject constructor(
     @Assisted localCollection: LocalJtxCollection,
     @Assisted collection: Collection,
     @Assisted resync: ResyncType?,
+    @IoDispatcher ioDispatcher: CoroutineDispatcher,
     private val productIds: ProductIds,
-    @SyncDispatcher syncDispatcher: CoroutineDispatcher
+    @SyncTransferSemaphore syncTransferSemaphore: Semaphore
 ): SyncManager<LocalJtxObject, LocalJtxCollection, DavCalendar>(
     account,
     httpClient,
@@ -66,7 +69,8 @@ class JtxSyncManager @AssistedInject constructor(
     localCollection,
     collection,
     resync,
-    syncDispatcher
+    ioDispatcher,
+    syncTransferSemaphore
 ) {
 
     @AssistedFactory

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -63,7 +63,6 @@ import java.io.IOException
 import java.security.cert.CertificateException
 import java.util.Optional
 import java.util.concurrent.CancellationException
-import java.util.concurrent.atomic.AtomicInteger
 import java.util.logging.Level
 import java.util.logging.Logger
 import javax.inject.Inject
@@ -376,22 +375,18 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
      *
      * @return whether local resources have been processed so that a synchronization is always necessary
      */
-    protected open suspend fun uploadDirty(): Boolean = coroutineScope {    // structured concurrency
-        val numUploaded = AtomicInteger(0)
+    protected open suspend fun uploadDirty(): Boolean {
+        var numUploaded = 0
 
         localCollection.findDirty().collect { local ->
-            launch {
-                syncTransferSemaphore.withPermit {
-                    SyncException.wrapWithLocalResource(local) {
-                        uploadDirty(local)
-                        numUploaded.incrementAndGet()
-                    }
-                }
+            SyncException.wrapWithLocalResource(local) {
+                uploadDirty(local)
+                numUploaded++
             }
         }
 
-        logger.info("Sent ${numUploaded.get()} record(s) to server")
-        numUploaded.get() > 0
+        logger.info("Sent $numUploaded record(s) to server")
+        return numUploaded > 0
     }
 
     /**

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -56,13 +56,14 @@ import io.ktor.util.appendAll
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import java.io.IOException
 import java.security.cert.CertificateException
-import java.util.LinkedList
 import java.util.Optional
 import java.util.concurrent.CancellationException
-import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.logging.Level
 import java.util.logging.Logger
 import javax.inject.Inject
@@ -91,7 +92,8 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
     val localCollection: CollectionType,
     val collection: Collection,
     val resync: ResyncType?,
-    val syncDispatcher: CoroutineDispatcher
+    val ioDispatcher: CoroutineDispatcher,
+    val syncTransferSemaphore: Semaphore
 ) {
 
     enum class SyncAlgorithm {
@@ -140,7 +142,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
         } ?: emptyMap()
     }
 
-    suspend fun performSync() = withContext(syncDispatcher) {
+    suspend fun performSync() = withContext(ioDispatcher) {
         // dismiss previous error notifications
         syncNotificationManager.dismissCollectionError(localCollectionTag = localCollection.tag)
 
@@ -374,17 +376,22 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
      *
      * @return whether local resources have been processed so that a synchronization is always necessary
      */
-    protected open suspend fun uploadDirty(): Boolean {
-        var numUploaded = 0
+    protected open suspend fun uploadDirty(): Boolean = coroutineScope {    // structured concurrency
+        val numUploaded = AtomicInteger(0)
 
         localCollection.findDirty().collect { local ->
-            SyncException.wrapWithLocalResource(local) {
-                uploadDirty(local)
-                numUploaded++
+            launch {
+                syncTransferSemaphore.withPermit {
+                    SyncException.wrapWithLocalResource(local) {
+                        uploadDirty(local)
+                        numUploaded.incrementAndGet()
+                    }
+                }
             }
         }
-        logger.info("Sent $numUploaded record(s) to server")
-        return numUploaded > 0
+
+        logger.info("Sent ${numUploaded.get()} record(s) to server")
+        numUploaded.get() > 0
     }
 
     /**
@@ -590,19 +597,10 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
      * @param listRemote function to list remote resources (for instance, all since a certain sync-token)
      */
     protected open suspend fun syncRemote(listRemote: suspend (MultiResponseCallback) -> Unit) = coroutineScope {    // structured concurrency
-        // download queue
-        val toDownload = LinkedBlockingQueue<Url>()
-        fun download(url: Url?) {
-            if (url != null)
-                toDownload += url
-
-            if (toDownload.size >= MAX_MULTIGET_RESOURCES || url == null) {
-                while (toDownload.isNotEmpty()) {
-                    val bunch = LinkedList<Url>()
-                    toDownload.drainTo(bunch, MAX_MULTIGET_RESOURCES)
-                    launch {
-                        downloadRemote(bunch)
-                    }
+        val batchDownloader = BatchDownloader(batchSize = MAX_MULTIGET_RESOURCES) { bunch ->
+            launch {
+                syncTransferSemaphore.withPermit {
+                    downloadRemote(bunch)
                 }
             }
         }
@@ -627,7 +625,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
                         SyncException.wrapWithLocalResource(local) {
                             if (local == null) {
                                 logger.info("$name has been added remotely, queueing download")
-                                download(response.href)
+                                batchDownloader += response.href
                             } else {
                                 val localETag = local.eTag
                                 val remoteETag = response[GetETag::class.java]?.eTag
@@ -636,7 +634,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
                                     logger.info("$name has not been changed on server (ETag still $remoteETag)")
                                 } else {
                                     logger.info("$name has been changed on server (current ETag=$remoteETag, last known ETag=$localETag)")
-                                    download(response.href)
+                                    batchDownloader += response.href
                                 }
 
                                 // mark as remotely present, so that this resource won't be deleted at the end
@@ -660,7 +658,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
         }
 
         // download remaining resources
-        download(null)
+        batchDownloader.flush()
     }
 
     protected abstract suspend fun listAllRemote(callback: MultiResponseCallback)

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -878,7 +878,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
     companion object {
 
         /** Maximum number of resources that are requested with one multiget request. */
-        const val MAX_MULTIGET_RESOURCES = 10
+        const val MAX_MULTIGET_RESOURCES = 20
 
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -597,10 +597,10 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
      * @param listRemote function to list remote resources (for instance, all since a certain sync-token)
      */
     protected open suspend fun syncRemote(listRemote: suspend (MultiResponseCallback) -> Unit) = coroutineScope {    // structured concurrency
-        val batchDownloader = BatchDownloader(batchSize = MAX_MULTIGET_RESOURCES) { bunch ->
+        val batchDownloader = BatchDownloader { batch ->
             launch {
                 syncTransferSemaphore.withPermit {
-                    downloadRemote(bunch)
+                    downloadRemote(batch)
                 }
             }
         }
@@ -625,7 +625,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
                         SyncException.wrapWithLocalResource(local) {
                             if (local == null) {
                                 logger.info("$name has been added remotely, queueing download")
-                                batchDownloader += response.href
+                                batchDownloader.enqueue(response.href)
                             } else {
                                 val localETag = local.eTag
                                 val remoteETag = response[GetETag::class.java]?.eTag
@@ -634,7 +634,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
                                     logger.info("$name has not been changed on server (ETag still $remoteETag)")
                                 } else {
                                     logger.info("$name has been changed on server (current ETag=$remoteETag, last known ETag=$localETag)")
-                                    batchDownloader += response.href
+                                    batchDownloader.enqueue(response.href)
                                 }
 
                                 // mark as remotely present, so that this resource won't be deleted at the end
@@ -872,14 +872,6 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
             },
             callback = callback
         )
-    }
-
-
-    companion object {
-
-        /** Maximum number of resources that are requested with one multiget request. */
-        const val MAX_MULTIGET_RESOURCES = 20
-
     }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
@@ -18,7 +18,8 @@ import at.bitfire.dav4jvm.property.webdav.WebDAV
 import at.bitfire.davdroid.ProductIds
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.Collection
-import at.bitfire.davdroid.di.qualifier.SyncDispatcher
+import at.bitfire.davdroid.di.qualifier.IoDispatcher
+import at.bitfire.davdroid.di.qualifier.SyncTransferSemaphore
 import at.bitfire.davdroid.resource.LocalResource
 import at.bitfire.davdroid.resource.LocalTask
 import at.bitfire.davdroid.resource.LocalTaskList
@@ -40,6 +41,7 @@ import io.ktor.client.HttpClient
 import io.ktor.http.Url
 import io.ktor.http.content.TextContent
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.sync.Semaphore
 import net.fortuna.ical4j.model.Component
 import net.fortuna.ical4j.model.component.VToDo
 import net.fortuna.ical4j.model.property.ProdId
@@ -58,8 +60,9 @@ class TasksSyncManager @AssistedInject constructor(
     @Assisted localCollection: LocalTaskList,
     @Assisted collection: Collection,
     @Assisted resync: ResyncType?,
+    @IoDispatcher ioDispatcher: CoroutineDispatcher,
     private val productIds: ProductIds,
-    @SyncDispatcher syncDispatcher: CoroutineDispatcher
+    @SyncTransferSemaphore syncTransferSemaphore: Semaphore
 ): SyncManager<LocalTask, LocalTaskList, DavCalendar>(
     account,
     httpClient,
@@ -68,7 +71,8 @@ class TasksSyncManager @AssistedInject constructor(
     localCollection,
     collection,
     resync,
-    syncDispatcher
+    ioDispatcher,
+    syncTransferSemaphore
 ) {
 
     @AssistedFactory

--- a/core/src/test/kotlin/at/bitfire/davdroid/sync/BatchDownloaderTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/sync/BatchDownloaderTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.sync
+
+import io.ktor.http.Url
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.ConcurrentLinkedQueue
+
+class BatchDownloaderTest {
+
+    private fun url(i: Int) = Url("https://example.com/$i")
+
+    @Test
+    fun testEnqueue_BelowBatchSize_DoesNotDownload() = runTest {
+        val batches = mutableListOf<List<Url>>()
+        val downloader = BatchDownloader(batchSize = 3) { batches += it }
+
+        downloader.enqueue(url(1))
+        downloader.enqueue(url(2))
+
+        assertTrue(batches.isEmpty())
+    }
+
+    @Test
+    fun testEnqueue_ReachesBatchSize_DownloadsOnceAndClearsQueue() = runTest {
+        val batches = mutableListOf<List<Url>>()
+        val downloader = BatchDownloader(batchSize = 3) { batches += it }
+
+        downloader.enqueue(url(1))
+        downloader.enqueue(url(2))
+        downloader.enqueue(url(3))
+
+        assertEquals(listOf(listOf(url(1), url(2), url(3))), batches)
+
+        // queue has been cleared, so a flush() has nothing to download
+        downloader.flush()
+        assertEquals(1, batches.size)
+    }
+
+    @Test
+    fun testEnqueue_MultipleBatches_DownloadsEachFullBatchInOrder() = runTest {
+        val batches = mutableListOf<List<Url>>()
+        val downloader = BatchDownloader(batchSize = 2) { batches += it }
+
+        for (i in 1..5)
+            downloader.enqueue(url(i))
+
+        // 5 items with batchSize=2 -> two full batches downloaded so far, one item still queued
+        assertEquals(
+            listOf(
+                listOf(url(1), url(2)),
+                listOf(url(3), url(4))
+            ),
+            batches
+        )
+    }
+
+    @Test
+    fun testFlush_NonEmptyRemainder_DownloadsRemainder() = runTest {
+        val batches = mutableListOf<List<Url>>()
+        val downloader = BatchDownloader(batchSize = 10) { batches += it }
+
+        downloader.enqueue(url(1))
+        downloader.enqueue(url(2))
+        downloader.flush()
+
+        assertEquals(listOf(listOf(url(1), url(2))), batches)
+    }
+
+    @Test
+    fun testFlush_EmptyQueue_DoesNotDownload() = runTest {
+        val batches = mutableListOf<List<Url>>()
+        val downloader = BatchDownloader(batchSize = 10) { batches += it }
+
+        downloader.flush()
+
+        assertTrue(batches.isEmpty())
+    }
+
+    @Test
+    fun testPlusAssign_BehavesLikeEnqueue() = runTest {
+        val batches = mutableListOf<List<Url>>()
+        val downloader = BatchDownloader(batchSize = 1) { batches += it }
+
+        downloader += url(1)
+
+        assertEquals(listOf(listOf(url(1))), batches)
+    }
+
+    @Test
+    fun testEnqueue_ConcurrentCalls_NoLostOrDuplicatedUrls() = runTest {
+        val downloaded = ConcurrentLinkedQueue<Url>()
+        val downloader = BatchDownloader(batchSize = 7) { downloaded += it }
+
+        val urls = (1..50).map { url(it) }
+        urls.map { u ->
+            async { downloader.enqueue(u) }
+        }.awaitAll()
+        downloader.flush()
+
+        assertEquals(urls.size, downloaded.size)
+        assertEquals(urls.toSet(), downloaded.toSet())
+    }
+
+}

--- a/core/src/test/kotlin/at/bitfire/davdroid/sync/BatchDownloaderTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/sync/BatchDownloaderTest.kt
@@ -63,29 +63,7 @@ class BatchDownloaderTest {
     }
 
     @Test
-    fun testFlush_NonEmptyRemainder_DownloadsRemainder() = runTest {
-        val batches = mutableListOf<List<Url>>()
-        val downloader = BatchDownloader(batchSize = 10) { batches += it }
-
-        downloader.enqueue(url(1))
-        downloader.enqueue(url(2))
-        downloader.flush()
-
-        assertEquals(listOf(listOf(url(1), url(2))), batches)
-    }
-
-    @Test
-    fun testFlush_EmptyQueue_DoesNotDownload() = runTest {
-        val batches = mutableListOf<List<Url>>()
-        val downloader = BatchDownloader(batchSize = 10) { batches += it }
-
-        downloader.flush()
-
-        assertTrue(batches.isEmpty())
-    }
-
-    @Test
-    fun testPlusAssign_BehavesLikeEnqueue() = runTest {
+    fun testEnqueue_BatchSizeOne_DownloadsImmediately() = runTest {
         val batches = mutableListOf<List<Url>>()
         val downloader = BatchDownloader(batchSize = 1) { batches += it }
 
@@ -107,6 +85,28 @@ class BatchDownloaderTest {
 
         assertEquals(urls.size, downloaded.size)
         assertEquals(urls.toSet(), downloaded.toSet())
+    }
+
+    @Test
+    fun testFlush_NonEmptyRemainder_DownloadsRemainder() = runTest {
+        val batches = mutableListOf<List<Url>>()
+        val downloader = BatchDownloader(batchSize = 10) { batches += it }
+
+        downloader.enqueue(url(1))
+        downloader.enqueue(url(2))
+        downloader.flush()
+
+        assertEquals(listOf(listOf(url(1), url(2))), batches)
+    }
+
+    @Test
+    fun testFlush_EmptyQueue_DoesNotDownload() = runTest {
+        val batches = mutableListOf<List<Url>>()
+        val downloader = BatchDownloader(batchSize = 10) { batches += it }
+
+        downloader.flush()
+
+        assertTrue(batches.isEmpty())
     }
 
 }

--- a/core/src/test/kotlin/at/bitfire/davdroid/sync/BatchDownloaderTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/sync/BatchDownloaderTest.kt
@@ -89,7 +89,7 @@ class BatchDownloaderTest {
         val batches = mutableListOf<List<Url>>()
         val downloader = BatchDownloader(batchSize = 1) { batches += it }
 
-        downloader += url(1)
+        downloader.enqueue(url(1))
 
         assertEquals(listOf(listOf(url(1))), batches)
     }


### PR DESCRIPTION
### Purpose

Get rid of some bad patterns in `SyncManager`:

- `SyncDispatcher` that causes unwanted side effects (see #2519 / #2004)
- multiget downloading over untestable function-in-function

### Short description

- Extracted batch downloading into separate `BatchDownloader` to make it more understandable and _testable_ (also added tests).
- Use explicit `Semaphore` to restrict simultaneous downloads/uploads instead of the bad `SyncDispatcher` pattern that has unwanted side effects.

Not in scope / open for further PRs:

- Still uses questionable `withContext(ioDispatcher) { coroutineScope { launch {} } }` pattern for structured concurrency.
- Make upload/remote deletions parallel again.