### PR TITLE
Use IO dispatcher instead of default dispatcher

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/di/TestCoroutineDispatchersModule.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/di/TestCoroutineDispatchersModule.kt
@@ -6,7 +6,6 @@ package at.bitfire.davdroid.di
 
 import android.os.Looper
 import at.bitfire.davdroid.di.TestCoroutineDispatchersModule.testScheduler
-import at.bitfire.davdroid.di.qualifier.DefaultDispatcher
 import at.bitfire.davdroid.di.qualifier.IoDispatcher
 import dagger.Module
 import dagger.Provides
@@ -23,7 +22,7 @@ import kotlinx.coroutines.test.setMain
 /**
  * Provides test dispatchers to be injected instead of the normal ones.
  *
- * [DefaultDispatcher]/[IoDispatcher] and [Dispatchers.Main] (which is used by
+ * [IoDispatcher] and [Dispatchers.Main] (which is used by
  * [androidx.lifecycle.viewModelScope] by default) are synchronized with [testScheduler],
  * so that [kotlinx.coroutines.test.runTest] can determine when launched coroutines are done etc.
  *
@@ -42,13 +41,8 @@ object TestCoroutineDispatchersModule {
 
     private val testScheduler = TestCoroutineScheduler()
 
-    private val defaultDispatcher = StandardTestDispatcher(testScheduler)
     private val ioDispatcher = StandardTestDispatcher(testScheduler)
     private val mainDispatcher = UnconfinedTestDispatcher(testScheduler)
-
-    @Provides
-    @DefaultDispatcher
-    fun defaultDispatcher(): CoroutineDispatcher = defaultDispatcher
 
     @Provides
     @IoDispatcher

--- a/core/src/main/kotlin/at/bitfire/davdroid/CoreApp.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/CoreApp.kt
@@ -6,7 +6,7 @@ package at.bitfire.davdroid
 
 import android.app.Application
 import androidx.hilt.work.HiltWorkerFactory
-import at.bitfire.davdroid.di.qualifier.DefaultDispatcher
+import at.bitfire.davdroid.di.qualifier.IoDispatcher
 import at.bitfire.davdroid.log.LogManager
 import at.bitfire.davdroid.startup.StartupPlugin
 import at.bitfire.davdroid.sync.account.AccountsCleanupWorker
@@ -34,8 +34,8 @@ abstract class CoreApp: Application() {
     lateinit var logManager: LogManager
 
     @Inject
-    @DefaultDispatcher
-    lateinit var defaultDispatcher: CoroutineDispatcher
+    @IoDispatcher
+    lateinit var ioDispatcher: CoroutineDispatcher
 
     @Inject
     lateinit var plugins: Set<@JvmSuppressWildcards StartupPlugin>
@@ -61,9 +61,9 @@ abstract class CoreApp: Application() {
 
         // don't block UI for some background checks
         @OptIn(DelicateCoroutinesApi::class)
-        GlobalScope.launch(defaultDispatcher) {
+        GlobalScope.launch(ioDispatcher) {
             // clean up orphaned accounts in DB from time to time
-            AccountsCleanupWorker.Companion.enable(this@CoreApp)
+            AccountsCleanupWorker.enable(this@CoreApp)
 
             // create/update app shortcuts
             UiUtils.updateShortcuts(this@CoreApp)

--- a/core/src/main/kotlin/at/bitfire/davdroid/di/CoroutineDispatchersModule.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/di/CoroutineDispatchersModule.kt
@@ -4,7 +4,6 @@
 
 package at.bitfire.davdroid.di
 
-import at.bitfire.davdroid.di.qualifier.DefaultDispatcher
 import at.bitfire.davdroid.di.qualifier.IoDispatcher
 import dagger.Module
 import dagger.Provides
@@ -16,10 +15,6 @@ import kotlinx.coroutines.Dispatchers
 @Module
 @InstallIn(SingletonComponent::class)
 class CoroutineDispatchersModule {
-
-    @Provides
-    @DefaultDispatcher
-    fun defaultDispatcher(): CoroutineDispatcher = Dispatchers.Default
 
     @Provides
     @IoDispatcher

--- a/core/src/main/kotlin/at/bitfire/davdroid/di/qualifier/CoroutineQualifiers.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/di/qualifier/CoroutineQualifiers.kt
@@ -18,8 +18,4 @@ annotation class ApplicationScope
 
 @Retention(AnnotationRetention.RUNTIME)
 @Qualifier
-annotation class DefaultDispatcher
-
-@Retention(AnnotationRetention.RUNTIME)
-@Qualifier
 annotation class IoDispatcher

--- a/core/src/main/kotlin/at/bitfire/davdroid/log/LogManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/log/LogManager.kt
@@ -52,7 +52,7 @@ class LogManager @Inject constructor(
     private val prefs: PreferenceRepository
 ) : AutoCloseable {
 
-    private val scope = CoroutineScope(Dispatchers.Default)
+    private val scope = CoroutineScope(Dispatchers.IO)
 
     init {
         // observe preference changes

--- a/core/src/main/kotlin/at/bitfire/davdroid/repository/AccountRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/repository/AccountRepository.kt
@@ -15,7 +15,7 @@ import at.bitfire.davdroid.accounts.LegacyAccount
 import at.bitfire.davdroid.db.HomeSet
 import at.bitfire.davdroid.db.Service
 import at.bitfire.davdroid.db.ServiceType
-import at.bitfire.davdroid.di.qualifier.DefaultDispatcher
+import at.bitfire.davdroid.di.qualifier.IoDispatcher
 import at.bitfire.davdroid.resource.LocalAddressBookStore
 import at.bitfire.davdroid.resource.LocalCalendarStore
 import at.bitfire.davdroid.servicedetection.DavResourceFinder
@@ -54,7 +54,7 @@ class AccountRepository @Inject constructor(
     private val automaticSyncManager: Lazy<AutomaticSyncManager>,
     @ApplicationContext private val context: Context,
     private val collectionRepository: DavCollectionRepository,
-    @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     private val homeSetRepository: DavHomeSetRepository,
     private val localCalendarStore: Lazy<LocalCalendarStore>,
     private val localAddressBookStore: Lazy<LocalAddressBookStore>,
@@ -190,7 +190,7 @@ class AccountRepository @Inject constructor(
         val listener = OnAccountsUpdateListener { accounts ->
             trySend(accounts.filter { it.type == accountType }.toSet())
         }
-        withContext(defaultDispatcher) {  // causes disk I/O
+        withContext(ioDispatcher) {  // causes disk I/O
             accountManager.addOnAccountsUpdatedListener(listener, null, true)
         }
 
@@ -212,7 +212,7 @@ class AccountRepository @Inject constructor(
      * @throws IllegalArgumentException if the new account name already exists
      * @throws Exception (or sub-classes) on other errors
      */
