### PR TITLE
Remove `runBlocking()` from account settings migrations

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/db/CollectionDao.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/CollectionDao.kt
@@ -29,6 +29,9 @@ interface CollectionDao {
     @Query("SELECT * FROM collection WHERE serviceId=:serviceId")
     suspend fun getByService(serviceId: Long): List<Collection>
 
+    @Query("SELECT * FROM collection WHERE serviceId=:serviceId")
+    fun getByServiceBlocking(serviceId: Long): List<Collection>
+
     @Query("SELECT * FROM collection WHERE serviceId=:serviceId AND homeSetId IS :homeSetId")
     fun getByServiceAndHomeset(serviceId: Long, homeSetId: Long?): List<Collection>
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration17.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration17.kt
@@ -23,7 +23,6 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntKey
 import dagger.multibindings.IntoMap
-import kotlinx.coroutines.runBlocking
 import java.util.logging.Level
 import java.util.logging.Logger
 import javax.inject.Inject
@@ -51,42 +50,40 @@ class AccountSettingsMigration17 @Inject constructor(
             logger.log(Level.WARNING, "Missing permissions for contacts authority, won't set collection ID for address books", e)
             null
         }?.use { provider ->
-            runBlocking {
-                val service = serviceRepository.getByAccountAndType(account.name, Service.TYPE_CARDDAV) ?: return@runBlocking
+            val service = serviceRepository.getByAccountAndTypeBlocking(account.name, Service.TYPE_CARDDAV) ?: return@use
 
-                val accountManager = AccountManager.get(context)
-                // Get all old address books of this account, i.e. the ones which have a "real_account_name" of this account.
-                // After this migration is run, address books won't be associated to accounts anymore but only to their respective collection/URL.
-                val oldAddressBookAccounts = accountManager.getAccountsByType(addressBookAccountType)
-                    .filter { addressBookAccount ->
-                        account.name == accountManager.getUserData(addressBookAccount, "real_account_name")
-                    }
+            val accountManager = AccountManager.get(context)
+            // Get all old address books of this account, i.e. the ones which have a "real_account_name" of this account.
+            // After this migration is run, address books won't be associated to accounts anymore but only to their respective collection/URL.
+            val oldAddressBookAccounts = accountManager.getAccountsByType(addressBookAccountType)
+                .filter { addressBookAccount ->
+                    account.name == accountManager.getUserData(addressBookAccount, "real_account_name")
+                }
 
-                val accountSettings = accountSettingsFactory.create(account)
-                val groupMethod = accountSettings.getGroupMethod()
+            val accountSettings = accountSettingsFactory.create(account)
+            val groupMethod = accountSettings.getGroupMethod()
 
-                for (oldAddressBookAccount in oldAddressBookAccounts) {
-                    // Old address books only have a URL, so use it to determine the collection ID
-                    logger.info("Migrating address book ${oldAddressBookAccount.name}")
-                    val oldAddressBook = localAddressBookFactory.create(account, oldAddressBookAccount, provider, groupMethod)
+            for (oldAddressBookAccount in oldAddressBookAccounts) {
+                // Old address books only have a URL, so use it to determine the collection ID
+                logger.info("Migrating address book ${oldAddressBookAccount.name}")
+                val oldAddressBook = localAddressBookFactory.create(account, oldAddressBookAccount, provider, groupMethod)
 
-                    val url: String? = accountManager.getUserData(oldAddressBookAccount, LOCAL_ADDRESS_BOOK_ACCOUNT_USER_DATA_URL)
-                    if (url == null) {
-                        logger.warning("Address book ${oldAddressBookAccount.name} doesn't have an assigned URL, can't migrate")
-                        continue
-                    }
+                val url: String? = accountManager.getUserData(oldAddressBookAccount, LOCAL_ADDRESS_BOOK_ACCOUNT_USER_DATA_URL)
+                if (url == null) {
+                    logger.warning("Address book ${oldAddressBookAccount.name} doesn't have an assigned URL, can't migrate")
+                    continue
+                }
 
-                    collectionRepository.getByServiceAndUrl(service.id, url)?.let { collection ->
-                        // Set collection ID and rename the account
-                        localAddressBookStore.update(provider, oldAddressBook, collection)
-                        // The user-data-url is not being set in localAddressBookStore.update() anymore,
-                        // but we need to keep it for the migration
-                        accountManager.setAndVerifyUserData(
-                            oldAddressBook.addressBookAccount,
-                            LOCAL_ADDRESS_BOOK_ACCOUNT_USER_DATA_URL,
-                            collection.url.toString()
-                        )
-                    }
+                collectionRepository.getByServiceAndUrl(service.id, url)?.let { collection ->
+                    // Set collection ID and rename the account
+                    localAddressBookStore.update(provider, oldAddressBook, collection)
+                    // The user-data-url is not being set in localAddressBookStore.update() anymore,
+                    // but we need to keep it for the migration
+                    accountManager.setAndVerifyUserData(
+                        oldAddressBook.addressBookAccount,
+                        LOCAL_ADDRESS_BOOK_ACCOUNT_USER_DATA_URL,
+                        collection.url.toString()
+                    )
                 }
             }
         }

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration18.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration18.kt
@@ -19,7 +19,6 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntKey
 import dagger.multibindings.IntoMap
-import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
 /**
@@ -40,24 +39,22 @@ class AccountSettingsMigration18 @Inject constructor(
 
     override fun migrate(account: Account) {
         val accountManager = AccountManager.get(context)
-        runBlocking {
-            db.serviceDao().getByAccountAndType(account.name, Service.TYPE_CARDDAV)?.let { service ->
-                db.collectionDao().getByService(service.id).forEach { collection ->
-                    // Find associated address book account by collection ID (if it exists)
-                    val addressBookAccount = accountManager
-                        .getAccountsByType(context.getString(R.string.account_type_address_book))
-                        .firstOrNull {
-                            accountManager.getUserData(
-                                it,
-                                LocalAddressBook.USER_DATA_COLLECTION_ID
-                            ) == collection.id.toString()
-                        }
-
-                    if (addressBookAccount != null) {
-                        // (Re-)assign address book to account
-                        accountManager.setAndVerifyUserData(addressBookAccount, LocalAddressBook.USER_DATA_ACCOUNT_NAME, account.name)
-                        accountManager.setAndVerifyUserData(addressBookAccount, LocalAddressBook.USER_DATA_ACCOUNT_TYPE, account.type)
+        db.serviceDao().getByAccountAndTypeBlocking(account.name, Service.TYPE_CARDDAV)?.let { service ->
+            db.collectionDao().getByServiceBlocking(service.id).forEach { collection ->
+                // Find associated address book account by collection ID (if it exists)
+                val addressBookAccount = accountManager
+                    .getAccountsByType(context.getString(R.string.account_type_address_book))
+                    .firstOrNull {
+                        accountManager.getUserData(
+                            it,
+                            LocalAddressBook.USER_DATA_COLLECTION_ID
+                        ) == collection.id.toString()
                     }
+
+                if (addressBookAccount != null) {
+                    // (Re-)assign address book to account
+                    accountManager.setAndVerifyUserData(addressBookAccount, LocalAddressBook.USER_DATA_ACCOUNT_NAME, account.name)
+                    accountManager.setAndVerifyUserData(addressBookAccount, LocalAddressBook.USER_DATA_ACCOUNT_TYPE, account.type)
                 }
             }
         }

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration20.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration20.kt
@@ -27,7 +27,6 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntKey
 import dagger.multibindings.IntoMap
-import kotlinx.coroutines.runBlocking
 import org.dmfs.tasks.contract.TaskContract.TaskLists
 import javax.inject.Inject
 
@@ -51,15 +50,13 @@ class AccountSettingsMigration20 @Inject constructor(
     val accountManager = AccountManager.get(context)
 
     override fun migrate(account: Account) {
-        runBlocking {
-            serviceRepository.getByAccountAndType(account.name, Service.TYPE_CARDDAV)?.let { cardDavService ->
-                migrateAddressBooks(account, cardDavService.id)
-            }
+        serviceRepository.getByAccountAndTypeBlocking(account.name, Service.TYPE_CARDDAV)?.let { cardDavService ->
+            migrateAddressBooks(account, cardDavService.id)
+        }
 
-            serviceRepository.getByAccountAndType(account.name, Service.TYPE_CALDAV)?.let { calDavService ->
-                migrateCalendars(account, calDavService.id)
-                migrateTaskLists(account, calDavService.id)
-            }
+        serviceRepository.getByAccountAndTypeBlocking(account.name, Service.TYPE_CALDAV)?.let { calDavService ->
+            migrateCalendars(account, calDavService.id)
+            migrateTaskLists(account, calDavService.id)
         }
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration9.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration9.kt
@@ -15,7 +15,6 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntKey
 import dagger.multibindings.IntoMap
-import kotlinx.coroutines.runBlocking
 import java.util.logging.Logger
 import javax.inject.Inject
 
@@ -28,8 +27,8 @@ class AccountSettingsMigration9 @Inject constructor(
     private val logger: Logger
 ): AccountSettingsMigration {
 
-    override fun migrate(account: Account) = runBlocking {
-        val hasCalDAV = db.serviceDao().getByAccountAndType(account.name, Service.TYPE_CALDAV) != null
+    override fun migrate(account: Account) {
+        val hasCalDAV = db.serviceDao().getByAccountAndTypeBlocking(account.name, Service.TYPE_CALDAV) != null
         if (!hasCalDAV && ContentResolver.getIsSyncable(account, TaskProvider.ProviderName.OpenTasks.authority) != 0) {
             logger.info("Disabling OpenTasks sync for $account")
             ContentResolver.setIsSyncable(account, TaskProvider.ProviderName.OpenTasks.authority, 0)


### PR DESCRIPTION
Only use blocking functions in account settings migrations.

Part of #2677 

Note: You probably want to view the diff using the "hide whitespace" option.