### PR TITLE
Fix threading for building HTTP proxies

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/TestUtils.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/TestUtils.kt
@@ -4,7 +4,6 @@
 
 package at.bitfire.davdroid
 
-import android.app.Instrumentation
 import android.content.Context
 import android.util.Log
 import androidx.work.Configuration
@@ -55,13 +54,5 @@ object TestUtils {
             WorkInfo.State.RUNNING,
             WorkInfo.State.SUCCEEDED
         ))
-
-    fun <T> Instrumentation.runOnMain(block: () -> T): T {
-        var result: T? = null
-        runOnMainSync {
-            result = block()
-        }
-        return result!!
-    }
 
 }

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/TestUtils.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/TestUtils.kt
@@ -4,6 +4,7 @@
 
 package at.bitfire.davdroid
 
+import android.app.Instrumentation
 import android.content.Context
 import android.util.Log
 import androidx.work.Configuration
@@ -54,5 +55,13 @@ object TestUtils {
             WorkInfo.State.RUNNING,
             WorkInfo.State.SUCCEEDED
         ))
+
+    fun <T> Instrumentation.runOnMain(block: () -> T): T {
+        var result: T? = null
+        runOnMainSync {
+            result = block()
+        }
+        return result!!
+    }
 
 }

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
@@ -4,6 +4,7 @@
 
 package at.bitfire.davdroid.network
 
+import androidx.test.annotation.UiThreadTest
 import at.bitfire.davdroid.MockEngineQueue
 import at.bitfire.davdroid.MockEngineUtils.Default
 import at.bitfire.davdroid.MockEngineUtils.basic
@@ -104,30 +105,34 @@ class HttpClientBuilderTest {
     }
 
     @Test
