### PR TITLE
Fix task dirty flag regression with properties

### DIFF
--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
@@ -27,51 +27,12 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName) :
 
     private val testAccount = Account(javaClass.name, TaskContract.LOCAL_ACCOUNT_TYPE)
 
-    private fun createTaskList(): DmfsTaskList {
-        val info = ContentValues()
-        info.put(TaskLists.LIST_NAME, "Test Task List")
-        info.put(TaskLists.LIST_COLOR, 0xffff0000)
-        info.put(TaskLists.OWNER, "test@example.com")
-        info.put(TaskLists.SYNC_ENABLED, 1)
-        info.put(TaskLists.VISIBLE, 1)
-
-        val dmfsTaskListProvider = DmfsTaskListProvider(testAccount, provider, providerName)
-        return dmfsTaskListProvider.createAndGetTaskList(info)
-    }
-
     @Test
     fun testTouchRelations() {
         val taskList = createTaskList()
         try {
             // insert child before parent
-            val childId = taskList.addTask(
-                Entity(
-                    contentValuesOf(
-                        Tasks.LIST_ID to taskList.id,
-                        Tasks._UID to "child",
-                        Tasks.TITLE to "Child task",
-                        Tasks.PARENT_ID to null
-                    )
-                ).apply {
-                    addSubValue(
-                        taskList.tasksPropertiesUri(),
-                        contentValuesOf(
-                            TaskContract.Properties.MIMETYPE to Property.Relation.CONTENT_ITEM_TYPE,
-                            Property.Relation.RELATED_UID to "parent",
-                            Property.Relation.RELATED_TYPE to Property.Relation.RELTYPE_PARENT
-                        )
-                    )
-                }
-            )
-            val parentId = taskList.addTask(
-                Entity(
-                    contentValuesOf(
-                        Tasks.LIST_ID to taskList.id,
-                        Tasks._UID to "parent",
-                        Tasks.TITLE to "Parent task"
-                    )
-                )
-            )
+            val (childId, parentId) = addChildAndParentWithRelation(taskList, "child", "parent")
 
             // OpenTasks should provide the correct relation
             taskList.provider.client.query(
@@ -123,34 +84,7 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName) :
         try {
             // insert child before parent, so RELATED_ID gets backfilled by the provider
             // but PARENT_ID is not yet (see touchRelations()'s doc comment)
-            val childId = taskList.addTask(
-                Entity(
-                    contentValuesOf(
-                        Tasks.LIST_ID to taskList.id,
-                        Tasks._UID to "dirty-test-child",
-                        Tasks.TITLE to "Child task",
-                        Tasks.PARENT_ID to null
-                    )
-                ).apply {
-                    addSubValue(
-                        taskList.tasksPropertiesUri(),
-                        contentValuesOf(
-                            TaskContract.Properties.MIMETYPE to Property.Relation.CONTENT_ITEM_TYPE,
-                            Property.Relation.RELATED_UID to "dirty-test-parent",
-                            Property.Relation.RELATED_TYPE to Property.Relation.RELTYPE_PARENT
-                        )
-                    )
-                }
-            )
-            taskList.addTask(
-                Entity(
-                    contentValuesOf(
-                        Tasks.LIST_ID to taskList.id,
-                        Tasks._UID to "dirty-test-parent",
-                        Tasks.TITLE to "Parent task"
-                    )
-                )
-            )
+            val (childId, _) = addChildAndParentWithRelation(taskList, "dirty-test-child", "dirty-test-parent")
 
             // simulate the state right after a sync applied this task: not dirty
             taskList.updateTaskRow(childId, contentValuesOf(Tasks._DIRTY to 0))
@@ -523,37 +457,26 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName) :
     fun testUpdateTask() {
         val taskList = createTaskList()
         try {
-            val entity = Entity(
+            val entity = taskEntity(
+                taskList,
                 contentValuesOf(
                     Tasks.LIST_ID to taskList.id,
                     Tasks.TITLE to "Update Test Task"
-                )
-            ).apply {
-                addSubValue(
-                    taskList.tasksPropertiesUri(),
-                    contentValuesOf(
-                        TaskContract.Properties.MIMETYPE to Property.Category.CONTENT_ITEM_TYPE,
-                        Property.Category.CATEGORY_NAME to "Work"
-                    )
-                )
-            }
+                ),
+                TaskContract.Properties.MIMETYPE to Property.Category.CONTENT_ITEM_TYPE,
+                Property.Category.CATEGORY_NAME to "Work"
+            )
             val id = taskList.addTask(entity)
 
             // Update with new entity
-            val updatedEntity = Entity(
+            val updatedEntity = taskEntity(
+                taskList,
                 contentValuesOf(
                     Tasks.TITLE to "Updated Task Title"
-                )
-            ).apply {
-                // Use base properties URI for sub-values, MIMETYPE goes in ContentValues
-                addSubValue(
-                    taskList.tasksPropertiesUri(),
-                    contentValuesOf(
-                        TaskContract.Properties.MIMETYPE to Property.Category.CONTENT_ITEM_TYPE,
-                        Property.Category.CATEGORY_NAME to "Work"
-                    )
-                )
-            }
+                ),
+                TaskContract.Properties.MIMETYPE to Property.Category.CONTENT_ITEM_TYPE,
+                Property.Category.CATEGORY_NAME to "Work"
+            )
 
             taskList.updateTask(id, updatedEntity)
 
@@ -579,36 +502,26 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName) :
     fun testUpdateTask_WithBatch() {
         val taskList = createTaskList()
         try {
-            val entity = Entity(
+            val entity = taskEntity(
+                taskList,
                 contentValuesOf(
                     Tasks.LIST_ID to taskList.id,
                     Tasks.TITLE to "Batch Update Test"
-                )
-            ).apply {
-                addSubValue(
-                    taskList.tasksPropertiesUri(),
-                    contentValuesOf(
-                        TaskContract.Properties.MIMETYPE to Property.Comment.CONTENT_ITEM_TYPE,
-                        Property.Comment.COMMENT to "Original Comment"
-                    )
-                )
-            }
+                ),
+                TaskContract.Properties.MIMETYPE to Property.Comment.CONTENT_ITEM_TYPE,
+                Property.Comment.COMMENT to "Original Comment"
+            )
             val id = taskList.addTask(entity)
 
             // Update via batch
-            val updatedEntity = Entity(
+            val updatedEntity = taskEntity(
+                taskList,
                 contentValuesOf(
                     Tasks.TITLE to "Updated Title"
-                )
-            ).apply {
-                addSubValue(
-                    taskList.tasksPropertiesUri(),
-                    contentValuesOf(
-                        TaskContract.Properties.MIMETYPE to Property.Comment.CONTENT_ITEM_TYPE,
-                        Property.Comment.COMMENT to "Updated Comment"
-                    )
-                )
-            }
+                ),
+                TaskContract.Properties.MIMETYPE to Property.Comment.CONTENT_ITEM_TYPE,
+                Property.Comment.COMMENT to "Updated Comment"
+            )
 
             val batch = TasksBatchOperation(taskList.client)
             taskList.updateTask(id, updatedEntity, batch)
@@ -635,38 +548,28 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName) :
         // with _DIRTY=0 must not end up dirty again because of the property rows.
         val taskList = createTaskList()
         try {
-            val entity = Entity(
+            val entity = taskEntity(
+                taskList,
                 contentValuesOf(
                     Tasks.LIST_ID to taskList.id,
                     Tasks.TITLE to "Dirty Regression Test"
-                )
-            ).apply {
-                addSubValue(
-                    taskList.tasksPropertiesUri(),
-                    contentValuesOf(
-                        TaskContract.Properties.MIMETYPE to Property.Category.CONTENT_ITEM_TYPE,
-                        Property.Category.CATEGORY_NAME to "Work"
-                    )
-                )
-            }
+                ),
+                TaskContract.Properties.MIMETYPE to Property.Category.CONTENT_ITEM_TYPE,
+                Property.Category.CATEGORY_NAME to "Work"
+            )
             val id = taskList.addTask(entity)
 
             // simulate what the sync adapter does when applying a downloaded task:
             // update the main row (with _DIRTY=0) and its properties in one batch
