### PR TITLE
Refactor SyncManager to use Flow directly

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -58,6 +58,8 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
@@ -668,19 +670,22 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
 
             coroutineScope {    // structured concurrency
                 val processMultiStatusScope = this
-                remoteList.collect { item ->
-                    if (item is MultiStatusItem.Response && item.relation == Response.HrefRelation.MEMBER) {
+
+                remoteList
+                    .filterIsInstance<MultiStatusItem.Response>()
+                    .filter { it.relation == Response.HrefRelation.MEMBER }
+                    .collect {
                         // launches coroutines in scope
-                        processMemberResponse(processMultiStatusScope, item.response, batchDownloader)
+                        processMemberResponse(processMultiStatusScope, it.response, batchDownloader)
                     }
-                }
-                // wait until all coroutines in processMultiStatusScope have finished
+
+                // wait until all coroutines launched in processMultiStatusScope have finished
             }
 
             // download remaining resources
             batchDownloader.flush()
 
-            // wait until all coroutines in processRemoteListScope have finished
+            // wait until all coroutines launched in processRemoteListScope have finished
         }
     }
 
@@ -712,6 +717,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
             var furtherResults = false
             coroutineScope {    // structured concurrency
                 val processMultiStatusScope = this
+
                 remoteList.collect { item ->
                     when (item) {
                         is MultiStatusItem.Response ->
@@ -729,7 +735,8 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
                             (item.property as? SyncToken)?.let { syncToken = it }
                     }
                 }
-                // wait until all coroutines in processMultiStatusScope have finished
+
+                // wait until all coroutines launched in processMultiStatusScope have finished
             }
 
             // download remaining resources
@@ -740,7 +747,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
                 furtherResults
             )
 
-            // wait until all coroutines in processRemoteChangesScope have finished
+            // wait until all coroutines launched in processRemoteChangesScope have finished
         }
 
     protected open fun listRemoteChanges(syncState: SyncState?): Flow<MultiStatusItem> =

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -56,6 +56,7 @@ import io.ktor.http.content.OutgoingContent
 import io.ktor.http.headers
 import io.ktor.util.appendAll
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
@@ -189,9 +190,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
 
                         // list and process all entries at current sync state (which may be the same as or newer than remoteSyncState)
                         logger.info("Processing remote entries")
-                        syncRemote { callback ->
-                            listAllRemote().forEachResponse(callback)
-                        }
+                        processRemoteList(listAllRemote())
 
                         logger.info("Deleting entries which are not present remotely anymore")
                         deleteNotPresentRemotely()
