### PR TITLE
[Ktor] Handle explicit `Content-Encoding: identity`

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
@@ -188,6 +188,20 @@ class HttpClientBuilderTest {
     }
 
     @Test
+    fun testContentEncoding_HandlesIdentityEncoding() = runTest {
+        val engine = MockEngine.basic(
+            "Some Content",
+            headers = headersOf(HttpHeaders.ContentEncoding, "identity")
+        )
+
+        httpClientBuilder.build(engine).use { client ->
+            val response = client.get("https://example.com/")
+            assertEquals(200, response.status.value)
+            assertEquals("Some Content", response.bodyAsText())
+        }
+    }
+
+    @Test
     fun testFollowRedirects_DisabledByDefault() = runTest {
         val engine = MockEngine { request ->
             if (request.url.encodedPath == "/") {

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
@@ -375,11 +375,8 @@ class HttpClientBuilder private constructor(
             )
         }
 
-        // offer gzip/deflate compression and decompress responses transparently
-        install(ContentEncoding) {
-            gzip()
-            deflate()
-        }
+        // offer gzip/deflate/identity compression and decompress responses transparently
+        ContentEncoding()
 
         // add network logging (with redaction of sensitive headers), if requested
         if (config.logger.isLoggable(Level.FINEST)) {


### PR DESCRIPTION
### Purpose

Use default `ContentEncoding` to properly handle identity encoding in the system.

Problem was that `install(ContentEncoding)` explicitly added gzip and deflate, but not identity. When a server sent an _explicit_ `Content-Encoding: identity`, Ktor failed because the identity encoding was not installed.

The default `ContentEncoding()` helper installs all three.

Fixes https://github.com/bitfireAT/davx5/issues/926.

### Short description

- Updated encoding handling to use the default `ContentEncoding` for identity encoding cases.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.