-            val updatedEntity = Entity(
+            val updatedEntity = taskEntity(
+                taskList,
                 contentValuesOf(
                     Tasks.TITLE to "Dirty Regression Test (updated)",
                     Tasks._DIRTY to 0
-                )
-            ).apply {
-                addSubValue(
-                    taskList.tasksPropertiesUri(),
-                    contentValuesOf(
-                        TaskContract.Properties.MIMETYPE to Property.Category.CONTENT_ITEM_TYPE,
-                        Property.Category.CATEGORY_NAME to "Work"
-                    )
-                )
-            }
+                ),
+                TaskContract.Properties.MIMETYPE to Property.Category.CONTENT_ITEM_TYPE,
+                Property.Category.CATEGORY_NAME to "Work"
+            )
             taskList.updateTask(id, updatedEntity)
 
             val dirty = taskList.getTaskRow(id, arrayOf(Tasks._DIRTY))?.getAsInteger(Tasks._DIRTY)
@@ -814,5 +717,56 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName) :
             taskList.delete()
         }
     }
+
+
+    // helpers
+
+    /** Inserts a child task with a Relation property pointing to [parentUid], then the parent task. */
+    private fun addChildAndParentWithRelation(
+        taskList: DmfsTaskList,
+        childUid: String,
+        parentUid: String
+    ): Pair<Long, Long> {
+        val childId = taskList.addTask(
+            taskEntity(
+                taskList,
+                contentValuesOf(
+                    Tasks.LIST_ID to taskList.id,
+                    Tasks._UID to childUid,
+                    Tasks.TITLE to "Child task",
+                    Tasks.PARENT_ID to null
+                ),
+                TaskContract.Properties.MIMETYPE to Property.Relation.CONTENT_ITEM_TYPE,
+                Property.Relation.RELATED_UID to parentUid,
+                Property.Relation.RELATED_TYPE to Property.Relation.RELTYPE_PARENT
+            )
+        )
+        val parentId = taskList.addTask(
+            Entity(contentValuesOf(Tasks.LIST_ID to taskList.id, Tasks._UID to parentUid, Tasks.TITLE to "Parent task"))
+        )
+        return childId to parentId
+    }
+
+    private fun createTaskList(): DmfsTaskList {
+        val info = ContentValues()
+        info.put(TaskLists.LIST_NAME, "Test Task List")
+        info.put(TaskLists.LIST_COLOR, 0xffff0000)
+        info.put(TaskLists.OWNER, "test@example.com")
+        info.put(TaskLists.SYNC_ENABLED, 1)
+        info.put(TaskLists.VISIBLE, 1)
+
+        val dmfsTaskListProvider = DmfsTaskListProvider(testAccount, provider, providerName)
+        return dmfsTaskListProvider.createAndGetTaskList(info)
+    }
+
+    /** Builds an [Entity] with [entityValues] as the main row and a single property sub-value. */
+    private fun taskEntity(
+        taskList: DmfsTaskList,
+        entityValues: ContentValues,
+        vararg propertyValues: Pair<String, Any?>
+    ): Entity =
+        Entity(entityValues).apply {
+            addSubValue(taskList.tasksPropertiesUri(), contentValuesOf(*propertyValues))
+        }
 
 }

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
@@ -579,6 +579,54 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName) :
     }
 
     @Test
