### PR TITLE
[Coroutines] Clean up `AppSettingsViewModel`

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsViewModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsViewModel.kt
@@ -39,7 +39,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import java.util.Optional
 import javax.inject.Inject
 import kotlin.jvm.optionals.getOrNull
@@ -109,7 +108,7 @@ class AppSettingsViewModel @Inject constructor(
         UiUtils.updateTheme(context)
     }
 
-    fun resetHints() = runBlocking(ioDispatcher) {
+    fun resetHints() = viewModelScope.launch(ioDispatcher) {
         settings.remove(BackupsPage.Model.SETTING_BACKUPS_ACCEPTED)
         settings.remove(BatteryOptimizationsPageViewModel.HINT_BATTERY_OPTIMIZATIONS)
         settings.remove(BatteryOptimizationsPageViewModel.HINT_AUTOSTART_PERMISSION)


### PR DESCRIPTION
### Purpose

See #2678

### Short description

- Replace `runBlocking` by `viewModelScope.launch`

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

