### PR TITLE
[Ktor] Use OkHttp logging format

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
@@ -35,7 +35,6 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.junit4.MockKRule
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -296,11 +295,9 @@ class HttpClientBuilderTest {
             }
 
         val log = messages.joinToString("\n")
-        // sensitive header values must not be logged
-        assertFalse(log.contains("super-secret-token-12345"))
-        assertFalse(log.contains("secret-cookie-value"))
-        // they must be redacted
-        assertTrue(log.contains("***"))
+        // sensitive header values must be redacted
+        assertTrue(log.contains("Authorization: ██\n"))
+        assertTrue(log.contains("Set-Cookie: ██\n"))
     }
 
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
@@ -33,6 +33,7 @@ import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.cookies.HttpCookies
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.plugins.logging.LoggingFormat
 import io.ktor.http.HttpHeaders
 import io.ktor.http.URLBuilder
 import io.ktor.http.URLProtocol
@@ -356,6 +357,38 @@ class HttpClientBuilder private constructor(
         }
     }
 
+    private fun HttpClientConfig<*>.installLoggingPlugin() {
+        install(Logging) {
+            // log to configured java.util.Logger with "finest"
+            logger = object : io.ktor.client.plugins.logging.Logger {
+                override fun log(message: String) {
+                    config.logger.finest(message)
+                }
+            }
+
+            // use configured log level (with/without body)
+            level = config.trafficLogLevel
+
+            // LoggingFormat.Default shows multiple list headers with ";"
+            // https://github.com/bitfireAT/davx5-ose/issues/2630 / https://youtrack.jetbrains.com/issue/KTOR-8385
+            format = LoggingFormat.OkHttp
+
+            // don't log some confidential headers
+            val headersToIgnore = arrayOf(
+                HttpHeaders.Authorization,
+                HttpHeaders.Cookie,
+                HttpHeaders.SetCookie,
+                "Set-Cookie2"       // obsoleted, but included here for good measure
+            )
+            sanitizeHeader { header ->
+                headersToIgnore.any { headerToIgnore ->
+                    header.equals(headerToIgnore, ignoreCase = true)
+                }
+            }
+        }
+
+    }
+
     /**
      * Installs all Ktor-level plugins (cookies, timeouts, content negotiation, user agent,
      * compression, auth, logging) that are shared between [build] (real [OkHttp] engine) and
@@ -400,29 +433,8 @@ class HttpClientBuilder private constructor(
         ContentEncoding()
 
         // add network logging (with redaction of sensitive headers), if requested
-        if (config.logger.isLoggable(Level.FINEST)) {
-            install(Logging) {
-                logger = object : io.ktor.client.plugins.logging.Logger {
-                    override fun log(message: String) {
-                        config.logger.finest(message)
-                    }
-                }
-                level = config.trafficLogLevel
-
-                // don't log some confidential headers
-                val headersToIgnore = arrayOf(
-                    HttpHeaders.Authorization,
-                    HttpHeaders.Cookie,
-                    HttpHeaders.SetCookie,
-                    "Set-Cookie2"       // obsoleted, but included here for good measure
-                )
-                sanitizeHeader { header ->
-                    headersToIgnore.any { headerToIgnore ->
-                        header.equals(headerToIgnore, ignoreCase = true)
-                    }
-                }
-            }
-        }
+        if (config.logger.isLoggable(Level.FINEST))
+            installLoggingPlugin()
     }
 
     /**


### PR DESCRIPTION
### Purpose

Use OkHttp logging format to avoid confusion:

- default logging format logs multiple header values separated with `;` although they're actually sent with `,` (or binary / in HTTP/2 format)
- okhttp logging format joins with `,` as expected

Closes #2630.

### Short description

- Extracted logging plugin into a separate method for better organization.
- Updated logging format to OkHttp.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.