### PR TITLE
Make view/share logs primary action of verbose logging notification

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/log/LogFileHandler.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/log/LogFileHandler.kt
@@ -138,6 +138,9 @@ class LogFileHandler @Inject constructor(
                 ).build()
             )
 
+            // also view/share the logs when tapping the notification
+            builder.setContentIntent(pendingShare)
+
             builder.build()
         }
    }


### PR DESCRIPTION
This avoids nothing happening when tapping the collapsed notification.
