### PR TITLE
[Release notes] Remove refactoring category; include Dependabot again

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,8 +2,6 @@ changelog:
   exclude:
     labels:
       - ignore-for-release
-    authors:
-      - dependabot[bot]
   categories:
     - title: ✨ New features
       labels:
@@ -11,9 +9,6 @@ changelog:
     - title: 🪲 Bug fixes
       labels:
         - pr-bugfix
-    - title: 🛠️ Refactoring
-      labels:
-        - refactoring
     - title: ⚙️ CI/CD
       labels:
         - ci-cd


### PR DESCRIPTION
"refactoring" is rather a label for issues than for PRs. In the change logs, some entries are currently showing up as "refactoring" and some as "other changes", although they have the same scope. Also, we don't use the refactoring label consequently.

Dependabot PRs could be interesting for users, for instance to trace whether a bug has been introduced with a specific dependency version. So I suggest to include Dependabot PRs in the Changelog again.

Thus I think it makes sense to just have Features / Bug fixes / Other changes in the release notes.