### PR TITLE
Remove autostart permission hint

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsViewModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/AppSettingsViewModel.kt
@@ -111,7 +111,6 @@ class AppSettingsViewModel @Inject constructor(
     fun resetHints() = viewModelScope.launch(ioDispatcher) {
         settings.remove(BackupsPage.Model.SETTING_BACKUPS_ACCEPTED)
         settings.remove(BatteryOptimizationsPageViewModel.HINT_BATTERY_OPTIMIZATIONS)
-        settings.remove(BatteryOptimizationsPageViewModel.HINT_AUTOSTART_PERMISSION)
         settings.remove(OpenSourcePage.Model.SETTING_NEXT_DONATION_POPUP)
         settings.remove(TasksViewModel.HINT_OPENTASKS_NOT_INSTALLED)
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/intro/BatteryOptimizationsPage.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/intro/BatteryOptimizationsPage.kt
@@ -11,7 +11,6 @@ import androidx.activity.result.contract.ActivityResultContract
 import androidx.compose.runtime.Composable
 import androidx.core.net.toUri
 import at.bitfire.davdroid.settings.SettingsManager
-import at.bitfire.davdroid.ui.intro.BatteryOptimizationsPageViewModel.Companion.HINT_AUTOSTART_PERMISSION
 import at.bitfire.davdroid.ui.intro.BatteryOptimizationsPageViewModel.Companion.HINT_BATTERY_OPTIMIZATIONS
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
@@ -19,7 +18,7 @@ import javax.inject.Inject
 class BatteryOptimizationsPage @Inject constructor(
     @ApplicationContext val context: Context,
     val settingsManager: SettingsManager
-): IntroPage() {
+) : IntroPage() {
 
     override fun getShowPolicy(): ShowPolicy {
         // show fragment when:
@@ -27,8 +26,8 @@ class BatteryOptimizationsPage @Inject constructor(
         // 2a. evil manufacturer AND
         // 2b. "don't show anymore" has not been clicked
         return if (
-            (!BatteryOptimizationsPageViewModel.isExempted(context) && settingsManager.getBooleanOrNull(HINT_BATTERY_OPTIMIZATIONS) != false) ||
-            (BatteryOptimizationsPageViewModel.manufacturerWarning && settingsManager.getBooleanOrNull(HINT_AUTOSTART_PERMISSION) != false)
+            !BatteryOptimizationsPageViewModel.isExempted(context) &&
+            settingsManager.getBooleanOrNull(HINT_BATTERY_OPTIMIZATIONS) != false
         )
             ShowPolicy.SHOW_ALWAYS
         else
@@ -42,7 +41,7 @@ class BatteryOptimizationsPage @Inject constructor(
 
 
     @SuppressLint("BatteryLife")
-    object IgnoreBatteryOptimizationsContract: ActivityResultContract<String, Unit?>() {
+    object IgnoreBatteryOptimizationsContract : ActivityResultContract<String, Unit?>() {
         override fun createIntent(context: Context, input: String): Intent {
             return Intent(
                 android.provider.Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/intro/BatteryOptimizationsPage.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/intro/BatteryOptimizationsPage.kt
@@ -21,10 +21,7 @@ class BatteryOptimizationsPage @Inject constructor(
 ) : IntroPage() {
 
     override fun getShowPolicy(): ShowPolicy {
-        // show fragment when:
-        // 1. DAVx5 is not whitelisted yet and "don't show anymore" has not been clicked, and/or
-        // 2a. evil manufacturer AND
-        // 2b. "don't show anymore" has not been clicked
+        // show fragment when DAVx5 is not whitelisted yet and "don't show anymore" has not been clicked
         return if (
             !BatteryOptimizationsPageViewModel.isExempted(context) &&
             settingsManager.getBooleanOrNull(HINT_BATTERY_OPTIMIZATIONS) != false

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/intro/BatteryOptimizationsPageContent.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/intro/BatteryOptimizationsPageContent.kt
@@ -4,7 +4,6 @@
 
 package at.bitfire.davdroid.ui.intro
 
-import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
@@ -18,7 +17,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -34,10 +32,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import at.bitfire.davdroid.R
-import at.bitfire.davdroid.ui.ExternalUris
-import at.bitfire.davdroid.ui.ExternalUris.withStatParams
 import at.bitfire.davdroid.ui.composable.AppTheme
-import java.util.Locale
 
 @Composable
 fun BatteryOptimizationsPageContent(
@@ -57,16 +52,12 @@ fun BatteryOptimizationsPageContent(
             ignoreBatteryOptimizationsResultLauncher.launch(context.packageName)
     }
 
-    val hintAutostartPermission by model.hintAutostartPermission.collectAsStateWithLifecycle(false)
     BatteryOptimizationsPageContent(
         dontShowBattery = hintBatteryOptimizations == false,
         onChangeDontShowBattery = model::updateHintBatteryOptimizations,
         isExempted = uiState.isExempted,
         shouldBeExempted = uiState.shouldBeExempted,
-        onChangeShouldBeExempted = model::updateShouldBeExempted,
-        dontShowAutostart = hintAutostartPermission == false,
-        onChangeDontShowAutostart = model::updateHintAutostartPermission,
-        manufacturerWarning = BatteryOptimizationsPageViewModel.manufacturerWarning
+        onChangeShouldBeExempted = model::updateShouldBeExempted
     )
 }
 
@@ -76,10 +67,7 @@ fun BatteryOptimizationsPageContent(
     onChangeDontShowBattery: (Boolean) -> Unit = {},
     isExempted: Boolean,
     shouldBeExempted: Boolean,
-    onChangeShouldBeExempted: (Boolean) -> Unit = {},
-    dontShowAutostart: Boolean,
-    onChangeDontShowAutostart: (Boolean) -> Unit = {},
-    manufacturerWarning: Boolean
+    onChangeShouldBeExempted: (Boolean) -> Unit = {}
 ) {
     val uriHandler = LocalUriHandler.current
 
@@ -143,65 +131,6 @@ fun BatteryOptimizationsPageContent(
                 }
             }
         }
-        if (manufacturerWarning) {
-            Card(
-                modifier = Modifier
-                    .padding(8.dp)
-            ) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp)
-                ) {
-                    Text(
-                        text = stringResource(
-                            R.string.intro_autostart_title,
-                            Build.MANUFACTURER.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
-                        ),
-                        style = MaterialTheme.typography.labelLarge,
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                    Text(
-                        text = stringResource(R.string.intro_autostart_text),
-                        style = MaterialTheme.typography.bodyLarge,
-                        modifier = Modifier.padding(top = 12.dp)
-                    )
-
-                    val context = LocalContext.current
-                    OutlinedButton(
-                        onClick = {
-                            uriHandler.openUri(
-                                ExternalUris.Homepage.baseUrl.buildUpon()
-                                    .appendPath(ExternalUris.Homepage.PATH_FAQ)
-                                    .appendPath(ExternalUris.Homepage.PATH_FAQ_SYNC_NOT_RUN)
-                                    .appendQueryParameter(
-                                        "manufacturer",
-                                        Build.MANUFACTURER.lowercase(Locale.ROOT)
-                                    )
-                                    .withStatParams(context, "BatteryOptimizationsPage")
-                                    .build().toString()
-                            )
-                        }
-                    ) {
-                        Text(stringResource(R.string.intro_more_info))
-                    }
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Checkbox(
-                            checked = dontShowAutostart,
-                            onCheckedChange = { onChangeDontShowAutostart(dontShowAutostart) }
-                        )
-                        Text(
-                            text = stringResource(R.string.intro_autostart_dont_show),
-                            style = MaterialTheme.typography.bodyMedium,
-                            modifier = Modifier
-                                .clickable { onChangeDontShowAutostart(dontShowAutostart) }
-                        )
-                    }
-                }
-            }
-        }
         Text(
             text = stringResource(
                 R.string.intro_leave_unchecked,
@@ -220,9 +149,7 @@ private fun BatteryOptimizationsContent_Preview() {
         BatteryOptimizationsPageContent(
             dontShowBattery = true,
             isExempted = false,
-            shouldBeExempted = true,
-            dontShowAutostart = false,
-            manufacturerWarning = true
+            shouldBeExempted = true
         )
     }
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/intro/BatteryOptimizationsPageViewModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/intro/BatteryOptimizationsPageViewModel.kt
@@ -6,7 +6,6 @@ package at.bitfire.davdroid.ui.intro
 
 import android.content.Context
 import android.content.IntentFilter
-import android.os.Build
 import android.os.PowerManager
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -14,15 +13,12 @@ import androidx.compose.runtime.setValue
 import androidx.core.content.getSystemService
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import at.bitfire.davdroid.BuildConfig
 import at.bitfire.davdroid.settings.SettingsManager
-import at.bitfire.davdroid.ui.intro.BatteryOptimizationsPageViewModel.Companion.evilManufacturers
 import at.bitfire.davdroid.util.PermissionUtils
 import at.bitfire.davdroid.util.broadcastReceiverFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.launch
-import java.util.Locale
 import javax.inject.Inject
 
 @HiltViewModel
@@ -40,36 +36,6 @@ class BatteryOptimizationsPageViewModel @Inject constructor(
          */
         const val HINT_BATTERY_OPTIMIZATIONS = "hint_BatteryOptimizations"
 
-        /**
-         * Whether the autostart permission notice shall be shown. If this setting is true
-         * or null/not set, the notice shall be shown. Only if this setting is false, the notice
-         * shall not be shown.
-         *
-         * Type: Boolean
-         */
-        const val HINT_AUTOSTART_PERMISSION = "hint_AutostartPermissions"
-
-        /**
-         * List of manufacturers which are known to restrict background processes or otherwise
-         * block synchronization.
-         *
-         * See https://www.davx5.com/faq/synchronization-is-not-run-as-expected for why this is evil.
-         * See https://github.com/jaredrummler/AndroidDeviceNames/blob/master/json/ for manufacturer values.
-         */
-        private val evilManufacturers = arrayOf(
-            "asus", "lenovo", "letv", "meizu", "nokia",
-            "oneplus", "oppo", "sony", "vivo", "wiko", "xiaomi", "zte")
-
-        /**
-         * Whether the device has been produced by an evil manufacturer.
-         *
-         * Always true for debug builds (to test the UI).
-         *
-         * @see evilManufacturers
-         */
-        val manufacturerWarning =
-            (evilManufacturers.contains(Build.MANUFACTURER.lowercase(Locale.ROOT)) || BuildConfig.DEBUG)
-
         fun isExempted(context: Context) =
             context.getSystemService<PowerManager>()!!.isIgnoringBatteryOptimizations(context.packageName)
     }
@@ -83,8 +49,6 @@ class BatteryOptimizationsPageViewModel @Inject constructor(
         private set
 
     val hintBatteryOptimizations = settings.getBooleanFlow(HINT_BATTERY_OPTIMIZATIONS)
-
-    val hintAutostartPermission = settings.getBooleanFlow(HINT_AUTOSTART_PERMISSION)
 
     init {
         viewModelScope.launch {
@@ -109,10 +73,6 @@ class BatteryOptimizationsPageViewModel @Inject constructor(
 
     fun updateHintBatteryOptimizations(value: Boolean) {
         settings.putBoolean(HINT_BATTERY_OPTIMIZATIONS, value)
-    }
-
-    fun updateHintAutostartPermission(value: Boolean) {
-        settings.putBoolean(HINT_AUTOSTART_PERMISSION, value)
     }
 
 }

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -46,9 +46,6 @@
     <string name="intro_battery_title">Regular sync intervals</string>
     <string name="intro_battery_text">For synchronization at regular intervals, %s must be allowed to run in the background. Otherwise, Android may pause synchronization at any time.</string>
     <string name="intro_battery_dont_show">I don\'t need regular sync intervals.*</string>
-    <string name="intro_autostart_title">%s compatibility</string>
-    <string name="intro_autostart_text">Vendor-specific firmware may block synchronization. If you\'re affected, you can only resolve this manually.</string>
-    <string name="intro_autostart_dont_show">I have done the required settings. Don\'t remind me anymore.*</string>
     <string name="intro_leave_unchecked">* Leave unchecked to be reminded later. Can be reset in app settings / %s.</string>
     <string name="intro_more_info">More information</string>
     <string name="intro_tasks_jtx">jtx Board</string>


### PR DESCRIPTION
### Purpose

Remove the autostart permission / evil manufacturer hint because it's not a problem anymore.

### Short description

- Removed the autostart permission hint.
- Cleaned up related code.

Old vs new page layout without auto-start hint (regular sync/battery optimization exception is kept as is):

<img width="270" height="570" alt="image" src="https://github.com/user-attachments/assets/991edbd7-239b-4f70-9dd5-123573e468f1" />
<img width="270" height="570" alt="image" src="https://github.com/user-attachments/assets/2bc53e31-ccf3-4951-a63c-67d5ebf93109" />

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.