### PR TITLE
Convert `AccountSettingsActivity` to use `AccountId`

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/db/ServiceDao.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/ServiceDao.kt
@@ -8,6 +8,8 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import at.bitfire.davdroid.accounts.AccountId
+import at.bitfire.davdroid.accounts.LegacyAccount
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -15,6 +17,12 @@ interface ServiceDao {
 
     @Query("SELECT * FROM service WHERE accountName=:accountName AND type=:type")
     suspend fun getByAccountAndType(accountName: String, @ServiceType type: String): Service?
+
+    suspend fun getByAccountAndType(accountId: AccountId, @ServiceType type: String): Service? {
+        return when (accountId) {
+            is LegacyAccount -> getByAccountAndType(accountId.androidAccount.name, type)
+        }
+    }
 
     @Query("SELECT * FROM service WHERE accountName=:accountName AND type=:type")
     fun getByAccountAndTypeFlow(accountName: String, @ServiceType type: String): Flow<Service?>

--- a/core/src/main/kotlin/at/bitfire/davdroid/repository/AccountRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/repository/AccountRepository.kt
@@ -10,6 +10,8 @@ import android.accounts.OnAccountsUpdateListener
 import android.content.Context
 import androidx.annotation.WorkerThread
 import at.bitfire.davdroid.R
+import at.bitfire.davdroid.accounts.AccountId
+import at.bitfire.davdroid.accounts.LegacyAccount
 import at.bitfire.davdroid.db.HomeSet
 import at.bitfire.davdroid.db.Service
 import at.bitfire.davdroid.db.ServiceType
@@ -32,7 +34,10 @@ import dagger.Lazy
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -62,6 +67,28 @@ class AccountRepository @Inject constructor(
     private val accountType = context.getString(R.string.account_type)
     private val accountManager = AccountManager.get(context)
 
+    private val accountRenameFlow = MutableSharedFlow<AccountRename>()
+    
+    fun getAccountNameFlow(accountId: AccountId): Flow<String> {
+        return flow {
+            var currentName = getAccountName(accountId)
+            emit(currentName)
+            
+            accountRenameFlow.collect { accountRename -> 
+                if (accountRename.oldName == currentName) {
+                    currentName = accountRename.newName
+                    emit(currentName)
+                }
+            }
+        }
+    }
+    
+    private fun getAccountName(accountId: AccountId): String {
+        return when (accountId) {
+            is LegacyAccount -> accountId.androidAccount.name
+        }
+    }
+    
     /**
      * Creates a new account with discovered services and enables periodic syncs with
      * default sync interval times.
@@ -212,6 +239,8 @@ class AccountRepository @Inject constructor(
             if (newNameFromApi.name != newName)
                 throw IllegalStateException("renameAccount returned ${newNameFromApi.name} instead of $newName")
 
+            accountRenameFlow.emit(AccountRename(oldAccount.name, newName))
+            
             // account renamed, cancel maybe running synchronization of old account
             syncWorkerManager.get().cancelAllWork(oldAccount)
 
@@ -281,4 +310,5 @@ class AccountRepository @Inject constructor(
         return serviceId
     }
 
+    private data class AccountRename(val oldName: String, val newName: String)
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/servicedetection/RefreshCollectionsWorker.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/servicedetection/RefreshCollectionsWorker.kt
@@ -24,6 +24,7 @@ import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import at.bitfire.dav4jvm.ktor.exception.UnauthorizedException
 import at.bitfire.davdroid.R
+import at.bitfire.davdroid.accounts.toAccountId
 import at.bitfire.davdroid.network.HttpClientBuilder
 import at.bitfire.davdroid.push.PushRegistrationManager
 import at.bitfire.davdroid.repository.DavServiceRepository
@@ -183,7 +184,7 @@ class RefreshCollectionsWorker @AssistedInject constructor(
         } catch (e: UnauthorizedException) {
             logger.log(Level.SEVERE, "Not authorized (anymore)", e)
             // notify that we need to re-authenticate in the account settings
-            val settingsIntent = AccountSettingsActivity.createIntent(applicationContext, account)
+            val settingsIntent = AccountSettingsActivity.createIntent(applicationContext, account.toAccountId())
             notifyRefreshError(
                 applicationContext.getString(R.string.sync_error_authentication_failed),
                 settingsIntent

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncNotificationManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncNotificationManager.kt
@@ -18,6 +18,7 @@ import androidx.core.net.toUri
 import at.bitfire.dav4jvm.ktor.exception.UnauthorizedException
 import at.bitfire.dav4jvm.ktor.resolve
 import at.bitfire.davdroid.R
+import at.bitfire.davdroid.accounts.toAccountId
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.resource.LocalCollection
 import at.bitfire.davdroid.resource.LocalResource
@@ -116,7 +117,7 @@ class SyncNotificationManager @AssistedInject constructor(
     ) = notificationRegistry.notifyIfPossible(NotificationRegistry.NOTIFY_SYNC_ERROR, tag = notificationTag) {
         val contentIntent: Intent
         if (e is UnauthorizedException) {
-            contentIntent = AccountSettingsActivity.createIntent(context, account)
+            contentIntent = AccountSettingsActivity.createIntent(context, account.toAccountId())
         } else {
             contentIntent = buildDebugInfoIntent(syncDataType, e, local, remote)
         }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountActivity.kt
@@ -50,7 +50,7 @@ class AccountActivity : AppCompatActivity() {
             AccountScreen(
                 account = account,
                 onAccountSettings = {
-                    val intent = AccountSettingsActivity.createIntent(this, account)
+                    val intent = AccountSettingsActivity.createIntent(this, account.toAccountId())
                     startActivity(intent, null)
                 },
                 onCreateAddressBook = {

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsActivity.kt
@@ -4,14 +4,15 @@
 
 package at.bitfire.davdroid.ui.account
 
-import android.accounts.Account
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.TaskStackBuilder
-import androidx.core.content.IntentCompat
+import at.bitfire.davdroid.accounts.AccountId
+import at.bitfire.davdroid.accounts.AccountIdIntentSerializer
+import at.bitfire.davdroid.accounts.toAndroidAccount
 import at.bitfire.davdroid.ui.account.AccountActivity.Companion.editAccountActivityIntent
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -21,31 +22,30 @@ class AccountSettingsActivity: AppCompatActivity() {
     companion object {
         private const val EXTRA_ACCOUNT = "account"
         
-        fun createIntent(context: Context, account: Account): Intent {
-            return Intent(context, AccountSettingsActivity::class.java).apply { 
-                putExtra(EXTRA_ACCOUNT, account)
+        fun createIntent(context: Context, accountId: AccountId): Intent {
+            return Intent(context, AccountSettingsActivity::class.java).apply {
+                AccountIdIntentSerializer.addExtra(this, EXTRA_ACCOUNT, accountId)
             }
         }
         
-        fun Intent.editAccountSettingsActivityIntent(account: Account) {
-            putExtra(EXTRA_ACCOUNT, account)
+        fun Intent.editAccountSettingsActivityIntent(accountId: AccountId) {
+            AccountIdIntentSerializer.addExtra(this, EXTRA_ACCOUNT, accountId)
         }
     }
 
-    private val account by lazy {
-        IntentCompat.getParcelableExtra(intent, EXTRA_ACCOUNT, Account::class.java) ?: throw IllegalArgumentException("EXTRA_ACCOUNT must be set")
+    private val accountId by lazy {
+        AccountIdIntentSerializer.fromIntent(intent, EXTRA_ACCOUNT)
+            ?: throw IllegalArgumentException("EXTRA_ACCOUNT must be set")
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        title = account.name
-
         setContent {
             AccountSettingsScreen(
-                account = account,
+                accountId = accountId,
                 onNavWifiPermissionsScreen = {
-                    val intent = WifiPermissionsActivity.createIntent(this, account)
+                    val intent = WifiPermissionsActivity.createIntent(this, accountId.toAndroidAccount())
                     startActivity(intent)
                 },
                 onNavUp = ::onSupportNavigateUp,
@@ -56,7 +56,7 @@ class AccountSettingsActivity: AppCompatActivity() {
     override fun supportShouldUpRecreateTask(targetIntent: Intent) = true
 
     override fun onPrepareSupportNavigateUpTaskStack(builder: TaskStackBuilder) {
-        builder.editIntentAt(builder.intentCount - 1)?.editAccountActivityIntent(account)
+        builder.editIntentAt(builder.intentCount - 1)?.editAccountActivityIntent(accountId.toAndroidAccount())
     }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsScreen.kt
@@ -4,7 +4,6 @@
 
 package at.bitfire.davdroid.ui.account
 
-import android.accounts.Account
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.security.KeyChain
@@ -57,6 +56,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import at.bitfire.davdroid.R
+import at.bitfire.davdroid.accounts.AccountId
 import at.bitfire.davdroid.settings.AccountSettings.Companion.SYNC_INTERVAL_MANUALLY
 import at.bitfire.davdroid.settings.Credentials
 import at.bitfire.davdroid.ui.ExternalUris
@@ -75,11 +75,11 @@ import kotlinx.coroutines.launch
 @Composable
 fun AccountSettingsScreen(
     onNavUp: () -> Unit,
-    account: Account,
+    accountId: AccountId,
     onNavWifiPermissionsScreen: () -> Unit
 ) {
     val model = hiltViewModel { factory: AccountSettingsViewModel.Factory ->
-        factory.create(account)
+        factory.create(accountId)
     }
     val uiState by model.uiState.collectAsState()
     val canAccessWifiSsid by PermissionUtils.rememberCanAccessWifiSsid()
@@ -94,7 +94,7 @@ fun AccountSettingsScreen(
 
     AppTheme {
         AccountSettingsScreen(
-            accountName = account.name,
+            accountName = uiState.accountName,
             onNavUp = onNavUp,
             status = uiState.status,
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsViewModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsViewModel.kt
@@ -4,15 +4,17 @@
 
 package at.bitfire.davdroid.ui.account
 
-import android.accounts.Account
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import at.bitfire.davdroid.R
+import at.bitfire.davdroid.accounts.AccountId
+import at.bitfire.davdroid.accounts.toAndroidAccount
 import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.Service
 import at.bitfire.davdroid.di.qualifier.DefaultDispatcher
 import at.bitfire.davdroid.network.OAuthIntegration
+import at.bitfire.davdroid.repository.AccountRepository
 import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.settings.Credentials
 import at.bitfire.davdroid.settings.SettingsManager
@@ -42,7 +44,8 @@ import java.util.logging.Logger
 
 @HiltViewModel(assistedFactory = AccountSettingsViewModel.Factory::class)
 class AccountSettingsViewModel @AssistedInject constructor(
-    @Assisted val account: Account,
+    @Assisted val accountId: AccountId,
+    private val accountRepository: AccountRepository,
     private val accountSettingsFactory: AccountSettings.Factory,
     private val authService: AuthorizationService,
     @ApplicationContext val context: Context,
@@ -57,11 +60,12 @@ class AccountSettingsViewModel @AssistedInject constructor(
 
     @AssistedFactory
     interface Factory {
-        fun create(account: Account): AccountSettingsViewModel
+        fun create(accountId: AccountId): AccountSettingsViewModel
     }
 
     // settings
     data class UiState(
+        val accountName: String = "",
         val status: String? = null,
 
         val hasContactsSync: Boolean = false,
@@ -96,13 +100,19 @@ class AccountSettingsViewModel @AssistedInject constructor(
     /**
      * Only acquire account settings on a worker thread!
      */
-    private val accountSettings by lazy { accountSettingsFactory.create(account) }
+    private val accountSettings by lazy { accountSettingsFactory.create(accountId.toAndroidAccount()) }
 
 
     init {
         settings.addOnChangeListener(this)
         viewModelScope.launch {
             reload()
+            
+            accountRepository.getAccountNameFlow(accountId).collect { accountName ->
+                _uiState.update { 
+                    it.copy(accountName = accountName)
+                }
+            }
         }
     }
 
@@ -118,32 +128,36 @@ class AccountSettingsViewModel @AssistedInject constructor(
     }
 
     private suspend fun reload() = withContext(defaultDispatcher) {
-        val hasContactsSync = serviceDao.getByAccountAndType(account.name, Service.TYPE_CARDDAV) != null
-        val hasCalendarSync = serviceDao.getByAccountAndType(account.name, Service.TYPE_CALDAV) != null
+        val hasContactsSync = serviceDao.getByAccountAndType(accountId, Service.TYPE_CARDDAV) != null
+        val hasCalendarSync = serviceDao.getByAccountAndType(accountId, Service.TYPE_CALDAV) != null
         val hasTasksSync = hasCalendarSync && tasksProvider != null
 
-        _uiState.value = UiState(
-            hasContactsSync = hasContactsSync,
-            syncIntervalContacts = accountSettings.getSyncInterval(SyncDataType.CONTACTS),
-            hasCalendarsSync = hasCalendarSync,
-            syncIntervalCalendars = accountSettings.getSyncInterval(SyncDataType.EVENTS),
-            hasTasksSync = hasTasksSync,
-            syncIntervalTasks = accountSettings.getSyncInterval(SyncDataType.TASKS),
+        _uiState.update { 
+            it.copy(
+                status = null,
 
-            syncWifiOnly = accountSettings.getSyncWifiOnly(),
-            syncWifiOnlySSIDs = accountSettings.getSyncWifiOnlySSIDs(),
-            ignoreVpns = accountSettings.getIgnoreVpns(),
+                hasContactsSync = hasContactsSync,
+                syncIntervalContacts = accountSettings.getSyncInterval(SyncDataType.CONTACTS),
+                hasCalendarsSync = hasCalendarSync,
+                syncIntervalCalendars = accountSettings.getSyncInterval(SyncDataType.EVENTS),
+                hasTasksSync = hasTasksSync,
+                syncIntervalTasks = accountSettings.getSyncInterval(SyncDataType.TASKS),
 
-            credentials = accountSettings.credentials(),
-            allowCredentialsChange = accountSettings.changingCredentialsAllowed(),
+                syncWifiOnly = accountSettings.getSyncWifiOnly(),
+                syncWifiOnlySSIDs = accountSettings.getSyncWifiOnlySSIDs(),
+                ignoreVpns = accountSettings.getIgnoreVpns(),
 
-            timeRangePastDays = accountSettings.getTimeRangePastDays(),
-            defaultAlarmMinBefore = accountSettings.getDefaultAlarm(),
-            manageCalendarColors = accountSettings.getManageCalendarColors(),
-            eventColors = accountSettings.getEventColors(),
+                credentials = accountSettings.credentials(),
+                allowCredentialsChange = accountSettings.changingCredentialsAllowed(),
 
-            contactGroupMethod = accountSettings.getGroupMethod(),
-        )
+                timeRangePastDays = accountSettings.getTimeRangePastDays(),
+                defaultAlarmMinBefore = accountSettings.getDefaultAlarm(),
+                manageCalendarColors = accountSettings.getManageCalendarColors(),
+                eventColors = accountSettings.getEventColors(),
+
+                contactGroupMethod = accountSettings.getGroupMethod(),
+            )
+        }
     }
 
 
@@ -285,7 +299,7 @@ class AccountSettingsViewModel @AssistedInject constructor(
      *                  themselves (full resync) shall be downloaded again
      */
     private fun resync(dataType: SyncDataType, resync: ResyncType) {
-        syncWorkerManager.enqueueOneTime(account, dataType = dataType, resync = resync)
+        syncWorkerManager.enqueueOneTime(accountId.toAndroidAccount(), dataType = dataType, resync = resync)
     }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/WifiPermissionsActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/WifiPermissionsActivity.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.core.app.TaskStackBuilder
 import androidx.core.content.IntentCompat
 import at.bitfire.davdroid.R
+import at.bitfire.davdroid.accounts.toAccountId
 import at.bitfire.davdroid.ui.account.AccountSettingsActivity.Companion.editAccountSettingsActivityIntent
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -57,7 +58,7 @@ class WifiPermissionsActivity: AppCompatActivity() {
     override fun supportShouldUpRecreateTask(targetIntent: Intent) = true
 
     override fun onPrepareSupportNavigateUpTaskStack(builder: TaskStackBuilder) {
-        builder.editIntentAt(builder.intentCount - 1)?.editAccountSettingsActivityIntent(account)
+        builder.editIntentAt(builder.intentCount - 1)?.editAccountSettingsActivityIntent(account.toAccountId())
     }
 
 }


### PR DESCRIPTION
`AccountSettingsScreen` is displaying the account name in the toolbar. So I added `AccountRepository.getAccountNameFlow()` to get the current name for a given `AccountId`. It emits the current name and then the new name whenever the account is renamed.

Part of #2033 