@@ -219,23 +218,21 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
                         var furtherChanges = false
                         do {
                             logger.info("Listing changes since $syncState")
-                            syncRemote { callback ->
-                                try {
-                                    val result = listRemoteChanges(syncState, callback)
-                                    syncState = SyncState.fromSyncToken(result.first, initialSync)
-                                    furtherChanges = result.second
-                                } catch (e: HttpException) {
-                                    if (e.errors.contains(Error(WebDAV.ValidSyncToken))) {
-                                        logger.info("Sync token invalid, performing initial sync")
-                                        initialSync = true
-                                        resetPresentRemotely()
+                            try {
+                                val (token, further) = processRemoteChanges(listRemoteChanges(syncState))
+                                syncState = SyncState.fromSyncToken(token, initialSync)
+                                furtherChanges = further
+                            } catch (e: HttpException) {
+                                if (e.errors.contains(Error(WebDAV.ValidSyncToken))) {
+                                    logger.info("Sync token invalid, performing initial sync")
+                                    initialSync = true
+                                    resetPresentRemotely()
 
-                                        val result = listRemoteChanges(null, callback)
-                                        syncState = SyncState.fromSyncToken(result.first, initialSync)
-                                        furtherChanges = result.second
-                                    } else
-                                        throw e
-                                }
+                                    val (token, further) = processRemoteChanges(listRemoteChanges(null))
+                                    syncState = SyncState.fromSyncToken(token, initialSync)
+                                    furtherChanges = further
+                                } else
+                                    throw e
                             }
 
                             logger.info("Saving sync state: $syncState")
@@ -598,12 +595,68 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
     }
 
     /**
-     * Calls a function to list remote resources. All resources from the returned
-     * list are downloaded and processed.
+     * Processes a single `<response>` element from a remote listing: downloads new or
+     * changed resources, and marks unchanged ones as remotely present. Ignores collections.
      *
-     * @param listRemote function to list remote resources (for instance, all since a certain sync-token)
+     * @param scope             scope to launch per-resource processing in
+     * @param response          the `<response>` element to process
+     * @param batchDownloader   downloader to enqueue new/changed resources with
      */
-    protected open suspend fun syncRemote(listRemote: suspend (MultiResponseCallback) -> Unit) =
+    private fun processMemberResponse(scope: CoroutineScope, response: Response, batchDownloader: BatchDownloader) {
+        // ignore collections
+        if (response[ResourceType::class.java]?.types?.contains(WebDAV.Collection) == true)
+            return
+
+        val name = response.hrefName()
+
+        if (response.isSuccess()) {
+            logger.fine("Found remote resource: $name")
+
+            scope.launch {
+                val local = localCollection.findByName(name)
+                SyncException.wrapWithLocalResource(local) {
+                    if (local == null) {
+                        logger.info("$name has been added remotely, queueing download")
+                        batchDownloader.enqueue(response.href)
+                    } else {
+                        val localETag = local.eTag
+                        val remoteETag = response[GetETag::class.java]?.eTag
+                            ?: throw DavException("Server didn't provide ETag")
+                        if (localETag == remoteETag) {
+                            logger.info("$name has not been changed on server (ETag still $remoteETag)")
+                        } else {
+                            logger.info("$name has been changed on server (current ETag=$remoteETag, last known ETag=$localETag)")
+                            batchDownloader.enqueue(response.href)
+                        }
+
+                        // mark as remotely present, so that this resource won't be deleted at the end
+                        local.updateFlags(LocalResource.FLAG_REMOTELY_PRESENT)
+                    }
+                }
+            }
+
+        } else if (response.status == HttpStatusCode.NotFound) {
+            // collection sync: resource has been deleted on remote server
+            scope.launch {
+                localCollection.findByName(name)?.let { local ->
+                    SyncException.wrapWithLocalResource(local) {
+                        logger.info("$name has been deleted on server, deleting locally")
+                        local.deleteLocal()
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Processes a full remote listing (PROPFIND/REPORT). All resources from [remoteList]
+     * are downloaded and processed.
+     *
+     * @param remoteList remote listing to process
+     *
+     * @return properties found outside `<response>` elements (for instance `sync-token`)
+     */
+    protected open suspend fun processRemoteList(remoteList: Flow<MultiStatusItem>): List<Property> =
         coroutineScope {    // structured concurrency
             val batchDownloader = BatchDownloader { batch ->
                 launch {
@@ -613,96 +666,85 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
                 }
             }
 
+            val extraProperties = mutableListOf<Property>()
             coroutineScope {    // structured concurrency
-                listRemote { response, relation ->
-                    // ignore non-members
-                    if (relation != Response.HrefRelation.MEMBER)
-                        return@listRemote
-
-                    // ignore collections
-                    if (response[ResourceType::class.java]?.types?.contains(WebDAV.Collection) == true)
-                        return@listRemote
-
-                    val name = response.hrefName()
-
-                    if (response.isSuccess()) {
-                        logger.fine("Found remote resource: $name")
-
-                        launch {
-                            val local = localCollection.findByName(name)
-                            SyncException.wrapWithLocalResource(local) {
-                                if (local == null) {
-                                    logger.info("$name has been added remotely, queueing download")
-                                    batchDownloader.enqueue(response.href)
-                                } else {
-                                    val localETag = local.eTag
-                                    val remoteETag = response[GetETag::class.java]?.eTag
-                                        ?: throw DavException("Server didn't provide ETag")
-                                    if (localETag == remoteETag) {
-                                        logger.info("$name has not been changed on server (ETag still $remoteETag)")
-                                    } else {
-                                        logger.info("$name has been changed on server (current ETag=$remoteETag, last known ETag=$localETag)")
-                                        batchDownloader.enqueue(response.href)
-                                    }
-
-                                    // mark as remotely present, so that this resource won't be deleted at the end
-                                    local.updateFlags(LocalResource.FLAG_REMOTELY_PRESENT)
-                                }
-                            }
-                        }
-
-                    } else if (response.status == HttpStatusCode.NotFound) {
-                        // collection sync: resource has been deleted on remote server
-                        launch {
-                            localCollection.findByName(name)?.let { local ->
-                                SyncException.wrapWithLocalResource(local) {
-                                    logger.info("$name has been deleted on server, deleting locally")
-                                    local.deleteLocal()
-                                }
-                            }
-                        }
+                val scope = this
+                remoteList.collect { item ->
+                    when (item) {
+                        is MultiStatusItem.Response ->
+                            if (item.relation == Response.HrefRelation.MEMBER)
+                                processMemberResponse(scope, item.response, batchDownloader)
+                        is MultiStatusItem.ExtraProperty ->
+                            extraProperties += item.property
                     }
                 }
             }
 
             // download remaining resources
             batchDownloader.flush()
+
+            extraProperties
         }
 
     protected abstract fun listAllRemote(): Flow<MultiStatusItem>
 
-    protected open suspend fun listRemoteChanges(
-        syncState: SyncState?,
-        callback: MultiResponseCallback
-    ): Pair<SyncToken, Boolean> {
-        var furtherResults = false
+    /**
+     * Processes remote changes as received by [listRemoteChanges] (RFC 6578 `sync-collection` REPORT).
+     * All changed/new resources from [remoteList] are downloaded, and resources deleted on the
+     * server are deleted locally.
+     *
+     * @param remoteList remote changes to process
+     *
+     * @return sync-token of the processed changes, and whether the server indicated further results
+     */
+    protected open suspend fun processRemoteChanges(remoteList: Flow<MultiStatusItem>): Pair<SyncToken, Boolean> =
+        coroutineScope {    // structured concurrency
+            val batchDownloader = BatchDownloader { batch ->
+                launch {
+                    syncTransferSemaphore.withPermit {
+                        downloadRemote(batch)
+                    }
+                }
+            }
 
-        val report = davCollection.reportChanges(
+            var furtherResults = false
+            val extraProperties = mutableListOf<Property>()
+            coroutineScope {    // structured concurrency
+                val scope = this
+                remoteList.collect { item ->
+                    when (item) {
+                        is MultiStatusItem.Response ->
+                            when (item.relation) {
+                                Response.HrefRelation.SELF ->
+                                    furtherResults = item.response.status == HttpStatusCode.InsufficientStorage
+
+                                Response.HrefRelation.MEMBER ->
+                                    processMemberResponse(scope, item.response, batchDownloader)
+
+                                else ->
+                                    logger.fine("Unexpected sync-collection response: ${item.response}")
+                            }
+                        is MultiStatusItem.ExtraProperty ->
+                            extraProperties += item.property
+                    }
+                }
+            }
+
+            // download remaining resources
+            batchDownloader.flush()
+
+            val syncToken = extraProperties.filterIsInstance<SyncToken>().firstOrNull()
+                ?: throw DavException("Received sync-collection response without sync-token")
+
+            Pair(syncToken, furtherResults)
+        }
+
+    protected open fun listRemoteChanges(syncState: SyncState?): Flow<MultiStatusItem> =
+        davCollection.reportChanges(
             syncState?.takeIf { syncState.type == SyncState.Type.SYNC_TOKEN }?.value,
             false, null,
             WebDAV.GetETag
-        ).forEachResponse { response, relation ->
-            when (relation) {
-                Response.HrefRelation.SELF ->
-                    furtherResults = response.status == HttpStatusCode.InsufficientStorage
-
-                Response.HrefRelation.MEMBER ->
-                    callback(response, relation)
-
-                else ->
-                    logger.fine("Unexpected sync-collection response: $response")
-            }
-        }
-
-        var syncToken: SyncToken? = null
-        report.filterIsInstance<SyncToken>().firstOrNull()?.let {
-            syncToken = it
-        }
-        if (syncToken == null)
-            throw DavException("Received sync-collection response without sync-token")
-
-        return Pair(syncToken, furtherResults)
-    }
+        )
 
     /**
      * Downloads and processes resources, given as a list of URLs. Will be called with a list
@@ -879,29 +921,4 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
         )
     }
 
-    /**
-     * Bridges a [Flow] of [MultiStatusItem]s back to callback style, invoking [callback]
-     * for every [MultiStatusItem.Response] the flow emits.
-     *
-     * This is a temporary adapter to keep [syncRemote] and friends close to their
-     * pre-[Flow] shape. The goal is to migrate them to work with [Flow] directly and
-     * drop callback-style processing (and this helper) entirely.
-     *
-     * @return properties found outside `<response>` elements (for instance `sync-token`)
-     */
-    private suspend fun Flow<MultiStatusItem>.forEachResponse(
-        callback: MultiResponseCallback
-    ): List<Property> {
-        val extraProperties = mutableListOf<Property>()
-        collect { item ->
-            when (item) {
-                is MultiStatusItem.Response -> callback(item.response, item.relation)
-                is MultiStatusItem.ExtraProperty -> extraProperties += item.property
-            }
-        }
-        return extraProperties
-    }
-
 }
-
-typealias MultiResponseCallback = suspend (Response, Response.HrefRelation) -> Unit

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -655,8 +655,11 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
      */
     protected open suspend fun processRemoteList(remoteList: Flow<MultiStatusItem>) {
         coroutineScope {    // structured concurrency
+            val processRemoteListScope = this
+
+            // launches coroutines in processRemoteListScope
             val batchDownloader = BatchDownloader { batch ->
-                launch {
+                processRemoteListScope.launch {
                     syncTransferSemaphore.withPermit {
                         downloadRemote(batch)
                     }
@@ -664,15 +667,20 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
             }
 
             coroutineScope {    // structured concurrency
-                val scope = this
+                val processMultiStatusScope = this
                 remoteList.collect { item ->
-                    if (item is MultiStatusItem.Response && item.relation == Response.HrefRelation.MEMBER)
-                        processMemberResponse(scope, item.response, batchDownloader)
+                    if (item is MultiStatusItem.Response && item.relation == Response.HrefRelation.MEMBER) {
+                        // launches coroutines in scope
+                        processMemberResponse(processMultiStatusScope, item.response, batchDownloader)
+                    }
                 }
+                // wait until all coroutines in processMultiStatusScope have finished
             }
 
             // download remaining resources
             batchDownloader.flush()
+
+            // wait until all coroutines in processRemoteListScope have finished
         }
     }
 
@@ -688,9 +696,12 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
      * @return sync-token of the processed changes, and whether the server indicated further results
      */
     protected open suspend fun processRemoteChanges(remoteList: Flow<MultiStatusItem>): Pair<SyncToken, Boolean> =
-        coroutineScope {        // structured concurrency – wait for all batch downloads (including flush)
+        coroutineScope {        // structured concurrency
+            val processRemoteChangesScope = this
+
+            // launches coroutines in processRemoteChangesScope
             val batchDownloader = BatchDownloader { batch ->
-                launch {
+                processRemoteChangesScope.launch {
                     syncTransferSemaphore.withPermit {
                         downloadRemote(batch)
                     }
@@ -699,8 +710,8 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
 
             var syncToken: SyncToken? = null
             var furtherResults = false
-            coroutineScope {    // structured concurrency – wait for all per-response processing
-                val scope = this
+            coroutineScope {    // structured concurrency
+                val processMultiStatusScope = this
                 remoteList.collect { item ->
                     when (item) {
                         is MultiStatusItem.Response ->
@@ -709,7 +720,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
                                     furtherResults = item.response.status == HttpStatusCode.InsufficientStorage
 
                                 Response.HrefRelation.MEMBER ->
-                                    processMemberResponse(scope, item.response, batchDownloader)
+                                    processMemberResponse(processMultiStatusScope, item.response, batchDownloader)
 
                                 else ->
                                     logger.fine("Unexpected sync-collection response: ${item.response}")
@@ -718,6 +729,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
                             (item.property as? SyncToken)?.let { syncToken = it }
                     }
                 }
+                // wait until all coroutines in processMultiStatusScope have finished
             }
 
             // download remaining resources
@@ -727,6 +739,8 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
                 syncToken ?: throw DavException("Received sync-collection response without sync-token"),
                 furtherResults
             )
+
+            // wait until all coroutines in processRemoteChangesScope have finished
         }
 
     protected open fun listRemoteChanges(syncState: SyncState?): Flow<MultiStatusItem> =

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -214,12 +214,12 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
                             initialSync = true
                         }
 
-                        var furtherChanges = false
+                        var furtherChanges: Boolean
                         do {
                             logger.info("Listing changes since $syncState")
                             try {
-                                val (token, further) = processRemoteChanges(listRemoteChanges(syncState))
-                                syncState = SyncState.fromSyncToken(token, initialSync)
+                                val (newToken, further) = processRemoteChanges(listRemoteChanges(syncState))
+                                syncState = SyncState.fromSyncToken(newToken, initialSync)
                                 furtherChanges = further
                             } catch (e: HttpException) {
                                 if (e.errors.contains(Error(WebDAV.ValidSyncToken))) {
@@ -227,8 +227,8 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
                                     initialSync = true
                                     resetPresentRemotely()
 
-                                    val (token, further) = processRemoteChanges(listRemoteChanges(null))
-                                    syncState = SyncState.fromSyncToken(token, initialSync)
+                                    val (newToken, further) = processRemoteChanges(listRemoteChanges(null))
+                                    syncState = SyncState.fromSyncToken(newToken, initialSync = true)
                                     furtherChanges = further
                                 } else
                                     throw e
@@ -246,7 +246,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
                             deleteNotPresentRemotely()
 
                             // remove initial sync flag
-                            syncState!!.initialSync = false
+                            syncState.initialSync = false
                             logger.info("Initial sync completed, saving sync state: $syncState")
                             localCollection.lastSyncState = syncState
                         }

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -10,7 +10,6 @@ import android.os.DeadObjectException
 import android.os.RemoteException
 import androidx.annotation.VisibleForTesting
 import at.bitfire.dav4jvm.Error
-import at.bitfire.dav4jvm.Property
 import at.bitfire.dav4jvm.QuotedStringUtils
 import at.bitfire.dav4jvm.ktor.DavCollection
 import at.bitfire.dav4jvm.ktor.DavResource
@@ -653,10 +652,8 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
      * are downloaded and processed.
      *
      * @param remoteList remote listing to process
-     *
-     * @return properties found outside `<response>` elements (for instance `sync-token`)
      */
-    protected open suspend fun processRemoteList(remoteList: Flow<MultiStatusItem>): List<Property> =
+    protected open suspend fun processRemoteList(remoteList: Flow<MultiStatusItem>) {
         coroutineScope {    // structured concurrency
             val batchDownloader = BatchDownloader { batch ->
                 launch {
@@ -666,25 +663,18 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
                 }
             }
 
-            val extraProperties = mutableListOf<Property>()
             coroutineScope {    // structured concurrency
                 val scope = this
                 remoteList.collect { item ->
-                    when (item) {
-                        is MultiStatusItem.Response ->
-                            if (item.relation == Response.HrefRelation.MEMBER)
-                                processMemberResponse(scope, item.response, batchDownloader)
-                        is MultiStatusItem.ExtraProperty ->
-                            extraProperties += item.property
-                    }
+                    if (item is MultiStatusItem.Response && item.relation == Response.HrefRelation.MEMBER)
+                        processMemberResponse(scope, item.response, batchDownloader)
                 }
             }
 
             // download remaining resources
             batchDownloader.flush()
-
-            extraProperties
         }
+    }
 
     protected abstract fun listAllRemote(): Flow<MultiStatusItem>
 
@@ -698,7 +688,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
      * @return sync-token of the processed changes, and whether the server indicated further results
      */
     protected open suspend fun processRemoteChanges(remoteList: Flow<MultiStatusItem>): Pair<SyncToken, Boolean> =
-        coroutineScope {    // structured concurrency
+        coroutineScope {        // structured concurrency – wait for all batch downloads (including flush)
             val batchDownloader = BatchDownloader { batch ->
                 launch {
                     syncTransferSemaphore.withPermit {
@@ -707,9 +697,9 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
                 }
             }
 
+            var syncToken: SyncToken? = null
             var furtherResults = false
-            val extraProperties = mutableListOf<Property>()
-            coroutineScope {    // structured concurrency
+            coroutineScope {    // structured concurrency – wait for all per-response processing
                 val scope = this
                 remoteList.collect { item ->
                     when (item) {
@@ -725,7 +715,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
                                     logger.fine("Unexpected sync-collection response: ${item.response}")
                             }
                         is MultiStatusItem.ExtraProperty ->
-                            extraProperties += item.property
+                            (item.property as? SyncToken)?.let { syncToken = it }
                     }
                 }
             }
@@ -733,10 +723,10 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
             // download remaining resources
             batchDownloader.flush()
 
-            val syncToken = extraProperties.filterIsInstance<SyncToken>().firstOrNull()
-                ?: throw DavException("Received sync-collection response without sync-token")
-
-            Pair(syncToken, furtherResults)
+            Pair(
+                syncToken ?: throw DavException("Received sync-collection response without sync-token"),
+                furtherResults
+            )
         }
 
     protected open fun listRemoteChanges(syncState: SyncState?): Flow<MultiStatusItem> =

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -58,8 +58,6 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
@@ -191,7 +189,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
 
                         // list and process all entries at current sync state (which may be the same as or newer than remoteSyncState)
                         logger.info("Processing remote entries")
-                        processRemoteList(listAllRemote())
+                        processRemoteMembers(listAllRemote())
 
                         logger.info("Deleting entries which are not present remotely anymore")
                         deleteNotPresentRemotely()
@@ -220,7 +218,9 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
                         do {
                             logger.info("Listing changes since $syncState")
                             try {
-                                val (newToken, further) = processRemoteChanges(listRemoteChanges(syncState))
+                                val (syncToken, further) = processRemoteMembers(listRemoteChanges(syncState))
+                                val newToken = syncToken
+                                    ?: throw DavException("Received sync-collection response without sync-token")
                                 syncState = SyncState.fromSyncToken(newToken, initialSync)
                                 furtherChanges = further
                             } catch (e: HttpException) {
@@ -229,7 +229,9 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
                                     initialSync = true
                                     resetPresentRemotely()
 
-                                    val (newToken, further) = processRemoteChanges(listRemoteChanges(null))
+                                    val (syncToken, further) = processRemoteMembers(listRemoteChanges(null))
+                                    val newToken = syncToken
+                                        ?: throw DavException("Received sync-collection response without sync-token")
                                     syncState = SyncState.fromSyncToken(newToken, initialSync = true)
                                     furtherChanges = further
                                 } else
@@ -650,63 +652,22 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
     }
 
     /**
-     * Processes a full remote listing (PROPFIND/REPORT). All resources from [remoteList]
-     * are downloaded and processed.
+     * Processes a remote listing: all resources from [remoteList] are downloaded and processed.
+     * Handles both full listings (PROPFIND/REPORT) and sync-collection changes (RFC 6578); for the
+     * latter, extracts the sync-token and whether the server indicated further results.
      *
-     * @param remoteList remote listing to process
+     * @param remoteList remote listing (or changes) to process
+     *
+     * @return sync-token, if any was found in [remoteList] (only present for sync-collection changes),
+     *         and whether the server indicated further results
      */
-    protected open suspend fun processRemoteList(remoteList: Flow<MultiStatusItem>) {
-        coroutineScope {    // structured concurrency
-            val processRemoteListScope = this
-
-            // launches coroutines in processRemoteListScope
-            val batchDownloader = BatchDownloader { batch ->
-                processRemoteListScope.launch {
-                    syncTransferSemaphore.withPermit {
-                        downloadRemote(batch)
-                    }
-                }
-            }
-
-            coroutineScope {    // structured concurrency
-                val processMultiStatusScope = this
-
-                remoteList
-                    .filterIsInstance<MultiStatusItem.Response>()
-                    .filter { it.relation == Response.HrefRelation.MEMBER }
-                    .collect {
-                        // launches coroutines in scope
-                        processMemberResponse(processMultiStatusScope, it.response, batchDownloader)
-                    }
-
-                // wait until all coroutines launched in processMultiStatusScope have finished
-            }
-
-            // download remaining resources
-            batchDownloader.flush()
-
-            // wait until all coroutines launched in processRemoteListScope have finished
-        }
-    }
-
-    protected abstract fun listAllRemote(): Flow<MultiStatusItem>
-
-    /**
-     * Processes remote changes as received by [listRemoteChanges] (RFC 6578 `sync-collection` REPORT).
-     * All changed/new resources from [remoteList] are downloaded, and resources deleted on the
-     * server are deleted locally.
-     *
-     * @param remoteList remote changes to process
-     *
-     * @return sync-token of the processed changes, and whether the server indicated further results
-     */
-    protected open suspend fun processRemoteChanges(remoteList: Flow<MultiStatusItem>): Pair<SyncToken, Boolean> =
+    protected suspend fun processRemoteMembers(remoteList: Flow<MultiStatusItem>): Pair<SyncToken?, Boolean> =
         coroutineScope {        // structured concurrency
-            val processRemoteChangesScope = this
+            val processRemoteScope = this
 
-            // launches coroutines in processRemoteChangesScope
+            // launches coroutines in processRemoteScope
             val batchDownloader = BatchDownloader { batch ->
-                processRemoteChangesScope.launch {
+                processRemoteScope.launch {
                     syncTransferSemaphore.withPermit {
                         downloadRemote(batch)
                     }
@@ -742,13 +703,12 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
             // download remaining resources
             batchDownloader.flush()
 
-            Pair(
-                syncToken ?: throw DavException("Received sync-collection response without sync-token"),
-                furtherResults
-            )
+            Pair(syncToken, furtherResults)
 
-            // wait until all coroutines launched in processRemoteChangesScope have finished
+            // wait until all coroutines launched in processRemoteScope have finished
         }
+
+    protected abstract fun listAllRemote(): Flow<MultiStatusItem>
 
     protected open fun listRemoteChanges(syncState: SyncState?): Flow<MultiStatusItem> =
         davCollection.reportChanges(


### PR DESCRIPTION
### Purpose

Follow-up of #2640.

Refactor `SyncManager` to use the multi-status Flow directly, removing callback-based processing.

### Short description

- Replaced callback-based processing in SyncManager with Kotlin Flow
- Removed legacy callback infrastructure
- Better documentation of structured concurrency (with explicit scope names).
- No logical changes, especially not in structured concurrency.

Duplicates a few lines of code by removing one `syncRemote` and adding two

- `processRemoteList` and
- `processRemoteChanges`,

but these belong to different sync algorithms and should be separately. My plan is to move each of them into the corresponding `SyncAlgorithm` implementation in the follow-up PR.

**Not in scope / for follow up-PRs:**

- extract SyncAlgorithm (without logical change) to reduce `SyncManager` responsibilities and make the sync algorithm testable and better maintainable. → #2701
- reduce structured concurrency usage

### Checklist

- [x] The PR has a proper title, description and label.
- [ ] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [ ] I have added documentation to complex functions and functions that can be used by other modules.
- [ ] I have added reasonable tests or consciously decided to not add tests.