+    @UiThreadTest
     fun testBuildProxy_Http() = runTest {
         every { settingsManager.getInt(Settings.PROXY_TYPE) } returns Settings.PROXY_TYPE_HTTP
         every { settingsManager.getString(Settings.PROXY_HOST) } returns "proxy.example.com"
         every { settingsManager.getInt(Settings.PROXY_PORT) } returns 8080
 
-        // ProxyBuilder.http resolves DNS, which throws NetworkOnMainThreadException if called directly on the main thread.
-        // The build method should handle threading automatically.
-        withContext(Dispatchers.Main) { httpClientBuilder.build() }.use { client ->
+        // HttpClientBuilder.build should be safe to run on the main thread. No network requests should be made
+        httpClientBuilder.build().use { client ->
             val proxy = (client.engine as OkHttpEngine).config.proxy
-            assertEquals(ProxyBuilder.http(Url("http://proxy.example.com:8080")), proxy)
+            // However, for the test, ProxyBuilder.http requires Internet connection, so should be done in IO
+            val expectedProxy = withContext(Dispatchers.IO) { ProxyBuilder.http(Url("http://proxy.example.com:8080")) }
+            assertEquals(expectedProxy, proxy)
         }
     }
 
     @Test
+    @UiThreadTest
     fun testBuildProxy_Socks() = runTest {
         every { settingsManager.getInt(Settings.PROXY_TYPE) } returns Settings.PROXY_TYPE_SOCKS
         every { settingsManager.getString(Settings.PROXY_HOST) } returns "proxy.example.com"
         every { settingsManager.getInt(Settings.PROXY_PORT) } returns 1080
 
-        // ProxyBuilder.socks resolves DNS, which throws NetworkOnMainThreadException if called directly on the main thread.
-        // The build method should handle threading automatically.
-        withContext(Dispatchers.Main) { httpClientBuilder.build() }.use { client ->
+        // HttpClientBuilder.build should be safe to run on the main thread. No network requests should be made
+        httpClientBuilder.build().use { client ->
             val proxy = (client.engine as OkHttpEngine).config.proxy
-            assertEquals(ProxyBuilder.socks("proxy.example.com", 1080), proxy)
+            // However, for the test, ProxyBuilder.socks requires Internet connection, so should be done in IO
+            val expectedProxy = withContext(Dispatchers.IO) { ProxyBuilder.socks("proxy.example.com", 1080) }
+            assertEquals(expectedProxy, proxy)
         }
     }
 

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
@@ -108,9 +108,13 @@ class HttpClientBuilderTest {
         every { settingsManager.getString(Settings.PROXY_HOST) } returns "proxy.example.com"
         every { settingsManager.getInt(Settings.PROXY_PORT) } returns 8080
 
-        httpClientBuilder.build().use { client ->
-            val proxy = (client.engine as OkHttpEngine).config.proxy
-            assertEquals(ProxyBuilder.http(Url("http://proxy.example.com:8080")), proxy)
+        // ProxyBuilder.http resolves DNS, which throws NetworkOnMainThreadException if called directly on the main thread.
+        // The build method should handle threading automatically.
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            httpClientBuilder.build().use { client ->
+                val proxy = (client.engine as OkHttpEngine).config.proxy
+                assertEquals(ProxyBuilder.http(Url("http://proxy.example.com:8080")), proxy)
+            }
         }
     }
 
@@ -120,48 +124,14 @@ class HttpClientBuilderTest {
         every { settingsManager.getString(Settings.PROXY_HOST) } returns "proxy.example.com"
         every { settingsManager.getInt(Settings.PROXY_PORT) } returns 1080
 
-        httpClientBuilder.build().use { client ->
-            val proxy = (client.engine as OkHttpEngine).config.proxy
-            assertEquals(ProxyBuilder.socks("proxy.example.com", 1080), proxy)
-        }
-    }
-
-    @Test
-    fun testBuildProxy_HttpDoesNotThrowOnMainThread() {
-        every { settingsManager.getInt(Settings.PROXY_TYPE) } returns Settings.PROXY_TYPE_HTTP
-        every { settingsManager.getString(Settings.PROXY_HOST) } returns "proxy.example.com"
-        every { settingsManager.getInt(Settings.PROXY_PORT) } returns 8080
-
-        // ProxyBuilder.http resolves DNS, which throws NetworkOnMainThreadException if called
-        // directly on the main thread. The fix wraps it in withContext(Dispatchers.IO).
-        var caught: Throwable? = null
+        // ProxyBuilder.socks resolves DNS, which throws NetworkOnMainThreadException if called directly on the main thread.
+        // The build method should handle threading automatically.
         InstrumentationRegistry.getInstrumentation().runOnMainSync {
-            try {
-                httpClientBuilder.build().close()
-            } catch (t: Throwable) {
-                caught = t
+            httpClientBuilder.build().use { client ->
+                val proxy = (client.engine as OkHttpEngine).config.proxy
+                assertEquals(ProxyBuilder.socks("proxy.example.com", 1080), proxy)
             }
         }
-        caught?.let { throw it }
-    }
-
-    @Test
-    fun testBuildProxy_SocksDoesNotThrowOnMainThread() {
-        every { settingsManager.getInt(Settings.PROXY_TYPE) } returns Settings.PROXY_TYPE_SOCKS
-        every { settingsManager.getString(Settings.PROXY_HOST) } returns "proxy.example.com"
-        every { settingsManager.getInt(Settings.PROXY_PORT) } returns 1080
-
-        // ProxyBuilder.socks resolves DNS, which throws NetworkOnMainThreadException if called
-        // directly on the main thread. The fix wraps it in withContext(Dispatchers.IO).
-        var caught: Throwable? = null
-        InstrumentationRegistry.getInstrumentation().runOnMainSync {
-            try {
-                httpClientBuilder.build().close()
-            } catch (t: Throwable) {
-                caught = t
-            }
-        }
-        caught?.let { throw it }
     }
 
     @Test

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
@@ -4,6 +4,7 @@
 
 package at.bitfire.davdroid.network
 
+import androidx.test.platform.app.InstrumentationRegistry
 import at.bitfire.davdroid.MockEngineQueue
 import at.bitfire.davdroid.MockEngineUtils.Default
 import at.bitfire.davdroid.MockEngineUtils.basic
@@ -123,6 +124,44 @@ class HttpClientBuilderTest {
             val proxy = (client.engine as OkHttpEngine).config.proxy
             assertEquals(ProxyBuilder.socks("proxy.example.com", 1080), proxy)
         }
+    }
+
+    @Test
+    fun testBuildProxy_HttpDoesNotThrowOnMainThread() {
+        every { settingsManager.getInt(Settings.PROXY_TYPE) } returns Settings.PROXY_TYPE_HTTP
+        every { settingsManager.getString(Settings.PROXY_HOST) } returns "proxy.example.com"
+        every { settingsManager.getInt(Settings.PROXY_PORT) } returns 8080
+
+        // ProxyBuilder.http resolves DNS, which throws NetworkOnMainThreadException if called
+        // directly on the main thread. The fix wraps it in withContext(Dispatchers.IO).
+        var caught: Throwable? = null
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            try {
+                httpClientBuilder.build().close()
+            } catch (t: Throwable) {
+                caught = t
+            }
+        }
+        caught?.let { throw it }
+    }
+
+    @Test
+    fun testBuildProxy_SocksDoesNotThrowOnMainThread() {
+        every { settingsManager.getInt(Settings.PROXY_TYPE) } returns Settings.PROXY_TYPE_SOCKS
+        every { settingsManager.getString(Settings.PROXY_HOST) } returns "proxy.example.com"
+        every { settingsManager.getInt(Settings.PROXY_PORT) } returns 1080
+
+        // ProxyBuilder.socks resolves DNS, which throws NetworkOnMainThreadException if called
+        // directly on the main thread. The fix wraps it in withContext(Dispatchers.IO).
+        var caught: Throwable? = null
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            try {
+                httpClientBuilder.build().close()
+            } catch (t: Throwable) {
+                caught = t
+            }
+        }
+        caught?.let { throw it }
     }
 
     @Test

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
@@ -9,6 +9,7 @@ import at.bitfire.davdroid.MockEngineQueue
 import at.bitfire.davdroid.MockEngineUtils.Default
 import at.bitfire.davdroid.MockEngineUtils.basic
 import at.bitfire.davdroid.ProductIds