+    fun testUpdateTask_DoesNotReDirtyTaskWithProperties() {
+        // Reproduces https://github.com/bitfireAT/davx5-ose/issues/2668:
+        // a task with a property (e.g. a category) that is updated by the sync adapter
+        // with _DIRTY=0 must not end up dirty again because of the property rows.
+        val taskList = createTaskList()
+        try {
+            val entity = Entity(
+                contentValuesOf(
+                    Tasks.LIST_ID to taskList.id,
+                    Tasks.TITLE to "Dirty Regression Test"
+                )
+            ).apply {
+                addSubValue(
+                    taskList.tasksPropertiesUri(),
+                    contentValuesOf(
+                        TaskContract.Properties.MIMETYPE to Property.Category.CONTENT_ITEM_TYPE,
+                        Property.Category.CATEGORY_NAME to "Work"
+                    )
+                )
+            }
+            val id = taskList.addTask(entity)
+
+            // simulate what the sync adapter does when applying a downloaded task:
+            // update the main row (with _DIRTY=0) and its properties in one batch
+            val updatedEntity = Entity(
+                contentValuesOf(
+                    Tasks.TITLE to "Dirty Regression Test (updated)",
+                    Tasks._DIRTY to 0
+                )
+            ).apply {
+                addSubValue(
+                    taskList.tasksPropertiesUri(),
+                    contentValuesOf(
+                        TaskContract.Properties.MIMETYPE to Property.Category.CONTENT_ITEM_TYPE,
+                        Property.Category.CATEGORY_NAME to "Work"
+                    )
+                )
+            }
+            taskList.updateTask(id, updatedEntity)
+
+            val dirty = taskList.getTaskRow(id, arrayOf(Tasks._DIRTY))?.getAsInteger(Tasks._DIRTY)
+            assertEquals(0, dirty)
+        } finally {
+            taskList.delete()
+        }
+    }
+
+    @Test
     fun testUpdateTasks() = runTest {
         val taskList = createTaskList()
         try {

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskListTest.kt
@@ -115,6 +115,56 @@ class DmfsTaskListTest(providerName: TaskProvider.ProviderName) :
         }
     }
 
