### PR TITLE
Use suspending methods for SyncWorkerManager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,5 +90,3 @@ gradle-app.setting
 
 # Javadoc
 javadoc/
-
-graphify-out

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,5 @@ gradle-app.setting
 
 # Javadoc
 javadoc/
+
+graphify-out

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -85,6 +85,7 @@ dependencies {
     // Kotlin / Android
     implementation(libs.kotlin.stdlib)
     implementation(libs.kotlinx.coroutines)
+    implementation(libs.kotlinx.coroutines.guava)
     coreLibraryDesugaring(libs.android.desugaring)
 
     // Hilt

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncAdapterImplTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncAdapterImplTest.kt
@@ -95,7 +95,7 @@ class SyncAdapterImplTest {
 
         mockkObject(workManager) {
             // don't actually create a worker
-            every { syncWorkerManager.enqueueOneTime(any(), any()) } returns "TheSyncWorker"
+            coEvery { syncWorkerManager.enqueueOneTime(any(), any()) } returns "TheSyncWorker"
 
             // assume worker takes a long time
             every { workManager.getWorkInfosForUniqueWorkFlow("TheSyncWorker") } just Awaits
@@ -119,7 +119,7 @@ class SyncAdapterImplTest {
 
         mockkObject(workManager) {
             // don't actually create a worker
-            every { syncWorkerManager.enqueueOneTime(any(), any()) } returns "TheSyncWorker"
+            coEvery { syncWorkerManager.enqueueOneTime(any(), any()) } returns "TheSyncWorker"
 
             // assume worker takes a long time
             every { workManager.getWorkInfosForUniqueWorkFlow("TheSyncWorker") } just Awaits
@@ -140,7 +140,7 @@ class SyncAdapterImplTest {
 
         mockkObject(workManager) {
             // don't actually create a worker
-            every { syncWorkerManager.enqueueOneTime(any(), any()) } returns "TheSyncWorker"
+            coEvery { syncWorkerManager.enqueueOneTime(any(), any()) } returns "TheSyncWorker"
 
             // assume worker immediately returns with success
             val success = mockk<WorkInfo>()

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/worker/SyncWorkerManagerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/worker/SyncWorkerManagerTest.kt
@@ -14,6 +14,7 @@ import at.bitfire.davdroid.sync.account.TestAccount
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -58,7 +59,7 @@ class SyncWorkerManagerTest {
     // one-time sync workers
 
     @Test
-    fun testEnqueueOneTime() {
+    fun testEnqueueOneTime() = runTest {
         val workerName = OneTimeSyncWorker.workerName(account, SyncDataType.EVENTS)
         assertFalse(TestUtils.workScheduledOrRunningOrSuccessful(context, workerName))
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncAdapterImpl.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncAdapterImpl.kt
@@ -35,9 +35,7 @@ import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.future.asCompletableFuture
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
@@ -117,9 +115,9 @@ class SyncAdapterImpl @Inject constructor(
         }
 
         logger.fine("Starting OneTimeSyncWorker for $account $authority and waiting for it")
-        val workerName = waitScope.async {
+        val workerName = runBlocking(waitScope.coroutineContext) {
             syncWorkerManager.enqueueOneTime(account, dataType = SyncDataType.fromAuthority(authority), fromUpload = upload)
-        }.asCompletableFuture().get()
+        }
 
         // Android 14+ does not handle pending sync state correctly.
         // As a defensive workaround, we can cancel specifically this still pending sync only

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncAdapterImpl.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/adapter/SyncAdapterImpl.kt
@@ -35,7 +35,9 @@ import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.future.asCompletableFuture
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
@@ -115,7 +117,9 @@ class SyncAdapterImpl @Inject constructor(
         }
 
         logger.fine("Starting OneTimeSyncWorker for $account $authority and waiting for it")
-        val workerName = syncWorkerManager.enqueueOneTime(account, dataType = SyncDataType.fromAuthority(authority), fromUpload = upload)
+        val workerName = waitScope.async {
+            syncWorkerManager.enqueueOneTime(account, dataType = SyncDataType.fromAuthority(authority), fromUpload = upload)
+        }.asCompletableFuture().get()
 
         // Android 14+ does not handle pending sync state correctly.
         // As a defensive workaround, we can cancel specifically this still pending sync only

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/worker/SyncWorkerManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/worker/SyncWorkerManager.kt
@@ -59,7 +59,9 @@ class SyncWorkerManager @Inject constructor(
     val tasksAppManager: Lazy<TasksAppManager>
 ) {
 
-    private val enqueueSemaphore = Semaphore(1)
+    private companion object {
+        val enqueueSemaphore = Semaphore(1)
+    }
 
     // one-time sync workers
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/worker/SyncWorkerManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/worker/SyncWorkerManager.kt
@@ -41,8 +41,8 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.guava.await
-import kotlinx.coroutines.sync.Semaphore
-import kotlinx.coroutines.sync.withPermit
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.util.concurrent.TimeUnit
 import java.util.logging.Logger
 import javax.inject.Inject
@@ -60,7 +60,11 @@ class SyncWorkerManager @Inject constructor(
 ) {
 
     private companion object {
-        val enqueueSemaphore = Semaphore(1)
+        /**
+         * Makes sure job appending works correctly, and that there are no multiple places trying to enqueue jobs at
+         * the same time.
+         */
+        val enqueueMutex = Mutex()
     }
 
     // one-time sync workers
@@ -165,7 +169,7 @@ class SyncWorkerManager @Inject constructor(
         appended work, stop adding more work. */
 
         val workManager = WorkManager.getInstance(context)
-        enqueueSemaphore.withPermit {
+        enqueueMutex.withLock {
             val currentWork = workManager.getWorkInfosForUniqueWork(name).await()
             val alreadyAppended = currentWork.any {
                 it.state in setOf(WorkInfo.State.BLOCKED, WorkInfo.State.ENQUEUED)

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/worker/SyncWorkerManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/worker/SyncWorkerManager.kt
@@ -22,6 +22,7 @@ import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.WorkQuery
 import androidx.work.WorkRequest
+import androidx.work.await
 import at.bitfire.davdroid.push.PushNotificationManager
 import at.bitfire.davdroid.sync.ResyncType
 import at.bitfire.davdroid.sync.SyncDataType
@@ -39,6 +40,9 @@ import dagger.Lazy
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.guava.await
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import java.util.concurrent.TimeUnit
 import java.util.logging.Logger
 import javax.inject.Inject
@@ -54,6 +58,8 @@ class SyncWorkerManager @Inject constructor(
     val pushNotificationManager: Lazy<PushNotificationManager>,
     val tasksAppManager: Lazy<TasksAppManager>
 ) {
+
+    private val enqueueSemaphore = Semaphore(1)
 
     // one-time sync workers
 
@@ -129,7 +135,7 @@ class SyncWorkerManager @Inject constructor(
      *
      * @return existing or newly created worker name
      */
-    fun enqueueOneTime(
+    suspend fun enqueueOneTime(
         account: Account,
         dataType: SyncDataType,
         manual: Boolean = false,
@@ -157,15 +163,15 @@ class SyncWorkerManager @Inject constructor(
         appended work, stop adding more work. */
 
         val workManager = WorkManager.getInstance(context)
-        synchronized(SyncWorkerManager::class.java) {
-            val currentWork = workManager.getWorkInfosForUniqueWork(name).get()
+        enqueueSemaphore.withPermit {
+            val currentWork = workManager.getWorkInfosForUniqueWork(name).await()
             val alreadyAppended = currentWork.any {
                 it.state in setOf(WorkInfo.State.BLOCKED, WorkInfo.State.ENQUEUED)
             }
             if (!alreadyAppended) {
                 val op = workManager.enqueueUniqueWork(name, ExistingWorkPolicy.APPEND_OR_REPLACE, request)
                 // for synchronization: wait until work is actually enqueued
-                op.result
+                op.await()
             } else
                 logger.fine("Another one-time sync already waiting, not adding more of $name")
         }
@@ -179,7 +185,7 @@ class SyncWorkerManager @Inject constructor(
      *
      * Arguments: see [enqueueOneTime]
      */
-    fun enqueueOneTimeAllAuthorities(
+    suspend fun enqueueOneTimeAllAuthorities(
         account: Account,
         manual: Boolean = false,
         resync: ResyncType? = null,

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/AccountsViewModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/AccountsViewModel.kt
@@ -19,6 +19,7 @@ import android.provider.ContactsContract
 import androidx.core.content.getSystemService
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.WorkQuery
@@ -54,6 +55,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import java.text.Collator
 import java.util.logging.Logger
 
@@ -281,8 +283,10 @@ class AccountsViewModel @AssistedInject constructor(
         ShortcutManagerCompat.reportShortcutUsed(context, UiUtils.SHORTCUT_SYNC_ALL)
 
         // Enqueue sync worker for all accounts and authorities. Will sync once internet is available
-        for (account in accountRepository.getAll())
-            syncWorkerManager.enqueueOneTimeAllAuthorities(account, manual = true)
+        viewModelScope.launch {
+            for (account in accountRepository.getAll())
+                syncWorkerManager.enqueueOneTimeAllAuthorities(account, manual = true)
+        }
     }
 
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreenViewModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreenViewModel.kt
@@ -30,7 +30,6 @@ import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -221,7 +220,9 @@ class AccountScreenViewModel @AssistedInject constructor(
     }
 
     fun sync() {
-        syncWorkerManager.enqueueOneTimeAllAuthorities(account, manual = true)
+        viewModelScope.launch {
+            syncWorkerManager.enqueueOneTimeAllAuthorities(account, manual = true)
+        }
     }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsViewModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsViewModel.kt
@@ -285,7 +285,7 @@ class AccountSettingsViewModel @AssistedInject constructor(
      *                  themselves (full resync) shall be downloaded again
      * @param tasks     whether tasks shall be synchronized, too (false: only events, true: events and tasks)
      */
-    private fun resyncCalendars(resync: ResyncType, tasks: Boolean) {
+    private suspend fun resyncCalendars(resync: ResyncType, tasks: Boolean) {
         resync(SyncDataType.EVENTS, resync)
         if (tasks)
             resync(SyncDataType.TASKS, resync)
@@ -298,7 +298,7 @@ class AccountSettingsViewModel @AssistedInject constructor(
      * @param resync    whether only the list of entries (resync) or also all entries
      *                  themselves (full resync) shall be downloaded again
      */
-    private fun resync(dataType: SyncDataType, resync: ResyncType) {
+    private suspend fun resync(dataType: SyncDataType, resync: ResyncType) {
         syncWorkerManager.enqueueOneTime(accountId.toAndroidAccount(), dataType = dataType, resync = resync)
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -110,6 +110,7 @@ kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", v
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-guava = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-guava", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 ktor-client-auth = { module = "io.ktor:ktor-client-auth", version.ref = "ktor" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }


### PR DESCRIPTION
### Purpose

As a first step for #2654, `SyncWorkerManager` is using some "not recommended" methods, and not suspending.

### Short description

- Added KotlinX coroutines Guava dependency for `await` of `ListenableFuture`.
- Made all scheduling functions of `SyncWorkerManager` suspend.
  - Replaced `get` calls with `await`.
  - Replaced `result` calls with `await`.
  - Replaced `synchronized` with semaphore.
- `SyncAdapterImpl` uses `waitScope` with `runBlocking`.
- View models use view model scope with `launch`.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

