### PR TITLE
Add validation and tests for jtx objects

### DIFF
--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxCollectionTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxCollectionTest.kt
@@ -200,6 +200,11 @@ class JtxCollectionTest {
         assertEquals("TWO", attachmentDataTwo)
     }
 
+    @Test(expected = IllegalArgumentException::class)
+    fun testAddJtxObjects_emptyList_throws() {
+        collection.addJtxObjects(emptyList())
+    }
+
     @Test
     fun testCountJtxObjects_empty() {
         assertEquals(0, collection.countJtxObjects(null, null))

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxRecurringCollectionTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/jtx/JtxRecurringCollectionTest.kt
@@ -146,32 +146,6 @@ class JtxRecurringCollectionTest {
     }
 
     @Test
-    fun testUpdateJtxObjectAndExceptions_withExceptionId_throws() = runTest {
-        val uid = "testUpdateJtxObjectAndExceptions_withExceptionId"
-        insertRecurring(uid = uid)
-
-        val exceptionId = collection.findJtxObject(
-            "${JtxContract.JtxICalObject.UID}=? AND ${JtxContract.JtxICalObject.RECURID} IS NOT NULL AND ${JtxContract.JtxICalObject.SEQUENCE} > 0",
-            arrayOf(uid)
-        )!!.entityValues.getAsLong(JtxContract.JtxICalObject.ID)
-
-        try {
-            recurringCollection.updateJtxObjectAndExceptions(exceptionId, JtxEntityAndExceptions(
-                main = JtxEntity(Entity(contentValuesOf(
-                    JtxContract.JtxICalObject.ICALOBJECT_COLLECTIONID to collection.id,
-                    JtxContract.JtxICalObject.COMPONENT to Component.VTODO.name,
-                    JtxContract.JtxICalObject.UID to uid,
-                    JtxContract.JtxICalObject.SUMMARY to "Should not work"
-                ))),
-                exceptions = emptyList()
-            ))
-            fail("updateJtxObjectAndExceptions must throw when called with an exception ID")
-        } catch (_: LocalStorageException) {
-            // expected
-        }
-    }
-
-    @Test
     fun testIterateJtxObjectAndExceptions() = runTest {
         val uid1 = "testIterateJtxObjectAndExceptions1"
         val uid2 = "testIterateJtxObjectAndExceptions2"
@@ -266,6 +240,86 @@ class JtxRecurringCollectionTest {
     }
 
     @Test
+    fun testUpdateJtxObjectAndExceptions_NonRecurring() = runTest {
+        // reproduces https://github.com/bitfireAT/davx5-ose/discussions/2617:
+        // updating a non-recurring jtx object (no RRULE/RDATE, so cleanUp() drops exceptions
+        // and leaves an empty list) must not crash. addJtxObjects() used to unconditionally call
+        // getResult(0), which throws ArrayIndexOutOfBoundsException when nothing was inserted.
+        val uid = "testUpdateJtxObjectAndExceptions_NonRecurring"
+        val addedId = recurringCollection.addJtxEntityAndExceptions(
+            JtxEntityAndExceptions(
+                main = JtxEntity(
+                    Entity(
+                        contentValuesOf(
+                            JtxContract.JtxICalObject.ICALOBJECT_COLLECTIONID to collection.id,
+                            JtxContract.JtxICalObject.COMPONENT to Component.VTODO.name,
+                            JtxContract.JtxICalObject.UID to uid,
+                            JtxContract.JtxICalObject.SUMMARY to "Non-recurring Main"
+                            // no RRULE/RDATE -> not recurring
+                        )
+                    )
+                ),
+                exceptions = emptyList()
+            )
+        )
+
+        val updatedMain = JtxEntity(
+            Entity(
+                contentValuesOf(
+                    JtxContract.JtxICalObject.ICALOBJECT_COLLECTIONID to collection.id,
+                    JtxContract.JtxICalObject.COMPONENT to Component.VTODO.name,
+                    JtxContract.JtxICalObject.UID to uid,
+                    JtxContract.JtxICalObject.SUMMARY to "Updated Non-recurring Main"
+                )
+            )
+        )
+
+        recurringCollection.updateJtxObjectAndExceptions(
+            addedId,
+            JtxEntityAndExceptions(main = updatedMain, exceptions = emptyList())
+        )
+
+        val result = recurringCollection.getById(addedId)
+        assertEquals(
+            "Updated Non-recurring Main",
+            result!!.main.entityValues.getAsString(JtxContract.JtxICalObject.SUMMARY)
+        )
+        assertTrue(result.exceptions.isEmpty())
+    }
+
+    @Test
+    fun testUpdateJtxObjectAndExceptions_withExceptionId_throws() = runTest {
+        val uid = "testUpdateJtxObjectAndExceptions_withExceptionId"
+        insertRecurring(uid = uid)
+
+        val exceptionId = collection.findJtxObject(
+            "${JtxContract.JtxICalObject.UID}=? AND ${JtxContract.JtxICalObject.RECURID} IS NOT NULL AND ${JtxContract.JtxICalObject.SEQUENCE} > 0",
+            arrayOf(uid)
+        )!!.entityValues.getAsLong(JtxContract.JtxICalObject.ID)
+
+        try {
+            recurringCollection.updateJtxObjectAndExceptions(
+                exceptionId, JtxEntityAndExceptions(
+                    main = JtxEntity(
+                        Entity(
+                            contentValuesOf(
+                                JtxContract.JtxICalObject.ICALOBJECT_COLLECTIONID to collection.id,
+                                JtxContract.JtxICalObject.COMPONENT to Component.VTODO.name,
+                                JtxContract.JtxICalObject.UID to uid,
+                                JtxContract.JtxICalObject.SUMMARY to "Should not work"
+                            )
+                        )
+                    ),
+                    exceptions = emptyList()
+                )
+            )
+            fail("updateJtxObjectAndExceptions must throw when called with an exception ID")
+        } catch (_: LocalStorageException) {
+            // expected
+        }
+    }
+
+    @Test
     fun testDeleteJtxObjectAndExceptions_batch() = runTest {
         val now = 1754233504000L
         val uid = "testDeleteJtxObjectAndExceptions_batch"
@@ -356,23 +410,6 @@ class JtxRecurringCollectionTest {
         assertEquals(0, collection.countJtxObjects(
             "${JtxContract.JtxICalObject.UID}=?", arrayOf(uid)
         ))
-    }
-
-
-    @Test
-    fun testFindExceptionRow() {
-        val uid = "testFindExceptionRow"
-        insertRecurring(uid = uid)
-
-        val result = recurringCollection.findExceptionRow(uid, "20250804T150504Z")
-        assertNotNull(result)
-        assertEquals(uid, result!!.getAsString(JtxContract.JtxICalObject.UID))
-        assertEquals("20250804T150504Z", result.getAsString(JtxContract.JtxICalObject.RECURID))
-    }
-
-    @Test
-    fun testFindExceptionRow_NotFound() {
-        assertNull(recurringCollection.findExceptionRow("does-not-exist", "20250804T150504Z"))
     }
 
 
@@ -600,6 +637,22 @@ class JtxRecurringCollectionTest {
                 }))
             ), result, onlyFieldsInExpected = true
         )
