### PR TITLE
Unify `StartupPlugin` sync/async calls → `StartupAction.onAppCreate()`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,8 @@ Android library. The sync engine, database layer, and Jetpack Compose UI for DAV
 
 **ViewModel pattern** — Each Compose screen has a `@HiltViewModel` in `ui/`. Keep business logic out of Composables; Composables observe state from the ViewModel.
 
-**Startup plugins** — App-initialization hooks implement the `StartupPlugin` interface and are registered via set-based Hilt injection. Do not add init logic directly to `CoreApp`.
+**Startup actions** — App-initialization hooks implement the `StartupAction` interface and are registered via set-based
+Hilt injection. Do not add init logic directly to `CoreApp`.
 
 **Background sync** — Sync runs in WorkManager workers (`sync/worker/`). The Hilt worker factory wires DI into workers.
 
@@ -49,7 +50,7 @@ sync/         Sync managers (Calendar, Contacts, Tasks, Jtx) and workers, Androi
 network/      HTTP/WebDAV layer (Ktor + OkHttp + dav4jvm)
 webdav/       WebDAV file operations
 ui/           Compose screens, ViewModels, Activities
-startup/      StartupPlugin interface and built-in plugins
+startup/      StartupAction interface and built-in actions
 settings/     Preference management and migrations
 push/         UnifiedPush / FCM integration
 log/          Logging infrastructure

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/di/TestStartupActionsModule.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/di/TestStartupActionsModule.kt
@@ -17,7 +17,7 @@ import dagger.multibindings.Multibinds
 )
 abstract class TestStartupActionsModule {
 
-    // provides empty set of startup plugins so that nothing interferes with tests
+    // provides empty set of startup actions so that nothing interferes with tests
     @Multibinds
     abstract fun empty(): Set<StartupAction>
 

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/di/TestStartupActionsModule.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/di/TestStartupActionsModule.kt
@@ -13,9 +13,9 @@ import dagger.multibindings.Multibinds
 @Module
 @TestInstallIn(
     components = [SingletonComponent::class],
-    replaces = [StartupPluginsModule::class]
+    replaces = [StartupActionsModule::class]
 )
-abstract class TestStartupPluginsModule {
+abstract class TestStartupActionsModule {
 
     // provides empty set of startup plugins so that nothing interferes with tests
     @Multibinds

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/di/TestStartupPluginsModule.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/di/TestStartupPluginsModule.kt
@@ -4,7 +4,7 @@
 
 package at.bitfire.davdroid.di
 
-import at.bitfire.davdroid.startup.StartupPlugin
+import at.bitfire.davdroid.startup.StartupAction
 import dagger.Module
 import dagger.hilt.components.SingletonComponent
 import dagger.hilt.testing.TestInstallIn
@@ -19,6 +19,6 @@ abstract class TestStartupPluginsModule {
 
     // provides empty set of startup plugins so that nothing interferes with tests
     @Multibinds
-    abstract fun empty(): Set<StartupPlugin>
+    abstract fun empty(): Set<StartupAction>
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/CoreApp.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/CoreApp.kt
@@ -45,12 +45,10 @@ abstract class CoreApp: Application() {
         UiUtils.updateTheme(this)   // when this is called in the asynchronous thread below, it recreates
                                  // some current activity and causes an IllegalStateException in rare cases
 
-        // run synchronous startup actions
-        runActions(
-            label = "blocking",
-            priority = StartupAction::priority,
-            run = StartupAction::onAppCreate
-        )
+        // run startup actions synchronously (they launch a coroutine if possible)
+        actions.sortedBy { it.priority }.forEach { action ->
+            logger.fine("Running startup action: $action")
+        }
 
         /* Don't block app startup for some background tasks. A thread is used instead of coroutines
         because neither the scope nor the dispatcher should be set here. There may also be non-suspending
@@ -61,27 +59,6 @@ abstract class CoreApp: Application() {
 
             // create/update app shortcuts
             UiUtils.updateShortcuts(this@CoreApp)
-
-            // run asynchronous startup actions
-            runActions(
-                label = "background",
-                priority = StartupAction::priorityAsync,
-                run = StartupAction::onAppCreateAsync
-            )
-        }
-    }
-
-    /**
-     * Executes startup actions with non-null priority in priority order (lowest number first).
-     *
-     * @param label Descriptive label for logging purposes.
-     * @param priority Function to determine the priority of a [StartupAction].
-     * @param run Function to execute the action.
-     */
-    private fun runActions(label: String, priority: (StartupAction) -> Int?, run: (StartupAction) -> Unit) {
-        actions.filter { priority(it) != null }.sortedBy { priority(it) }.forEach { action ->
-            logger.fine("Running $label startup action: $action")
-            run(action)
         }
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/CoreApp.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/CoreApp.kt
@@ -8,7 +8,7 @@ import android.app.Application
 import androidx.hilt.work.HiltWorkerFactory
 import at.bitfire.davdroid.di.qualifier.IoDispatcher
 import at.bitfire.davdroid.log.LogManager
-import at.bitfire.davdroid.startup.StartupPlugin
+import at.bitfire.davdroid.startup.StartupAction
 import at.bitfire.davdroid.sync.account.AccountsCleanupWorker
 import at.bitfire.davdroid.ui.UiUtils
 import kotlinx.coroutines.CoroutineDispatcher
@@ -38,7 +38,7 @@ abstract class CoreApp: Application() {
     lateinit var ioDispatcher: CoroutineDispatcher
 
     @Inject
-    lateinit var plugins: Set<@JvmSuppressWildcards StartupPlugin>
+    lateinit var plugins: Set<@JvmSuppressWildcards StartupAction>
 
     @Inject
     lateinit var workerFactory: HiltWorkerFactory

--- a/core/src/main/kotlin/at/bitfire/davdroid/CoreApp.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/CoreApp.kt
@@ -6,17 +6,13 @@ package at.bitfire.davdroid
 
 import android.app.Application
 import androidx.hilt.work.HiltWorkerFactory
-import at.bitfire.davdroid.di.qualifier.IoDispatcher
 import at.bitfire.davdroid.log.LogManager
 import at.bitfire.davdroid.startup.StartupAction
 import at.bitfire.davdroid.sync.account.AccountsCleanupWorker
 import at.bitfire.davdroid.ui.UiUtils
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
 import java.util.logging.Logger
 import javax.inject.Inject
+import kotlin.concurrent.thread
 
 /**
  * The actual app should extend this class. The derived class must then be set
@@ -34,11 +30,7 @@ abstract class CoreApp: Application() {
     lateinit var logManager: LogManager
 
     @Inject
-    @IoDispatcher
-    lateinit var ioDispatcher: CoroutineDispatcher
-
-    @Inject
-    lateinit var plugins: Set<@JvmSuppressWildcards StartupAction>
+    lateinit var actions: Set<@JvmSuppressWildcards StartupAction>
 
     @Inject
     lateinit var workerFactory: HiltWorkerFactory
@@ -53,25 +45,26 @@ abstract class CoreApp: Application() {
         UiUtils.updateTheme(this)   // when this is called in the asynchronous thread below, it recreates
                                  // some current activity and causes an IllegalStateException in rare cases
 
-        // run startup plugins (sync)
-        for (plugin in plugins.sortedBy { it.priority() }) {
-            logger.fine("Running startup plugin: $plugin (onAppCreate)")
-            plugin.onAppCreate()
+        // run synchronous startup actions
+        actions.filter { it.priority() != null }.sortedBy { it.priority() }.forEach { action ->
+            logger.fine("Running blocking startup action: $action.onAppCreate()")
+            action.onAppCreate()
         }
 
-        // don't block UI for some background checks
-        @OptIn(DelicateCoroutinesApi::class)
-        GlobalScope.launch(ioDispatcher) {
+        /* Don't block app startup for some background tasks. A thread is used instead of coroutines
+        because neither the scope nor the dispatcher should be set here. There may also be non-suspending
+        actions that may still need some time, like updating dynamic shortcuts etc. */
+        thread {
             // clean up orphaned accounts in DB from time to time
             AccountsCleanupWorker.enable(this@CoreApp)
 
             // create/update app shortcuts
             UiUtils.updateShortcuts(this@CoreApp)
 
-            // run startup plugins (async)
-            for (plugin in plugins.sortedBy { it.priorityAsync() }) {
-                logger.fine("Running startup plugin: $plugin (onAppCreateAsync)")
-                plugin.onAppCreateAsync()
+            // run asynchronous startup actions
+            actions.filter { it.priorityAsync() != null }.sortedBy { it.priorityAsync() }.forEach { action ->
+                logger.fine("Running background startup action: $action.onAppCreateAsync()")
+                action.onAppCreateAsync()
             }
         }
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/CoreApp.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/CoreApp.kt
@@ -46,10 +46,11 @@ abstract class CoreApp: Application() {
                                  // some current activity and causes an IllegalStateException in rare cases
 
         // run synchronous startup actions
-        actions.filter { it.priority() != null }.sortedBy { it.priority() }.forEach { action ->
-            logger.fine("Running blocking startup action: $action.onAppCreate()")
-            action.onAppCreate()
-        }
+        runActions(
+            label = "blocking",
+            priority = StartupAction::priority,
+            run = StartupAction::onAppCreate
+        )
 
         /* Don't block app startup for some background tasks. A thread is used instead of coroutines
         because neither the scope nor the dispatcher should be set here. There may also be non-suspending
@@ -62,10 +63,25 @@ abstract class CoreApp: Application() {
             UiUtils.updateShortcuts(this@CoreApp)
 
             // run asynchronous startup actions
-            actions.filter { it.priorityAsync() != null }.sortedBy { it.priorityAsync() }.forEach { action ->
-                logger.fine("Running background startup action: $action.onAppCreateAsync()")
-                action.onAppCreateAsync()
-            }
+            runActions(
+                label = "background",
+                priority = StartupAction::priorityAsync,
+                run = StartupAction::onAppCreateAsync
+            )
+        }
+    }
+
+    /**
+     * Executes startup actions with non-null priority in priority order (lowest number first).
+     *
+     * @param label Descriptive label for logging purposes.
+     * @param priority Function to determine the priority of a [StartupAction].
+     * @param run Function to execute the action.
+     */
+    private fun runActions(label: String, priority: (StartupAction) -> Int?, run: (StartupAction) -> Unit) {
+        actions.filter { priority(it) != null }.sortedBy { priority(it) }.forEach { action ->
+            logger.fine("Running $label startup action: $action")
+            run(action)
         }
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/CoreApp.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/CoreApp.kt
@@ -8,11 +8,8 @@ import android.app.Application
 import androidx.hilt.work.HiltWorkerFactory
 import at.bitfire.davdroid.log.LogManager
 import at.bitfire.davdroid.startup.StartupAction
-import at.bitfire.davdroid.sync.account.AccountsCleanupWorker
-import at.bitfire.davdroid.ui.UiUtils
 import java.util.logging.Logger
 import javax.inject.Inject
-import kotlin.concurrent.thread
 
 /**
  * The actual app should extend this class. The derived class must then be set
@@ -41,24 +38,10 @@ abstract class CoreApp: Application() {
 
         logger.fine("Logging using LogManager $logManager")
 
-        // set light/dark mode
-        UiUtils.updateTheme(this)   // when this is called in the asynchronous thread below, it recreates
-                                 // some current activity and causes an IllegalStateException in rare cases
-
         // run startup actions synchronously (they launch a coroutine if possible)
         actions.sortedBy { it.priority }.forEach { action ->
             logger.fine("Running startup action: $action")
-        }
-
-        /* Don't block app startup for some background tasks. A thread is used instead of coroutines
-        because neither the scope nor the dispatcher should be set here. There may also be non-suspending
-        actions that may still need some time, like updating dynamic shortcuts etc. */
-        thread {
-            // clean up orphaned accounts in DB from time to time
-            AccountsCleanupWorker.enable(this@CoreApp)
-
-            // create/update app shortcuts
-            UiUtils.updateShortcuts(this@CoreApp)
+            action.onAppCreate()
         }
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/di/CoroutineScopesModule.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/di/CoroutineScopesModule.kt
@@ -21,6 +21,6 @@ class CoroutineScopesModule {
     @Singleton
     @Provides
     @ApplicationScope
-    fun applicationScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    fun applicationScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/di/StartupActionsModule.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/di/StartupActionsModule.kt
@@ -4,8 +4,12 @@
 
 package at.bitfire.davdroid.di
 
+import at.bitfire.davdroid.startup.AppCompatThemeSetup
 import at.bitfire.davdroid.startup.CrashHandlerSetup
+import at.bitfire.davdroid.startup.DynamicShortcutsAction
+import at.bitfire.davdroid.startup.EnableAccountsCleanupAction
 import at.bitfire.davdroid.startup.StartupAction
+import at.bitfire.davdroid.startup.StrictModeSetup
 import at.bitfire.davdroid.startup.TasksAppWatcher
 import dagger.Binds
 import dagger.Module
@@ -19,7 +23,23 @@ interface StartupActionsModule {
 
     @Binds
     @IntoSet
+    fun appCompatThemeSetup(impl: AppCompatThemeSetup): StartupAction
+
+    @Binds
+    @IntoSet
     fun crashHandlerSetup(impl: CrashHandlerSetup): StartupAction
+
+    @Binds
+    @IntoSet
+    fun dynamicShortcutsAction(impl: DynamicShortcutsAction): StartupAction
+
+    @Binds
+    @IntoSet
+    fun enableAccountsCleanupAction(impl: EnableAccountsCleanupAction): StartupAction
+
+    @Binds
+    @IntoSet
+    fun strictModeSetup(impl: StrictModeSetup): StartupAction
 
     @Binds
     @IntoSet

--- a/core/src/main/kotlin/at/bitfire/davdroid/di/StartupActionsModule.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/di/StartupActionsModule.kt
@@ -15,7 +15,7 @@ import dagger.multibindings.IntoSet
 
 @Module
 @InstallIn(SingletonComponent::class)
-interface StartupPluginsModule {
+interface StartupActionsModule {
 
     @Binds
     @IntoSet

--- a/core/src/main/kotlin/at/bitfire/davdroid/di/StartupPluginsModule.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/di/StartupPluginsModule.kt
@@ -5,7 +5,7 @@
 package at.bitfire.davdroid.di
 
 import at.bitfire.davdroid.startup.CrashHandlerSetup
-import at.bitfire.davdroid.startup.StartupPlugin
+import at.bitfire.davdroid.startup.StartupAction
 import at.bitfire.davdroid.startup.TasksAppWatcher
 import dagger.Binds
 import dagger.Module
@@ -19,10 +19,10 @@ interface StartupPluginsModule {
 
     @Binds
     @IntoSet
-    fun crashHandlerSetup(impl: CrashHandlerSetup): StartupPlugin
+    fun crashHandlerSetup(impl: CrashHandlerSetup): StartupAction
 
     @Binds
     @IntoSet
-    fun tasksAppWatcher(impl: TasksAppWatcher): StartupPlugin
+    fun tasksAppWatcher(impl: TasksAppWatcher): StartupAction
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/di/qualifier/CoroutineQualifiers.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/di/qualifier/CoroutineQualifiers.kt
@@ -11,10 +11,6 @@ import javax.inject.Qualifier
 
 /**
  * A [kotlinx.coroutines.CoroutineScope] that lives for as long as the application process.
- *
- * Its default dispatcher is only a safe fallback (off the main thread) — callers must choose
- * their own dispatcher explicitly when calling `.launch(...)` on it instead of relying on that
- * default.
  */
 @Retention(AnnotationRetention.RUNTIME)
 @Qualifier

--- a/core/src/main/kotlin/at/bitfire/davdroid/di/qualifier/CoroutineQualifiers.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/di/qualifier/CoroutineQualifiers.kt
@@ -9,6 +9,13 @@ import javax.inject.Qualifier
 
 // CoroutineScope qualifiers
 
+/**
+ * A [kotlinx.coroutines.CoroutineScope] that lives for as long as the application process.
+ *
+ * Its default dispatcher is only a safe fallback (off the main thread) — callers must choose
+ * their own dispatcher explicitly when calling `.launch(...)` on it instead of relying on that
+ * default.
+ */
 @Retention(AnnotationRetention.RUNTIME)
 @Qualifier
 annotation class ApplicationScope

--- a/core/src/main/kotlin/at/bitfire/davdroid/push/UnifiedPushService.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/push/UnifiedPushService.kt
@@ -5,8 +5,10 @@
 package at.bitfire.davdroid.push
 
 import at.bitfire.davdroid.di.qualifier.ApplicationScope
+import at.bitfire.davdroid.di.qualifier.IoDispatcher
 import dagger.Lazy
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.unifiedpush.android.connector.FailedReason
@@ -33,6 +35,9 @@ class UnifiedPushService : PushService() {
     @ApplicationScope
     lateinit var applicationScope: CoroutineScope
 
+    @IoDispatcher
+    lateinit var ioDispatcher: CoroutineDispatcher
+
     @Inject
     lateinit var logger: Logger
 
@@ -48,7 +53,7 @@ class UnifiedPushService : PushService() {
         logger.log(Level.INFO, "Got UnifiedPush endpoint {0} for service {1}", arrayOf<Any>(endpoint.url, serviceId))
 
         // register new endpoint at CalDAV/CardDAV servers
-        applicationScope.launch {
+        applicationScope.launch(ioDispatcher) {
             pushRegistrationManager.get().processSubscription(serviceId, endpoint)
         }
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/push/UnifiedPushService.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/push/UnifiedPushService.kt
@@ -35,6 +35,7 @@ class UnifiedPushService : PushService() {
     @ApplicationScope
     lateinit var applicationScope: CoroutineScope
 
+    @Inject
     @IoDispatcher
     lateinit var ioDispatcher: CoroutineDispatcher
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/push/UnifiedPushService.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/push/UnifiedPushService.kt
@@ -5,10 +5,8 @@
 package at.bitfire.davdroid.push
 
 import at.bitfire.davdroid.di.qualifier.ApplicationScope
-import at.bitfire.davdroid.di.qualifier.IoDispatcher
 import dagger.Lazy
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.unifiedpush.android.connector.FailedReason
@@ -36,10 +34,6 @@ class UnifiedPushService : PushService() {
     lateinit var applicationScope: CoroutineScope
 
     @Inject
-    @IoDispatcher
-    lateinit var ioDispatcher: CoroutineDispatcher
-
-    @Inject
     lateinit var logger: Logger
 
     @Inject
@@ -54,7 +48,7 @@ class UnifiedPushService : PushService() {
         logger.log(Level.INFO, "Got UnifiedPush endpoint {0} for service {1}", arrayOf<Any>(endpoint.url, serviceId))
 
         // register new endpoint at CalDAV/CardDAV servers
-        applicationScope.launch(ioDispatcher) {
+        applicationScope.launch {
             pushRegistrationManager.get().processSubscription(serviceId, endpoint)
         }
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/startup/AppCompatThemeSetup.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/startup/AppCompatThemeSetup.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.startup
+
+import android.content.Context
+import at.bitfire.davdroid.startup.StartupAction.Companion.PRIORITY_DEFAULT
+import at.bitfire.davdroid.ui.UiUtils
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+/**
+ * Sets the light/dark mode according to the current settings.
+ *
+ * Must run synchronously on the main thread: when called from a background thread, it may
+ * recreate the current activity and cause an [IllegalStateException] in rare cases.
+ */
+class AppCompatThemeSetup @Inject constructor(
+    @ApplicationContext private val context: Context
+) : StartupAction {
+
+    override val priority = PRIORITY_DEFAULT
+
+    override fun onAppCreate() {
+        UiUtils.updateTheme(context)
+    }
+
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/startup/CrashHandlerSetup.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/startup/CrashHandlerSetup.kt
@@ -8,8 +8,8 @@ import android.content.Context
 import android.os.Build
 import android.os.StrictMode
 import at.bitfire.davdroid.BuildConfig
-import at.bitfire.davdroid.startup.StartupPlugin.Companion.PRIORITY_DEFAULT
-import at.bitfire.davdroid.startup.StartupPlugin.Companion.PRIORITY_HIGHEST
+import at.bitfire.davdroid.startup.StartupAction.Companion.PRIORITY_DEFAULT
+import at.bitfire.davdroid.startup.StartupAction.Companion.PRIORITY_HIGHEST
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.util.Optional
 import java.util.logging.Logger
@@ -23,7 +23,7 @@ class CrashHandlerSetup @Inject constructor(
     @ApplicationContext private val context: Context,
     private val logger: Logger,
     private val crashHandler: Optional<Thread.UncaughtExceptionHandler>
-): StartupPlugin {
+) : StartupAction {
 
     override fun onAppCreate() {
         if (BuildConfig.DEBUG) {

--- a/core/src/main/kotlin/at/bitfire/davdroid/startup/CrashHandlerSetup.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/startup/CrashHandlerSetup.kt
@@ -17,8 +17,8 @@ import kotlin.jvm.optionals.getOrNull
  * Sets up the uncaught exception (crash) handler and enables StrictMode in debug builds.
  */
 class CrashHandlerSetup @Inject constructor(
-    private val logger: Logger,
-    private val crashHandler: Optional<Thread.UncaughtExceptionHandler>
+    private val crashHandler: Optional<Thread.UncaughtExceptionHandler>,
+    private val logger: Logger
 ) : StartupAction {
 
     override fun priority() = PRIORITY_FIRST

--- a/core/src/main/kotlin/at/bitfire/davdroid/startup/CrashHandlerSetup.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/startup/CrashHandlerSetup.kt
@@ -4,13 +4,10 @@
 
 package at.bitfire.davdroid.startup
 
-import android.content.Context
 import android.os.Build
 import android.os.StrictMode
 import at.bitfire.davdroid.BuildConfig
-import at.bitfire.davdroid.startup.StartupAction.Companion.PRIORITY_DEFAULT
-import at.bitfire.davdroid.startup.StartupAction.Companion.PRIORITY_HIGHEST
-import dagger.hilt.android.qualifiers.ApplicationContext
+import at.bitfire.davdroid.startup.StartupAction.Companion.PRIORITY_LAST
 import java.util.Optional
 import java.util.logging.Logger
 import javax.inject.Inject
@@ -20,10 +17,11 @@ import kotlin.jvm.optionals.getOrNull
  * Sets up the uncaught exception (crash) handler and enables StrictMode in debug builds.
  */
 class CrashHandlerSetup @Inject constructor(
-    @ApplicationContext private val context: Context,
     private val logger: Logger,
     private val crashHandler: Optional<Thread.UncaughtExceptionHandler>
 ) : StartupAction {
+
+    override fun priority() = PRIORITY_LAST
 
     override fun onAppCreate() {
         if (BuildConfig.DEBUG) {
@@ -60,12 +58,5 @@ class CrashHandlerSetup @Inject constructor(
                 logger.info("Using default uncaught exception handler")
         }
    }
-
-    override fun priority() = PRIORITY_HIGHEST
-
-    override suspend fun onAppCreateAsync() {
-    }
-
-    override fun priorityAsync(): Int = PRIORITY_DEFAULT
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/startup/CrashHandlerSetup.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/startup/CrashHandlerSetup.kt
@@ -7,7 +7,7 @@ package at.bitfire.davdroid.startup
 import android.os.Build
 import android.os.StrictMode
 import at.bitfire.davdroid.BuildConfig
-import at.bitfire.davdroid.startup.StartupAction.Companion.PRIORITY_LAST
+import at.bitfire.davdroid.startup.StartupAction.Companion.PRIORITY_FIRST
 import java.util.Optional
 import java.util.logging.Logger
 import javax.inject.Inject
@@ -21,7 +21,7 @@ class CrashHandlerSetup @Inject constructor(
     private val crashHandler: Optional<Thread.UncaughtExceptionHandler>
 ) : StartupAction {
 
-    override fun priority() = PRIORITY_LAST
+    override fun priority() = PRIORITY_FIRST
 
     override fun onAppCreate() {
         if (BuildConfig.DEBUG) {

--- a/core/src/main/kotlin/at/bitfire/davdroid/startup/CrashHandlerSetup.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/startup/CrashHandlerSetup.kt
@@ -21,7 +21,7 @@ class CrashHandlerSetup @Inject constructor(
     private val logger: Logger
 ) : StartupAction {
 
-    override fun priority() = PRIORITY_FIRST
+    override val priority = PRIORITY_FIRST
 
     override fun onAppCreate() {
         if (BuildConfig.DEBUG) {

--- a/core/src/main/kotlin/at/bitfire/davdroid/startup/CrashHandlerSetup.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/startup/CrashHandlerSetup.kt
@@ -4,8 +4,6 @@
 
 package at.bitfire.davdroid.startup
 
-import android.os.Build
-import android.os.StrictMode
 import at.bitfire.davdroid.BuildConfig
 import at.bitfire.davdroid.startup.StartupAction.Companion.PRIORITY_FIRST
 import java.util.Optional
@@ -14,7 +12,7 @@ import javax.inject.Inject
 import kotlin.jvm.optionals.getOrNull
 
 /**
- * Sets up the uncaught exception (crash) handler and enables StrictMode in debug builds.
+ * Sets up the uncaught exception (crash) handler in release builds.
  */
 class CrashHandlerSetup @Inject constructor(
     private val crashHandler: Optional<Thread.UncaughtExceptionHandler>,
@@ -24,39 +22,16 @@ class CrashHandlerSetup @Inject constructor(
     override val priority = PRIORITY_FIRST
 
     override fun onAppCreate() {
-        if (BuildConfig.DEBUG) {
-            logger.info("Debug build, enabling StrictMode with logging")
+        // we don't need this for debugging because we can observe crashes directly then
+        if (BuildConfig.DEBUG)
+            return
 
-            StrictMode.setThreadPolicy(
-                StrictMode.ThreadPolicy.Builder()
-                    .detectAll()
-                    .penaltyLog()
-                    .build()
-            )
-
-            val builder = StrictMode.VmPolicy.Builder()     // don't use detectAll() because it causes "untagged socket" warnings
-                .detectActivityLeaks()
-                .detectFileUriExposure()
-                .detectLeakedClosableObjects()
-                .detectLeakedRegistrationObjects()
-                .detectLeakedSqlLiteObjects()
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-                builder.detectContentUriWithoutPermission()
-            /*if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)   // often triggered by Conscrypt
-               builder.detectNonSdkApiUsage()*/
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
-                builder.detectUnsafeIntentLaunch()
-            StrictMode.setVmPolicy(builder.penaltyLog().build())
-
-        } else {
-            // release build
-            val handler = crashHandler.getOrNull()
-            if (handler != null) {
-                logger.info("Setting uncaught exception handler: ${handler.javaClass.name}")
-                Thread.setDefaultUncaughtExceptionHandler(handler)
-            } else
-                logger.info("Using default uncaught exception handler")
-        }
+        val handler = crashHandler.getOrNull()
+        if (handler != null) {
+            logger.info("Setting uncaught exception handler: ${handler.javaClass.name}")
+            Thread.setDefaultUncaughtExceptionHandler(handler)
+        } else
+            logger.info("Using default uncaught exception handler")
    }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/startup/DynamicShortcutsAction.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/startup/DynamicShortcutsAction.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.startup
+
+import android.content.Context
+import at.bitfire.davdroid.di.qualifier.ApplicationScope
+import at.bitfire.davdroid.di.qualifier.IoDispatcher
+import at.bitfire.davdroid.startup.StartupAction.Companion.PRIORITY_LAST
+import at.bitfire.davdroid.ui.UiUtils
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Creates/updates the app's dynamic shortcuts.
+ */
+class DynamicShortcutsAction @Inject constructor(
+    @ApplicationScope private val applicationScope: CoroutineScope,
+    @ApplicationContext private val context: Context,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+) : StartupAction {
+
+    override val priority = PRIORITY_LAST
+
+    override fun onAppCreate() {
+        applicationScope.launch(ioDispatcher) {
+            UiUtils.updateShortcuts(context)
+        }
+    }
+
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/startup/EnableAccountsCleanupAction.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/startup/EnableAccountsCleanupAction.kt
@@ -5,31 +5,22 @@
 package at.bitfire.davdroid.startup
 
 import android.content.Context
-import at.bitfire.davdroid.di.qualifier.ApplicationScope
-import at.bitfire.davdroid.di.qualifier.IoDispatcher
 import at.bitfire.davdroid.startup.StartupAction.Companion.PRIORITY_LAST
 import at.bitfire.davdroid.sync.account.AccountsCleanupWorker
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
  * Enables periodic work that cleans up orphaned accounts in the database.
  */
 class EnableAccountsCleanupAction @Inject constructor(
-    @ApplicationScope private val applicationScope: CoroutineScope,
-    @ApplicationContext private val context: Context,
-    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+    @ApplicationContext private val context: Context
 ) : StartupAction {
 
     override val priority = PRIORITY_LAST
 
     override fun onAppCreate() {
-        applicationScope.launch(ioDispatcher) {
-            AccountsCleanupWorker.enable(context)
-        }
+        AccountsCleanupWorker.enable(context)
     }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/startup/EnableAccountsCleanupAction.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/startup/EnableAccountsCleanupAction.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.startup
+
+import android.content.Context
+import at.bitfire.davdroid.di.qualifier.ApplicationScope
+import at.bitfire.davdroid.di.qualifier.IoDispatcher
+import at.bitfire.davdroid.startup.StartupAction.Companion.PRIORITY_LAST
+import at.bitfire.davdroid.sync.account.AccountsCleanupWorker
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Enables periodic work that cleans up orphaned accounts in the database.
+ */
+class EnableAccountsCleanupAction @Inject constructor(
+    @ApplicationScope private val applicationScope: CoroutineScope,
+    @ApplicationContext private val context: Context,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+) : StartupAction {
+
+    override val priority = PRIORITY_LAST
+
+    override fun onAppCreate() {
+        applicationScope.launch(ioDispatcher) {
+            AccountsCleanupWorker.enable(context)
+        }
+    }
+
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/startup/StartupAction.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/startup/StartupAction.kt
@@ -12,7 +12,7 @@ interface StartupAction {
     }
 
     /**
-     * Priority of this plugin's [onAppCreate]. Lower values are executed first.
+     * Priority of this action's [onAppCreate]. Lower values are executed first.
      * `null` if this action has no synchronous startup work.
      */
     fun priority(): Int? = null
@@ -31,7 +31,7 @@ interface StartupAction {
     }
 
     /**
-     * Priority of this plugin's [onAppCreateAsync]. Lower values are executed first.
+     * Priority of this action's [onAppCreateAsync]. Lower values are executed first.
      * `null` if this action has no asynchronous startup work.
      */
     fun priorityAsync(): Int? = null

--- a/core/src/main/kotlin/at/bitfire/davdroid/startup/StartupAction.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/startup/StartupAction.kt
@@ -7,8 +7,8 @@ package at.bitfire.davdroid.startup
 interface StartupAction {
 
     companion object {
+        const val PRIORITY_FIRST = 0
         const val PRIORITY_DEFAULT = 100
-        const val PRIORITY_LAST = 1000
     }
 
     /**

--- a/core/src/main/kotlin/at/bitfire/davdroid/startup/StartupAction.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/startup/StartupAction.kt
@@ -15,7 +15,7 @@ interface StartupAction {
      * Priority of this action's [onAppCreate]. Lower values are executed first.
      * `null` if this action has no synchronous startup work.
      */
-    fun priority(): Int? = null
+    val priority: Int? get() = null
 
     /**
      * Synchronous startup action that will be run during [at.bitfire.davdroid.CoreApp.onCreate]
@@ -34,7 +34,8 @@ interface StartupAction {
      * Priority of this action's [onAppCreateAsync]. Lower values are executed first.
      * `null` if this action has no asynchronous startup work.
      */
-    fun priorityAsync(): Int? = null
+    val priorityAsync: Int?
+        get() = null
 
     /**
      * Runs on a background thread after [at.bitfire.davdroid.CoreApp.onCreate]. Use for startup tasks that

--- a/core/src/main/kotlin/at/bitfire/davdroid/startup/StartupAction.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/startup/StartupAction.kt
@@ -14,9 +14,8 @@ interface StartupAction {
 
     /**
      * Priority of this action's [onAppCreate]. Lower values are executed first.
-     * `null` if this action has no synchronous startup work.
      */
-    val priority: Int?
+    val priority: Int
 
     /**
      * Run during [at.bitfire.davdroid.CoreApp.onCreate].

--- a/core/src/main/kotlin/at/bitfire/davdroid/startup/StartupAction.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/startup/StartupAction.kt
@@ -8,37 +8,48 @@ interface StartupAction {
 
     companion object {
         const val PRIORITY_DEFAULT = 100
-        const val PRIORITY_HIGHEST = 0
+        const val PRIORITY_LAST = 1000
     }
 
     /**
-     * Runs synchronously during [at.bitfire.davdroid.CoreApp.onCreate]. Use only for tasks that must be completed before
-     * the app can run. Causes the app to start slower.
-     *
-     * Will be run before [onAppCreateAsync].
-     */
-    fun onAppCreate()
-
-    /**
      * Priority of this plugin's [onAppCreate]. Lower values are executed first.
+     * `null` if this action has no synchronous startup work.
      */
-    fun priority(): Int
-
+    fun priority(): Int? = null
 
     /**
-     * Runs asynchronously after [at.bitfire.davdroid.CoreApp.onCreate]. Use for tasks that can be run in the background.
+     * Synchronous startup action that will be run during [at.bitfire.davdroid.CoreApp.onCreate]
+     * and before [onAppCreateAsync].
      *
-     * Will be run after [onAppCreate].
+     * Will only be run when [priority] is not null (see there for order of execution).
      *
-     * The coroutine scope will usually be `GlobalScope` (which has no end because we don't get
-     * a signal before the app is terminated) on the default dispatcher, but can be a custom scope
-     * for testing.
+     * **Must only be used for tasks that must be completed before the app
+     * can run. Causes the app to start slower.**
      */
-    suspend fun onAppCreateAsync()
+    fun onAppCreate() {
+        // default implementation is empty so that implementations don't have to override it
+    }
 
     /**
      * Priority of this plugin's [onAppCreateAsync]. Lower values are executed first.
+     * `null` if this action has no asynchronous startup work.
      */
-    fun priorityAsync(): Int
+    fun priorityAsync(): Int? = null
+
+    /**
+     * Runs on a background thread after [at.bitfire.davdroid.CoreApp.onCreate]. Use for startup tasks that
+     * don't need to complete before the app can run.
+     *
+     * Will be run in a separate thread that is launched at the end of [at.bitfire.davdroid.CoreApp.onCreate].
+     *
+     * Will only be run if [priorityAsync] is not null (see there for order of execution).
+     *
+     * If the action uses coroutines, it shall choose its scope (like
+     * [at.bitfire.davdroid.di.qualifier.ApplicationScope]) and dispatcher explicitly, so this method
+     * is non-suspending.
+     */
+    fun onAppCreateAsync() {
+        // default implementation is empty so that implementations don't have to override it
+    }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/startup/StartupAction.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/startup/StartupAction.kt
@@ -15,42 +15,19 @@ interface StartupAction {
      * Priority of this action's [onAppCreate]. Lower values are executed first.
      * `null` if this action has no synchronous startup work.
      */
-    val priority: Int? get() = null
+    val priority: Int?
 
     /**
-     * Synchronous startup action that will be run during [at.bitfire.davdroid.CoreApp.onCreate]
-     * and before [onAppCreateAsync].
+     * Run during [at.bitfire.davdroid.CoreApp.onCreate].
      *
-     * Will only be run when [priority] is not null (see there for order of execution).
+     * Keep the runtime of this method at a minimum; it directly increases app startup
+     * time which is a critical measure.
      *
-     * **Must only be used for tasks that must be completed before the app
-     * can run. Causes the app to start slower.**
+     * If ever possible, implementations should do work asynchronously by launching a
+     * coroutine in [at.bitfire.davdroid.di.qualifier.ApplicationScope] and doing it there.
+     * (Don't forget to off-load blocking code to the I/O dispatcher.)
      */
-    fun onAppCreate() {
-        // default implementation is empty so that implementations don't have to override it
-    }
+    fun onAppCreate()
 
-    /**
-     * Priority of this action's [onAppCreateAsync]. Lower values are executed first.
-     * `null` if this action has no asynchronous startup work.
-     */
-    val priorityAsync: Int?
-        get() = null
-
-    /**
-     * Runs on a background thread after [at.bitfire.davdroid.CoreApp.onCreate]. Use for startup tasks that
-     * don't need to complete before the app can run.
-     *
-     * Will be run in a separate thread that is launched at the end of [at.bitfire.davdroid.CoreApp.onCreate].
-     *
-     * Will only be run if [priorityAsync] is not null (see there for order of execution).
-     *
-     * If the action uses coroutines, it shall choose its scope (like
-     * [at.bitfire.davdroid.di.qualifier.ApplicationScope]) and dispatcher explicitly, so this method
-     * is non-suspending.
-     */
-    fun onAppCreateAsync() {
-        // default implementation is empty so that implementations don't have to override it
-    }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/startup/StartupAction.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/startup/StartupAction.kt
@@ -9,6 +9,7 @@ interface StartupAction {
     companion object {
         const val PRIORITY_FIRST = 0
         const val PRIORITY_DEFAULT = 100
+        const val PRIORITY_LAST = 1000
     }
 
     /**

--- a/core/src/main/kotlin/at/bitfire/davdroid/startup/StartupAction.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/startup/StartupAction.kt
@@ -4,7 +4,7 @@
 
 package at.bitfire.davdroid.startup
 
-interface StartupPlugin {
+interface StartupAction {
 
     companion object {
         const val PRIORITY_DEFAULT = 100

--- a/core/src/main/kotlin/at/bitfire/davdroid/startup/StrictModeSetup.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/startup/StrictModeSetup.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.startup
+
+import android.os.Build
+import android.os.StrictMode
+import at.bitfire.davdroid.BuildConfig
+import at.bitfire.davdroid.startup.StartupAction.Companion.PRIORITY_FIRST
+import java.util.logging.Logger
+import javax.inject.Inject
+
+/**
+ * Enables StrictMode in debug builds.
+ */
+class StrictModeSetup @Inject constructor(
+    private val logger: Logger
+) : StartupAction {
+
+    override val priority = PRIORITY_FIRST
+
+    override fun onAppCreate() {
+        if (!BuildConfig.DEBUG)
+            return
+
+        logger.info("Debug build, enabling StrictMode with logging")
+
+        StrictMode.setThreadPolicy(
+            StrictMode.ThreadPolicy.Builder()
+                .detectAll()
+                .penaltyLog()
+                .build()
+        )
+
+        val builder =
+            StrictMode.VmPolicy.Builder()     // don't use detectAll() because it causes "untagged socket" warnings
+                .detectActivityLeaks()
+                .detectFileUriExposure()
+                .detectLeakedClosableObjects()
+                .detectLeakedRegistrationObjects()
+                .detectLeakedSqlLiteObjects()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+            builder.detectContentUriWithoutPermission()
+        /*if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)   // often triggered by Conscrypt
+           builder.detectNonSdkApiUsage()*/
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
+            builder.detectUnsafeIntentLaunch()
+        StrictMode.setVmPolicy(builder.penaltyLog().build())
+    }
+
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/startup/TasksAppWatcher.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/startup/TasksAppWatcher.kt
@@ -5,6 +5,7 @@
 package at.bitfire.davdroid.startup
 
 import android.content.Context
+import androidx.annotation.WorkerThread
 import at.bitfire.davdroid.di.qualifier.ApplicationScope
 import at.bitfire.davdroid.di.qualifier.IoDispatcher
 import at.bitfire.davdroid.startup.StartupAction.Companion.PRIORITY_DEFAULT
@@ -15,6 +16,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.util.logging.Logger
 import javax.inject.Inject
 import javax.inject.Provider
@@ -31,18 +33,20 @@ class TasksAppWatcher @Inject constructor(
     private val tasksAppManager: Provider<TasksAppManager>
 ) : StartupAction {
 
-    override val priorityAsync = PRIORITY_DEFAULT
+    override val priority = PRIORITY_DEFAULT
 
-    override fun onAppCreateAsync() {
+    override fun onAppCreate() {
         logger.info("Watching for package changes in order to detect tasks app changes")
         applicationScope.launch(ioDispatcher) {
             packageChangedFlow(context).collect {
-                onPackageChanged()
+                withContext(ioDispatcher) {
+                    onPackageChanged()
+                }
             }
         }
     }
 
-
+    @WorkerThread
     private fun onPackageChanged() {
         val manager = tasksAppManager.get()
         val currentProvider = manager.currentProvider()
@@ -50,7 +54,7 @@ class TasksAppWatcher @Inject constructor(
 
         if (currentProvider == null) {
             // Iterate through all supported providers and select one, if available.
-            var newProvider = TaskProvider.ProviderName.entries
+            val newProvider = TaskProvider.ProviderName.entries
                 .firstOrNull { provider ->
                     context.packageManager.resolveContentProvider(provider.authority, 0) != null
                 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/startup/TasksAppWatcher.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/startup/TasksAppWatcher.kt
@@ -37,7 +37,7 @@ class TasksAppWatcher @Inject constructor(
 
     override fun onAppCreate() {
         logger.info("Watching for package changes in order to detect tasks app changes")
-        applicationScope.launch(ioDispatcher) {
+        applicationScope.launch {
             packageChangedFlow(context).collect {
                 withContext(ioDispatcher) {
                     onPackageChanged()

--- a/core/src/main/kotlin/at/bitfire/davdroid/startup/TasksAppWatcher.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/startup/TasksAppWatcher.kt
@@ -6,11 +6,13 @@ package at.bitfire.davdroid.startup
 
 import android.content.Context
 import at.bitfire.davdroid.di.qualifier.ApplicationScope
+import at.bitfire.davdroid.di.qualifier.IoDispatcher
 import at.bitfire.davdroid.startup.StartupAction.Companion.PRIORITY_DEFAULT
 import at.bitfire.davdroid.sync.TasksAppManager
 import at.bitfire.davdroid.util.packageChangedFlow
 import at.bitfire.synctools.storage.TaskProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import java.util.logging.Logger
@@ -24,6 +26,7 @@ import javax.inject.Provider
 class TasksAppWatcher @Inject constructor(
     @ApplicationScope private val applicationScope: CoroutineScope,
     @ApplicationContext private val context: Context,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     private val logger: Logger,
     private val tasksAppManager: Provider<TasksAppManager>
 ) : StartupAction {
@@ -31,8 +34,8 @@ class TasksAppWatcher @Inject constructor(
     override fun priorityAsync() = PRIORITY_DEFAULT
 
     override fun onAppCreateAsync() {
-        applicationScope.launch {
-            logger.info("Watching for package changes in order to detect tasks app changes")
+        logger.info("Watching for package changes in order to detect tasks app changes")
+        applicationScope.launch(ioDispatcher) {
             packageChangedFlow(context).collect {
                 onPackageChanged()
             }

--- a/core/src/main/kotlin/at/bitfire/davdroid/startup/TasksAppWatcher.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/startup/TasksAppWatcher.kt
@@ -5,7 +5,7 @@
 package at.bitfire.davdroid.startup
 
 import android.content.Context
-import at.bitfire.davdroid.startup.StartupPlugin.Companion.PRIORITY_DEFAULT
+import at.bitfire.davdroid.startup.StartupAction.Companion.PRIORITY_DEFAULT
 import at.bitfire.davdroid.sync.TasksAppManager
 import at.bitfire.davdroid.util.packageChangedFlow
 import at.bitfire.synctools.storage.TaskProvider
@@ -22,7 +22,7 @@ class TasksAppWatcher @Inject constructor(
     @ApplicationContext private val context: Context,
     private val logger: Logger,
     private val tasksAppManager: Provider<TasksAppManager>
-): StartupPlugin {
+) : StartupAction {
 
     override fun onAppCreate() {
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/startup/TasksAppWatcher.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/startup/TasksAppWatcher.kt
@@ -5,11 +5,14 @@
 package at.bitfire.davdroid.startup
 
 import android.content.Context
+import at.bitfire.davdroid.di.qualifier.ApplicationScope
 import at.bitfire.davdroid.startup.StartupAction.Companion.PRIORITY_DEFAULT
 import at.bitfire.davdroid.sync.TasksAppManager
 import at.bitfire.davdroid.util.packageChangedFlow
 import at.bitfire.synctools.storage.TaskProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import java.util.logging.Logger
 import javax.inject.Inject
 import javax.inject.Provider
@@ -19,24 +22,22 @@ import javax.inject.Provider
  * the selected tasks app and task sync settings accordingly.
  */
 class TasksAppWatcher @Inject constructor(
+    @ApplicationScope private val applicationScope: CoroutineScope,
     @ApplicationContext private val context: Context,
     private val logger: Logger,
     private val tasksAppManager: Provider<TasksAppManager>
 ) : StartupAction {
 
-    override fun onAppCreate() {
-    }
+    override fun priorityAsync() = PRIORITY_DEFAULT
 
-    override fun priority() = PRIORITY_DEFAULT
-
-    override suspend fun onAppCreateAsync() {
-        logger.info("Watching for package changes in order to detect tasks app changes")
-        packageChangedFlow(context).collect {
-            onPackageChanged()
+    override fun onAppCreateAsync() {
+        applicationScope.launch {
+            logger.info("Watching for package changes in order to detect tasks app changes")
+            packageChangedFlow(context).collect {
+                onPackageChanged()
+            }
         }
     }
-
-    override fun priorityAsync() = PRIORITY_DEFAULT
 
 
     private fun onPackageChanged() {

--- a/core/src/main/kotlin/at/bitfire/davdroid/startup/TasksAppWatcher.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/startup/TasksAppWatcher.kt
@@ -31,7 +31,7 @@ class TasksAppWatcher @Inject constructor(
     private val tasksAppManager: Provider<TasksAppManager>
 ) : StartupAction {
 
-    override fun priorityAsync() = PRIORITY_DEFAULT
+    override val priorityAsync = PRIORITY_DEFAULT
 
     override fun onAppCreateAsync() {
         logger.info("Watching for package changes in order to detect tasks app changes")

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/account/AccountsCleanupWorker.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/account/AccountsCleanupWorker.kt
@@ -112,6 +112,8 @@ class AccountsCleanupWorker @AssistedInject constructor(
 
         /**
          * Enqueues [AccountsCleanupWorker] to be run regularly (but not necessarily now).
+         *
+         * Non-blocking ([WorkManager.enqueueUniquePeriodicWork]).
          */
         fun enable(context: Context) {
             // run every day

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/UiUtils.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/UiUtils.kt
@@ -42,8 +42,6 @@ import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import java.util.logging.Level
 import java.util.logging.Logger
 
@@ -80,22 +78,20 @@ object UiUtils {
         AppCompatDelegate.setDefaultNightMode(mode)
     }
 
-    suspend fun updateShortcuts(context: Context) {
+    fun updateShortcuts(context: Context) {
         if (Build.VERSION.SDK_INT >= 25)
             context.getSystemService<ShortcutManager>()?.let { shortcutManager ->
-                withContext(Dispatchers.IO) {
-                    try {
-                        shortcutManager.dynamicShortcuts = listOf(
-                            ShortcutInfo.Builder(context, SHORTCUT_SYNC_ALL)
-                                .setIcon(Icon.createWithResource(context, R.drawable.ic_sync_shortcut))
-                                .setShortLabel(context.getString(R.string.accounts_sync_all))
-                                .setIntent(Intent(Intent.ACTION_SYNC, null, context, AccountsActivity::class.java))
-                                .build()
-                        )
-                    } catch(e: Exception) {
-                        val logger = EntryPointAccessors.fromApplication(context, UiUtilsEntryPoint::class.java).logger()
-                        logger.log(Level.WARNING, "Couldn't update dynamic shortcut(s)", e)
-                    }
+                try {
+                    shortcutManager.dynamicShortcuts = listOf(
+                        ShortcutInfo.Builder(context, SHORTCUT_SYNC_ALL)
+                            .setIcon(Icon.createWithResource(context, R.drawable.ic_sync_shortcut))
+                            .setShortLabel(context.getString(R.string.accounts_sync_all))
+                            .setIntent(Intent(Intent.ACTION_SYNC, null, context, AccountsActivity::class.java))
+                            .build()
+                    )
+                } catch (e: Exception) {
+                    val logger = EntryPointAccessors.fromApplication(context, UiUtilsEntryPoint::class.java).logger()
+                    logger.log(Level.WARNING, "Couldn't update dynamic shortcut(s)", e)
                 }
             }
     }


### PR DESCRIPTION
### Purpose

Simplifies the startup-hook coroutine model: replaces the two-phase `StartupPlugin` (sync `onAppCreate()` + suspend `onAppCreateAsync()`, each with its own priority) with a single `StartupAction.onAppCreate()`, where each implementation decides for itself whether to launch a coroutine.

### Short description

- Removed `onAppCreateAsync()`/`priorityAsync()`; `StartupAction` now has one `onAppCreate()` + one `priority`.
- `CoreApp.onCreate()` dropped the `GlobalScope.launch(ioDispatcher) { ... }` block; actions that need background work launch their own coroutine via the injected `@ApplicationScope` `CoroutineScope` + `@IoDispatcher`.
- `applicationScope`'s default dispatcher changed from `Dispatchers.Main` to `Dispatchers.IO`.
- `UiUtils.updateShortcuts()` is no longer `suspend`; the IO dispatch responsibility moved to the caller (`DynamicShortcutsAction`).

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.