### PR TITLE
[Experimental] [AccountSettings] Make migrations suspendable

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/settings/AccountSettingsTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/settings/AccountSettingsTest.kt
@@ -41,7 +41,7 @@ class AccountSettingsTest {
 
     @Test(expected = IllegalArgumentException::class)
     fun testUpdate_MissingMigrations() {
-        TestAccount.provide(version = 1) { account ->
+        TestAccount.provideBlocking(version = 1) { account ->
             // will run AccountSettings.update
             accountSettingsFactory.create(account, abortOnMissingMigration = true)
         }
@@ -49,7 +49,7 @@ class AccountSettingsTest {
 
     @Test
     fun testUpdate_RunAllMigrations() {
-        TestAccount.provide(version = 6) { account ->
+        TestAccount.provideBlocking(version = 6) { account ->
             // will run AccountSettings.update
             accountSettingsFactory.create(account, abortOnMissingMigration = true)
 

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration17Test.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration17Test.kt
@@ -19,6 +19,7 @@ import at.bitfire.synctools.util.setAndVerifyUserData
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -52,7 +53,7 @@ class AccountSettingsMigration17Test {
 
 
     @Test
-    fun testMigrate_OldAddressBook_CollectionInDB() {
+    fun testMigrate_OldAddressBook_CollectionInDB() = runTest {
         val localAddressBookUserDataUrl = "url"
         TestAccount.provide(version = 16) { account ->
             val accountManager = AccountManager.get(context)

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration18Test.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration18Test.kt
@@ -20,6 +20,7 @@ import io.mockk.every
 import io.mockk.junit4.MockKRule
 import io.mockk.mockkObject
 import io.mockk.verify
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -51,7 +52,7 @@ class AccountSettingsMigration18Test {
 
 
     @Test
-    fun testMigrate_AddressBook_InvalidCollection() {
+    fun testMigrate_AddressBook_InvalidCollection() = runTest {
         val addressBookAccountType = context.getString(R.string.account_type_address_book)
         var addressBookAccount = Account("Address Book", addressBookAccountType)
 
@@ -69,7 +70,7 @@ class AccountSettingsMigration18Test {
     }
 
     @Test
-    fun testMigrate_AddressBook_NoCollection() {
+    fun testMigrate_AddressBook_NoCollection() = runTest {
         val addressBookAccountType = context.getString(R.string.account_type_address_book)
         var addressBookAccount = Account("Address Book", addressBookAccountType)
 
@@ -87,7 +88,7 @@ class AccountSettingsMigration18Test {
     }
 
     @Test
-    fun testMigrate_AddressBook_ValidCollection() {
+    fun testMigrate_AddressBook_ValidCollection() = runTest {
         val account = Account("test", "test")
 
         db.serviceDao().insertOrReplace(Service(

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration19Test.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration19Test.kt
@@ -20,6 +20,7 @@ import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
 import io.mockk.mockkObject
 import io.mockk.verify
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -62,7 +63,7 @@ class AccountSettingsMigration19Test {
 
 
     @Test
-    fun testMigrate_CancelsOldWorkersAndUpdatesAutomaticSync() {
+    fun testMigrate_CancelsOldWorkersAndUpdatesAutomaticSync() = runTest {
         val workManager = WorkManager.getInstance(context)
         mockkObject(workManager)
 

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/account/AccountsCleanupWorkerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/account/AccountsCleanupWorkerTest.kt
@@ -92,7 +92,7 @@ class AccountsCleanupWorkerTest {
 
     @Test
     fun testCleanUpServices_oneAccount() {
-        TestAccount.provide { existingAccount ->
+        TestAccount.provideBlocking { existingAccount ->
             // Insert services, one that reference the existing account and one that references an invalid account
             db.serviceDao().insertOrReplace(Service(id = 1, accountName = existingAccount.name, type = Service.TYPE_CALDAV, principal = null))
             assertNotNull(db.serviceDao().get(1))
@@ -131,7 +131,7 @@ class AccountsCleanupWorkerTest {
 
     @Test
     fun testCleanUpAddressBooks_keepsAddressBookWithAccount() {
-        TestAccount.provide { existingAccount ->
+        TestAccount.provideBlocking { existingAccount ->
             // Create address book account _with_ corresponding account and verify
             val userData = Bundle(2).apply {
                 putString(LocalAddressBook.USER_DATA_ACCOUNT_NAME, existingAccount.name)

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/account/TestAccount.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/account/TestAccount.kt
@@ -55,7 +55,19 @@ object TestAccount {
     /**
      * Convenience method to create a test account and remove it after executing the block.
      */
-    fun provide(version: Int = AccountSettings.CURRENT_VERSION, block: (Account) -> Unit) {
+    fun provideBlocking(version: Int = AccountSettings.CURRENT_VERSION, block: (Account) -> Unit) {
+        val account = create(version)
+        try {
+            block(account)
+        } finally {
+            remove(account)
+        }
+    }
+
+    /**
+     * Convenience method to create a test account and remove it after executing the (suspending) block.
+     */
+    suspend fun provide(version: Int = AccountSettings.CURRENT_VERSION, block: suspend (Account) -> Unit) {
         val account = create(version)
         try {
             block(account)

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettings.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettings.kt
@@ -23,6 +23,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.runBlocking
 import net.openid.appauth.AuthState
 import java.util.Collections
 import java.util.logging.Level
@@ -87,7 +88,9 @@ class AccountSettings @AssistedInject constructor(
                 if (version < CURRENT_VERSION) {
                     currentlyUpdating += account
                     try {
-                        update(version, abortOnMissingMigration)
+                        runBlocking {
+                            update(version, abortOnMissingMigration)
+                        }
                     } finally {
                         currentlyUpdating -= account
                     }
@@ -152,8 +155,7 @@ class AccountSettings @AssistedInject constructor(
             SyncDataType.EVENTS -> KEY_SYNC_INTERVAL_CALENDARS
             SyncDataType.TASKS -> KEY_SYNC_INTERVAL_TASKS
         }
-        val seconds = accountManager.getUserData(account, key)?.toLong()
-        return when (seconds) {
+        return when (val seconds = accountManager.getUserData(account, key)?.toLong()) {
             null -> settingsManager.getLongOrNull(Settings.DEFAULT_SYNC_INTERVAL)   // no setting → default value
             SYNC_INTERVAL_MANUALLY -> null      // manual sync
             else -> seconds
@@ -323,7 +325,7 @@ class AccountSettings @AssistedInject constructor(
 
     // update from previous account settings
 
-    private fun update(baseVersion: Int, abortOnMissingMigration: Boolean) {
+    private suspend fun update(baseVersion: Int, abortOnMissingMigration: Boolean) {
         for (toVersion in baseVersion+1 ..CURRENT_VERSION) {
             val fromVersion = toVersion - 1
             logger.info("Updating account ${account.name} settings version $fromVersion → $toVersion")

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration.kt
@@ -21,6 +21,6 @@ interface AccountSettingsMigration {
      *
      * @param   account          The account to migrate
      */
-    fun migrate(account: Account)
+    suspend fun migrate(account: Account)
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration10.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration10.kt
@@ -35,7 +35,7 @@ class AccountSettingsMigration10 @Inject constructor(
     @ApplicationContext private val context: Context
 ): AccountSettingsMigration {
 
-    override fun migrate(account: Account) {
+    override suspend fun migrate(account: Account) {
         val providerName = TaskProvider.ProviderName.OpenTasks
         TaskProvider.acquireRecentClient(context, providerName)?.use { client ->
             val tasksUri = TaskContract.Tasks.getContentUri(providerName.authority)!!.asSyncAdapter(account)

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration11.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration11.kt
@@ -30,7 +30,7 @@ class AccountSettingsMigration11 @Inject constructor(
     private val tasksAppManager: TasksAppManager
 ): AccountSettingsMigration {
 
-    override fun migrate(account: Account) {
+    override suspend fun migrate(account: Account) {
         val accountManager: AccountManager = AccountManager.get(context)
         tasksAppManager.currentProvider()?.let { provider ->
             val interval = getSyncFrameworkInterval(account, provider.authority)

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration12.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration12.kt
@@ -40,7 +40,7 @@ class AccountSettingsMigration12 @Inject constructor(
     private val logger: Logger
 ): AccountSettingsMigration {
 
-    override fun migrate(account: Account) {
+    override suspend fun migrate(account: Account) {
         if (ContextCompat.checkSelfPermission(context, android.Manifest.permission.WRITE_CALENDAR) == PackageManager.PERMISSION_GRANTED) {
             context.contentResolver.acquireContentProviderClient(CalendarContract.AUTHORITY)?.use { provider ->
                 // Attention: CalendarProvider does NOT limit the results of the ExtendedProperties query

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration13.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration13.kt
@@ -28,7 +28,7 @@ class AccountSettingsMigration13 @Inject constructor(
     @ApplicationContext private val context: Context
 ): AccountSettingsMigration {
 
-    override fun migrate(account: Account) {
+    override suspend fun migrate(account: Account) {
         // proxy settings are managed by SharedPreferencesProvider
         val preferences = PreferenceManager.getDefaultSharedPreferences(context)
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration14.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration14.kt
@@ -27,7 +27,7 @@ class AccountSettingsMigration14 @Inject constructor(
     private val logger: Logger
 ): AccountSettingsMigration {
 
-    override fun migrate(account: Account) {
+    override suspend fun migrate(account: Account) {
         // Cancel any potentially running syncs for this account (sync framework)
         ContentResolver.cancelSync(account, null)
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration15.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration15.kt
@@ -24,7 +24,7 @@ class AccountSettingsMigration15 @Inject constructor(
     private val automaticSyncManager: AutomaticSyncManager
 ): AccountSettingsMigration {
 
-    override fun migrate(account: Account) {
+    override suspend fun migrate(account: Account) {
         automaticSyncManager.updateAutomaticSync(account)
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration16.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration16.kt
@@ -32,7 +32,7 @@ class AccountSettingsMigration16 @Inject constructor(
     private val syncWorkerManager: SyncWorkerManager
 ): AccountSettingsMigration {
 
-    override fun migrate(account: Account) {
+    override suspend fun migrate(account: Account) {
         for (dataType in SyncDataType.entries) {
             logger.info("Re-enqueuing periodic sync workers for $account/$dataType, if necessary")
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration17.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration17.kt
@@ -23,7 +23,6 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntKey
 import dagger.multibindings.IntoMap
-import kotlinx.coroutines.runBlocking
 import java.util.logging.Level
 import java.util.logging.Logger
 import javax.inject.Inject
@@ -42,7 +41,7 @@ class AccountSettingsMigration17 @Inject constructor(
     private val serviceRepository: DavServiceRepository
 ): AccountSettingsMigration {
 
-    override fun migrate(account: Account) {
+    override suspend fun migrate(account: Account) {
         val addressBookAccountType = context.getString(R.string.account_type_address_book)
         try {
             context.contentResolver.acquireContentProviderClient(ContactsContract.AUTHORITY)
@@ -51,42 +50,42 @@ class AccountSettingsMigration17 @Inject constructor(
             logger.log(Level.WARNING, "Missing permissions for contacts authority, won't set collection ID for address books", e)
             null
         }?.use { provider ->
-            runBlocking {
-                val service = serviceRepository.getByAccountAndType(account.name, Service.TYPE_CARDDAV) ?: return@runBlocking
+            val service = serviceRepository.getByAccountAndType(account.name, Service.TYPE_CARDDAV) ?: return@use
 
-                val accountManager = AccountManager.get(context)
-                // Get all old address books of this account, i.e. the ones which have a "real_account_name" of this account.
-                // After this migration is run, address books won't be associated to accounts anymore but only to their respective collection/URL.
-                val oldAddressBookAccounts = accountManager.getAccountsByType(addressBookAccountType)
-                    .filter { addressBookAccount ->
-                        account.name == accountManager.getUserData(addressBookAccount, "real_account_name")
-                    }
+            val accountManager = AccountManager.get(context)
+            // Get all old address books of this account, i.e. the ones which have a "real_account_name" of this account.
+            // After this migration is run, address books won't be associated to accounts anymore but only to their respective collection/URL.
+            val oldAddressBookAccounts = accountManager.getAccountsByType(addressBookAccountType)
+                .filter { addressBookAccount ->
+                    account.name == accountManager.getUserData(addressBookAccount, "real_account_name")
+                }
 
-                val accountSettings = accountSettingsFactory.create(account)
-                val groupMethod = accountSettings.getGroupMethod()
+            val accountSettings = accountSettingsFactory.create(account)
+            val groupMethod = accountSettings.getGroupMethod()
 
-                for (oldAddressBookAccount in oldAddressBookAccounts) {
-                    // Old address books only have a URL, so use it to determine the collection ID
-                    logger.info("Migrating address book ${oldAddressBookAccount.name}")
-                    val oldAddressBook = localAddressBookFactory.create(account, oldAddressBookAccount, provider, groupMethod)
+            for (oldAddressBookAccount in oldAddressBookAccounts) {
+                // Old address books only have a URL, so use it to determine the collection ID
+                logger.info("Migrating address book ${oldAddressBookAccount.name}")
+                val oldAddressBook =
+                    localAddressBookFactory.create(account, oldAddressBookAccount, provider, groupMethod)
 
-                    val url: String? = accountManager.getUserData(oldAddressBookAccount, LOCAL_ADDRESS_BOOK_ACCOUNT_USER_DATA_URL)
-                    if (url == null) {
-                        logger.warning("Address book ${oldAddressBookAccount.name} doesn't have an assigned URL, can't migrate")
-                        continue
-                    }
+                val url: String? =
+                    accountManager.getUserData(oldAddressBookAccount, LOCAL_ADDRESS_BOOK_ACCOUNT_USER_DATA_URL)
+                if (url == null) {
+                    logger.warning("Address book ${oldAddressBookAccount.name} doesn't have an assigned URL, can't migrate")
+                    continue
+                }
 
-                    collectionRepository.getByServiceAndUrl(service.id, url)?.let { collection ->
-                        // Set collection ID and rename the account
-                        localAddressBookStore.update(provider, oldAddressBook, collection)
-                        // The user-data-url is not being set in localAddressBookStore.update() anymore,
-                        // but we need to keep it for the migration
-                        accountManager.setAndVerifyUserData(
-                            oldAddressBook.addressBookAccount,
-                            LOCAL_ADDRESS_BOOK_ACCOUNT_USER_DATA_URL,
-                            collection.url.toString()
-                        )
-                    }
+                collectionRepository.getByServiceAndUrl(service.id, url)?.let { collection ->
+                    // Set collection ID and rename the account
+                    localAddressBookStore.update(provider, oldAddressBook, collection)
+                    // The user-data-url is not being set in localAddressBookStore.update() anymore,
+                    // but we need to keep it for the migration
+                    accountManager.setAndVerifyUserData(
+                        oldAddressBook.addressBookAccount,
+                        LOCAL_ADDRESS_BOOK_ACCOUNT_USER_DATA_URL,
+                        collection.url.toString()
+                    )
                 }
             }
         }

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration18.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration18.kt
@@ -19,7 +19,6 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntKey
 import dagger.multibindings.IntoMap
-import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
 /**
@@ -38,26 +37,32 @@ class AccountSettingsMigration18 @Inject constructor(
     private val db: AppDatabase
 ): AccountSettingsMigration {
 
-    override fun migrate(account: Account) {
+    override suspend fun migrate(account: Account) {
         val accountManager = AccountManager.get(context)
-        runBlocking {
-            db.serviceDao().getByAccountAndType(account.name, Service.TYPE_CARDDAV)?.let { service ->
-                db.collectionDao().getByService(service.id).forEach { collection ->
-                    // Find associated address book account by collection ID (if it exists)
-                    val addressBookAccount = accountManager
-                        .getAccountsByType(context.getString(R.string.account_type_address_book))
-                        .firstOrNull {
-                            accountManager.getUserData(
-                                it,
-                                LocalAddressBook.USER_DATA_COLLECTION_ID
-                            ) == collection.id.toString()
-                        }
-
-                    if (addressBookAccount != null) {
-                        // (Re-)assign address book to account
-                        accountManager.setAndVerifyUserData(addressBookAccount, LocalAddressBook.USER_DATA_ACCOUNT_NAME, account.name)
-                        accountManager.setAndVerifyUserData(addressBookAccount, LocalAddressBook.USER_DATA_ACCOUNT_TYPE, account.type)
+        db.serviceDao().getByAccountAndType(account.name, Service.TYPE_CARDDAV)?.let { service ->
+            db.collectionDao().getByService(service.id).forEach { collection ->
+                // Find associated address book account by collection ID (if it exists)
+                val addressBookAccount = accountManager
+                    .getAccountsByType(context.getString(R.string.account_type_address_book))
+                    .firstOrNull {
+                        accountManager.getUserData(
+                            it,
+                            LocalAddressBook.USER_DATA_COLLECTION_ID
+                        ) == collection.id.toString()
                     }
+
+                if (addressBookAccount != null) {
+                    // (Re-)assign address book to account
+                    accountManager.setAndVerifyUserData(
+                        addressBookAccount,
+                        LocalAddressBook.USER_DATA_ACCOUNT_NAME,
+                        account.name
+                    )
+                    accountManager.setAndVerifyUserData(
+                        addressBookAccount,
+                        LocalAddressBook.USER_DATA_ACCOUNT_TYPE,
+                        account.type
+                    )
                 }
             }
         }

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration19.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration19.kt
@@ -30,7 +30,7 @@ class AccountSettingsMigration19 @Inject constructor(
     private val automaticSyncManager: AutomaticSyncManager
 ): AccountSettingsMigration {
 
-    override fun migrate(account: Account) {
+    override suspend fun migrate(account: Account) {
         // cancel old workers
         val workManager = WorkManager.getInstance(context)
         val authorities = listOf(

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration20.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration20.kt
@@ -27,7 +27,6 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntKey
 import dagger.multibindings.IntoMap
-import kotlinx.coroutines.runBlocking
 import org.dmfs.tasks.contract.TaskContract.TaskLists
 import javax.inject.Inject
 
@@ -50,16 +49,14 @@ class AccountSettingsMigration20 @Inject constructor(
 
     val accountManager = AccountManager.get(context)
 
-    override fun migrate(account: Account) {
-        runBlocking {
-            serviceRepository.getByAccountAndType(account.name, Service.TYPE_CARDDAV)?.let { cardDavService ->
-                migrateAddressBooks(account, cardDavService.id)
-            }
+    override suspend fun migrate(account: Account) {
+        serviceRepository.getByAccountAndType(account.name, Service.TYPE_CARDDAV)?.let { cardDavService ->
+            migrateAddressBooks(account, cardDavService.id)
+        }
 
-            serviceRepository.getByAccountAndType(account.name, Service.TYPE_CALDAV)?.let { calDavService ->
-                migrateCalendars(account, calDavService.id)
-                migrateTaskLists(account, calDavService.id)
-            }
+        serviceRepository.getByAccountAndType(account.name, Service.TYPE_CALDAV)?.let { calDavService ->
+            migrateCalendars(account, calDavService.id)
+            migrateTaskLists(account, calDavService.id)
         }
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration21.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration21.kt
@@ -38,7 +38,7 @@ class AccountSettingsMigration21 @Inject constructor(
     /**
      * Cancel any possibly forever pending account syncs of the different authorities
      */
-    override fun migrate(account: Account) {
+    override suspend fun migrate(account: Account) {
         if (Build.VERSION.SDK_INT >= 34) {
             // Request new dummy syncs (yes, seems like this is needed)
             val extras = Bundle().apply {

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration7.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration7.kt
@@ -24,7 +24,7 @@ class AccountSettingsMigration7 @Inject constructor(
     @ApplicationContext private val context: Context
 ): AccountSettingsMigration {
 
-    override fun migrate(account: Account) {
+    override suspend fun migrate(account: Account) {
         // add calendar colors
         context.contentResolver.acquireContentProviderClient(CalendarContract.AUTHORITY)?.use { client ->
             val provider = AndroidCalendarProvider(account, client)

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration8.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration8.kt
@@ -30,7 +30,7 @@ class AccountSettingsMigration8 @Inject constructor(
      * There is a mistake in this method. [TaskContract.Tasks.SYNC_VERSION] is used to store the
      * SEQUENCE and should not be used for the eTag.
      */
-    override fun migrate(account: Account) {
+    override suspend fun migrate(account: Account) {
         val providerName = TaskProvider.ProviderName.OpenTasks
         TaskProvider.acquireRecentClient(context, providerName)?.use { client ->
             // ETag is now in sync_version instead of sync1

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration9.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration9.kt
@@ -15,7 +15,6 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntKey
 import dagger.multibindings.IntoMap
-import kotlinx.coroutines.runBlocking
 import java.util.logging.Logger
 import javax.inject.Inject
 
@@ -28,7 +27,7 @@ class AccountSettingsMigration9 @Inject constructor(
     private val logger: Logger
 ): AccountSettingsMigration {
 
-    override fun migrate(account: Account) = runBlocking {
+    override suspend fun migrate(account: Account) {
         val hasCalDAV = db.serviceDao().getByAccountAndType(account.name, Service.TYPE_CALDAV) != null
         if (!hasCalDAV && ContentResolver.getIsSyncable(account, TaskProvider.ProviderName.OpenTasks.authority) != 0) {
             logger.info("Disabling OpenTasks sync for $account")


### PR DESCRIPTION
### Purpose

Make database migrations suspendable to support coroutine-based operations.

Bridge/`runBlocking` is now in the synchronized block of the `AccountSettings`.

> [!CAUTION]
> **TODO:** Check architecture and where the `runBlocking` should actually be, and whether `AccountSettingsMigrations` should even be suspending when the `AccountSettings` API is not. Maybe it's better to just wrap the DB calls in runBlocking like we currently do. **Maybe this PR isn't a good idea at all.**

### Short description

- Updated migration logic to support suspend.
- Updated related tests to verify suspendable behavior.

### Checklist

- [ ] The PR has a proper title, description and label.
- [ ] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [ ] I have added documentation to complex functions and functions that can be used by other modules.
- [ ] I have added reasonable tests or consciously decided to not add tests.