-    suspend fun rename(oldName: String, newName: String): Unit = withContext(defaultDispatcher) {
+    suspend fun rename(oldName: String, newName: String): Unit = withContext(ioDispatcher) {
         val oldAccount = fromName(oldName)
         val newAccount = fromName(newName)
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncAdapterImpl.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncAdapterImpl.kt
@@ -73,7 +73,7 @@ class SyncAdapterImpl @Inject constructor(
      * Scope used to wait until the synchronization is finished. Will be cancelled when the sync framework
      * requests cancellation.
      */
-    private val waitScope = CoroutineScope(Dispatchers.Default)
+    private val waitScope = CoroutineScope(Dispatchers.IO)
 
     override fun onPerformSync(accountOrAddressBookAccount: Account, extras: Bundle, authority: String, provider: ContentProviderClient, syncResult: SyncResult) {
         // We have to pass this old SyncFramework extra for an Android 7 workaround

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/AccountsViewModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/AccountsViewModel.kt
@@ -185,7 +185,7 @@ class AccountsViewModel @AssistedInject constructor(
         }
 
         emit(anyShowAlwaysPage)
-    }.flowOn(Dispatchers.Default)
+    }.flowOn(Dispatchers.IO)
 
 
     // warnings

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/CollectionSelectedUseCase.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/CollectionSelectedUseCase.kt
@@ -6,7 +6,7 @@ package at.bitfire.davdroid.ui
 
 import android.accounts.Account
 import at.bitfire.davdroid.di.qualifier.ApplicationScope
-import at.bitfire.davdroid.di.qualifier.DefaultDispatcher
+import at.bitfire.davdroid.di.qualifier.IoDispatcher
 import at.bitfire.davdroid.push.PushRegistrationManager
 import at.bitfire.davdroid.repository.AccountRepository
 import at.bitfire.davdroid.repository.DavCollectionRepository
@@ -30,7 +30,7 @@ class CollectionSelectedUseCase @Inject constructor(
     private val accountRepository: AccountRepository,
     @ApplicationScope private val applicationScope: CoroutineScope,
     private val collectionRepository: DavCollectionRepository,
-    @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     private val pushRegistrationManager: PushRegistrationManager,
     private val serviceRepository: DavServiceRepository,
     private val syncWorkerManager: SyncWorkerManager
@@ -56,7 +56,7 @@ class CollectionSelectedUseCase @Inject constructor(
             // Stop previous delay, if exists
             previousJob?.cancel()
 
-            applicationScope.launch(defaultDispatcher) {
+            applicationScope.launch(ioDispatcher) {
                 // wait
                 delay(DELAY_MS)
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/TasksViewModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/TasksViewModel.kt
@@ -11,7 +11,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import at.bitfire.davdroid.di.qualifier.DefaultDispatcher
+import at.bitfire.davdroid.di.qualifier.IoDispatcher
 import at.bitfire.davdroid.settings.SettingsManager
 import at.bitfire.davdroid.sync.TasksAppManager
 import at.bitfire.davdroid.util.packageChangedFlow
@@ -26,7 +26,7 @@ import javax.inject.Inject
 @HiltViewModel
 class TasksViewModel @Inject constructor(
     @ApplicationContext val context: Context,
-    @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     private val settings: SettingsManager,
     private val tasksAppManager: TasksAppManager
 ) : ViewModel() {
@@ -77,7 +77,7 @@ class TasksViewModel @Inject constructor(
             false
         }
 
-    fun selectProvider(provider: TaskProvider.ProviderName) = viewModelScope.launch(defaultDispatcher) {
+    fun selectProvider(provider: TaskProvider.ProviderName) = viewModelScope.launch(ioDispatcher) {
         tasksAppManager.selectProvider(provider)
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreenViewModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreenViewModel.kt
@@ -13,7 +13,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.Collection
-import at.bitfire.davdroid.di.qualifier.DefaultDispatcher
+import at.bitfire.davdroid.di.qualifier.IoDispatcher
 import at.bitfire.davdroid.repository.AccountRepository
 import at.bitfire.davdroid.repository.DavCollectionRepository
 import at.bitfire.davdroid.repository.DavServiceRepository
@@ -51,7 +51,7 @@ class AccountScreenViewModel @AssistedInject constructor(
     private val collectionRepository: DavCollectionRepository,
     @ApplicationContext val context: Context,
     private val collectionSelectedUseCase: Lazy<CollectionSelectedUseCase>,
-    @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     getBindableHomesetsFromService: GetBindableHomeSetsFromServiceUseCase,
     getServiceCollectionPager: GetServiceCollectionPagerUseCase,
     private val logger: Logger,
@@ -86,13 +86,13 @@ class AccountScreenViewModel @AssistedInject constructor(
      */
     private val _showOnlyPersonal = MutableStateFlow(false)
     val showOnlyPersonal = _showOnlyPersonal.asStateFlow()
-    private suspend fun reloadShowOnlyPersonal() = withContext(Dispatchers.Default) {
+    private suspend fun reloadShowOnlyPersonal() = withContext(ioDispatcher) {
         accountSettings?.let {
             _showOnlyPersonal.value = it.getShowOnlyPersonal()
         }
     }
     fun setShowOnlyPersonal(showOnlyPersonal: Boolean) {
-        viewModelScope.launch(defaultDispatcher) {
+        viewModelScope.launch(ioDispatcher) {
             accountSettings?.setShowOnlyPersonal(showOnlyPersonal)
             reloadShowOnlyPersonal()
         }
@@ -103,7 +103,7 @@ class AccountScreenViewModel @AssistedInject constructor(
      */
     private var _showOnlyPersonalLocked = MutableStateFlow(false)
     val showOnlyPersonalLocked = _showOnlyPersonalLocked.asStateFlow()
-    private suspend fun reloadShowOnlyPersonalLocked() = withContext(Dispatchers.Default) {
+    private suspend fun reloadShowOnlyPersonalLocked() = withContext(ioDispatcher) {
         accountSettings?.let {
             _showOnlyPersonalLocked.value = it.getShowOnlyPersonalLocked()
         }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsViewModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsViewModel.kt
@@ -12,7 +12,7 @@ import at.bitfire.davdroid.accounts.AccountId
 import at.bitfire.davdroid.accounts.toAndroidAccount
 import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.Service
-import at.bitfire.davdroid.di.qualifier.DefaultDispatcher
+import at.bitfire.davdroid.di.qualifier.IoDispatcher
 import at.bitfire.davdroid.network.OAuthIntegration
 import at.bitfire.davdroid.repository.AccountRepository
 import at.bitfire.davdroid.settings.AccountSettings
@@ -50,7 +50,7 @@ class AccountSettingsViewModel @AssistedInject constructor(
     private val authService: AuthorizationService,
     @ApplicationContext val context: Context,
     db: AppDatabase,
-    @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     private val logger: Logger,
     private val oAuthIntegration: OAuthIntegration,
     private val settings: SettingsManager,
@@ -127,7 +127,7 @@ class AccountSettingsViewModel @AssistedInject constructor(
         }
     }
 
-    private suspend fun reload() = withContext(defaultDispatcher) {
+    private suspend fun reload() = withContext(ioDispatcher) {
         val hasContactsSync = serviceDao.getByAccountAndType(accountId, Service.TYPE_CARDDAV) != null
         val hasCalendarSync = serviceDao.getByAccountAndType(accountId, Service.TYPE_CALDAV) != null
         val hasTasksSync = hasCalendarSync && tasksProvider != null
@@ -162,37 +162,37 @@ class AccountSettingsViewModel @AssistedInject constructor(
 
 
     fun updateContactsSyncInterval(syncInterval: Long) {
-        CoroutineScope(defaultDispatcher).launch {
+        CoroutineScope(ioDispatcher).launch {
             accountSettings.setSyncInterval(SyncDataType.CONTACTS, syncInterval.takeUnless { it == -1L })
             reload()
         }
     }
 
     fun updateCalendarSyncInterval(syncInterval: Long) {
-        CoroutineScope(defaultDispatcher).launch {
+        CoroutineScope(ioDispatcher).launch {
             accountSettings.setSyncInterval(SyncDataType.EVENTS, syncInterval.takeUnless { it == -1L })
             reload()
         }
     }
 
     fun updateTasksSyncInterval(syncInterval: Long) {
-        CoroutineScope(defaultDispatcher).launch {
+        CoroutineScope(ioDispatcher).launch {
             accountSettings.setSyncInterval(SyncDataType.TASKS, syncInterval.takeUnless { it == -1L })
             reload()
         }
     }
 
-    fun updateSyncWifiOnly(wifiOnly: Boolean) = CoroutineScope(defaultDispatcher).launch {
+    fun updateSyncWifiOnly(wifiOnly: Boolean) = CoroutineScope(ioDispatcher).launch {
         accountSettings.setSyncWiFiOnly(wifiOnly)
         reload()
     }
 
-    fun updateSyncWifiOnlySSIDs(ssids: List<String>?) = CoroutineScope(defaultDispatcher).launch {
+    fun updateSyncWifiOnlySSIDs(ssids: List<String>?) = CoroutineScope(ioDispatcher).launch {
         accountSettings.setSyncWifiOnlySSIDs(ssids)
         reload()
     }
 
-    fun updateIgnoreVpns(ignoreVpns: Boolean) = CoroutineScope(defaultDispatcher).launch {
+    fun updateIgnoreVpns(ignoreVpns: Boolean) = CoroutineScope(ioDispatcher).launch {
         accountSettings.setIgnoreVpns(ignoreVpns)
         reload()
     }
@@ -204,7 +204,7 @@ class AccountSettingsViewModel @AssistedInject constructor(
         accountSettings.credentials().authState?.lastAuthorizationResponse?.request
 
     fun authenticate(authResponse: AuthorizationResponse) {
-        CoroutineScope(defaultDispatcher).launch {
+        CoroutineScope(ioDispatcher).launch {
             try {
                 // save new credentials
                 val authState = oAuthIntegration.authenticate(authService, authResponse)
@@ -228,13 +228,13 @@ class AccountSettingsViewModel @AssistedInject constructor(
         }
     }
 
-    fun updateCredentials(credentials: Credentials) = CoroutineScope(defaultDispatcher).launch {
+    fun updateCredentials(credentials: Credentials) = CoroutineScope(ioDispatcher).launch {
         accountSettings.credentials(credentials)
         reload()
     }
 
 
-    fun updateTimeRangePastDays(days: Int?) = CoroutineScope(defaultDispatcher).launch {
+    fun updateTimeRangePastDays(days: Int?) = CoroutineScope(ioDispatcher).launch {
         accountSettings.setTimeRangePastDays(days)
         reload()
 
@@ -249,21 +249,21 @@ class AccountSettingsViewModel @AssistedInject constructor(
         )
     }
 
-    fun updateDefaultAlarm(minBefore: Int?) = CoroutineScope(defaultDispatcher).launch {
+    fun updateDefaultAlarm(minBefore: Int?) = CoroutineScope(ioDispatcher).launch {
         accountSettings.setDefaultAlarm(minBefore)
         reload()
 
         resyncCalendars(resync = ResyncType.RESYNC_ENTRIES, tasks = false)
     }
 
-    fun updateManageCalendarColors(manage: Boolean) = CoroutineScope(defaultDispatcher).launch {
+    fun updateManageCalendarColors(manage: Boolean) = CoroutineScope(ioDispatcher).launch {
         accountSettings.setManageCalendarColors(manage)
         reload()
 
         resyncCalendars(resync = ResyncType.RESYNC_LIST, tasks = true)
     }
 
-    fun updateEventColors(manageColors: Boolean) = CoroutineScope(defaultDispatcher).launch {
+    fun updateEventColors(manageColors: Boolean) = CoroutineScope(ioDispatcher).launch {
         accountSettings.setEventColors(manageColors)
         reload()
 
@@ -271,7 +271,7 @@ class AccountSettingsViewModel @AssistedInject constructor(
     }
 
 
-    fun updateContactGroupMethod(groupMethod: GroupMethod) = CoroutineScope(defaultDispatcher).launch {
+    fun updateContactGroupMethod(groupMethod: GroupMethod) = CoroutineScope(ioDispatcher).launch {
         accountSettings.setGroupMethod(groupMethod)
         reload()
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionSelectedUseCase.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionSelectedUseCase.kt
@@ -5,7 +5,7 @@
 package at.bitfire.davdroid.ui.account
 
 import android.accounts.Account
-import at.bitfire.davdroid.di.qualifier.DefaultDispatcher
+import at.bitfire.davdroid.di.qualifier.IoDispatcher
 import at.bitfire.davdroid.push.PushRegistrationManager
 import at.bitfire.davdroid.repository.AccountRepository
 import at.bitfire.davdroid.repository.DavCollectionRepository
@@ -31,7 +31,7 @@ import javax.inject.Singleton
 class CollectionSelectedUseCase @Inject constructor(
     private val accountRepository: AccountRepository,
     private val collectionRepository: DavCollectionRepository,
-    @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     private val pushRegistrationManager: PushRegistrationManager,
     private val serviceRepository: DavServiceRepository,
     private val syncWorkerManager: SyncWorkerManager
@@ -60,7 +60,7 @@ class CollectionSelectedUseCase @Inject constructor(
             // Stop previous delay, if exists
             previousJob?.cancel()
 
-            scope.launch(defaultDispatcher) {
+            scope.launch(ioDispatcher) {
                 // wait
                 delay(DELAY_MS)
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateCalendarViewModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateCalendarViewModel.kt
@@ -63,7 +63,7 @@ class CreateCalendarViewModel @AssistedInject constructor(
         val result = timeZones.sortedBy { collator.getCollationKey(it.displayName) }
 
         emit(result)
-    }.flowOn(Dispatchers.Default)
+    }.flowOn(Dispatchers.IO)
 
 
     // UI state

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/widget/SyncWidgetViewModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/widget/SyncWidgetViewModel.kt
@@ -20,7 +20,7 @@ class SyncWidgetViewModel @Inject constructor(
     private val syncWorkerManager: SyncWorkerManager
 ): ViewModel() {
 
-    fun requestSync() = viewModelScope.launch(Dispatchers.Default) {
+    fun requestSync() = viewModelScope.launch(Dispatchers.IO) {
         for (account in accountRepository.getAll())
             syncWorkerManager.enqueueOneTimeAllAuthorities(account, manual = true)
     }


### PR DESCRIPTION
Replace all instances where `Dispatchers.Default` was used with `Dispatchers.IO`.

Fixes https://github.com/bitfireAT/davx5/issues/930