### PR TITLE
Add link to "tested with" page on login screens

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/AdvancedLogin.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/AdvancedLogin.kt
@@ -108,7 +108,7 @@ fun AdvancedLoginScreen(
                     .padding(vertical = 8.dp)
             )
 
-            LoginDetailsHelpCard(includeServiceDiscovery = true)
+            LoginDetailsHelpCard(includeServiceDiscovery = true, screenName = "AdvancedLogin")
 
             OutlinedTextField(
                 value = url,

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/AdvancedLogin.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/AdvancedLogin.kt
@@ -33,11 +33,8 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.core.text.HtmlCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import at.bitfire.davdroid.R
-import at.bitfire.davdroid.ui.ExternalUris
-import at.bitfire.davdroid.ui.UiUtils.toAnnotatedString
 import at.bitfire.davdroid.ui.composable.Assistant
 import at.bitfire.davdroid.ui.composable.PasswordTextField
 import at.bitfire.davdroid.ui.composable.SelectClientCertificateCard
@@ -111,18 +108,7 @@ fun AdvancedLoginScreen(
                     .padding(vertical = 8.dp)
             )
 
-            val manualUrl = ExternalUris.Manual.baseUrl.buildUpon()
-                .appendPath(ExternalUris.Manual.PATH_ACCOUNTS_COLLECTIONS)
-                .fragment(ExternalUris.Manual.FRAGMENT_SERVICE_DISCOVERY)
-                .build()
-            val urlInfo = HtmlCompat.fromHtml(stringResource(R.string.login_base_url_info, manualUrl), HtmlCompat.FROM_HTML_MODE_COMPACT)
-            Text(
-                text = urlInfo.toAnnotatedString(),
-                style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 8.dp, bottom = 16.dp)
-            )
+            LoginDetailsHelpCard(includeServiceDiscovery = true)
 
             OutlinedTextField(
                 value = url,

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/EmailLogin.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/EmailLogin.kt
@@ -93,7 +93,10 @@ fun EmailLoginScreen(
                     .padding(vertical = 8.dp)
             )
 
-            LoginDetailsHelpCard(includeServiceDiscovery = true)
+            LoginDetailsHelpCard(
+                includeEmailBaseUrl = true,
+                includeServiceDiscovery = true
+            )
 
             OutlinedTextField(
                 value = email,

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/EmailLogin.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/EmailLogin.kt
@@ -30,11 +30,8 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.core.text.HtmlCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import at.bitfire.davdroid.R
-import at.bitfire.davdroid.ui.ExternalUris
-import at.bitfire.davdroid.ui.UiUtils.toAnnotatedString
 import at.bitfire.davdroid.ui.composable.Assistant
 import at.bitfire.davdroid.ui.composable.PasswordTextField
 
@@ -96,18 +93,7 @@ fun EmailLoginScreen(
                     .padding(vertical = 8.dp)
             )
 
-            val manualUrl = ExternalUris.Manual.baseUrl.buildUpon()
-                .appendPath(ExternalUris.Manual.PATH_ACCOUNTS_COLLECTIONS)
-                .fragment(ExternalUris.Manual.FRAGMENT_SERVICE_DISCOVERY)
-                .build()
-            val emailInfo = HtmlCompat.fromHtml(stringResource(R.string.login_email_address_info, manualUrl), HtmlCompat.FROM_HTML_MODE_COMPACT)
-            Text(
-                text = emailInfo.toAnnotatedString(),
-                style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 8.dp, bottom = 16.dp)
-            )
+            LoginDetailsHelpCard(includeServiceDiscovery = true)
 
             OutlinedTextField(
                 value = email,

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/EmailLogin.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/EmailLogin.kt
@@ -95,7 +95,8 @@ fun EmailLoginScreen(
 
             LoginDetailsHelpCard(
                 includeEmailBaseUrl = true,
-                includeServiceDiscovery = true
+                includeServiceDiscovery = true,
+                screenName = "EmailLogin"
             )
 
             OutlinedTextField(

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginDetailsHelpCard.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginDetailsHelpCard.kt
@@ -28,6 +28,7 @@ import at.bitfire.davdroid.ui.composable.IconCard
 @Composable
 @Preview
 fun LoginDetailsHelpCard(
+    includeEmailBaseUrl: Boolean = false,
     includeServiceDiscovery: Boolean = false,
     screenName: String? = null
 ) {
@@ -37,6 +38,13 @@ fun LoginDetailsHelpCard(
     ) {
         val context = LocalContext.current
         Column {
+            if (includeEmailBaseUrl)
+                Text(
+                    stringResource(R.string.login_email_address_info),
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+
             if (includeServiceDiscovery) {
                 val manualUrl = ExternalUris.Manual.baseUrl.buildUpon()
                     .appendPath(ExternalUris.Manual.PATH_ACCOUNTS_COLLECTIONS)
@@ -56,7 +64,7 @@ fun LoginDetailsHelpCard(
 
             val testedWith = ExternalUris.Homepage.baseUrl.buildUpon()
                 .appendPath(ExternalUris.Homepage.PATH_TESTED_SERVICES)
-                .withStatParams(context, screen = "UrlLoginScreen")
+                .withStatParams(context, screen = screenName)
                 .build()
             Text(
                 AnnotatedString.fromHtml(stringResource(R.string.login_see_tested_with, testedWith.toString())),
@@ -68,6 +76,9 @@ fun LoginDetailsHelpCard(
 
 @Composable
 @Preview
-fun LoginDetailsHelpCard_Preview_IncludingServiceDiscovery() {
-    LoginDetailsHelpCard(includeServiceDiscovery = true)
+fun LoginDetailsHelpCard_Preview_IncludingEverything() {
+    LoginDetailsHelpCard(
+        includeEmailBaseUrl = true,
+        includeServiceDiscovery = true
+    )
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginDetailsHelpCard.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginDetailsHelpCard.kt
@@ -18,11 +18,9 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.core.text.HtmlCompat
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.ui.ExternalUris
 import at.bitfire.davdroid.ui.ExternalUris.withStatParams
-import at.bitfire.davdroid.ui.UiUtils.toAnnotatedString
 import at.bitfire.davdroid.ui.composable.IconCard
 
 @Composable
@@ -51,23 +49,19 @@ fun LoginDetailsHelpCard(
                     .fragment(ExternalUris.Manual.FRAGMENT_SERVICE_DISCOVERY)
                     .withStatParams(context, screen = screenName)
                     .build()
-                val urlInfo = HtmlCompat.fromHtml(
-                    stringResource(R.string.login_base_url_info, manualUrl),
-                    HtmlCompat.FROM_HTML_MODE_COMPACT
-                )
                 Text(
-                    text = urlInfo.toAnnotatedString(),
+                    text = AnnotatedString.fromHtml(stringResource(R.string.login_base_url_info, manualUrl)),
                     style = MaterialTheme.typography.bodyMedium,
                     modifier = Modifier.padding(bottom = 8.dp)
                 )
             }
 
-            val testedWith = ExternalUris.Homepage.baseUrl.buildUpon()
+            val testedWithUrl = ExternalUris.Homepage.baseUrl.buildUpon()
                 .appendPath(ExternalUris.Homepage.PATH_TESTED_SERVICES)
                 .withStatParams(context, screen = screenName)
-                .build()
+                .build().toString()
             Text(
-                AnnotatedString.fromHtml(stringResource(R.string.login_see_tested_with, testedWith.toString())),
+                AnnotatedString.fromHtml(stringResource(R.string.login_see_tested_with, testedWithUrl)),
                 style = MaterialTheme.typography.bodyMedium
             )
         }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginDetailsHelpCard.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginDetailsHelpCard.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.ui.setup
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.fromHtml
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.core.text.HtmlCompat
+import at.bitfire.davdroid.R
+import at.bitfire.davdroid.ui.ExternalUris
+import at.bitfire.davdroid.ui.ExternalUris.withStatParams
+import at.bitfire.davdroid.ui.UiUtils.toAnnotatedString
+import at.bitfire.davdroid.ui.composable.IconCard
+
+@Composable
+@Preview
+fun LoginDetailsHelpCard(
+    includeServiceDiscovery: Boolean = false,
+    screenName: String? = null
+) {
+    IconCard(
+        icon = Icons.Default.Info,
+        modifier = Modifier.padding(bottom = 8.dp)
+    ) {
+        val context = LocalContext.current
+        Column {
+            if (includeServiceDiscovery) {
+                val manualUrl = ExternalUris.Manual.baseUrl.buildUpon()
+                    .appendPath(ExternalUris.Manual.PATH_ACCOUNTS_COLLECTIONS)
+                    .fragment(ExternalUris.Manual.FRAGMENT_SERVICE_DISCOVERY)
+                    .withStatParams(context, screen = screenName)
+                    .build()
+                val urlInfo = HtmlCompat.fromHtml(
+                    stringResource(R.string.login_base_url_info, manualUrl),
+                    HtmlCompat.FROM_HTML_MODE_COMPACT
+                )
+                Text(
+                    text = urlInfo.toAnnotatedString(),
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+            }
+
+            val testedWith = ExternalUris.Homepage.baseUrl.buildUpon()
+                .appendPath(ExternalUris.Homepage.PATH_TESTED_SERVICES)
+                .withStatParams(context, screen = "UrlLoginScreen")
+                .build()
+            Text(
+                AnnotatedString.fromHtml(stringResource(R.string.login_see_tested_with, testedWith.toString())),
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
+    }
+}
+
+@Composable
+@Preview
+fun LoginDetailsHelpCard_Preview_IncludingServiceDiscovery() {
+    LoginDetailsHelpCard(includeServiceDiscovery = true)
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreen.kt
@@ -24,13 +24,10 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import at.bitfire.davdroid.R
-import at.bitfire.davdroid.ui.ExternalUris
-import at.bitfire.davdroid.ui.ExternalUris.withStatParams
 import at.bitfire.davdroid.ui.composable.AppTheme
 
 @Composable
@@ -90,16 +87,11 @@ fun LoginScreenContent(
                         Text(stringResource(R.string.login_title))
                     },
                     actions = {
-                        val specificHelpUri = helpUri ?: ExternalUris.Homepage.baseUrl.buildUpon()
-                            .appendPath(ExternalUris.Homepage.PATH_TESTED_SERVICES)
-                            .withStatParams(LocalContext.current, "LoginScreen")
-                            .build()
-                        val uriHandler = LocalUriHandler.current
-                        IconButton(onClick = {
-                            // show tested-with page
-                            uriHandler.openUri(specificHelpUri.toString())
-                        }) {
-                            Icon(Icons.AutoMirrored.Default.Help, stringResource(R.string.help))
+                        if (helpUri != null) {
+                            val uriHandler = LocalUriHandler.current
+                            IconButton(onClick = { uriHandler.openUri(helpUri.toString()) }) {
+                                Icon(Icons.AutoMirrored.Default.Help, stringResource(R.string.help))
+                            }
                         }
                     }
                 )

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/StandardLoginTypePage.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/StandardLoginTypePage.kt
@@ -42,6 +42,12 @@ fun StandardLoginTypePage(
         onNext = onContinue
     ) {
         Column(Modifier.padding(8.dp)) {
+            Text(
+                stringResource(R.string.login_generic_login),
+                style = MaterialTheme.typography.headlineSmall,
+                modifier = Modifier.padding(top = 16.dp, bottom = 8.dp)
+            )
+
             LoginDetailsHelpCard(screenName = "StandardLoginTypePage")
 
             for (type in StandardLoginTypesProvider.genericLoginTypes)

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/StandardLoginTypePage.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/StandardLoginTypePage.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
@@ -17,6 +19,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.text.HtmlCompat
@@ -25,6 +29,7 @@ import at.bitfire.davdroid.ui.ExternalUris
 import at.bitfire.davdroid.ui.ExternalUris.withStatParams
 import at.bitfire.davdroid.ui.UiUtils.toAnnotatedString
 import at.bitfire.davdroid.ui.composable.Assistant
+import at.bitfire.davdroid.ui.composable.IconCard
 
 @Composable
 fun StandardLoginTypePage(
@@ -42,11 +47,18 @@ fun StandardLoginTypePage(
         onNext = onContinue
     ) {
         Column(Modifier.padding(8.dp)) {
-            Text(
-                stringResource(R.string.login_generic_login),
-                style = MaterialTheme.typography.headlineSmall,
-                modifier = Modifier.padding(vertical = 8.dp)
-            )
+            IconCard(icon = Icons.Default.Info) {
+                val testedWith = ExternalUris.Homepage.baseUrl.buildUpon()
+                    .appendPath(ExternalUris.Homepage.PATH_TESTED_SERVICES)
+                    .withStatParams(LocalContext.current, screen = "StandardLoginTypePage")
+                    .build()
+                Text(
+                    AnnotatedString.fromHtml(stringResource(R.string.login_see_tested_with, testedWith.toString())),
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(vertical = 8.dp)
+                )
+            }
+
             for (type in StandardLoginTypesProvider.genericLoginTypes)
                 LoginTypeSelector(
                     title = stringResource(type.title),

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/StandardLoginTypePage.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/StandardLoginTypePage.kt
@@ -8,8 +8,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
@@ -19,8 +17,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.text.HtmlCompat
@@ -29,7 +25,6 @@ import at.bitfire.davdroid.ui.ExternalUris
 import at.bitfire.davdroid.ui.ExternalUris.withStatParams
 import at.bitfire.davdroid.ui.UiUtils.toAnnotatedString
 import at.bitfire.davdroid.ui.composable.Assistant
-import at.bitfire.davdroid.ui.composable.IconCard
 
 @Composable
 fun StandardLoginTypePage(
@@ -47,17 +42,7 @@ fun StandardLoginTypePage(
         onNext = onContinue
     ) {
         Column(Modifier.padding(8.dp)) {
-            IconCard(icon = Icons.Default.Info) {
-                val testedWith = ExternalUris.Homepage.baseUrl.buildUpon()
-                    .appendPath(ExternalUris.Homepage.PATH_TESTED_SERVICES)
-                    .withStatParams(LocalContext.current, screen = "StandardLoginTypePage")
-                    .build()
-                Text(
-                    AnnotatedString.fromHtml(stringResource(R.string.login_see_tested_with, testedWith.toString())),
-                    style = MaterialTheme.typography.bodyMedium,
-                    modifier = Modifier.padding(vertical = 8.dp)
-                )
-            }
+            LoginDetailsHelpCard()
 
             for (type in StandardLoginTypesProvider.genericLoginTypes)
                 LoginTypeSelector(

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/StandardLoginTypePage.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/StandardLoginTypePage.kt
@@ -42,7 +42,7 @@ fun StandardLoginTypePage(
         onNext = onContinue
     ) {
         Column(Modifier.padding(8.dp)) {
-            LoginDetailsHelpCard()
+            LoginDetailsHelpCard(screenName = "StandardLoginTypePage")
 
             for (type in StandardLoginTypesProvider.genericLoginTypes)
                 LoginTypeSelector(

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/UrlLogin.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/UrlLogin.kt
@@ -31,11 +31,8 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.core.text.HtmlCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import at.bitfire.davdroid.R
-import at.bitfire.davdroid.ui.ExternalUris
-import at.bitfire.davdroid.ui.UiUtils.toAnnotatedString
 import at.bitfire.davdroid.ui.composable.Assistant
 import at.bitfire.davdroid.ui.composable.PasswordTextField
 
@@ -102,18 +99,7 @@ fun UrlLoginScreen(
                     .padding(vertical = 8.dp)
             )
 
-            val manualUrl = ExternalUris.Manual.baseUrl.buildUpon()
-                .appendPath(ExternalUris.Manual.PATH_ACCOUNTS_COLLECTIONS)
-                .fragment(ExternalUris.Manual.FRAGMENT_SERVICE_DISCOVERY)
-                .build()
-            val urlInfo = HtmlCompat.fromHtml(stringResource(R.string.login_base_url_info, manualUrl), HtmlCompat.FROM_HTML_MODE_COMPACT)
-            Text(
-                text = urlInfo.toAnnotatedString(),
-                style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 8.dp, bottom = 16.dp)
-            )
+            LoginDetailsHelpCard(includeServiceDiscovery = true)
 
             OutlinedTextField(
                 value = url,

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/UrlLogin.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/UrlLogin.kt
@@ -99,7 +99,7 @@ fun UrlLoginScreen(
                     .padding(vertical = 8.dp)
             )
 
-            LoginDetailsHelpCard(includeServiceDiscovery = true)
+            LoginDetailsHelpCard(includeServiceDiscovery = true, screenName = "UrlLogin")
 
             OutlinedTextField(
                 value = url,

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -290,7 +290,7 @@
 
     <!-- AddAccountActivity -->
     <string name="login_title">Add account</string>
-    <string name="login_see_tested_with"><![CDATA[If you\'re unsure what to choose, consult your provider\'s documentation and our <a href="%s>tested services</a> page.]]></string>
+    <string name="login_see_tested_with"><![CDATA[If you\'re unsure what to choose, consult your provider\'s documentation and our <a href="%s">tested services</a> page.]]></string>
     <string name="login_privacy_hint"><![CDATA[All data will only be transferred between your server and your device. %1$s will not send them anywhere else. See <a href=\"%2$s\">privacy policy</a>.]]></string>
     <string name="login_generic_login">Generic login</string>
     <string name="login_provider_login">Provider-specific login</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -290,6 +290,7 @@
 
     <!-- AddAccountActivity -->
     <string name="login_title">Add account</string>
+    <string name="login_see_tested_with"><![CDATA[If you\'re unsure what to choose, consult your provider\'s documentation and our <a href="%s>tested services</a> page.]]></string>
     <string name="login_privacy_hint"><![CDATA[All data will only be transferred between your server and your device. %1$s will not send them anywhere else. See <a href=\"%2$s\">privacy policy</a>.]]></string>
     <string name="login_generic_login">Generic login</string>
     <string name="login_provider_login">Provider-specific login</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -299,7 +299,7 @@
     <string name="login_type_email">Login with email address</string>
     <string name="login_email_address">Email address</string>
     <string name="login_email_address_error">Valid email address required</string>
-    <string name="login_email_address_info"><![CDATA[The email domain is used as base URL. <a href="%s">Services are discovered</a> using DNS records and well-known URLs.]]></string>
+    <string name="login_email_address_info">The email domain is used as base URL.</string>
     <string name="login_password">Password</string>
     <string name="login_password_hide">Hide password</string>
     <string name="login_password_show">Show password</string>


### PR DESCRIPTION
### Purpose

Adds a link to the tested-services page on the login setup screens. Closes #2652.

### Short description

- Added reusable `LoginDetailsHelpCard` with a link to the tested-services page.
- Shown on `StandardLoginTypePage`, `UrlLogin`, `EmailLogin`, `AdvancedLogin`; replaces the old help icon in `LoginScreen`'s toolbar.

Help icon is still kept for the provider-specific logins and Managed etc. (because they don't have an info card.)

Screenshots:

<img width="270" height="570" alt="grafik" src="https://github.com/user-attachments/assets/76406da0-5bd1-478b-a0b9-8ae10f35e24c" />
<img width="270" height="570" alt="grafik" src="https://github.com/user-attachments/assets/0957b582-4c84-4e68-b4c6-334f6055616a" />
<img width="270" height="570" alt="grafik" src="https://github.com/user-attachments/assets/5302e4e9-4fe4-4ac2-9af2-ea56944ed5ab" />
<img width="270" height="570" alt="grafik" src="https://github.com/user-attachments/assets/a351aa63-7c40-4326-853f-5d57d8ac630a" />


### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.