### PR TITLE
Update JtxBoard min version to 2.17.00

### DIFF
--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/TaskProvider.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/TaskProvider.kt
@@ -29,8 +29,8 @@ object TaskProvider {
         JtxBoard(
             authority = "at.techbee.jtx.provider",
             packageName = "at.techbee.jtx",
-            minVersionCode = 210000000,
-            minVersionName = "2.10.00",
+            minVersionCode = 217020009,
+            minVersionName = "2.17.00",
             permissions = arrayOf("at.techbee.jtx.permission.READ", "at.techbee.jtx.permission.WRITE")
         ),
         TasksOrg(


### PR DESCRIPTION
### Purpose

Update the minimum required version of JtxBoard to 2.17.00 because of https://github.com/bitfireAT/davx5-ose/discussions/2693.

### Short description

- Updated the minimum version requirement for JtxBoard in the project configuration.

Version code / name taken from https://github.com/TechbeeAT/jtxBoard/commit/f33fb8ffbcf683fbbe5d7c4df4a7303a54a75e35.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.