+    }
+
+    @Test
+    fun testFindExceptionRow() {
+        val uid = "testFindExceptionRow"
+        insertRecurring(uid = uid)
+
+        val result = recurringCollection.findExceptionRow(uid, "20250804T150504Z")
+        assertNotNull(result)
+        assertEquals(uid, result!!.getAsString(JtxContract.JtxICalObject.UID))
+        assertEquals("20250804T150504Z", result.getAsString(JtxContract.JtxICalObject.RECURID))
+    }
+
+    @Test
+    fun testFindExceptionRow_NotFound() {
+        assertNull(recurringCollection.findExceptionRow("does-not-exist", "20250804T150504Z"))
     }
 
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollection.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxCollection.kt
@@ -122,13 +122,15 @@ class JtxCollection(
     /**
      * Inserts a list of jtx objects into this collection.
      *
-     * @param jtxEntities objects to insert
+     * @param jtxEntities objects to insert (must not be empty)
      *
      * @return ID of the first inserted object
      *
+     * @throws IllegalArgumentException when [jtxEntities] is empty
      * @throws LocalStorageException when the content provider returns an error
      */
     fun addJtxObjects(jtxEntities: List<JtxEntity>): Long {
+        require(jtxEntities.isNotEmpty()) { "jtxEntities must not be empty" }
         try {
             val batch = JtxBatchOperation(client)
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxRecurringCollection.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/jtx/JtxRecurringCollection.kt
@@ -168,7 +168,8 @@ class JtxRecurringCollection(
             collection.updateJtxObject(id, cleaned.main)
 
             // add updated exceptions
-            collection.addJtxObjects(cleaned.exceptions)
+            if (cleaned.exceptions.isNotEmpty())
+                collection.addJtxObjects(cleaned.exceptions)
 
             return id
         } catch (e: RemoteException) {


### PR DESCRIPTION
### Purpose

Add validation for empty jtx objects lists in `JtxCollection.addJtxObjects`. Fixes #2619.

### Short description

- Added validation for empty list in `addJtxObjects`
- Added test for updating non-recurring jtx object with exceptions
- Ordered tests as in tested file

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.