### PR TITLE
`Android10Resolver`: use `asyncSend` instead of `runBlocking`

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/network/Android10ResolverTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/network/Android10ResolverTest.kt
@@ -14,18 +14,18 @@ import org.xbill.DNS.Type
 import java.net.Inet4Address
 import java.net.InetAddress
 
+@SdkSuppress(minSdkVersion = Build.VERSION_CODES.Q)
 class Android10ResolverTest {
 
     val FQDN_DAVX5 = "www.davx5.com"
 
     @Test
-    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.Q, maxSdkVersion = 34)
     fun testResolveA() {
         val www = InetAddress.getAllByName(FQDN_DAVX5).filterIsInstance<Inet4Address>().first()
 
-        val srvLookup = Lookup(FQDN_DAVX5, Type.A)
-        srvLookup.setResolver(Android10Resolver())
-        val resultGeneric = srvLookup.run()
+        val lookup = Lookup(FQDN_DAVX5, Type.A)
+        lookup.setResolver(Android10Resolver())
+        val resultGeneric = lookup.run()
         assertEquals(1, resultGeneric.size)
 
         val result = resultGeneric.first() as ARecord

--- a/core/src/main/kotlin/at/bitfire/davdroid/network/Android10Resolver.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/network/Android10Resolver.kt
@@ -7,16 +7,15 @@ package at.bitfire.davdroid.network
 import android.net.DnsResolver
 import android.os.Build
 import androidx.annotation.RequiresApi
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.asExecutor
-import kotlinx.coroutines.runBlocking
 import org.xbill.DNS.EDNSOption
 import org.xbill.DNS.Message
 import org.xbill.DNS.Resolver
 import org.xbill.DNS.TSIG
 import java.io.IOException
 import java.time.Duration
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import java.util.concurrent.Executor
 
 /**
  * dnsjava [Resolver] that uses Android's [DnsResolver] API, which can resolve raw queries and
@@ -25,11 +24,10 @@ import java.time.Duration
 @RequiresApi(Build.VERSION_CODES.Q)
 class Android10Resolver : Resolver {
 
-    private val executor = Dispatchers.IO.asExecutor()
     private val resolver = DnsResolver.getInstance()
 
-    override fun send(query: Message): Message = runBlocking {
-        val future = CompletableDeferred<Message>()
+    override fun sendAsync(query: Message, executor: Executor): CompletionStage<Message> {
+        val future = CompletableFuture<Message>()
 
         resolver.rawQuery(null, query.toWire(), DnsResolver.FLAG_EMPTY, executor, null, object: DnsResolver.Callback<ByteArray> {
             override fun onAnswer(rawAnswer: ByteArray, rcode: Int) {
@@ -42,7 +40,7 @@ class Android10Resolver : Resolver {
             }
         })
 
-        future.await()
+        return future
     }
 
 


### PR DESCRIPTION
### Purpose

Part of #2654.

`Android10Resolver` currently has bad patterns:

1. It uses `runBlocking(/* without dispatcher */)` and mixes coroutines with Java completeable futures in a non-intended way.
2. It overrides `send()` instead of `sendAsync()` and duplicates logic that is already in dnsjava's `send()`.
3. Test sets `maxSdkVersion` so that it's currently not even run.

### Short description

- Updated Android10Resolver to use async send without coroutines
- Removed maxSdkVersion restriction in tests

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.