### PR TITLE
[WebDAV] make operation signatures and DB access suspendable

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/db/WebDavDocumentDao.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/WebDavDocumentDao.kt
@@ -18,13 +18,13 @@ import androidx.room.Update
 interface WebDavDocumentDao {
 
     @Query("SELECT * FROM webdav_document WHERE id=:id")
-    fun get(id: Long): WebDavDocument?
+    suspend fun get(id: Long): WebDavDocument?
 
     @Query("SELECT * FROM webdav_document WHERE mountId=:mountId AND (parentId=:parentId OR (parentId IS NULL AND :parentId IS NULL)) AND name=:name")
-    fun getByParentAndName(mountId: Long, parentId: Long?, name: String): WebDavDocument?
+    suspend fun getByParentAndName(mountId: Long, parentId: Long?, name: String): WebDavDocument?
 
     @RawQuery
-    fun query(query: RoomRawQuery): List<WebDavDocument>
+    suspend fun query(query: RoomRawQuery): List<WebDavDocument>
 
     /**
      * Gets all the child documents from a given parent id.
@@ -33,7 +33,7 @@ interface WebDavDocumentDao {
      * @param orderBy If desired, a SQL clause to specify how to order the results.
      *                **The caller is responsible for the correct formatting of this argument. Syntax won't be validated!**
      */
-    fun getChildren(parentId: Long, orderBy: String = DEFAULT_ORDER): List<WebDavDocument> {
+    suspend fun getChildren(parentId: Long, orderBy: String = DEFAULT_ORDER): List<WebDavDocument> {
         return query(
             RoomRawQuery("SELECT * FROM webdav_document WHERE parentId = ? ORDER BY $orderBy") {
                 it.bindLong(1, parentId)
@@ -42,19 +42,19 @@ interface WebDavDocumentDao {
     }
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insertOrReplace(document: WebDavDocument): Long
+    suspend fun insertOrReplace(document: WebDavDocument): Long
 
     @Query("DELETE FROM webdav_document WHERE parentId=:parentId")
-    fun removeChildren(parentId: Long)
+    suspend fun removeChildren(parentId: Long)
 
     @Insert
-    fun insert(document: WebDavDocument): Long
+    suspend fun insert(document: WebDavDocument): Long
 
     @Update
-    fun update(document: WebDavDocument)
+    suspend fun update(document: WebDavDocument)
 
     @Delete
-    fun delete(document: WebDavDocument)
+    suspend fun delete(document: WebDavDocument)
 
 
     // complex operations
@@ -67,7 +67,7 @@ interface WebDavDocumentDao {
      * @return ID of the row, that has been inserted or updated. -1 If the insert fails due to other reasons.
      */
     @Transaction
-    fun insertOrUpdate(document: WebDavDocument): Long {
+    suspend fun insertOrUpdate(document: WebDavDocument): Long {
         val parentId = document.parentId
             ?: return insert(document)
         val existingDocument = getByParentAndName(document.mountId, parentId, document.name)
@@ -77,7 +77,7 @@ interface WebDavDocumentDao {
     }
 
     @Transaction
-    fun getOrCreateRoot(mount: WebDavMount): WebDavDocument {
+    suspend fun getOrCreateRoot(mount: WebDavMount): WebDavDocument {
         getByParentAndName(mount.id, null, "")?.let { existing ->
             return existing
         }

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/DavDocumentsProvider.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/DavDocumentsProvider.kt
@@ -76,10 +76,13 @@ class DavDocumentsProvider : DocumentsProvider() {
     }
 
     override fun queryChildDocuments(parentDocumentId: String, projection: Array<out String>?, sortOrder: String?) =
+        runBlocking {
         entryPoint.queryChildDocumentsOperation().invoke(parentDocumentId, projection, sortOrder)
+        }
 
-    override fun isChildDocument(parentDocumentId: String, documentId: String) =
+    override fun isChildDocument(parentDocumentId: String, documentId: String) = runBlocking {
         entryPoint.isChildDocumentOperation().invoke(parentDocumentId, documentId)
+    }
 
 
     /*** copy/create/delete/move/rename ***/
@@ -119,7 +122,8 @@ class DavDocumentsProvider : DocumentsProvider() {
         entryPoint.openDocumentOperation().invoke(documentId, mode, signal)
     }
 
-    override fun openDocumentThumbnail(documentId: String, sizeHint: Point, signal: CancellationSignal?) =
+    override fun openDocumentThumbnail(documentId: String, sizeHint: Point, signal: CancellationSignal?) = runBlocking {
         entryPoint.openDocumentThumbnailOperation().invoke(documentId, sizeHint, signal)
+    }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/DavDocumentsProvider.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/DavDocumentsProvider.kt
@@ -22,6 +22,7 @@ import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.runBlocking
 
 /**
  * Provides functionality on WebDav documents.
@@ -32,8 +33,10 @@ import dagger.hilt.components.SingletonComponent
  * Note: A DocumentsProvider is a ContentProvider and thus has no well-defined lifecycle. It
  * is created by Android when it's first accessed and then stays in memory until the process
  * is killed.
+ *
+ * As a ContentProvider, this class is responsible for bridging its blocking API to the suspending operations.
  */
-class DavDocumentsProvider: DocumentsProvider() {
+class DavDocumentsProvider : DocumentsProvider() {
 
     @EntryPoint
     @InstallIn(SingletonComponent::class)
@@ -64,11 +67,13 @@ class DavDocumentsProvider: DocumentsProvider() {
 
     /*** query ***/
 
-    override fun queryRoots(projection: Array<out String>?) =
+    override fun queryRoots(projection: Array<out String>?) = runBlocking {
         entryPoint.queryRootsOperation().invoke(projection)
+    }
 
-    override fun queryDocument(documentId: String, projection: Array<out String>?) =
+    override fun queryDocument(documentId: String, projection: Array<out String>?) = runBlocking {
         entryPoint.queryDocumentOperation().invoke(documentId, projection)
+    }
 
     override fun queryChildDocuments(parentDocumentId: String, projection: Array<out String>?, sortOrder: String?) =
         entryPoint.queryChildDocumentsOperation().invoke(parentDocumentId, projection, sortOrder)
@@ -79,26 +84,40 @@ class DavDocumentsProvider: DocumentsProvider() {
 
     /*** copy/create/delete/move/rename ***/
 
-    override fun copyDocument(sourceDocumentId: String, targetParentDocumentId: String) =
+    override fun copyDocument(sourceDocumentId: String, targetParentDocumentId: String) = runBlocking {
         entryPoint.copyDocumentOperation().invoke(sourceDocumentId, targetParentDocumentId)
+    }
 
-    override fun createDocument(parentDocumentId: String, mimeType: String, displayName: String): String? =
+    override fun createDocument(
+        parentDocumentId: String,
+        mimeType: String,
+        displayName: String
+    ): String? = runBlocking {
         entryPoint.createDocumentOperation().invoke(parentDocumentId, mimeType, displayName)
+    }
 
-    override fun deleteDocument(documentId: String) =
+    override fun deleteDocument(documentId: String) = runBlocking {
         entryPoint.deleteDocumentOperation().invoke(documentId)
+    }
 
-    override fun moveDocument(sourceDocumentId: String, sourceParentDocumentId: String, targetParentDocumentId: String) =
+    override fun moveDocument(
+        sourceDocumentId: String,
+        sourceParentDocumentId: String,
+        targetParentDocumentId: String
+    ) = runBlocking {
         entryPoint.moveDocumentOperation().invoke(sourceDocumentId, sourceParentDocumentId, targetParentDocumentId)
+    }
 
-    override fun renameDocument(documentId: String, displayName: String): String? =
+    override fun renameDocument(documentId: String, displayName: String): String? = runBlocking {
         entryPoint.renameDocumentOperation().invoke(documentId, displayName)
+    }
 
 
     /*** read/write ***/
 
-    override fun openDocument(documentId: String, mode: String, signal: CancellationSignal?) =
+    override fun openDocument(documentId: String, mode: String, signal: CancellationSignal?) = runBlocking {
         entryPoint.openDocumentOperation().invoke(documentId, mode, signal)
+    }
 
     override fun openDocumentThumbnail(documentId: String, sizeHint: Point, signal: CancellationSignal?) =
         entryPoint.openDocumentThumbnailOperation().invoke(documentId, sizeHint, signal)

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/StreamingFileDescriptor.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/StreamingFileDescriptor.kt
@@ -133,7 +133,7 @@ class StreamingFileDescriptor @AssistedInject constructor(
 
 
     fun interface OnSuccessCallback {
-        fun onFinished(transferred: Long, success: Boolean)
+        suspend fun onFinished(transferred: Long, success: Boolean)
     }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/CopyDocumentOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/CopyDocumentOperation.kt
@@ -15,7 +15,6 @@ import at.bitfire.davdroid.webdav.throwForDocumentProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.ktor.http.URLBuilder
 import io.ktor.http.appendPathSegments
-import kotlinx.coroutines.runBlocking
 import java.io.FileNotFoundException
 import java.util.logging.Logger
 import javax.inject.Inject
@@ -29,7 +28,7 @@ class CopyDocumentOperation @Inject constructor(
 
     private val documentDao = db.webDavDocumentDao()
 
-    operator fun invoke(sourceDocumentId: String, targetParentDocumentId: String): String = runBlocking {
+    suspend operator fun invoke(sourceDocumentId: String, targetParentDocumentId: String): String {
         logger.fine("WebDAV copyDocument $sourceDocumentId $targetParentDocumentId")
         val srcDoc = documentDao.get(sourceDocumentId.toLong()) ?: throw FileNotFoundException()
         val dstFolder = documentDao.get(targetParentDocumentId.toLong()) ?: throw FileNotFoundException()
@@ -69,7 +68,7 @@ class CopyDocumentOperation @Inject constructor(
 
         DocumentProviderUtils.notifyFolderChanged(context, targetParentDocumentId)
 
-        /* return */ dstDocId
+        return dstDocId
     }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/CreateDocumentOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/CreateDocumentOperation.kt
@@ -21,7 +21,6 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.URLBuilder
 import io.ktor.http.appendPathSegments
 import io.ktor.http.headersOf
-import kotlinx.coroutines.runBlocking
 import java.io.FileNotFoundException
 import java.util.logging.Logger
 import javax.inject.Inject
@@ -35,7 +34,7 @@ class CreateDocumentOperation @Inject constructor(
 
     private val documentDao = db.webDavDocumentDao()
 
-    operator fun invoke(parentDocumentId: String, mimeType: String, displayName: String): String? = runBlocking {
+    suspend operator fun invoke(parentDocumentId: String, mimeType: String, displayName: String): String? {
         logger.fine("WebDAV createDocument $parentDocumentId $mimeType $displayName")
         val parent = documentDao.get(parentDocumentId.toLong()) ?: throw FileNotFoundException()
         val createDirectory = mimeType == Document.MIME_TYPE_DIR
@@ -75,14 +74,14 @@ class CreateDocumentOperation @Inject constructor(
 
                     DocumentProviderUtils.notifyFolderChanged(context, parentDocumentId)
 
-                    return@runBlocking docId.toString()
+                    return docId.toString()
                 } catch (e: HttpException) {
                     e.throwForDocumentProvider(context, ignorePreconditionFailed = true)
                 }
             }
         }
 
-        null
+        return null
     }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/DeleteDocumentOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/DeleteDocumentOperation.kt
@@ -12,7 +12,6 @@ import at.bitfire.davdroid.webdav.DavHttpClientBuilder
 import at.bitfire.davdroid.webdav.DocumentProviderUtils
 import at.bitfire.davdroid.webdav.throwForDocumentProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.runBlocking
 import java.io.FileNotFoundException
 import java.util.logging.Logger
 import javax.inject.Inject
@@ -26,7 +25,7 @@ class DeleteDocumentOperation @Inject constructor(
 
     private val documentDao = db.webDavDocumentDao()
 
-    operator fun invoke(documentId: String) = runBlocking {
+    suspend operator fun invoke(documentId: String) {
         logger.fine("WebDAV removeDocument $documentId")
         val doc = documentDao.get(documentId.toLong()) ?: throw FileNotFoundException()
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/IsChildDocumentOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/IsChildDocumentOperation.kt
@@ -17,7 +17,7 @@ class IsChildDocumentOperation @Inject constructor(
 
     private val documentDao = db.webDavDocumentDao()
 
-    operator fun invoke(parentDocumentId: String, documentId: String): Boolean {
+    suspend operator fun invoke(parentDocumentId: String, documentId: String): Boolean {
         logger.fine("WebDAV isChildDocument $parentDocumentId $documentId")
         val parent = documentDao.get(parentDocumentId.toLong()) ?: throw FileNotFoundException()
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/MoveDocumentOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/MoveDocumentOperation.kt
@@ -14,7 +14,6 @@ import at.bitfire.davdroid.webdav.throwForDocumentProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.ktor.http.URLBuilder
 import io.ktor.http.appendPathSegments
-import kotlinx.coroutines.runBlocking
 import java.io.FileNotFoundException
 import java.util.logging.Logger
 import javax.inject.Inject
@@ -28,7 +27,11 @@ class MoveDocumentOperation @Inject constructor(
 
     private val documentDao = db.webDavDocumentDao()
 
-    operator fun invoke(sourceDocumentId: String, sourceParentDocumentId: String, targetParentDocumentId: String): String = runBlocking {
+    suspend operator fun invoke(
+        sourceDocumentId: String,
+        sourceParentDocumentId: String,
+        targetParentDocumentId: String
+    ): String {
         logger.fine("WebDAV moveDocument $sourceDocumentId $sourceParentDocumentId $targetParentDocumentId")
         val doc = documentDao.get(sourceDocumentId.toLong()) ?: throw FileNotFoundException()
         val dstParent = documentDao.get(targetParentDocumentId.toLong()) ?: throw FileNotFoundException()
@@ -58,7 +61,7 @@ class MoveDocumentOperation @Inject constructor(
                 }
             }
 
-        doc.id.toString()
+        return doc.id.toString()
     }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/OpenDocumentOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/OpenDocumentOperation.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.runBlocking
 import java.io.FileNotFoundException
 import java.util.logging.Logger
 import javax.annotation.WillNotClose
@@ -39,7 +38,7 @@ class OpenDocumentOperation @Inject constructor(
 
     private val documentDao = db.webDavDocumentDao()
 
-    operator fun invoke(documentId: String, mode: String, signal: CancellationSignal?): ParcelFileDescriptor = runBlocking {
+    suspend operator fun invoke(documentId: String, mode: String, signal: CancellationSignal?): ParcelFileDescriptor {
         logger.fine("WebDAV openDocument $documentId $mode $signal")
 
         val doc = documentDao.get(documentId.toLong()) ?: throw FileNotFoundException()
@@ -66,7 +65,7 @@ class OpenDocumentOperation @Inject constructor(
         val contentType = doc.mimeType?.toString().toContentTypeOrNull()
 
         // RandomAccessCallback.Wrapper / StreamingFileDescriptor are responsible for closing httpClient
-        return@runBlocking if (
+        return if (
             androidSupportsRandomAccess &&
             readOnlyMode &&                     // WebDAV doesn't support random write access (natively)
             fileInfo.size != null &&            // file descriptor must return a useful value on getFileSize()

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/OpenDocumentThumbnailOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/OpenDocumentThumbnailOperation.kt
@@ -49,7 +49,11 @@ class OpenDocumentThumbnailOperation @Inject constructor(
 
     private val documentDao = db.webDavDocumentDao()
 
-    operator fun invoke(documentId: String, sizeHint: Point, signal: CancellationSignal?): AssetFileDescriptor? {
+    suspend operator fun invoke(
+        documentId: String,
+        sizeHint: Point,
+        signal: CancellationSignal?
+    ): AssetFileDescriptor? {
         logger.info("openDocumentThumbnail documentId=$documentId sizeHint=$sizeHint signal=$signal")
 
         // don't download the large images just to create a thumbnail on metered networks

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/QueryChildDocumentsOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/QueryChildDocumentsOperation.kt
@@ -32,6 +32,8 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.io.FileNotFoundException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.logging.Level
@@ -51,12 +53,12 @@ class QueryChildDocumentsOperation @Inject constructor(
 
     private val backgroundScope = CoroutineScope(SupervisorJob())
 
-    operator fun invoke(parentDocumentId: String, projection: Array<out String>?, sortOrder: String?) =
-        synchronized(QueryChildDocumentsOperation::class.java) {
+    suspend operator fun invoke(parentDocumentId: String, projection: Array<out String>?, sortOrder: String?) =
+        mutex.withLock {
             queryChildDocuments(parentDocumentId, projection, sortOrder)
         }
 
-    private fun queryChildDocuments(
+    private suspend fun queryChildDocuments(
         parentDocumentId: String,
         projection: Array<out String>?,
         sortOrder: String?
@@ -203,6 +205,9 @@ class QueryChildDocumentsOperation @Inject constructor(
          *  Value: whether the runner is still running (*true*) or has already finished (*false*).
          */
         private val runningQueryChildren = ConcurrentHashMap<Long, Boolean>()
+
+        /** Serializes [queryChildDocuments] across all instances. */
+        private val mutex = Mutex()
 
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/QueryDocumentOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/QueryDocumentOperation.kt
@@ -8,7 +8,6 @@ import android.database.Cursor
 import android.provider.DocumentsContract.Document
 import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.webdav.DocumentsCursor
-import kotlinx.coroutines.runBlocking
 import java.io.FileNotFoundException
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -22,7 +21,7 @@ class QueryDocumentOperation @Inject constructor(
     private val documentDao = db.webDavDocumentDao()
     private val mountDao = db.webDavMountDao()
 
-    operator fun invoke(documentId: String, projection: Array<out String>?): Cursor {
+    suspend operator fun invoke(documentId: String, projection: Array<out String>?): Cursor {
         logger.log(Level.FINE, "WebDAV queryDocument {0} {1}", arrayOf(documentId, projection?.joinToString("+")))
 
         val doc = documentDao.get(documentId.toLong()) ?: throw FileNotFoundException()
@@ -45,7 +44,7 @@ class QueryDocumentOperation @Inject constructor(
 
             // override display names of root documents
             if (parent == null) {
-                val mount = runBlocking { mountDao.getById(doc.mountId) }
+                val mount = mountDao.getById(doc.mountId)
                 bundle.putString(Document.COLUMN_DISPLAY_NAME, mount.name)
             }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/QueryRootsOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/QueryRootsOperation.kt
@@ -11,7 +11,6 @@ import android.provider.DocumentsContract.Root
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.AppDatabase
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.runBlocking
 import java.util.logging.Logger
 import javax.inject.Inject
 
@@ -24,7 +23,7 @@ class QueryRootsOperation @Inject constructor(
     private val documentDao = db.webDavDocumentDao()
     private val mountDao = db.webDavMountDao()
 
-    operator fun invoke(projection: Array<out String>?): Cursor {
+    suspend operator fun invoke(projection: Array<out String>?): Cursor {
         logger.fine("WebDAV queryRoots")
         val roots = MatrixCursor(projection ?: arrayOf(
             Root.COLUMN_ROOT_ID,
@@ -35,27 +34,25 @@ class QueryRootsOperation @Inject constructor(
             Root.COLUMN_SUMMARY
         ))
 
-        runBlocking {
-            for (mount in mountDao.getAll()) {
-                val rootDocument = documentDao.getOrCreateRoot(mount)
-                logger.info("Root ID: $rootDocument")
+        for (mount in mountDao.getAll()) {
+            val rootDocument = documentDao.getOrCreateRoot(mount)
+            logger.info("Root ID: $rootDocument")
 
-                roots.newRow().apply {
-                    add(Root.COLUMN_ROOT_ID, mount.id)
-                    add(Root.COLUMN_ICON, R.mipmap.ic_launcher)
-                    add(Root.COLUMN_TITLE, context.getString(R.string.webdav_provider_root_title))
-                    add(Root.COLUMN_DOCUMENT_ID, rootDocument.id.toString())
-                    add(Root.COLUMN_SUMMARY, mount.name)
-                    add(Root.COLUMN_FLAGS, Root.FLAG_SUPPORTS_CREATE or Root.FLAG_SUPPORTS_IS_CHILD)
+            roots.newRow().apply {
+                add(Root.COLUMN_ROOT_ID, mount.id)
+                add(Root.COLUMN_ICON, R.mipmap.ic_launcher)
+                add(Root.COLUMN_TITLE, context.getString(R.string.webdav_provider_root_title))
+                add(Root.COLUMN_DOCUMENT_ID, rootDocument.id.toString())
+                add(Root.COLUMN_SUMMARY, mount.name)
+                add(Root.COLUMN_FLAGS, Root.FLAG_SUPPORTS_CREATE or Root.FLAG_SUPPORTS_IS_CHILD)
 
-                    val quotaAvailable = rootDocument.quotaAvailable
-                    if (quotaAvailable != null)
-                        add(Root.COLUMN_AVAILABLE_BYTES, quotaAvailable)
+                val quotaAvailable = rootDocument.quotaAvailable
+                if (quotaAvailable != null)
+                    add(Root.COLUMN_AVAILABLE_BYTES, quotaAvailable)
 
-                    val quotaUsed = rootDocument.quotaUsed
-                    if (quotaAvailable != null && quotaUsed != null)
-                        add(Root.COLUMN_CAPACITY_BYTES, quotaAvailable + quotaUsed)
-                }
+                val quotaUsed = rootDocument.quotaUsed
+                if (quotaAvailable != null && quotaUsed != null)
+                    add(Root.COLUMN_CAPACITY_BYTES, quotaAvailable + quotaUsed)
             }
         }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/RenameDocumentOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/RenameDocumentOperation.kt
@@ -14,7 +14,6 @@ import at.bitfire.davdroid.webdav.DocumentProviderUtils.displayNameToMemberName
 import at.bitfire.davdroid.webdav.throwForDocumentProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.ktor.http.URLBuilder
-import kotlinx.coroutines.runBlocking
 import java.io.FileNotFoundException
 import java.util.logging.Logger
 import javax.inject.Inject
@@ -28,7 +27,7 @@ class RenameDocumentOperation @Inject constructor(
 
     private val documentDao = db.webDavDocumentDao()
 
-    operator fun invoke(documentId: String, displayName: String): String? = runBlocking {
+    suspend operator fun invoke(documentId: String, displayName: String): String? {
         logger.fine("WebDAV renameDocument $documentId $displayName")
         val doc = documentDao.get(documentId.toLong()) ?: throw FileNotFoundException()
 
@@ -52,14 +51,14 @@ class RenameDocumentOperation @Inject constructor(
 
                         DocumentProviderUtils.notifyFolderChanged(context, doc.parentId)
 
-                        return@runBlocking doc.id.toString()
+                        return doc.id.toString()
                     } catch (e: HttpException) {
                         e.throwForDocumentProvider(context, true)
                     }
                 }
             }
 
-        null
+        return null
     }
 
 }


### PR DESCRIPTION
### Purpose

Enable suspending database access operations to support non-blocking I/O.

Not in scope / for follow-up: make `DiskCache` and thumbnail stuff suspending.

Part of #2654.

### Short description

- Use suspending database access for WebDAV tables
- Move responsibility to bridge to blocking API to `DavDocumentsProvider`; operations themselves are then suspending

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.