### PR TITLE
Introduce IoCoroutineWorker for I/O-bound tasks

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/IoCoroutineWorkerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/IoCoroutineWorkerTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.WorkerParameters
+import androidx.work.testing.TestListenableWorkerBuilder
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import javax.inject.Inject
+import kotlin.coroutines.ContinuationInterceptor
+
+@HiltAndroidTest
+class IoCoroutineWorkerTest {
+
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+
+    @Inject
+    @ApplicationContext
+    lateinit var context: Context
+
+    @Inject
+    lateinit var workerFactory: HiltWorkerFactory
+
+    val executor: ExecutorService = Executors.newSingleThreadExecutor()
+
+    @Before
+    fun setUp() {
+        hiltRule.inject()
+    }
+
+    @After
+    fun tearDown() {
+        executor.shutdown()
+    }
+
+    @Test
+    fun testDoWork_runsOnInjectedIoDispatcher() = runTest {
+        val testIoDispatcher: CoroutineDispatcher = executor.asCoroutineDispatcher()
+        val worker = TestListenableWorkerBuilder<TestWorker>(context)
+            .setWorkerFactory(workerFactory)
+            .build()
+            .apply {
+                // override injected ioDispatcher by our custom one
+                ioDispatcher = testIoDispatcher
+            }
+
+        worker.doWork()
+
+        assertEquals(testIoDispatcher, worker.actualDispatcher)
+    }
+
+
+    @HiltWorker
+    class TestWorker @AssistedInject constructor(
+        @Assisted context: Context,
+        @Assisted params: WorkerParameters
+    ) : IoCoroutineWorker(context, params) {
+
+        var actualDispatcher: CoroutineDispatcher? = null
+
+        override suspend fun doIoWork(): Result {
+            actualDispatcher = currentCoroutineContext()[ContinuationInterceptor] as CoroutineDispatcher
+            return Result.success()
+        }
+
+    }
+
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/IoCoroutineWorker.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/IoCoroutineWorker.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import at.bitfire.davdroid.di.qualifier.IoDispatcher
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+/**
+ * Base class for [CoroutineWorker]s whose work should run on [IoDispatcher] instead of
+ * [CoroutineWorker]'s default (CPU-core-sized [kotlinx.coroutines.Dispatchers.Default]),
+ * which can be exhausted by concurrent background work easily and cause deadlocks.
+ *
+ * Use as base class for workers that primarily do I/O work.
+ *
+ * **Requires Hilt member injection**, so subclasses must be constructed as ([androidx.hilt.work.HiltWorker]).
+ */
+abstract class IoCoroutineWorker(
+    context: Context,
+    workerParams: WorkerParameters
+) : CoroutineWorker(context, workerParams) {
+
+    @Inject
+    @IoDispatcher
+    lateinit var ioDispatcher: CoroutineDispatcher
+
+    override suspend fun doWork(): Result = withContext(ioDispatcher) {
+        doIoWork()
+    }
+
+    abstract suspend fun doIoWork(): Result
+
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationWorker.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/push/PushRegistrationWorker.kt
@@ -6,8 +6,8 @@ package at.bitfire.davdroid.push
 
 import android.content.Context
 import androidx.hilt.work.HiltWorker
-import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import at.bitfire.davdroid.IoCoroutineWorker
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import java.util.logging.Logger
@@ -24,9 +24,9 @@ class PushRegistrationWorker @AssistedInject constructor(
     @Assisted workerParameters: WorkerParameters,
     private val logger: Logger,
     private val pushRegistrationManager: PushRegistrationManager
-) : CoroutineWorker(context, workerParameters) {
+) : IoCoroutineWorker(context, workerParameters) {
 
-    override suspend fun doWork(): Result {
+    override suspend fun doIoWork(): Result {
         logger.info("Running push registration worker")
 
         // update registrations for all services

--- a/core/src/main/kotlin/at/bitfire/davdroid/servicedetection/RefreshCollectionsWorker.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/servicedetection/RefreshCollectionsWorker.kt
@@ -12,7 +12,6 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.TaskStackBuilder
 import androidx.hilt.work.HiltWorker
-import androidx.work.CoroutineWorker
 import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
 import androidx.work.ForegroundInfo
@@ -23,6 +22,7 @@ import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import at.bitfire.dav4jvm.ktor.exception.UnauthorizedException
+import at.bitfire.davdroid.IoCoroutineWorker
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.accounts.toAccountId
 import at.bitfire.davdroid.network.HttpClientBuilder
@@ -71,7 +71,7 @@ class RefreshCollectionsWorker @AssistedInject constructor(
     private val pushRegistrationManager: PushRegistrationManager,
     private val serviceRefresherFactory: ServiceRefresher.Factory,
     serviceRepository: DavServiceRepository
-): CoroutineWorker(appContext, workerParams) {
+) : IoCoroutineWorker(appContext, workerParams) {
 
     companion object {
 
@@ -139,7 +139,7 @@ class RefreshCollectionsWorker @AssistedInject constructor(
         Account(service.accountName, applicationContext.getString(R.string.account_type))
     }
 
-    override suspend fun doWork(): Result {
+    override suspend fun doIoWork(): Result {
         if (service == null || account == null) {
             logger.warning("Missing service or account with service ID: $serviceId")
             return Result.failure()

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
@@ -10,11 +10,11 @@ import android.os.Build
 import androidx.annotation.IntDef
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
-import androidx.work.CoroutineWorker
 import androidx.work.Data
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
+import at.bitfire.davdroid.IoCoroutineWorker
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.push.PushNotificationManager
 import at.bitfire.davdroid.settings.AccountSettings
@@ -44,7 +44,7 @@ import kotlin.time.Duration.Companion.seconds
 abstract class BaseSyncWorker(
     context: Context,
     private val workerParams: WorkerParameters
-) : CoroutineWorker(context, workerParams) {
+) : IoCoroutineWorker(context, workerParams) {
 
     @Inject
     lateinit var accountSettingsFactory: AccountSettings.Factory
@@ -76,8 +76,7 @@ abstract class BaseSyncWorker(
     @Inject
     lateinit var taskSyncer: TaskSyncer.Factory
 
-
-    override suspend fun doWork(): Result {
+    override suspend fun doIoWork(): Result {
         // ensure we got the required arguments
         val account = Account(
             inputData.getString(INPUT_ACCOUNT_NAME) ?: throw IllegalArgumentException("INPUT_ACCOUNT_NAME required"),


### PR DESCRIPTION
### Purpose

Add a base class for I/O-bound coroutine workers to standardize dispatcher usage.

Fixes #2664. Immediate workaround for https://github.com/bitfireAT/davx5/issues/937.

### Short description

- Introduce `IoCoroutineWorker` base class with pre-configured I/O dispatcher
- Migrate existing workers (`RefreshCollectionsWorker`, `PushRegistrationWorker`, `BaseSyncWorker`) to use the new base class
- Add `IoCoroutineWorkerTest` to verify proper dispatcher injection

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.