+import at.bitfire.davdroid.TestUtils.runOnMain
 import at.bitfire.davdroid.settings.Settings
 import at.bitfire.davdroid.settings.SettingsManager
 import dagger.hilt.android.testing.BindValue
@@ -110,11 +111,9 @@ class HttpClientBuilderTest {
 
         // ProxyBuilder.http resolves DNS, which throws NetworkOnMainThreadException if called directly on the main thread.
         // The build method should handle threading automatically.
-        InstrumentationRegistry.getInstrumentation().runOnMainSync {
-            httpClientBuilder.build().use { client ->
-                val proxy = (client.engine as OkHttpEngine).config.proxy
-                assertEquals(ProxyBuilder.http(Url("http://proxy.example.com:8080")), proxy)
-            }
+        InstrumentationRegistry.getInstrumentation().runOnMain { httpClientBuilder.build() }.use { client ->
+            val proxy = (client.engine as OkHttpEngine).config.proxy
+            assertEquals(ProxyBuilder.http(Url("http://proxy.example.com:8080")), proxy)
         }
     }
 
@@ -126,11 +125,9 @@ class HttpClientBuilderTest {
 
         // ProxyBuilder.socks resolves DNS, which throws NetworkOnMainThreadException if called directly on the main thread.
         // The build method should handle threading automatically.
-        InstrumentationRegistry.getInstrumentation().runOnMainSync {
-            httpClientBuilder.build().use { client ->
-                val proxy = (client.engine as OkHttpEngine).config.proxy
-                assertEquals(ProxyBuilder.socks("proxy.example.com", 1080), proxy)
-            }
+        InstrumentationRegistry.getInstrumentation().runOnMain { httpClientBuilder.build() }.use { client ->
+            val proxy = (client.engine as OkHttpEngine).config.proxy
+            assertEquals(ProxyBuilder.socks("proxy.example.com", 1080), proxy)
         }
     }
 

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
@@ -4,12 +4,10 @@
 
 package at.bitfire.davdroid.network
 
-import androidx.test.platform.app.InstrumentationRegistry
 import at.bitfire.davdroid.MockEngineQueue
 import at.bitfire.davdroid.MockEngineUtils.Default
 import at.bitfire.davdroid.MockEngineUtils.basic
 import at.bitfire.davdroid.ProductIds
-import at.bitfire.davdroid.TestUtils.runOnMain
 import at.bitfire.davdroid.settings.Settings
 import at.bitfire.davdroid.settings.SettingsManager
 import dagger.hilt.android.testing.BindValue
@@ -35,7 +33,9 @@ import io.ktor.http.renderSetCookieHeader
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit4.MockKRule
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -111,7 +111,7 @@ class HttpClientBuilderTest {
 
         // ProxyBuilder.http resolves DNS, which throws NetworkOnMainThreadException if called directly on the main thread.
         // The build method should handle threading automatically.
-        InstrumentationRegistry.getInstrumentation().runOnMain { httpClientBuilder.build() }.use { client ->
+        withContext(Dispatchers.Main) { httpClientBuilder.build() }.use { client ->
             val proxy = (client.engine as OkHttpEngine).config.proxy
             assertEquals(ProxyBuilder.http(Url("http://proxy.example.com:8080")), proxy)
         }
@@ -125,7 +125,7 @@ class HttpClientBuilderTest {
 
         // ProxyBuilder.socks resolves DNS, which throws NetworkOnMainThreadException if called directly on the main thread.
         // The build method should handle threading automatically.
-        InstrumentationRegistry.getInstrumentation().runOnMain { httpClientBuilder.build() }.use { client ->
+        withContext(Dispatchers.Main) { httpClientBuilder.build() }.use { client ->
             val proxy = (client.engine as OkHttpEngine).config.proxy
             assertEquals(ProxyBuilder.socks("proxy.example.com", 1080), proxy)
         }

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/network/HttpClientBuilderTest.kt
@@ -35,8 +35,8 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit4.MockKRule
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.withContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -106,7 +106,7 @@ class HttpClientBuilderTest {
 
     @Test
     @UiThreadTest
-    fun testBuildProxy_Http() = runTest {
+    fun testBuildProxy_Http() {
         every { settingsManager.getInt(Settings.PROXY_TYPE) } returns Settings.PROXY_TYPE_HTTP
         every { settingsManager.getString(Settings.PROXY_HOST) } returns "proxy.example.com"
         every { settingsManager.getInt(Settings.PROXY_PORT) } returns 8080
@@ -115,14 +115,14 @@ class HttpClientBuilderTest {
         httpClientBuilder.build().use { client ->
             val proxy = (client.engine as OkHttpEngine).config.proxy
             // However, for the test, ProxyBuilder.http requires Internet connection, so should be done in IO
-            val expectedProxy = withContext(Dispatchers.IO) { ProxyBuilder.http(Url("http://proxy.example.com:8080")) }
+            val expectedProxy = runBlocking(Dispatchers.IO) { ProxyBuilder.http(Url("http://proxy.example.com:8080")) }
             assertEquals(expectedProxy, proxy)
         }
     }
 
     @Test
     @UiThreadTest
-    fun testBuildProxy_Socks() = runTest {
+    fun testBuildProxy_Socks() {
         every { settingsManager.getInt(Settings.PROXY_TYPE) } returns Settings.PROXY_TYPE_SOCKS
         every { settingsManager.getString(Settings.PROXY_HOST) } returns "proxy.example.com"
         every { settingsManager.getInt(Settings.PROXY_PORT) } returns 1080
@@ -131,7 +131,7 @@ class HttpClientBuilderTest {
         httpClientBuilder.build().use { client ->
             val proxy = (client.engine as OkHttpEngine).config.proxy
             // However, for the test, ProxyBuilder.socks requires Internet connection, so should be done in IO
-            val expectedProxy = withContext(Dispatchers.IO) { ProxyBuilder.socks("proxy.example.com", 1080) }
+            val expectedProxy = runBlocking(Dispatchers.IO) { ProxyBuilder.socks("proxy.example.com", 1080) }
             assertEquals(expectedProxy, proxy)
         }
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
@@ -300,7 +300,7 @@ class HttpClientBuilder private constructor(
         val proxy = when (settingsManager.getInt(Settings.PROXY_TYPE)) {
             Settings.PROXY_TYPE_SYSTEM -> null
             Settings.PROXY_TYPE_NONE -> Proxy.NO_PROXY
-            Settings.PROXY_TYPE_HTTP -> withContext(Dispatchers.IO) {
+            Settings.PROXY_TYPE_HTTP -> withContext(ioDispatcher) {
                 ProxyBuilder.http(
                     URLBuilder(
                         protocol = URLProtocol.HTTP,

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
@@ -295,12 +295,13 @@ class HttpClientBuilder private constructor(
             okBuilder.hostnameVerifier(securityContext.hostnameVerifier)
     }
 
-    private suspend fun buildProxy(engineConfig: HttpClientEngineConfig) {
-        // HTTP and Socks may make DNS queries, so they need to run on the IO dispatcher
+    private fun buildProxy(engineConfig: HttpClientEngineConfig) {
+        // ProxyBuilder.http/socks are blocking calls (they resolve DNS via InetSocketAddress),
+        // so they must run on a real background thread, not the (possibly virtual-time, test-fakeable) injected ioDispatcher.
         val proxy = when (settingsManager.getInt(Settings.PROXY_TYPE)) {
             Settings.PROXY_TYPE_SYSTEM -> null
             Settings.PROXY_TYPE_NONE -> Proxy.NO_PROXY
-            Settings.PROXY_TYPE_HTTP -> withContext(ioDispatcher) {
+            Settings.PROXY_TYPE_HTTP -> runBlocking(Dispatchers.IO) {
                 ProxyBuilder.http(
                     URLBuilder(
                         protocol = URLProtocol.HTTP,
@@ -309,7 +310,7 @@ class HttpClientBuilder private constructor(
                     ).build()
                 )
             }
-            Settings.PROXY_TYPE_SOCKS -> withContext(ioDispatcher) {
+            Settings.PROXY_TYPE_SOCKS -> runBlocking(Dispatchers.IO) {
                 ProxyBuilder.socks(
                     settingsManager.getString(Settings.PROXY_HOST) ?: "",
                     settingsManager.getInt(Settings.PROXY_PORT)
@@ -452,7 +453,7 @@ class HttpClientBuilder private constructor(
 
             engine {
                 // app-wide custom proxy support
-                runBlocking { buildProxy(this@engine) }
+                buildProxy(this@engine)
 
                 // okhttp engine configuration here
                 config {

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
@@ -292,8 +292,8 @@ class HttpClientBuilder private constructor(
     }
 
     private fun buildProxy(engineConfig: HttpClientEngineConfig) {
-        // ProxyBuilder.http/socks are blocking calls (they resolve DNS via InetSocketAddress),
-        // so they must run on a real background thread, not the (possibly virtual-time, test-fakeable) injected ioDispatcher.
+        // Create the proxies with InetSocketAddress.createUnresolved so that no DNS resolving is done here.
+        // If needed, it will be done when required, in the IO thread.
         val proxy = when (settingsManager.getInt(Settings.PROXY_TYPE)) {
             Settings.PROXY_TYPE_SYSTEM -> null
             Settings.PROXY_TYPE_NONE -> Proxy.NO_PROXY

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
@@ -309,7 +309,7 @@ class HttpClientBuilder private constructor(
                     ).build()
                 )
             }
-            Settings.PROXY_TYPE_SOCKS -> withContext(Dispatchers.IO) {
+            Settings.PROXY_TYPE_SOCKS -> withContext(ioDispatcher) {
                 ProxyBuilder.socks(
                     settingsManager.getString(Settings.PROXY_HOST) ?: "",
                     settingsManager.getInt(Settings.PROXY_PORT)

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
@@ -22,7 +22,6 @@ import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.HttpClientEngineConfig
-import io.ktor.client.engine.ProxyBuilder
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.DefaultRequest
 import io.ktor.client.plugins.HttpTimeout
@@ -35,18 +34,15 @@ import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.plugins.logging.LoggingFormat
 import io.ktor.http.HttpHeaders
-import io.ktor.http.URLBuilder
-import io.ktor.http.URLProtocol
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.util.appendIfNameAbsent
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import net.openid.appauth.AuthState
 import okhttp3.ConnectionSpec
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
+import java.net.InetSocketAddress
 import java.net.Proxy
 import java.util.Locale
 import java.util.logging.Level
@@ -301,21 +297,20 @@ class HttpClientBuilder private constructor(
         val proxy = when (settingsManager.getInt(Settings.PROXY_TYPE)) {
             Settings.PROXY_TYPE_SYSTEM -> null
             Settings.PROXY_TYPE_NONE -> Proxy.NO_PROXY
-            Settings.PROXY_TYPE_HTTP -> runBlocking(Dispatchers.IO) {
-                ProxyBuilder.http(
-                    URLBuilder(
-                        protocol = URLProtocol.HTTP,
-                        host = settingsManager.getString(Settings.PROXY_HOST) ?: "",
-                        port = settingsManager.getInt(Settings.PROXY_PORT)
-                    ).build()
-                )
-            }
-            Settings.PROXY_TYPE_SOCKS -> runBlocking(Dispatchers.IO) {
-                ProxyBuilder.socks(
+            Settings.PROXY_TYPE_HTTP -> Proxy(
+                Proxy.Type.HTTP,
+                InetSocketAddress.createUnresolved(
                     settingsManager.getString(Settings.PROXY_HOST) ?: "",
                     settingsManager.getInt(Settings.PROXY_PORT)
                 )
-            }
+            )
+            Settings.PROXY_TYPE_SOCKS -> Proxy(
+                Proxy.Type.SOCKS,
+                InetSocketAddress.createUnresolved(
+                    settingsManager.getString(Settings.PROXY_HOST) ?: "",
+                    settingsManager.getInt(Settings.PROXY_PORT)
+                )
+            )
             else -> /* Invalid proxy type, shouldn't happen */ null
         }
         if (proxy != null) {

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/HttpClientBuilder.kt
@@ -40,6 +40,8 @@ import io.ktor.http.URLProtocol
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.util.appendIfNameAbsent
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import net.openid.appauth.AuthState
 import okhttp3.ConnectionSpec
@@ -293,21 +295,26 @@ class HttpClientBuilder private constructor(
             okBuilder.hostnameVerifier(securityContext.hostnameVerifier)
     }
 
-    private fun buildProxy(engineConfig: HttpClientEngineConfig) {
+    private suspend fun buildProxy(engineConfig: HttpClientEngineConfig) {
+        // HTTP and Socks may make DNS queries, so they need to run on the IO dispatcher
         val proxy = when (settingsManager.getInt(Settings.PROXY_TYPE)) {
             Settings.PROXY_TYPE_SYSTEM -> null
             Settings.PROXY_TYPE_NONE -> Proxy.NO_PROXY
-            Settings.PROXY_TYPE_HTTP -> ProxyBuilder.http(
-                URLBuilder(
-                    protocol = URLProtocol.HTTP,
-                    host = settingsManager.getString(Settings.PROXY_HOST) ?: "",
-                    port = settingsManager.getInt(Settings.PROXY_PORT)
-                ).build()
-            )
-            Settings.PROXY_TYPE_SOCKS -> ProxyBuilder.socks(
-                settingsManager.getString(Settings.PROXY_HOST) ?: "",
-                settingsManager.getInt(Settings.PROXY_PORT)
-            )
+            Settings.PROXY_TYPE_HTTP -> withContext(Dispatchers.IO) {
+                ProxyBuilder.http(
+                    URLBuilder(
+                        protocol = URLProtocol.HTTP,
+                        host = settingsManager.getString(Settings.PROXY_HOST) ?: "",
+                        port = settingsManager.getInt(Settings.PROXY_PORT)
+                    ).build()
+                )
+            }
+            Settings.PROXY_TYPE_SOCKS -> withContext(Dispatchers.IO) {
+                ProxyBuilder.socks(
+                    settingsManager.getString(Settings.PROXY_HOST) ?: "",
+                    settingsManager.getInt(Settings.PROXY_PORT)
+                )
+            }
             else -> /* Invalid proxy type, shouldn't happen */ null
         }
         if (proxy != null) {
@@ -445,7 +452,7 @@ class HttpClientBuilder private constructor(
 
             engine {
                 // app-wide custom proxy support
-                buildProxy(this)
+                runBlocking { buildProxy(this@engine) }
 
                 // okhttp engine configuration here
                 config {


### PR DESCRIPTION
### Purpose

`buildProxy` runs on the default thread. If using an HTTP/SOCKS proxy it may do a DNS query, which can't run on the main thread.

### Short description

Made `buildProxy` suspending, and switched to the IO thread when necessary.
Inside the `engine` block of the client's config it must run as `runBlocking`, because the lambda is not suspending.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

