### PR TITLE
[Coroutines] Fix blocking calls in push message handling

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/push/PushMessageHandler.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/push/PushMessageHandler.kt
@@ -79,7 +79,7 @@ class PushMessageHandler @Inject constructor(
 
         } else {
             // fallback when no known topic is present (shouldn't happen)
-            val service = instance.toLongOrNull()?.let { serviceRepository.getBlocking(it) }
+            val service = instance.toLongOrNull()?.let { serviceRepository.get(it) }
             if (service != null) {
                 logger.warning("Got push message without topic and service, syncing all accounts")
                 val account = accountRepository.fromName(service.accountName)

--- a/core/src/main/kotlin/at/bitfire/davdroid/repository/AccountRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/repository/AccountRepository.kt
@@ -186,8 +186,10 @@ class AccountRepository @Inject constructor(
 
     suspend fun getAll(): Array<Account> = withContext(ioDispatcher) {
         // getAccountsByType is main-safe, but could still take some time (binder involved)
-        accountManager.getAccountsByType(accountType)
+        getAllBlocking()
     }
+
+    fun getAllBlocking() = accountManager.getAccountsByType(accountType)
 
     fun getAllFlow() = callbackFlow<Set<Account>> {
         val listener = OnAccountsUpdateListener { accounts ->

--- a/core/src/main/kotlin/at/bitfire/davdroid/repository/AccountRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/repository/AccountRepository.kt
@@ -184,7 +184,10 @@ class AccountRepository @Inject constructor(
     fun fromName(accountName: String) =
         Account(accountName, accountType)
 
-    fun getAll(): Array<Account> = accountManager.getAccountsByType(accountType)
+    suspend fun getAll(): Array<Account> = withContext(ioDispatcher) {
+        // getAccountsByType is main-safe, but could still take some time (binder involved)
+        accountManager.getAccountsByType(accountType)
+    }
 
     fun getAllFlow() = callbackFlow<Set<Account>> {
         val listener = OnAccountsUpdateListener { accounts ->

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/TasksAppManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/TasksAppManager.kt
@@ -90,7 +90,7 @@ class TasksAppManager @Inject constructor(
             notificationRegistry.get().notifyPermissions()
 
         // check all accounts and update task sync
-        for (account in accountRepository.get().getAll())
+        for (account in accountRepository.get().getAllBlocking())
             automaticSyncManager.updateAutomaticSync(account, SyncDataType.TASKS)
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/account/AccountsCleanupWorker.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/account/AccountsCleanupWorker.kt
@@ -62,7 +62,7 @@ class AccountsCleanupWorker @AssistedInject constructor(
 
         // Delete orphaned services in DB – only necessary as long as accounts are implemented as system accounts (not in DB)
         val accounts = accountRepository.getAllBlocking()
-        logger.info("Cleaning up accounts. Currently existing accounts: $accounts")
+        logger.info("Cleaning up accounts. Currently existing accounts: ${accounts.contentToString()}")
         val serviceDao = db.serviceDao()
         if (accounts.isEmpty())
             serviceDao.deleteAll()

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/account/AccountsCleanupWorker.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/account/AccountsCleanupWorker.kt
@@ -61,7 +61,7 @@ class AccountsCleanupWorker @AssistedInject constructor(
         // Later, accounts which are not in the DB should be deleted here
 
         // Delete orphaned services in DB – only necessary as long as accounts are implemented as system accounts (not in DB)
-        val accounts = accountRepository.getAll()
+        val accounts = accountRepository.getAllBlocking()
         logger.info("Cleaning up accounts. Currently existing accounts: $accounts")
         val serviceDao = db.serviceDao()
         if (accounts.isEmpty())
@@ -75,7 +75,7 @@ class AccountsCleanupWorker @AssistedInject constructor(
      */
     @VisibleForTesting
     internal fun cleanUpAddressBooks() {
-        val accounts = accountRepository.getAll()
+        val accounts = accountRepository.getAllBlocking()
         for (addressBookAccount in accountManager.getAccountsByType(context.getString(R.string.account_type_address_book))) {
             val accountName = accountManager.getUserData(addressBookAccount, LocalAddressBook.USER_DATA_ACCOUNT_NAME)
             val accountType = accountManager.getUserData(addressBookAccount, LocalAddressBook.USER_DATA_ACCOUNT_TYPE)

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoGenerator.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoGenerator.kt
@@ -313,7 +313,7 @@ class DebugInfoGenerator @Inject constructor(
         // accounts
         writer.append("\nACCOUNTS")
         val accountManager = AccountManager.get(context)
-        val accounts = accountRepository.getAll()
+        val accounts = accountRepository.getAllBlocking()
         for (account in accounts)
             dumpAccount(account, writer)
 


### PR DESCRIPTION
### Purpose

`PushMessageHandler.processMessage` (and related callers) ran blocking database and `AccountManager` calls directly from suspend code without dispatching to an IO thread, risking main-thread blocking when triggered from push events.

### Short description

- Replaced blocking `DavServiceRepository.getBlocking()` with the existing suspend `get()` in `PushMessageHandler`.
- Made `AccountRepository.getAll()` a suspend function that dispatches the `AccountManager` call via `withContext(ioDispatcher)`, keeping a `getAllBlocking()` variant for genuinely non-suspend callers.
- Updated all call sites (`PushMessageHandler`, `AccountsViewModel`, `SyncWidgetViewModel`, `TasksAppManager`, `AccountsCleanupWorker`, `DebugInfoGenerator`) to use whichever variant matches their calling context.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have self-reviewed the PR.
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.