### PR TITLE
Avoid using `runBlocking` in `AutomaticSyncManager`

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/db/ServiceDao.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/ServiceDao.kt
@@ -18,6 +18,9 @@ interface ServiceDao {
     @Query("SELECT * FROM service WHERE accountName=:accountName AND type=:type")
     suspend fun getByAccountAndType(accountName: String, @ServiceType type: String): Service?
 
+    @Query("SELECT * FROM service WHERE accountName=:accountName AND type=:type")
+    fun getByAccountAndTypeBlocking(accountName: String, @ServiceType type: String): Service?
+
     suspend fun getByAccountAndType(accountId: AccountId, @ServiceType type: String): Service? {
         return when (accountId) {
             is LegacyAccount -> getByAccountAndType(accountId.androidAccount.name, type)

--- a/core/src/main/kotlin/at/bitfire/davdroid/repository/DavServiceRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/repository/DavServiceRepository.kt
@@ -4,6 +4,7 @@
 
 package at.bitfire.davdroid.repository
 
+import androidx.annotation.WorkerThread
 import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.Service
 import at.bitfire.davdroid.db.ServiceType
@@ -25,6 +26,10 @@ class DavServiceRepository @Inject constructor(
 
     suspend fun getByAccountAndType(name: String, @ServiceType serviceType: String): Service? =
         dao.getByAccountAndType(name, serviceType)
+
+    @WorkerThread
+    fun getByAccountAndTypeBlocking(name: String, @ServiceType serviceType: String): Service? =
+        dao.getByAccountAndTypeBlocking(name, serviceType)
 
     fun getCalDavServiceFlow(accountName: String) =
         dao.getByAccountAndTypeFlow(accountName, Service.TYPE_CALDAV)

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/AutomaticSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/AutomaticSyncManager.kt
@@ -14,7 +14,6 @@ import at.bitfire.davdroid.resource.LocalAddressBookStore
 import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.sync.adapter.SyncFrameworkIntegration
 import at.bitfire.davdroid.sync.worker.SyncWorkerManager
-import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -138,7 +137,7 @@ class AutomaticSyncManager @Inject constructor(
             SyncDataType.EVENTS,
             SyncDataType.TASKS -> Service.TYPE_CALDAV
         }
-        val hasService = runBlocking { serviceRepository.getByAccountAndType(account.name, serviceType) != null }
+        val hasService = serviceRepository.getByAccountAndTypeBlocking(account.name, serviceType) != null
 
         val hasProvider = if (dataType == SyncDataType.TASKS)
             tasksAppManager.get().currentProvider() != null


### PR DESCRIPTION
Adds a blocking function to `DavServiceRepository` to avoid `AutomaticSyncManager` having to use `runBlocking` to call a suspending function.
