### PR TITLE
[Coroutines] Check WebDAV package

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/util/KeyedMutex.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/util/KeyedMutex.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.util
+
+import kotlinx.coroutines.sync.Mutex
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * A [Mutex] per key: concurrent operations for different keys don't block each other, while
+ * operations for the *same* key are still serialized. An entry is dropped again as soon as no
+ * coroutine is holding or waiting for it, so the map doesn't grow unbounded over its lifetime.
+ */
+class KeyedMutex {
+
+    class Entry {
+        val mutex = Mutex()
+        var refCount = 0
+    }
+
+    // access to a given key's Entry (including refCount) is only ever mutated from within
+    // ConcurrentHashMap's atomic compute/computeIfPresent, so no additional locking is needed here
+    val locks = ConcurrentHashMap<String, Entry>()
+
+    suspend inline fun <T> withLock(key: String, action: () -> T): T {
+        val entry = locks.compute(key) { _, existing ->
+            (existing ?: Entry()).apply { refCount++ }
+        }!!
+        try {
+            entry.mutex.lock()
+            try {
+                return action()
+            } finally {
+                entry.mutex.unlock()
+            }
+        } finally {
+            locks.computeIfPresent(key) { _, e ->
+                e.refCount--
+                if (e.refCount <= 0) null else e
+            }
+        }
+    }
+
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/util/KeyedMutex.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/util/KeyedMutex.kt
@@ -5,7 +5,10 @@
 package at.bitfire.davdroid.util
 
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.coroutines.CoroutineContext
 
 /**
  * A [Mutex] per key: concurrent operations for different keys don't block each other, while
@@ -23,16 +26,13 @@ class KeyedMutex {
     // ConcurrentHashMap's atomic compute/computeIfPresent, so no additional locking is needed here
     val locks = ConcurrentHashMap<String, Entry>()
 
-    suspend inline fun <T> withLock(key: String, action: () -> T): T {
+    suspend inline fun <T> withLock(key: String, coroutineContext: CoroutineContext? = null, crossinline action: () -> T): T {
         val entry = locks.compute(key) { _, existing ->
             (existing ?: Entry()).apply { refCount++ }
         }!!
         try {
-            entry.mutex.lock()
-            try {
-                return action()
-            } finally {
-                entry.mutex.unlock()
+            return entry.mutex.withLock {
+                if (coroutineContext != null) withContext(coroutineContext) { action() } else action()
             }
         } finally {
             locks.computeIfPresent(key) { _, e ->

--- a/core/src/main/kotlin/at/bitfire/davdroid/util/KeyedMutex.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/util/KeyedMutex.kt
@@ -6,9 +6,7 @@ package at.bitfire.davdroid.util
 
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withContext
 import java.util.concurrent.ConcurrentHashMap
-import kotlin.coroutines.CoroutineContext
 
 /**
  * A [Mutex] per key: concurrent operations for different keys don't block each other, while
@@ -26,13 +24,13 @@ class KeyedMutex {
     // ConcurrentHashMap's atomic compute/computeIfPresent, so no additional locking is needed here
     val locks = ConcurrentHashMap<String, Entry>()
 
-    suspend inline fun <T> withLock(key: String, coroutineContext: CoroutineContext? = null, crossinline action: () -> T): T {
+    suspend inline fun <T> withLock(key: String, action: () -> T): T {
         val entry = locks.compute(key) { _, existing ->
             (existing ?: Entry()).apply { refCount++ }
         }!!
         try {
             return entry.mutex.withLock {
-                if (coroutineContext != null) withContext(coroutineContext) { action() } else action()
+                action()
             }
         } finally {
             locks.computeIfPresent(key) { _, e ->

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/PagingReader.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/PagingReader.kt
@@ -92,8 +92,7 @@ class PagingReader(
      * @return number of bytes read (may be less than [size] when the page ends before);
      * 0 guarantees that there are no more bytes (EOF)
     */
-    @Synchronized
-    fun readPage(position: Long, size: Int, dst: ByteArray, dstOffset: Int): Int {
+    suspend fun readPage(position: Long, size: Int, dst: ByteArray, dstOffset: Int): Int = readPageMutex.withLock {
         logger.fine("read(position=$position, size=$size, dstOffset=$dstOffset)")
 
         // read max. 1 page
@@ -126,6 +125,10 @@ class PagingReader(
         System.arraycopy(page.data, inPageStart, dst, dstOffset, len)
 
         return len
+    }
+
+    companion object {
+        private val readPageMutex = Mutex()
     }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/PagingReader.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/PagingReader.kt
@@ -6,6 +6,9 @@ package at.bitfire.davdroid.webdav
 
 import androidx.annotation.RequiresApi
 import com.google.common.cache.LoadingCache
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.io.IOException
 import java.util.logging.Logger
 import kotlin.math.min
@@ -26,7 +29,7 @@ import kotlin.math.min
 class PagingReader(
     private val fileSize: Long,
     private val pageSize: Int,
-    private val pageCache: LoadingCache<RandomAccessCallback.PageIdentifier, ByteArray>
+    private val pageCache: LoadingCache<RandomAccessCallback.PageIdentifier, Deferred<ByteArray>>
 ) {
 
     val logger: Logger = Logger.getLogger(javaClass.name)
@@ -56,7 +59,7 @@ class PagingReader(
      *
      * @return number of bytes read (may be smaller than [size] if the file is not that big)
      */
-    fun read(offset: Long, size: Int, dst: ByteArray): Int {
+    suspend fun read(offset: Long, size: Int, dst: ByteArray): Int {
         // input validation
         if (offset > fileSize)
             throw IndexOutOfBoundsException()
@@ -106,7 +109,7 @@ class PagingReader(
                 if (pgSize == 0)
                     ByteArray(0)        // don't load 0-byte pages
                 else
-                    pageCache.get(RandomAccessCallback.PageIdentifier(offset = pgStart, size = pgSize))
+                    pageCache.get(RandomAccessCallback.PageIdentifier(offset = pgStart, size = pgSize)).await()
             if (pageData.size != pgSize)
                 throw IOException("Couldn't fetch whole file segment (expected $pgSize bytes, got ${pageData.size} bytes)")
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/PagingReader.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/PagingReader.kt
@@ -48,6 +48,10 @@ class PagingReader(
     /** currently loaded page */
     private var currentPage: CachedPage? = null
 
+    /** Instance field (not in companion): [currentPage] and [pageCache] are per-instance, so a shared mutex would
+     *  needlessly serialize reads across unrelated, concurrently open WebDAV files. */
+    private val readPageMutex = Mutex()
+
     /**
      * Reads a given number of bytes from a given position.
      *
@@ -128,10 +132,6 @@ class PagingReader(
         System.arraycopy(page.data, inPageStart, dst, dstOffset, len)
 
         return len
-    }
-
-    companion object {
-        private val readPageMutex = Mutex()
     }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallback.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/RandomAccessCallback.kt
@@ -35,6 +35,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import java.io.InterruptedIOException
@@ -77,7 +78,7 @@ class RandomAccessCallback @AssistedInject constructor(
     private val documentState = headResponse.toDocumentState() ?: throw IllegalArgumentException("Can only be used with ETag/Last-Modified")
 
     private val pageLoader = PageLoader(externalScope)
-    private val pageCache: LoadingCache<PageIdentifier, ByteArray> = CacheBuilder.newBuilder()
+    private val pageCache: LoadingCache<PageIdentifier, Deferred<ByteArray>> = CacheBuilder.newBuilder()
         .maximumSize(10)    // don't cache more than 10 entries (MAX_PAGE_SIZE each)
         .softValues()       // use SoftReference for the page contents so they will be garbage-collected if memory is needed
         .build(pageLoader)  // fetch actual content using pageLoader
@@ -141,7 +142,7 @@ class RandomAccessCallback @AssistedInject constructor(
      *
      * @param functionName  name of the operation, passed to [ErrnoException] in case of cancellation
      */
-    private fun<T> runBlockingFd(functionName: String, block: () -> T): T =
+    private fun<T> runBlockingFd(functionName: String, block: suspend () -> T): T =
         runBlocking {
             try {
                 externalScope.async {
@@ -151,7 +152,7 @@ class RandomAccessCallback @AssistedInject constructor(
                 logger.warning("Random file access cancelled in $functionName, throwing ErrnoException(EINTR)")
                 throw ErrnoException(functionName, OsConstants.EINTR, e)
             } catch (e: Throwable) {
-                throw e.toErrNoException("onRead")
+                throw e.toErrNoException(functionName)
             }
         }
 
@@ -181,15 +182,9 @@ class RandomAccessCallback @AssistedInject constructor(
      */
     inner class PageLoader(
         private val scope: CoroutineScope
-    ): CacheLoader<PageIdentifier, ByteArray>() {
+    ): CacheLoader<PageIdentifier, Deferred<ByteArray>>() {
 
-        override fun load(key: PageIdentifier) = runBlocking {
-            scope.async {
-                loadAsync(key)
-            }.await()
-        }
-
-        private suspend fun loadAsync(key: PageIdentifier): ByteArray {
+        override fun load(key: PageIdentifier): Deferred<ByteArray> = scope.async {
             val offset = key.offset
             val size = key.size
             logger.fine("Loading page $url $offset/$size")
@@ -212,7 +207,7 @@ class RandomAccessCallback @AssistedInject constructor(
 
                 result = response.bodyAsBytes()
             }
-            return result ?: throw DavException("No response body")
+            result ?: throw DavException("No response body")
         }
 
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/cache/DiskCache.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/cache/DiskCache.kt
@@ -4,6 +4,8 @@
 
 package at.bitfire.davdroid.webdav.cache
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.io.File
 import java.util.logging.Logger
 
@@ -23,6 +25,8 @@ class DiskCache(
          * after how many cache writes [trim] is called
          */
         const val CLEANUP_RATE = 15
+
+        private val fileMutex = Mutex()
     }
 
     private val logger = Logger.getGlobal()
@@ -46,8 +50,8 @@ class DiskCache(
      *
      * @return the file that contains the value
      */
-    fun getFileOrPut(key: String, generate: () -> ByteArray?): File? {
-        synchronized(this) {
+    suspend fun getFileOrPut(key: String, generate: () -> ByteArray?): File? {
+        fileMutex.withLock {
             val file = File(cacheDir, key)
             if (file.exists()) {
                 logger.fine("Cache hit: $key")
@@ -69,29 +73,34 @@ class DiskCache(
     }
 
 
-    @Synchronized
-    fun clear() {
-        cacheDir.listFiles()?.forEach { entry ->
-            entry.delete()
+    suspend fun clear() {
+        fileMutex.withLock {
+            cacheDir.listFiles()?.forEach { entry ->
+                entry.delete()
+            }
         }
     }
 
-    @Synchronized
-    fun entries(): Int {
-        return cacheDir.listFiles()!!.size
+    suspend fun entries(): Int {
+        return fileMutex.withLock {
+            cacheDir.listFiles()!!.size
+        }
     }
 
-    fun keys(): Array<String> = cacheDir.list()!!
+    suspend fun keys(): Array<String> {
+        return fileMutex.withLock {
+            cacheDir.list()!!
+        }
+    }
 
     /**
      * Trims the cache to keep it smaller than [maxSize].
      */
-    @Synchronized
-    fun trim(): Int {
+    suspend fun trim(): Int {
         var removed = 0
         logger.fine("Trimming disk cache to $maxSize bytes")
 
-        val files = cacheDir.listFiles()!!.toMutableList()
+        val files = fileMutex.withLock { cacheDir.listFiles() }!!.toMutableList()
         files.sortBy { file -> file.lastModified() }    // sort by modification time (ascending)
 
         while (files.sumOf { file -> file.length() } > maxSize) {

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/cache/DiskCache.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/cache/DiskCache.kt
@@ -4,8 +4,12 @@
 
 package at.bitfire.davdroid.webdav.cache
 
+import androidx.annotation.VisibleForTesting
+import at.bitfire.davdroid.webdav.cache.DiskCache.Companion.fileMutex
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import java.io.File
 import java.util.logging.Logger
 
@@ -50,57 +54,53 @@ class DiskCache(
      *
      * @return the file that contains the value
      */
-    suspend fun getFileOrPut(key: String, generate: () -> ByteArray?): File? {
-        fileMutex.withLock {
-            val file = File(cacheDir, key)
-            if (file.exists()) {
-                logger.fine("Cache hit: $key")
-                return file
-            } else {
-                logger.fine("Cache miss: $key → generating")
-                val result = generate() ?: return null
+    suspend fun getFileOrPut(key: String, generate: () -> ByteArray?): File? = fileMutex.withLock {
+        val file = File(cacheDir, key)
+        if (file.exists()) {
+            logger.fine("Cache hit: $key")
+            return file
+        } else {
+            logger.fine("Cache miss: $key → generating")
+            val result = generate() ?: return null
 
-                file.outputStream().use { output ->
-                    output.write(result)
-                }
-
-                if (writeCounter++.mod(CLEANUP_RATE) == 0)
-                    trim()
-
-                return file
+            file.outputStream().use { output ->
+                output.write(result)
             }
-        }
-    }
 
-
-    suspend fun clear() {
-        fileMutex.withLock {
-            cacheDir.listFiles()?.forEach { entry ->
-                entry.delete()
+            if (writeCounter++.mod(CLEANUP_RATE) == 0) withContext(Dispatchers.IO) {
+                trim()
             }
+
+            return file
         }
     }
 
-    suspend fun entries(): Int {
-        return fileMutex.withLock {
-            cacheDir.listFiles()!!.size
+
+    suspend fun clear() = fileMutex.withLock {
+        cacheDir.listFiles()?.forEach { entry ->
+            entry.delete()
         }
     }
 
-    suspend fun keys(): Array<String> {
-        return fileMutex.withLock {
-            cacheDir.list()!!
-        }
+    suspend fun entries(): Int = fileMutex.withLock {
+        cacheDir.listFiles()!!.size
+    }
+
+    suspend fun keys(): Array<String> = fileMutex.withLock {
+        cacheDir.list()!!
     }
 
     /**
      * Trims the cache to keep it smaller than [maxSize].
+     *
+     * Doesn't hold [fileMutex], it should be held by the calling function.
      */
-    suspend fun trim(): Int {
+    @VisibleForTesting
+    internal fun trim(): Int {
         var removed = 0
         logger.fine("Trimming disk cache to $maxSize bytes")
 
-        val files = fileMutex.withLock { cacheDir.listFiles() }!!.toMutableList()
+        val files = cacheDir.listFiles()!!.toMutableList()
         files.sortBy { file -> file.lastModified() }    // sort by modification time (ascending)
 
         while (files.sumOf { file -> file.length() } > maxSize) {

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/cache/DiskCache.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/cache/DiskCache.kt
@@ -5,12 +5,14 @@
 package at.bitfire.davdroid.webdav.cache
 
 import androidx.annotation.VisibleForTesting
-import at.bitfire.davdroid.webdav.cache.DiskCache.Companion.fileMutex
+import at.bitfire.davdroid.util.KeyedMutex
+import at.bitfire.davdroid.webdav.cache.DiskCache.Companion.structureMutex
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.logging.Logger
 
 /**
@@ -30,11 +32,26 @@ class DiskCache(
          */
         const val CLEANUP_RATE = 15
 
-        private val fileMutex = Mutex()
+        /**
+         * Serializes cache-wide structural operations ([clear], [entries], [keys], [trim]) across all
+         * [DiskCache] instances (they all share the same lock, regardless of [cacheDir]). These are all
+         * fast, blocking-but-brief file system calls – this lock is never held while running a
+         * [getFileOrPut] `generate` callback, so a single slow (e.g. network-bound) fetch can't stall
+         * unrelated cache reads/writes.
+         */
+        private val structureMutex = Mutex()
+
+        /**
+         * One [Mutex] per cache key, so that concurrent [getFileOrPut] calls for the *same* key are
+         * serialized (preventing torn writes to the same file), while calls for different keys – even
+         * while one of them is stuck in a slow `generate` callback – proceed independently instead of
+         * stalling behind a single global lock.
+         */
+        private val keyMutex = KeyedMutex()
     }
 
     private val logger = Logger.getGlobal()
-    private var writeCounter: Int = 0
+    private val writeCounter = AtomicInteger()
 
     init {
         if (!cacheDir.isDirectory)
@@ -54,7 +71,7 @@ class DiskCache(
      *
      * @return the file that contains the value
      */
-    suspend fun getFileOrPut(key: String, generate: () -> ByteArray?): File? = fileMutex.withLock {
+    suspend fun getFileOrPut(key: String, generate: () -> ByteArray?): File? = keyMutex.withLock(key) {
         val file = File(cacheDir, key)
         if (file.exists()) {
             logger.fine("Cache hit: $key")
@@ -67,8 +84,10 @@ class DiskCache(
                 output.write(result)
             }
 
-            if (writeCounter++.mod(CLEANUP_RATE) == 0) withContext(Dispatchers.IO) {
-                trim()
+            if (writeCounter.getAndIncrement().mod(CLEANUP_RATE) == 0) structureMutex.withLock {
+                withContext(Dispatchers.IO) {
+                    trim()
+                }
             }
 
             return file
@@ -76,24 +95,24 @@ class DiskCache(
     }
 
 
-    suspend fun clear() = fileMutex.withLock {
+    suspend fun clear() = structureMutex.withLock {
         cacheDir.listFiles()?.forEach { entry ->
             entry.delete()
         }
     }
 
-    suspend fun entries(): Int = fileMutex.withLock {
+    suspend fun entries(): Int = structureMutex.withLock {
         cacheDir.listFiles()!!.size
     }
 
-    suspend fun keys(): Array<String> = fileMutex.withLock {
+    suspend fun keys(): Array<String> = structureMutex.withLock {
         cacheDir.list()!!
     }
 
     /**
      * Trims the cache to keep it smaller than [maxSize].
      *
-     * Doesn't hold [fileMutex], it should be held by the calling function.
+     * Doesn't hold [structureMutex] itself, it must be held by the calling function.
      */
     @VisibleForTesting
     internal fun trim(): Int {

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/cache/DiskCache.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/cache/DiskCache.kt
@@ -6,7 +6,6 @@ package at.bitfire.davdroid.webdav.cache
 
 import androidx.annotation.VisibleForTesting
 import at.bitfire.davdroid.util.KeyedMutex
-import at.bitfire.davdroid.webdav.cache.DiskCache.Companion.structureMutex
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -72,63 +71,67 @@ class DiskCache(
      * @return the file that contains the value
      */
     suspend fun getFileOrPut(key: String, generate: () -> ByteArray?): File? = keyMutex.withLock(key) {
-        val file = File(cacheDir, key)
-        if (file.exists()) {
-            logger.fine("Cache hit: $key")
-            return file
-        } else {
-            logger.fine("Cache miss: $key → generating")
-            val result = generate() ?: return null
+        withContext(Dispatchers.IO) {
+            val file = File(cacheDir, key)
+            if (file.exists()) {
+                logger.fine("Cache hit: $key")
+                return@withContext file
+            } else {
+                logger.fine("Cache miss: $key → generating")
+                val result = generate() ?: return@withContext null
 
-            file.outputStream().use { output ->
-                output.write(result)
-            }
-
-            if (writeCounter.getAndIncrement().mod(CLEANUP_RATE) == 0) structureMutex.withLock {
-                withContext(Dispatchers.IO) {
-                    trim()
+                file.outputStream().use { output ->
+                    output.write(result)
                 }
-            }
 
-            return file
+                if (writeCounter.getAndIncrement().mod(CLEANUP_RATE) == 0) trim()
+
+                return@withContext file
+            }
         }
     }
 
 
     suspend fun clear() = structureMutex.withLock {
-        cacheDir.listFiles()?.forEach { entry ->
-            entry.delete()
+        withContext(Dispatchers.IO) {
+            cacheDir.listFiles()?.forEach { entry ->
+                entry.delete()
+            }
         }
     }
 
     suspend fun entries(): Int = structureMutex.withLock {
-        cacheDir.listFiles()!!.size
+        withContext(Dispatchers.IO) {
+            cacheDir.listFiles()!!.size
+        }
     }
 
     suspend fun keys(): Array<String> = structureMutex.withLock {
-        cacheDir.list()!!
+        withContext(Dispatchers.IO) {
+            cacheDir.list()!!
+        }
     }
 
     /**
      * Trims the cache to keep it smaller than [maxSize].
-     *
-     * Doesn't hold [structureMutex] itself, it must be held by the calling function.
      */
     @VisibleForTesting
-    internal fun trim(): Int {
-        var removed = 0
-        logger.fine("Trimming disk cache to $maxSize bytes")
+    internal suspend fun trim(): Int = structureMutex.withLock {
+        withContext(Dispatchers.IO) {
+            var removed = 0
+            logger.fine("Trimming disk cache to $maxSize bytes")
 
-        val files = cacheDir.listFiles()!!.toMutableList()
-        files.sortBy { file -> file.lastModified() }    // sort by modification time (ascending)
+            val files = cacheDir.listFiles()!!.toMutableList()
+            files.sortBy { file -> file.lastModified() }    // sort by modification time (ascending)
 
-        while (files.sumOf { file -> file.length() } > maxSize) {
-            val file = files.removeAt(0)      // take first (= oldest) file
-            logger.finer("Removing $file")
-            file.delete()
-            removed++
+            while (files.sumOf { file -> file.length() } > maxSize) {
+                val file = files.removeAt(0)      // take first (= oldest) file
+                logger.finer("Removing $file")
+                file.delete()
+                removed++
+            }
+            removed
         }
-        return removed
     }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/cache/ThumbnailCache.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/cache/ThumbnailCache.kt
@@ -40,7 +40,7 @@ class ThumbnailCache @Inject constructor(
     }
 
 
-    fun get(docKey: WebDavDocument.CacheKey, sizeHint: Point, generate: () -> ByteArray?): File? {
+    suspend fun get(docKey: WebDavDocument.CacheKey, sizeHint: Point, generate: () -> ByteArray?): File? {
         val key = Key(docKey, sizeHint)
         return storage.getFileOrPut(key.asString(), generate)
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/QueryChildDocumentsOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/QueryChildDocumentsOperation.kt
@@ -40,7 +40,13 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.logging.Level
 import java.util.logging.Logger
 import javax.inject.Inject
+import javax.inject.Singleton
 
+/**
+ * Singleton so that [backgroundScope] (and the running-query bookkeeping it launches into) has a
+ * single, well-defined lifetime instead of a new, uncancellable scope per Hilt injection.
+ */
+@Singleton
 class QueryChildDocumentsOperation @Inject constructor(
     @ApplicationContext private val context: Context,
     private val db: AppDatabase,

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/QueryChildDocumentsOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/QueryChildDocumentsOperation.kt
@@ -40,13 +40,11 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.logging.Level
 import java.util.logging.Logger
 import javax.inject.Inject
-import javax.inject.Singleton
 
 /**
  * Singleton so that [applicationScope] (and the running-query bookkeeping it launches into) has a
  * single, well-defined lifetime instead of a new, uncancellable scope per Hilt injection.
  */
-@Singleton
 class QueryChildDocumentsOperation @Inject constructor(
     @ApplicationContext private val context: Context,
     private val db: AppDatabase,

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/QueryChildDocumentsOperation.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/operation/QueryChildDocumentsOperation.kt
@@ -25,13 +25,13 @@ import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.WebDavDocument
 import at.bitfire.davdroid.db.WebDavDocumentDao
+import at.bitfire.davdroid.di.qualifier.ApplicationScope
 import at.bitfire.davdroid.webdav.DavHttpClientBuilder
 import at.bitfire.davdroid.webdav.DocumentSortByMapper
 import at.bitfire.davdroid.webdav.DocumentsCursor
 import dagger.Lazy
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -43,7 +43,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Singleton so that [backgroundScope] (and the running-query bookkeeping it launches into) has a
+ * Singleton so that [applicationScope] (and the running-query bookkeeping it launches into) has a
  * single, well-defined lifetime instead of a new, uncancellable scope per Hilt injection.
  */
 @Singleton
@@ -52,13 +52,12 @@ class QueryChildDocumentsOperation @Inject constructor(
     private val db: AppDatabase,
     private val documentSortByMapper: Lazy<DocumentSortByMapper>,
     private val davClientBuilder: DavHttpClientBuilder,
-    private val logger: Logger
+    private val logger: Logger,
+    @ApplicationScope private val applicationScope: CoroutineScope
 ) {
 
     private val authority = context.getString(R.string.webdav_authority)
     private val documentDao = db.webDavDocumentDao()
-
-    private val backgroundScope = CoroutineScope(SupervisorJob())
 
     suspend operator fun invoke(parentDocumentId: String, projection: Array<out String>?, sortOrder: String?) =
         mutex.withLock {
@@ -90,7 +89,7 @@ class QueryChildDocumentsOperation @Inject constructor(
 
         // Dispatch worker querying for the children and keep track of it
         val running = runningQueryChildren.getOrPut(parentId) {
-            backgroundScope.launch {
+            applicationScope.launch {
                 queryChildren(parent)
                 // Once the query is done, set query as finished (not running)
                 runningQueryChildren[parentId] = false

--- a/core/src/test/kotlin/at/bitfire/davdroid/webdav/DiskCacheTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/webdav/DiskCacheTest.kt
@@ -4,11 +4,9 @@
 
 package at.bitfire.davdroid.webdav
 
-import android.os.FileUtils
 import at.bitfire.davdroid.webdav.cache.DiskCache
-import com.google.common.io.ByteStreams
 import com.google.common.io.Files
-import ezvcard.util.IOUtils
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
@@ -50,7 +48,7 @@ class DiskCacheTest {
 
 
     @Test
-    fun testGetFile_Null() {
+    fun testGetFile_Null() = runTest {
         assertNull(cache.getFileOrPut(SOME_KEY) { null })
 
         // null value shouldn't have been written to cache
@@ -61,7 +59,7 @@ class DiskCacheTest {
     }
 
     @Test
-    fun testGetFile_NotNull() {
+    fun testGetFile_NotNull() = runTest {
         cache.getFileOrPut(SOME_KEY) { SOME_VALUE }!!.let {
             assertArrayEquals(SOME_VALUE, Files.asByteSource(it).read())
         }
@@ -75,7 +73,7 @@ class DiskCacheTest {
 
 
     @Test
-    fun testClear() {
+    fun testClear() = runTest {
         for (i in 1..50) {
             cache.getFileOrPut(i.toString()) { i.toString().toByteArray() }
         }
@@ -87,7 +85,7 @@ class DiskCacheTest {
 
 
     @Test
-    fun testTrim() {
+    fun testTrim() = runTest {
         assertEquals(0, cache.entries())
 
         cache.getFileOrPut(SOME_KEY) { SOME_VALUE }

--- a/core/src/test/kotlin/at/bitfire/davdroid/webdav/PagingReaderTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/webdav/PagingReaderTest.kt
@@ -7,6 +7,9 @@ package at.bitfire.davdroid.webdav
 import com.google.common.cache.CacheBuilder
 import com.google.common.cache.CacheLoader
 import com.google.common.cache.LoadingCache
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -20,7 +23,7 @@ import org.junit.Test
 class PagingReaderTest {
 
     @Test
-    fun testRead_AcrossThreePages() {
+    fun testRead_AcrossThreePages() = runTest {
         var idx = 0
         val reader = pagingReader(350, 100) { offset, size ->
             assertEquals(idx * 100L, offset)
@@ -44,7 +47,7 @@ class PagingReaderTest {
     }
 
     @Test
-    fun testRead_AtBeginning_FewBytes() {
+    fun testRead_AtBeginning_FewBytes() = runTest {
         val reader = pagingReader(200, 100) { offset, size ->
             assertEquals(0, offset)
             assertEquals(100, size)
@@ -56,7 +59,7 @@ class PagingReaderTest {
     }
 
     @Test
-    fun testRead_AtEOF() {
+    fun testRead_AtEOF() = runTest {
         val reader = pagingReader(200, 100) { _, _ ->
             throw AssertionError("Must not be called with size=0")
         }
@@ -65,7 +68,7 @@ class PagingReaderTest {
 
 
     @Test
-    fun testReadPage_LargeFile_FromMid_ToMid() {
+    fun testReadPage_LargeFile_FromMid_ToMid() = runTest {
         val reader = pagingReader(200, 100) { offset, size ->
             assertEquals(0, offset)
             assertEquals(100, size)
@@ -77,7 +80,7 @@ class PagingReaderTest {
     }
 
     @Test
-    fun testReadPage_LargeFile_FromMid_BeyondPage() {
+    fun testReadPage_LargeFile_FromMid_BeyondPage() = runTest {
         val reader = pagingReader(200, 100) { offset, size ->
             assertEquals(0, offset)
             assertEquals(100, size)
@@ -89,7 +92,7 @@ class PagingReaderTest {
     }
 
     @Test
-    fun testReadPage_LargeFile_FromStart_LessThanAPage() {
+    fun testReadPage_LargeFile_FromStart_LessThanAPage() = runTest {
         val reader = pagingReader(200, 100) { offset, size ->
             assertEquals(0, offset)
             assertEquals(100, size)
@@ -101,7 +104,7 @@ class PagingReaderTest {
     }
 
     @Test
-    fun testReadPage_LargeFile_FromStart_OnePage() {
+    fun testReadPage_LargeFile_FromStart_OnePage() = runTest {
         val reader = pagingReader(200, 100) { offset, size ->
             assertEquals(0, offset)
             assertEquals(100, size)
@@ -113,7 +116,7 @@ class PagingReaderTest {
     }
 
     @Test
-    fun testReadPage_LargeFile_FromStart_MoreThanAvailable() {
+    fun testReadPage_LargeFile_FromStart_MoreThanAvailable() = runTest {
         val reader = pagingReader(200, 100) { offset, size ->
             assertEquals(0, offset)
             assertEquals(100, size)
@@ -126,7 +129,7 @@ class PagingReaderTest {
 
 
     @Test
-    fun testReadPage_PageSizedFile_FromEnd() {
+    fun testReadPage_PageSizedFile_FromEnd() = runTest {
         val reader = pagingReader(100, 100) { _, _ ->
             throw AssertionError()
         }
@@ -136,7 +139,7 @@ class PagingReaderTest {
     }
 
     @Test
-    fun testReadPage_PageSizedFile_FromStart_Complete() {
+    fun testReadPage_PageSizedFile_FromStart_Complete() = runTest {
         val reader = pagingReader(100, 100) { offset, size ->
             assertEquals(0, offset)
             assertEquals(100, size)
@@ -148,7 +151,7 @@ class PagingReaderTest {
     }
 
     @Test
-    fun testReadPage_PageSizedFile_FromStart_MoreThanAvailable() {
+    fun testReadPage_PageSizedFile_FromStart_MoreThanAvailable() = runTest {
         val reader = pagingReader(100, 100) { offset, size ->
             assertEquals(0, offset)
             assertEquals(100, size)
@@ -161,7 +164,7 @@ class PagingReaderTest {
 
 
     @Test
-    fun testReadPage_SmallFile_FromStart_Partial() {
+    fun testReadPage_SmallFile_FromStart_Partial() = runTest {
         val reader = pagingReader(100, 1000) { offset, size ->
             assertEquals(0, offset)
             assertEquals(100, size)
@@ -173,7 +176,7 @@ class PagingReaderTest {
     }
 
     @Test
-    fun testReadPage_SmallFile_FromStart_Complete() {
+    fun testReadPage_SmallFile_FromStart_Complete() = runTest {
         val reader = pagingReader(100, 1000) { offset, size ->
             assertEquals(0, offset)
             assertEquals(100, size)
@@ -185,7 +188,7 @@ class PagingReaderTest {
     }
 
     @Test
-    fun testReadPage_SmallFile_FromStart_MoreThanAvailable() {
+    fun testReadPage_SmallFile_FromStart_MoreThanAvailable() = runTest {
         val reader = pagingReader(100, 1000) { offset, size ->
             assertEquals(0, offset)
             assertEquals(100, size)
@@ -197,10 +200,10 @@ class PagingReaderTest {
     }
 
 
-    private fun pageCache(loader: (offset: Long, size: Int) -> ByteArray): LoadingCache<RandomAccessCallback.PageIdentifier, ByteArray> =
+    private fun pageCache(loader: (offset: Long, size: Int) -> ByteArray): LoadingCache<RandomAccessCallback.PageIdentifier, Deferred<ByteArray>> =
         CacheBuilder.newBuilder()
-            .build(object: CacheLoader<RandomAccessCallback.PageIdentifier, ByteArray>() {
-                override fun load(key: RandomAccessCallback.PageIdentifier) = loader(key.offset, key.size)
+            .build(object: CacheLoader<RandomAccessCallback.PageIdentifier, Deferred<ByteArray>>() {
+                override fun load(key: RandomAccessCallback.PageIdentifier) = CompletableDeferred(loader(key.offset, key.size))
             })
 
     private fun pagingReader(fileSize: Long, pageSize: Int, loader: (offset: Long, size: Int) -> ByteArray) =


### PR DESCRIPTION
### Purpose

Finishes refactoring the webdav package so that it's more resilient, and makes a correct use of Kotlin coroutines.

### Short description

Briefly describe the approach taken to achieve the purpose.

Example:

- `PageLoader` now uses `Deferred<ByteArray>` instead of `ByteArray` directly. This allows loading the data only when needed, and fixes threading usages.
- Replaced `@Syncronized` and `synchronized` usages with mutex.
- Increased mutex usage to improve unsynchronized accesses to files.
- Made `QueryChildDocumentsOperation` a singleton because it relies on a background scope, which is not correctly reused by Hilt otherwise.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

