### PR TITLE
Propagate `GroupMethod` to `AndroidAddressBook`

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookTest.kt
@@ -259,6 +259,29 @@ class LocalAddressBookTest {
         }
     }
 
+    /**
+     * Tests that group memberships are read back as vCard CATEGORIES when the address book uses
+     * [GroupMethod.CATEGORIES] (regression test for https://github.com/bitfireAT/davx5/issues/934).
+     */
+    @Test
+    fun test_groupMethodCategories_includesGroupAsCategory() {
+        localTestAddressBook.provide(account, provider, GroupMethod.CATEGORIES) { localAddressBook ->
+            val group = localAddressBook.addGroup(Contact().apply { displayName = "Test Category" }, null, null, 0)
+            val contact = localAddressBook.addContact(Contact().apply {
+                uid = "categories-test"
+                displayName = "Test Contact"
+            }, "categories-test.vcf", null, 0)
+
+            val batch = ContactsBatchOperation(localAddressBook.ab.provider)
+            contact.androidContact.addToGroup(batch, group.id!!)
+            batch.commit()
+
+            val result = localAddressBook.findContactById(contact.id!!)
+            val readContact = result.androidContact.getContact()
+            assertEquals(listOf("Test Category"), readContact.categories)
+        }
+    }
+
 
     // helpers
 

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookTest.kt
@@ -259,29 +259,6 @@ class LocalAddressBookTest {
         }
     }
 
-    /**
-     * Tests that group memberships are read back as vCard CATEGORIES when the address book uses
-     * [GroupMethod.CATEGORIES] (regression test for https://github.com/bitfireAT/davx5/issues/934).
-     */
-    @Test
-    fun test_groupMethodCategories_includesGroupAsCategory() {
-        localTestAddressBook.provide(account, provider, GroupMethod.CATEGORIES) { localAddressBook ->
-            val group = localAddressBook.addGroup(Contact().apply { displayName = "Test Category" }, null, null, 0)
-            val contact = localAddressBook.addContact(Contact().apply {
-                uid = "categories-test"
-                displayName = "Test Contact"
-            }, "categories-test.vcf", null, 0)
-
-            val batch = ContactsBatchOperation(localAddressBook.ab.provider)
-            contact.androidContact.addToGroup(batch, group.id!!)
-            batch.commit()
-
-            val result = localAddressBook.findContactById(contact.id!!)
-            val readContact = result.androidContact.getContact()
-            assertEquals(listOf("Test Category"), readContact.categories)
-        }
-    }
-
 
     // helpers
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -79,7 +79,7 @@ open class LocalAddressBook @AssistedInject constructor(
 
     private val accountManager by lazy { AccountManager.get(context) }
 
-    internal val ab = AndroidAddressBook(context, _addressBookAccount, provider)
+    internal val ab = AndroidAddressBook(context, _addressBookAccount, provider, groupMethod)
 
     var addressBookAccount: Account by ab::addressBookAccount
 

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/contacts/TestAddressBook.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/contacts/TestAddressBook.kt
@@ -7,6 +7,7 @@ package at.bitfire.synctools.storage.contacts
 import android.content.ContentProviderClient
 import androidx.test.platform.app.InstrumentationRegistry
 import at.bitfire.synctools.test.account.TestAccount
+import at.bitfire.synctools.vcard.GroupMethod
 import java.util.concurrent.atomic.AtomicInteger
 
 object TestAddressBook {
@@ -14,9 +15,12 @@ object TestAddressBook {
     private val context by lazy { InstrumentationRegistry.getInstrumentation().targetContext }
     private val counter = AtomicInteger()
 
-    fun create(provider: ContentProviderClient): AndroidAddressBook {
+    fun create(
+        provider: ContentProviderClient,
+        groupMethod: GroupMethod = GroupMethod.GROUP_VCARDS
+    ): AndroidAddressBook {
         val account = TestAccount.create("Test Address Book ${counter.incrementAndGet()}")
-        return AndroidAddressBook(context, account, provider)
+        return AndroidAddressBook(context, account, provider, groupMethod)
     }
 
     fun remove(addressBook: AndroidAddressBook) = TestAccount.remove(addressBook.addressBookAccount)

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
@@ -48,11 +48,13 @@ import java.util.logging.Logger
  * @param context            application context (used to obtain the [AccountManager])
  * @param addressBookAccount account whose contacts and groups are managed
  * @param provider           content provider client for [ContactsContract]
+ * @param groupMethod        method used to represent group memberships (as vCard groups or as CATEGORIES)
  */
 class AndroidAddressBook(
     private val context: Context,
     var addressBookAccount: Account,
-    val provider: ContentProviderClient
+    val provider: ContentProviderClient,
+    val groupMethod: GroupMethod
 ) {
 
     private val logger
@@ -60,8 +62,6 @@ class AndroidAddressBook(
 
     private val accountManager: AccountManager
         get() = AccountManager.get(context)
-
-    val groupMethod: GroupMethod = GroupMethod.GROUP_VCARDS
 
     /**
      * Read-only flag for the address book itself.


### PR DESCRIPTION
### Purpose

Fixes https://github.com/bitfireAT/davx5/issues/934: In #2493, a bug was introduced that hardcoded the `groupType` for `AndroidAddressBook` without taking the actual value from `LocalAddressBook`.

### Short description

- Added `GroupMethod` parameter to `AndroidAddressBook`.
- Ensured group method is properly propagated from `LocalAddressBook`.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.