### PR TITLE
Read-only collections: reset instead of upload local changes

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/LocalTestCollection.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/LocalTestCollection.kt
@@ -19,8 +19,7 @@ class LocalTestCollection(
 
     val entries = mutableListOf<LocalTestResource>()
 
-    override val readOnly: Boolean
-        get() = throw NotImplementedError()
+    override val readOnly = false
 
     override fun findDeleted() = entries.filter { it.deleted }.asFlow()
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollection.kt
@@ -23,7 +23,7 @@ class LocalJtxCollection(internal val jtxCollection: JtxCollection) :
     LocalCollection<LocalJtxObject> {
 
     override val readOnly: Boolean
-        get() = throw NotImplementedError()
+        get() = jtxCollection.readonly
 
     override val tag: String
         get() = "jtx-${jtxCollection.account.name}-${jtxCollection.id}"

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
@@ -51,7 +51,6 @@ import java.io.Reader
 import java.io.StringReader
 import java.io.StringWriter
 import java.time.ZonedDateTime
-import java.util.Optional
 import java.util.logging.Level
 
 /**
@@ -140,54 +139,6 @@ class CalendarSyncManager @AssistedInject constructor(
             SyncAlgorithm.PROPFIND_REPORT
         else
             SyncAlgorithm.COLLECTION_SYNC
-
-    override suspend fun processLocallyDeleted(): Boolean {
-        if (localCollection.readOnly) {
-            var modified = false
-            localCollection.findDeleted().collect { event ->
-                logger.warning("Restoring locally deleted event (read-only calendar!)")
-                SyncException.wrapWithLocalResource(event) {
-                    event.resetDeleted()
-                }
-                modified = true
-            }
-
-            // This is unfortunately ugly: When an event has been inserted to a read-only calendar
-            // it's not enough to force synchronization (by returning true),
-            // but we also need to make sure all events are downloaded again.
-            if (modified)
-                localCollection.lastSyncState = null
-
-            return modified
-        }
-        // mirror deletions to remote collection (DELETE)
-        return super.processLocallyDeleted()
-    }
-
-    override suspend fun uploadDirty(): Boolean {
-        var modified = false
-        if (localCollection.readOnly) {
-            localCollection.findDirty().collect { event ->
-                logger.warning("Resetting locally modified event to ETag=null (read-only calendar!)")
-                SyncException.wrapWithLocalResource(event) {
-                    event.clearDirty(Optional.empty(), null, null)
-                }
-                modified = true
-            }
-
-            // This is unfortunately ugly: When an event has been inserted to a read-only calendar
-            // it's not enough to force synchronization (by returning true),
-            // but we also need to make sure all events are downloaded again.
-            if (modified)
-                localCollection.lastSyncState = null
-        }
-
-        // generate UID/file name for newly created events
-        val superModified = super.uploadDirty()
-
-        // return true when any operation returned true
-        return modified or superModified
-    }
 
     override fun generateUpload(resource: LocalEvent): GeneratedResource {
         val localEvent = resource.androidEvent

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
@@ -202,69 +202,12 @@ class ContactsSyncManager @AssistedInject constructor(
         else
             SyncAlgorithm.PROPFIND_REPORT
 
-    override suspend fun processLocallyDeleted() =
-            if (localCollection.readOnly) {
-                var modified = false
-                localCollection.findDeletedGroups().collect { group ->
-                    logger.warning("Restoring locally deleted group (read-only address book!)")
-                    SyncException.wrapWithLocalResource(group) {
-                        group.resetDeleted()
-                    }
-                    modified = true
-                }
-
-                localCollection.findDeletedContacts().collect { contact ->
-                    logger.warning("Restoring locally deleted contact (read-only address book!)")
-                    SyncException.wrapWithLocalResource(contact) {
-                        contact.resetDeleted()
-                    }
-                    modified = true
-                }
-
-                /* This is unfortunately dirty: When a contact has been inserted to a read-only address book
-                   that supports Collection Sync, it's not enough to force synchronization (by returning true),
-                   but we also need to make sure all contacts are downloaded again. */
-                if (modified)
-                    localCollection.lastSyncState = null
-
-                modified
-            } else
-                // mirror deletions to remote collection (DELETE)
-                super.processLocallyDeleted()
-
     override suspend fun uploadDirty(): Boolean {
-        var modified = false
-
-        if (localCollection.readOnly) {
-            localCollection.findDirtyGroups().collect { group ->
-                logger.warning("Resetting locally modified group to ETag=null (read-only address book!)")
-                SyncException.wrapWithLocalResource(group) {
-                    group.clearDirty(Optional.empty(), null)
-                }
-                modified = true
-            }
-
-            localCollection.findDirtyContacts().collect { contact ->
-                logger.warning("Resetting locally modified contact to ETag=null (read-only address book!)")
-                SyncException.wrapWithLocalResource(contact) {
-                    contact.clearDirty(Optional.empty(), null)
-                }
-                modified = true
-            }
-
-            // see same position in processLocallyDeleted
-            if (modified)
-                localCollection.lastSyncState = null
-
-        } else
+        if (!localCollection.readOnly)
             // we only need to handle changes in groups when the address book is read/write
             groupStrategy.beforeUploadDirty()
 
-        // generate UID/file name for newly created contacts
-        val superModified = super.uploadDirty()
-
-        // return true when any operation returned true
-        return modified or superModified
+        return super.uploadDirty()
     }
 
     override fun generateUpload(resource: LocalAddress): GeneratedResource {

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
@@ -203,9 +203,13 @@ class ContactsSyncManager @AssistedInject constructor(
             SyncAlgorithm.PROPFIND_REPORT
 
     override suspend fun uploadDirty(): Boolean {
-        if (!localCollection.readOnly)
-            // we only need to handle changes in groups when the address book is read/write
+        // local group housekeeping is needed regardless of whether we're actually uploading
+        groupStrategy.resolveLocalGroupChanges()
+
+        if (!localCollection.readOnly) {
+            // preparing groups for upload is only relevant when local changes are pushed
             groupStrategy.beforeUploadDirty()
+        }
 
         return super.uploadDirty()
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/ReadOnlyPolicy.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/ReadOnlyPolicy.kt
@@ -51,7 +51,11 @@ class ReadOnlyPolicy @Inject constructor(
         collection.findDirty().collect { local ->
             logger.warning("Resetting locally modified resource to ETag=null (read-only collection!)")
             SyncException.wrapWithLocalResource(local) {
-                local.clearDirty(Optional.empty(), null, null)
+                local.clearDirty(
+                    fileName = Optional.empty(),
+                    eTag = null,
+                    scheduleTag = null
+                )
             }
             modified = true
         }

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/ReadOnlyPolicy.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/ReadOnlyPolicy.kt
@@ -18,7 +18,7 @@ class ReadOnlyPolicy @Inject constructor(
 ) {
 
     /**
-     * Restores locally deleted resources instead of deleting them from the (read-only) server.
+     * Restores locally deleted resources from the server instead of deleting them from the (read-only) server.
      *
      * @return whether local resources have been restored so that a synchronization is always necessary
      */
@@ -32,8 +32,9 @@ class ReadOnlyPolicy @Inject constructor(
             modified = true
         }
 
-        // When a resource has been inserted to a read-only collection it's not enough to force
-        // synchronization (by returning true), we also need to make sure all resources are downloaded again.
+        /* When a resource has been inserted to a read-only collection it's not enough to force
+        synchronization (by returning true), we also need to make sure all resources are downloaded again
+        (force full re-sync) so that local additions are deleted again because they're not on the server. */
         if (modified)
             collection.lastSyncState = null
 
@@ -55,7 +56,9 @@ class ReadOnlyPolicy @Inject constructor(
             modified = true
         }
 
-        // see resetDeleted
+        /* When a resource has been inserted to a read-only collection it's not enough to force
+        synchronization (by returning true), we also need to make sure all resources are downloaded again
+        (force full re-sync) so that local additions are overwritten by the server items. */
         if (modified)
             collection.lastSyncState = null
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/ReadOnlyPolicy.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/ReadOnlyPolicy.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.sync
+
+import at.bitfire.davdroid.resource.LocalCollection
+import java.util.Optional
+import java.util.logging.Logger
+import javax.inject.Inject
+
+/**
+ * Handles local changes in a read-only collection: instead of pushing them to the server,
+ * resets them locally so that they will be downloaded again and overwritten with the server's version.
+ */
+class ReadOnlyPolicy @Inject constructor(
+    private val logger: Logger
+) {
+
+    /**
+     * Restores locally deleted resources instead of deleting them from the (read-only) server.
+     *
+     * @return whether local resources have been restored so that a synchronization is always necessary
+     */
+    suspend fun resetDeleted(collection: LocalCollection<*>): Boolean {
+        var modified = false
+        collection.findDeleted().collect { local ->
+            logger.warning("Restoring locally deleted resource (read-only collection!)")
+            SyncException.wrapWithLocalResource(local) {
+                local.resetDeleted()
+            }
+            modified = true
+        }
+
+        // When a resource has been inserted to a read-only collection it's not enough to force
+        // synchronization (by returning true), we also need to make sure all resources are downloaded again.
+        if (modified)
+            collection.lastSyncState = null
+
+        return modified
+    }
+
+    /**
+     * Resets locally modified entries to ETag=null instead of uploading them to the (read-only) server.
+     *
+     * @return whether local resources have been reset so that a synchronization is always necessary
+     */
+    suspend fun resetDirty(collection: LocalCollection<*>): Boolean {
+        var modified = false
+        collection.findDirty().collect { local ->
+            logger.warning("Resetting locally modified resource to ETag=null (read-only collection!)")
+            SyncException.wrapWithLocalResource(local) {
+                local.clearDirty(Optional.empty(), null, null)
+            }
+            modified = true
+        }
+
+        // see resetDeleted
+        if (modified)
+            collection.lastSyncState = null
+
+        return modified
+    }
+
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -115,6 +115,9 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
     lateinit var logger: Logger
 
     @Inject
+    lateinit var readOnlyPolicy: ReadOnlyPolicy
+
+    @Inject
     lateinit var syncStatsRepository: DavSyncStatsRepository
 
     @Inject
@@ -329,7 +332,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
      */
     protected open suspend fun processLocallyDeleted(): Boolean {
         if (localCollection.readOnly)
-            return restoreDeletedForReadOnly()
+            return readOnlyPolicy.resetDeleted(localCollection)
 
         var numDeleted = 0
 
@@ -371,30 +374,6 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
     }
 
     /**
-     * Restores locally deleted entries instead of deleting them from the (read-only) server.
-     *
-     * @return whether local resources have been restored so that a synchronization is always necessary
-     */
-    private suspend fun restoreDeletedForReadOnly(): Boolean {
-        var modified = false
-        localCollection.findDeleted().collect { local ->
-            logger.warning("Restoring locally deleted resource (read-only collection!)")
-            SyncException.wrapWithLocalResource(local) {
-                local.resetDeleted()
-            }
-            modified = true
-        }
-
-        // This is unfortunately ugly: When a resource has been inserted to a read-only collection
-        // it's not enough to force synchronization (by returning true),
-        // but we also need to make sure all resources are downloaded again.
-        if (modified)
-            localCollection.lastSyncState = null
-
-        return modified
-    }
-
-    /**
      * Processes locally modified resources to the server. This can mean:
      *
      * - uploading them to the server (HTTP `PUT`)
@@ -404,7 +383,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
      */
     protected open suspend fun uploadDirty(): Boolean {
         if (localCollection.readOnly)
-            return resetDirtyForReadOnly()
+            return readOnlyPolicy.resetDirty(localCollection)
 
         var numUploaded = 0
 
@@ -417,28 +396,6 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
 
         logger.info("Sent $numUploaded record(s) to server")
         return numUploaded > 0
-    }
-
-    /**
-     * Resets locally modified entries to ETag=null instead of uploading them to the (read-only) server.
-     *
-     * @return whether local resources have been reset so that a synchronization is always necessary
-     */
-    private suspend fun resetDirtyForReadOnly(): Boolean {
-        var modified = false
-        localCollection.findDirty().collect { local ->
-            logger.warning("Resetting locally modified resource to ETag=null (read-only collection!)")
-            SyncException.wrapWithLocalResource(local) {
-                local.clearDirty(Optional.empty(), null, null)
-            }
-            modified = true
-        }
-
-        // see restoreDeletedForReadOnly
-        if (modified)
-            localCollection.lastSyncState = null
-
-        return modified
     }
 
     /**

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -328,6 +328,9 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
      * @return whether local resources have been processed so that a synchronization is always necessary
      */
     protected open suspend fun processLocallyDeleted(): Boolean {
+        if (localCollection.readOnly)
+            return restoreDeletedForReadOnly()
+
         var numDeleted = 0
 
         // Remove locally deleted entries from server (if they have a name, i.e. if they were uploaded before),
@@ -368,6 +371,30 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
     }
 
     /**
+     * Restores locally deleted entries instead of deleting them from the (read-only) server.
+     *
+     * @return whether local resources have been restored so that a synchronization is always necessary
+     */
+    private suspend fun restoreDeletedForReadOnly(): Boolean {
+        var modified = false
+        localCollection.findDeleted().collect { local ->
+            logger.warning("Restoring locally deleted resource (read-only collection!)")
+            SyncException.wrapWithLocalResource(local) {
+                local.resetDeleted()
+            }
+            modified = true
+        }
+
+        // This is unfortunately ugly: When a resource has been inserted to a read-only collection
+        // it's not enough to force synchronization (by returning true),
+        // but we also need to make sure all resources are downloaded again.
+        if (modified)
+            localCollection.lastSyncState = null
+
+        return modified
+    }
+
+    /**
      * Processes locally modified resources to the server. This can mean:
      *
      * - uploading them to the server (HTTP `PUT`)
@@ -376,6 +403,9 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
      * @return whether local resources have been processed so that a synchronization is always necessary
      */
     protected open suspend fun uploadDirty(): Boolean {
+        if (localCollection.readOnly)
+            return resetDirtyForReadOnly()
+
         var numUploaded = 0
 
         localCollection.findDirty().collect { local ->
@@ -387,6 +417,28 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
 
         logger.info("Sent $numUploaded record(s) to server")
         return numUploaded > 0
+    }
+
+    /**
+     * Resets locally modified entries to ETag=null instead of uploading them to the (read-only) server.
+     *
+     * @return whether local resources have been reset so that a synchronization is always necessary
+     */
+    private suspend fun resetDirtyForReadOnly(): Boolean {
+        var modified = false
+        localCollection.findDirty().collect { local ->
+            logger.warning("Resetting locally modified resource to ETag=null (read-only collection!)")
+            SyncException.wrapWithLocalResource(local) {
+                local.clearDirty(Optional.empty(), null, null)
+            }
+            modified = true
+        }
+
+        // see restoreDeletedForReadOnly
+        if (modified)
+            localCollection.lastSyncState = null
+
+        return modified
     }
 
     /**

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/groups/CategoriesStrategy.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/groups/CategoriesStrategy.kt
@@ -14,7 +14,7 @@ class CategoriesStrategy(val addressBook: LocalAddressBook): ContactGroupStrateg
     private val logger: Logger
         get() = Logger.getGlobal()
 
-    override suspend fun beforeUploadDirty() {
+    override suspend fun resolveLocalGroupChanges() {
         // groups with DELETED=1: set all members to dirty, then remove group
         addressBook.findDeletedGroups().collect { group ->
             logger.fine("Finally removing group $group")

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/groups/ContactGroupStrategy.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/groups/ContactGroupStrategy.kt
@@ -8,7 +8,18 @@ import at.bitfire.synctools.mapping.contacts.Contact
 
 interface ContactGroupStrategy {
 
-    suspend fun beforeUploadDirty()
+    /**
+     * Local-only group housekeeping (e.g. dissolving groups, propagating group-level changes to
+     * member contacts) that must happen regardless of whether local changes will be uploaded.
+     */
+    suspend fun resolveLocalGroupChanges() {}
+
+    /**
+     * Prepares group state for upload. Only meaningful when local changes are actually pushed
+     * to the server.
+     */
+    suspend fun beforeUploadDirty() {}
+
     fun verifyContactBeforeSaving(contact: Contact)
     suspend fun postProcess()
 

--- a/core/src/test/kotlin/at/bitfire/davdroid/sync/ReadOnlyPolicyTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/sync/ReadOnlyPolicyTest.kt
@@ -32,8 +32,6 @@ class ReadOnlyPolicyTest {
     lateinit var collection: LocalCollection<LocalResource>
 
 
-    // resetDeleted
-
     @Test
     fun `resetDeleted() with no deleted resources returns false and keeps sync state`() = runTest {
         every { collection.findDeleted() } returns flowOf()
@@ -55,8 +53,6 @@ class ReadOnlyPolicyTest {
         verify { collection.lastSyncState = null }
     }
 
-
-    // resetDirty
 
     @Test
     fun `resetDirty() with no dirty resources returns false and keeps sync state`() = runTest {

--- a/core/src/test/kotlin/at/bitfire/davdroid/sync/ReadOnlyPolicyTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/sync/ReadOnlyPolicyTest.kt
@@ -7,32 +7,35 @@ package at.bitfire.davdroid.sync
 import at.bitfire.davdroid.resource.LocalCollection
 import at.bitfire.davdroid.resource.LocalResource
 import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit4.MockKRule
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
 import java.util.Optional
 import java.util.logging.Logger
 
 class ReadOnlyPolicyTest {
 
+    @get:Rule
+    val mockKRule = MockKRule(this)
+
     private val logger = Logger.getLogger(javaClass.name)
     private val policy = ReadOnlyPolicy(logger)
 
-    private fun localCollection(): LocalCollection<LocalResource> {
-        val collection = mockk<LocalCollection<LocalResource>>(relaxed = true)
-        return collection
-    }
+    @MockK(relaxed = true)
+    lateinit var collection: LocalCollection<LocalResource>
 
 
     // resetDeleted
 
     @Test
-    fun testResetDeleted_NoDeletedResources_ReturnsFalseAndKeepsSyncState() = runTest {
-        val collection = localCollection()
+    fun `resetDeleted() with no deleted resources returns false and keeps sync state`() = runTest {
         every { collection.findDeleted() } returns flowOf()
 
         assertFalse(policy.resetDeleted(collection))
@@ -40,8 +43,7 @@ class ReadOnlyPolicyTest {
     }
 
     @Test
-    fun testResetDeleted_DeletedResources_ResetsEachAndClearsSyncState() = runTest {
-        val collection = localCollection()
+    fun `resetDeleted() with deleted resources resets each and clears sync state`() = runTest {
         val resource1 = mockk<LocalResource>(relaxed = true)
         val resource2 = mockk<LocalResource>(relaxed = true)
         every { collection.findDeleted() } returns flowOf(resource1, resource2)
@@ -57,8 +59,7 @@ class ReadOnlyPolicyTest {
     // resetDirty
 
     @Test
-    fun testResetDirty_NoDirtyResources_ReturnsFalseAndKeepsSyncState() = runTest {
-        val collection = localCollection()
+    fun `resetDirty() with no dirty resources returns false and keeps sync state`() = runTest {
         every { collection.findDirty() } returns flowOf()
 
         assertFalse(policy.resetDirty(collection))
@@ -66,8 +67,7 @@ class ReadOnlyPolicyTest {
     }
 
     @Test
-    fun testResetDirty_DirtyResources_ClearsDirtyOnEachAndClearsSyncState() = runTest {
-        val collection = localCollection()
+    fun `resetDirty() with dirty resources clears dirty on each and clears sync state`() = runTest {
         val resource = mockk<LocalResource>(relaxed = true)
         every { collection.findDirty() } returns flowOf(resource)
 

--- a/core/src/test/kotlin/at/bitfire/davdroid/sync/ReadOnlyPolicyTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/sync/ReadOnlyPolicyTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.sync
+
+import at.bitfire.davdroid.resource.LocalCollection
+import at.bitfire.davdroid.resource.LocalResource
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Optional
+import java.util.logging.Logger
+
+class ReadOnlyPolicyTest {
+
+    private val logger = Logger.getLogger(javaClass.name)
+    private val policy = ReadOnlyPolicy(logger)
+
+    private fun localCollection(): LocalCollection<LocalResource> {
+        val collection = mockk<LocalCollection<LocalResource>>(relaxed = true)
+        return collection
+    }
+
+
+    // resetDeleted
+
+    @Test
+    fun testResetDeleted_NoDeletedResources_ReturnsFalseAndKeepsSyncState() = runTest {
+        val collection = localCollection()
+        every { collection.findDeleted() } returns flowOf()
+
+        assertFalse(policy.resetDeleted(collection))
+        verify(exactly = 0) { collection.lastSyncState = any() }
+    }
+
+    @Test
+    fun testResetDeleted_DeletedResources_ResetsEachAndClearsSyncState() = runTest {
+        val collection = localCollection()
+        val resource1 = mockk<LocalResource>(relaxed = true)
+        val resource2 = mockk<LocalResource>(relaxed = true)
+        every { collection.findDeleted() } returns flowOf(resource1, resource2)
+
+        assertTrue(policy.resetDeleted(collection))
+
+        verify { resource1.resetDeleted() }
+        verify { resource2.resetDeleted() }
+        verify { collection.lastSyncState = null }
+    }
+
+
+    // resetDirty
+
+    @Test
+    fun testResetDirty_NoDirtyResources_ReturnsFalseAndKeepsSyncState() = runTest {
+        val collection = localCollection()
+        every { collection.findDirty() } returns flowOf()
+
+        assertFalse(policy.resetDirty(collection))
+        verify(exactly = 0) { collection.lastSyncState = any() }
+    }
+
+    @Test
+    fun testResetDirty_DirtyResources_ClearsDirtyOnEachAndClearsSyncState() = runTest {
+        val collection = localCollection()
+        val resource = mockk<LocalResource>(relaxed = true)
+        every { collection.findDirty() } returns flowOf(resource)
+
+        assertTrue(policy.resetDirty(collection))
+
+        verify { resource.clearDirty(Optional.empty(), null, null) }
+        verify { collection.lastSyncState = null }
+    }
+
+}

--- a/core/src/test/kotlin/at/bitfire/davdroid/sync/groups/CategoriesStrategyTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/sync/groups/CategoriesStrategyTest.kt
@@ -11,8 +11,10 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.junit4.MockKRule
 import io.mockk.mockk
 import io.mockk.verify
+import junit.framework.AssertionFailedError
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import java.util.Optional
@@ -27,6 +29,13 @@ class CategoriesStrategyTest {
 
     private val strategy by lazy { CategoriesStrategy(addressBook) }
 
+    @Before
+    fun setUp() {
+        /* CategoriesStrategy is called by orchestrator depending on whether the collection is read-only;
+        but it doesn't check itself. */
+        every { addressBook.readOnly } throws AssertionFailedError()
+    }
+
 
     // resolveLocalGroupChanges
 
@@ -36,7 +45,6 @@ class CategoriesStrategyTest {
         every { addressBook.findDeletedGroups() } returns flowOf(group)
         every { addressBook.findDirtyGroups() } returns flowOf()
 
-        // must not depend on whether the address book is read-only: this is pure local housekeeping
         strategy.resolveLocalGroupChanges()
 
         verify { group.markMembersDirty() }

--- a/core/src/test/kotlin/at/bitfire/davdroid/sync/groups/CategoriesStrategyTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/sync/groups/CategoriesStrategyTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.sync.groups
+
+import at.bitfire.davdroid.resource.LocalAddressBook
+import at.bitfire.davdroid.resource.LocalGroup
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit4.MockKRule
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import java.util.Optional
+
+class CategoriesStrategyTest {
+
+    @get:Rule
+    val mockKRule = MockKRule(this)
+
+    @MockK(relaxed = true)
+    lateinit var addressBook: LocalAddressBook
+
+    private val strategy by lazy { CategoriesStrategy(addressBook) }
+
+
+    // resolveLocalGroupChanges
+
+    @Test
+    fun `resolveLocalGroupChanges() with deleted group marks members dirty and removes group`() = runTest {
+        val group = mockk<LocalGroup>(relaxed = true)
+        every { addressBook.findDeletedGroups() } returns flowOf(group)
+        every { addressBook.findDirtyGroups() } returns flowOf()
+
+        // must not depend on whether the address book is read-only: this is pure local housekeeping
+        strategy.resolveLocalGroupChanges()
+
+        verify { group.markMembersDirty() }
+        verify { group.androidGroup.delete() }
+    }
+
+    @Test
+    fun `resolveLocalGroupChanges() with dirty group marks members dirty and clears dirty flag`() = runTest {
+        val group = mockk<LocalGroup>(relaxed = true)
+        every { addressBook.findDeletedGroups() } returns flowOf()
+        every { addressBook.findDirtyGroups() } returns flowOf(group)
+
+        strategy.resolveLocalGroupChanges()
+
+        verify { group.markMembersDirty() }
+        verify { group.clearDirty(Optional.empty(), null) }
+    }
+
+}


### PR DESCRIPTION

### Purpose

Local changes in a read-only collection can't be pushed to the server (causes 403/404); they need to be reset locally instead so the collection converges back to the server's version. Fixes #599.

### Short description

- Added `ReadOnlyPolicy` (policy/strategy pattern) that is responsible for handling read-only collections.
  - Resets deleted and dirty resources (as previously implemented for contacts + events).
  - Used from `SyncManager` for all collection types, replacing the old contacts/events-specific duplicate logic.
  - Moves out logic from the already overloaded `SyncManager` (which still calls the strategy as orchestrator).
- Split `ContactGroupStrategy.beforeUploadDirty()` into `resolveLocalGroupChanges()` (local-only group housekeeping) and `beforeUploadDirty()`. The former now always runs, fixing locally deleted/modified groups never being cleaned up in read-only `CATEGORIES`-mode address books.

Note: number of lines (excluding tests) is +98 -113 (LoC net reduce).

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
