### PR TITLE
Include correct tasks provider package in PRODID

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
@@ -121,7 +121,10 @@ class TasksSyncManager @AssistedInject constructor(
         val updatedSequence = SequenceUpdater().increaseSequence(localTask.main)
 
         // map Android event to iCalendar (also generates UID, if necessary)
-        val handler = DmfsTaskHandler(ProdId(productIds.iCalProdId))
+        val handler = DmfsTaskHandler(
+            prodId = ProdId(productIds.iCalProdId),
+            providerName = localCollection.dmfsTaskList.providerName
+        )
         val mappedVToDos = handler.mapToVToDos(localTask)
 
         // persist UID if it was generated

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/JtxObjectHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/JtxObjectHandler.kt
@@ -6,6 +6,7 @@ package at.bitfire.synctools.mapping.jtx
 
 import android.content.Entity
 import at.bitfire.synctools.icalendar.AssociatedComponents
+import at.bitfire.synctools.icalendar.withUserAgents
 import at.bitfire.synctools.mapping.jtx.handler.AttachmentFetcher
 import at.bitfire.synctools.mapping.jtx.handler.AttachmentsHandler
 import at.bitfire.synctools.mapping.jtx.handler.AttendeesHandler
@@ -17,6 +18,7 @@ import at.bitfire.synctools.mapping.jtx.handler.CompletedHandler
 import at.bitfire.synctools.mapping.jtx.handler.ContactHandler
 import at.bitfire.synctools.mapping.jtx.handler.CreatedHandler
 import at.bitfire.synctools.mapping.jtx.handler.DescriptionHandler
+import at.bitfire.synctools.mapping.jtx.handler.ExtendedStatusHandler
 import at.bitfire.synctools.mapping.jtx.handler.GeoHandler
 import at.bitfire.synctools.mapping.jtx.handler.JtxObjectEntityHandler
 import at.bitfire.synctools.mapping.jtx.handler.LastModifiedHandler
@@ -35,7 +37,7 @@ import at.bitfire.synctools.mapping.jtx.handler.TimeFieldsHandler
 import at.bitfire.synctools.mapping.jtx.handler.UidHandler
 import at.bitfire.synctools.mapping.jtx.handler.UnknownPropertiesHandler
 import at.bitfire.synctools.mapping.jtx.handler.UrlHandler
-import at.bitfire.synctools.mapping.jtx.handler.ExtendedStatusHandler
+import at.bitfire.synctools.storage.TaskProvider
 import at.bitfire.synctools.storage.jtx.JtxObjectAndExceptions
 import at.techbee.jtx.JtxContract
 import net.fortuna.ical4j.model.Property
@@ -132,7 +134,7 @@ class JtxObjectHandler(
             associatedComponents = AssociatedComponents(
                 main = main,
                 exceptions = exceptions,
-                prodId = prodId
+                prodId = prodId.withUserAgents(listOf(TaskProvider.ProviderName.JtxBoard.packageName))
             ),
             uid = uid,
             generatedUid = generatedUid

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskHandler.kt
@@ -40,6 +40,7 @@ import java.util.UUID
 
 class DmfsTaskHandler(
     private val prodId: ProdId,
+    private val providerName: TaskProvider.ProviderName
 ) {
     private val entityHandlers = arrayOf<DmfsTaskEntityHandler>(
         UidHandler(),
@@ -103,7 +104,7 @@ class DmfsTaskHandler(
         val mappedTasks = AssociatedTasks(
             main = main,
             exceptions = exceptions,
-            prodId = prodId.withUserAgents(listOf(TaskProvider.ProviderName.JtxBoard.packageName))
+            prodId = prodId.withUserAgents(listOf(providerName.packageName))
         )
 
         return MappingResult(

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/ContactWriterTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/ContactWriterTest.kt
@@ -41,6 +41,13 @@ import java.time.LocalDate
 
 class ContactWriterTest {
 
+    @Test
+    fun testGenerate_SetsProductId() {
+        val vCard = generate { }
+        assertEquals(testProductId, vCard.productId.value)
+    }
+
+
     // test specific fields
 
     @Test
@@ -471,7 +478,7 @@ class ContactWriterTest {
 
     @Test
     fun testXPhoneticName() {
-        val vCard = generate() {
+        val vCard = generate {
             phoneticGivenName = "Given"
             phoneticMiddleName = "Middle"
             phoneticFamilyName = "Family"

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/JtxObjectHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/JtxObjectHandlerTest.kt
@@ -6,6 +6,7 @@ package at.bitfire.synctools.mapping.jtx
 
 import android.content.Entity
 import androidx.core.content.contentValuesOf
+import at.bitfire.synctools.storage.TaskProvider
 import at.bitfire.synctools.storage.jtx.JtxObjectAndExceptions
 import at.techbee.jtx.JtxContract
 import net.fortuna.ical4j.model.component.VJournal
@@ -27,6 +28,26 @@ class JtxObjectHandlerTest {
         prodId = ProdId(javaClass.simpleName),
         attachmentFetcher = FakeAttachmentFetcher()
     )
+
+    @Test
+    fun `mapToCalendarComponents sets PRODID with jtx Board package name`() {
+        val jtxObjectAndExceptions = JtxObjectAndExceptions(
+            main = Entity(
+                contentValuesOf(
+                    JtxContract.JtxICalObject.COMPONENT to "VTODO",
+                    JtxContract.JtxICalObject.UID to "uid"
+                )
+            ),
+            exceptions = emptyList()
+        )
+
+        val result = handler.mapToCalendarComponents(jtxObjectAndExceptions)
+
+        assertEquals(
+            ProdId("${javaClass.simpleName} (${TaskProvider.ProviderName.JtxBoard.packageName})"),
+            result.associatedComponents.prodId
+        )
+    }
 
     @Test
     fun `mapToCalendarComponents maps VTODO component`() {

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/tasks/DmfsTaskHandlerTest.kt
@@ -7,6 +7,7 @@ package at.bitfire.synctools.mapping.tasks
 import android.content.ContentValues
 import android.content.Entity
 import androidx.core.content.contentValuesOf
+import at.bitfire.synctools.storage.TaskProvider
 import at.bitfire.synctools.storage.tasks.TaskAndExceptions
 import net.fortuna.ical4j.model.Parameter
 import net.fortuna.ical4j.model.Property
@@ -29,7 +30,10 @@ import kotlin.jvm.optionals.getOrNull
 @RunWith(RobolectricTestRunner::class)
 class DmfsTaskHandlerTest {
 
-    private val handler = DmfsTaskHandler(prodId = ProdId(javaClass.simpleName))
+    private val handler = DmfsTaskHandler(
+        prodId = ProdId(javaClass.simpleName),
+        providerName = TaskProvider.ProviderName.OpenTasks
+    )
 
     @Test
     fun `mapToVToDos adds UID if necessary`() {
@@ -75,6 +79,21 @@ class DmfsTaskHandlerTest {
         val result = handler.mapToVToDos(taskAndExceptions)
 
         assertTrue(result.associatedTasks.main!!.getProperty<DtStamp>(Property.DTSTAMP).isPresent)
+    }
+
+    @Test
+    fun `mapToVToDos sets PRODID with provider package name`() {
+        val taskAndExceptions = TaskAndExceptions(
+            main = Entity(ContentValues()),
+            exceptions = emptyList()
+        )
+
+        val result = handler.mapToVToDos(taskAndExceptions)
+
+        assertEquals(
+            ProdId("${javaClass.simpleName} (${TaskProvider.ProviderName.OpenTasks.packageName})"),
+            result.associatedTasks.prodId
+        )
     }
 
     @Test


### PR DESCRIPTION
### Purpose

Tasks/jtx Board sync: add correct provider name to the PRODID field. Closes #2670.

### Short description

- Added provider name to PRODID generation
- Added tests for PRODID generation

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.