+    @Test
+    fun testTouchRelations_DoesNotReDirtyTask() {
+        // Reproduces https://github.com/bitfireAT/davx5-ose/issues/2668:
+        // touching relations must not re-dirty a task that was just synced (clean).
+        val taskList = createTaskList()
+        try {
+            // insert child before parent, so RELATED_ID gets backfilled by the provider
+            // but PARENT_ID is not yet (see touchRelations()'s doc comment)
+            val childId = taskList.addTask(
+                Entity(
+                    contentValuesOf(
+                        Tasks.LIST_ID to taskList.id,
+                        Tasks._UID to "dirty-test-child",
+                        Tasks.TITLE to "Child task",
+                        Tasks.PARENT_ID to null
+                    )
+                ).apply {
+                    addSubValue(
+                        taskList.tasksPropertiesUri(),
+                        contentValuesOf(
+                            TaskContract.Properties.MIMETYPE to Property.Relation.CONTENT_ITEM_TYPE,
+                            Property.Relation.RELATED_UID to "dirty-test-parent",
+                            Property.Relation.RELATED_TYPE to Property.Relation.RELTYPE_PARENT
+                        )
+                    )
+                }
+            )
+            taskList.addTask(
+                Entity(
+                    contentValuesOf(
+                        Tasks.LIST_ID to taskList.id,
+                        Tasks._UID to "dirty-test-parent",
+                        Tasks.TITLE to "Parent task"
+                    )
+                )
+            )
+
+            // simulate the state right after a sync applied this task: not dirty
+            taskList.updateTaskRow(childId, contentValuesOf(Tasks._DIRTY to 0))
+
+            // touching relations updates the child's relation property row to set PARENT_ID
+            taskList.touchRelations()
+
+            val dirty = taskList.getTaskRow(childId, arrayOf(Tasks._DIRTY))?.getAsInteger(Tasks._DIRTY)
+            assertEquals(0, dirty)
+        } finally {
+            taskList.delete()
+        }
+    }
+
 
     // test tasks CRUD
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
@@ -113,7 +113,7 @@ class DmfsTaskList(
         // insert property rows (with reference to task row ID)
         for (row in entity.subValues) {
             batch += BatchOperation.CpoBuilder
-                .newInsert(tasksPropertiesUri(asSyncAdapter = true))
+                .newInsert(tasksPropertiesUri())
                 .withValues(row.values)
                 .withValueBackReference(TaskContract.Properties.TASK_ID, taskRowIdx)
         }
@@ -219,6 +219,7 @@ class DmfsTaskList(
                         null
                     )?.use { propertiesCursor ->
                         while (propertiesCursor.moveToNext())
+                        // plain URI as sub-value key, not an actual provider operation
                             entity.addSubValue(
                                 tasksPropertiesUri(asSyncAdapter = false),
                                 propertiesCursor.toContentValues()
@@ -382,7 +383,7 @@ class DmfsTaskList(
     fun updateTask(id: Long, entity: Entity, batch: TasksBatchOperation) {
         // delete existing property rows for this task
         batch += BatchOperation.CpoBuilder
-            .newDelete(tasksPropertiesUri(asSyncAdapter = true))
+            .newDelete(tasksPropertiesUri())
             .withSelection("${TaskContract.Properties.TASK_ID}=?", arrayOf(id.toString()))
 
         // update main row
@@ -396,7 +397,7 @@ class DmfsTaskList(
         // insert new property rows (with reference to task ID)
         for (row in entity.subValues) {
             batch += BatchOperation.CpoBuilder
-                .newInsert(tasksPropertiesUri(asSyncAdapter = true))
+                .newInsert(tasksPropertiesUri())
                 .withValues(ContentValues(row.values).apply {
                     remove(TaskContract.Properties.PROPERTY_ID) // don't reuse property IDs
                     put(TaskContract.Properties.TASK_ID, id)
@@ -534,7 +535,11 @@ class DmfsTaskList(
     internal fun taskUri(id: Long, loadProperties: Boolean = false): Uri =
         ContentUris.withAppendedId(tasksUri(loadProperties), id)
 
-    internal fun tasksPropertiesUri(asSyncAdapter: Boolean = false): Uri {
+    /**
+     * Properties URI. Defaults to sync adapter so writes don't re-dirty the task (#2668);
+     * pass `false` only for the URI stored as a loaded [Entity]'s sub-value key.
+     */
+    internal fun tasksPropertiesUri(asSyncAdapter: Boolean = true): Uri {
         val uri = TaskContract.Properties.getContentUri(providerName.authority)
         return if (asSyncAdapter)
             uri.asSyncAdapter(account)

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
@@ -201,7 +201,6 @@ class DmfsTaskList(
      * @param id    task ID
      *
      * @return task entity (or `null` if not found)
-     *
      * @throws LocalStorageException when the content provider returns an error
      */
     fun getTask(id: Long): Entity? {
@@ -218,12 +217,13 @@ class DmfsTaskList(
                         arrayOf(id.toString()),
                         null
                     )?.use { propertiesCursor ->
-                        while (propertiesCursor.moveToNext())
-                        // plain URI as sub-value key, not an actual provider operation
+                        while (propertiesCursor.moveToNext()) {
+                            // plain URI as sub-value key, not an actual provider operation
                             entity.addSubValue(
                                 tasksPropertiesUri(asSyncAdapter = false),
                                 propertiesCursor.toContentValues()
                             )
+                        }
                     }
                     return entity
                 }
@@ -536,8 +536,12 @@ class DmfsTaskList(
         ContentUris.withAppendedId(tasksUri(loadProperties), id)
 
     /**
-     * Properties URI. Defaults to sync adapter so writes don't re-dirty the task (#2668);
-     * pass `false` only for the URI stored as a loaded [Entity]'s sub-value key.
+     * URI to access the task provider's [TaskContract.Properties].
+     *
+     * **Important: Always do write operations [asSyncAdapter]**, otherwise results will be marked
+     * as "dirty". Doing everything [asSyncAdapter] is a safe default choice.
+     *
+     * @param asSyncAdapter whether [asSyncAdapter] is applied to the properties URI
      */
     internal fun tasksPropertiesUri(asSyncAdapter: Boolean = true): Uri {
         val uri = TaskContract.Properties.getContentUri(providerName.authority)

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/tasks/DmfsTaskList.kt
@@ -113,7 +113,7 @@ class DmfsTaskList(
         // insert property rows (with reference to task row ID)
         for (row in entity.subValues) {
             batch += BatchOperation.CpoBuilder
-                .newInsert(tasksPropertiesUri())
+                .newInsert(tasksPropertiesUri(asSyncAdapter = true))
                 .withValues(row.values)
                 .withValueBackReference(TaskContract.Properties.TASK_ID, taskRowIdx)
         }
@@ -382,7 +382,7 @@ class DmfsTaskList(
     fun updateTask(id: Long, entity: Entity, batch: TasksBatchOperation) {
         // delete existing property rows for this task
         batch += BatchOperation.CpoBuilder
-            .newDelete(tasksPropertiesUri())
+            .newDelete(tasksPropertiesUri(asSyncAdapter = true))
             .withSelection("${TaskContract.Properties.TASK_ID}=?", arrayOf(id.toString()))
 
         // update main row
@@ -396,7 +396,7 @@ class DmfsTaskList(
         // insert new property rows (with reference to task ID)
         for (row in entity.subValues) {
             batch += BatchOperation.CpoBuilder
-                .newInsert(tasksPropertiesUri())
+                .newInsert(tasksPropertiesUri(asSyncAdapter = true))
                 .withValues(ContentValues(row.values).apply {
                     remove(TaskContract.Properties.PROPERTY_ID) // don't reuse property IDs
                     put(TaskContract.Properties.TASK_ID, id)


### PR DESCRIPTION
### Purpose

Fixes a regression in the task dirty flag when handling properties.

### Short description

- Restores correct behavior of the task dirty flag when properties are modified.
- Adds a test case to prevent future regressions.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.