### PR TITLE
[jtx Board] Filter known properties from OTHER properties in VALARMs

### DIFF
--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/AlarmProperties.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/AlarmProperties.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.synctools.mapping.jtx
+
+import net.fortuna.ical4j.model.Property
+
+/**
+ * iCalendar `VALARM` property names that are mapped to dedicated `JtxContract.JtxAlarm` columns.
+ *
+ * Used to keep [at.bitfire.synctools.mapping.jtx.builder.RemindersBuilder] (which must strip these
+ * out of `JtxContract.JtxAlarm.OTHER` when storing an alarm) and
+ * [at.bitfire.synctools.mapping.jtx.handler.RemindersHandler] (which must not re-add them from
+ * `JtxContract.JtxAlarm.OTHER`) in sync.
+ */
+val KNOWN_ALARM_PROPERTIES: Set<String> = setOf(
+    Property.ACTION,
+    Property.ATTACH,
+    Property.DESCRIPTION,
+    Property.DURATION,
+    Property.REPEAT,
+    Property.SUMMARY,
+    Property.TRIGGER
+)

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/AlarmProperties.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/AlarmProperties.kt
@@ -9,10 +9,9 @@ import net.fortuna.ical4j.model.Property
 /**
  * iCalendar `VALARM` property names that are mapped to dedicated `JtxContract.JtxAlarm` columns.
  *
- * Used to keep [at.bitfire.synctools.mapping.jtx.builder.RemindersBuilder] (which must strip these
- * out of `JtxContract.JtxAlarm.OTHER` when storing an alarm) and
- * [at.bitfire.synctools.mapping.jtx.handler.RemindersHandler] (which must not re-add them from
- * `JtxContract.JtxAlarm.OTHER`) in sync.
+ * Used to keep [at.bitfire.synctools.mapping.jtx.builder.RemindersBuilder] and
+ * [at.bitfire.synctools.mapping.jtx.handler.RemindersHandler] in sync, which must not process these
+ * properties when found in "other" properties.
  */
 val KNOWN_ALARM_PROPERTIES: Set<String> = setOf(
     Property.ACTION,

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/RemindersBuilder.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/builder/RemindersBuilder.kt
@@ -8,6 +8,7 @@ import android.content.ContentValues
 import android.content.Entity
 import androidx.core.content.contentValuesOf
 import at.bitfire.synctools.icalendar.DatePropertyTzMapper.normalizedDate
+import at.bitfire.synctools.mapping.jtx.KNOWN_ALARM_PROPERTIES
 import at.bitfire.synctools.mapping.jtx.builder.TimeZoneIdMapper.toTimeZoneId
 import at.bitfire.synctools.util.AndroidTimeUtils.toTimestamp
 import at.techbee.jtx.JtxContract
@@ -56,15 +57,7 @@ class RemindersBuilder : JtxObjectEntityBuilder {
             triggerTimezone = normalizedTriggerDate.toTimeZoneId()
         }
 
-        val otherProperties = alarm.propertyList.removeAll(
-            Property.ACTION,
-            Property.SUMMARY,
-            Property.DESCRIPTION,
-            Property.DURATION,
-            Property.ATTACH,
-            Property.REPEAT,
-            Property.TRIGGER
-        )
+        val otherProperties = alarm.propertyList.removeAll(*KNOWN_ALARM_PROPERTIES.toTypedArray())
         val other = JtxContract.getJsonStringFromXProperties(otherProperties)
 
         return contentValuesOf(

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/RemindersHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/RemindersHandler.kt
@@ -8,6 +8,7 @@ import android.content.ContentValues
 import android.content.Entity
 import at.bitfire.synctools.icalendar.plusAssign
 import at.bitfire.synctools.mapping.jtx.KNOWN_ALARM_PROPERTIES
+import at.bitfire.synctools.util.Utils.containsIgnoreCase
 import at.techbee.jtx.JtxContract
 import net.fortuna.ical4j.model.Component
 import net.fortuna.ical4j.model.ComponentContainer
@@ -79,7 +80,7 @@ class RemindersHandler : JtxObjectEntityHandler {
                 }
             }?.all ?: emptyList()
         otherProperties
-            .filterNot { it.name.uppercase() in KNOWN_ALARM_PROPERTIES }
+            .filterNot { KNOWN_ALARM_PROPERTIES.containsIgnoreCase(it.name) }
             .let { alarmProps += it }
 
         handleTrigger(values)?.let { trigger ->

--- a/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/RemindersHandler.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/mapping/jtx/handler/RemindersHandler.kt
@@ -7,6 +7,7 @@ package at.bitfire.synctools.mapping.jtx.handler
 import android.content.ContentValues
 import android.content.Entity
 import at.bitfire.synctools.icalendar.plusAssign
+import at.bitfire.synctools.mapping.jtx.KNOWN_ALARM_PROPERTIES
 import at.techbee.jtx.JtxContract
 import net.fortuna.ical4j.model.Component
 import net.fortuna.ical4j.model.ComponentContainer
@@ -68,16 +69,18 @@ class RemindersHandler : JtxObjectEntityHandler {
             alarmProps += Summary(summary)
         }
 
-        // Add all the unknown properties
-        values.getAsString(JtxContract.JtxAlarm.OTHER)
+        // Add unknown properties (except known alarm properties)
+        val otherProperties = values.getAsString(JtxContract.JtxAlarm.OTHER)
             ?.let { json ->
                 try {
                     JtxContract.getXPropertyListFromJson(json)
                 } catch (_: JSONException) {
                     null
                 }
-            }
-            ?.let { alarmProps += it.all }
+            }?.all ?: emptyList()
+        otherProperties
+            .filterNot { it.name.uppercase() in KNOWN_ALARM_PROPERTIES }
+            .let { alarmProps += it }
 
         handleTrigger(values)?.let { trigger ->
             alarmProps += trigger

--- a/synctools/src/main/kotlin/at/bitfire/synctools/util/Utils.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/util/Utils.kt
@@ -9,6 +9,9 @@ import java.util.Locale
 
 object Utils {
 
+    fun Set<String>.containsIgnoreCase(value: String): Boolean =
+        any { it.equals(value, ignoreCase = true) }
+
     fun String.capitalize(): String = split(' ').joinToString(" ") { word ->
         word.replaceFirstChar {
             if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/handler/RemindersHandlerTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/jtx/handler/RemindersHandlerTest.kt
@@ -205,6 +205,35 @@ class RemindersHandlerTest {
     }
 
     @Test
+    fun `Alarm with reserved property names in OTHER`() {
+        val input = Entity(ContentValues())
+        input.addSubValue(
+            JtxContract.JtxAlarm.CONTENT_URI,
+            contentValuesOf(
+                JtxContract.JtxAlarm.ACTION to "DISPLAY",
+                JtxContract.JtxAlarm.DESCRIPTION to "Default Tasks.org description",
+                JtxContract.JtxAlarm.TRIGGER_RELATIVE_DURATION to "PT0S",
+                // stale/corrupted OTHER blob with different values than the dedicated columns above - must be ignored entirely
+                JtxContract.JtxAlarm.OTHER to """{"ACTION":"AUDIO","DESCRIPTION":"stale description","TRIGGER":"PT99H","X-CUSTOM-PROP":"custom-value"}"""
+            )
+        )
+        val output = VToDo()
+
+        handler.process(from = input, main = input, to = output)
+
+        val alarm = output.alarms.first()
+        assertEquals(listOf("DISPLAY"), alarm.getProperties<Action>(Property.ACTION).map { it.value })
+        assertEquals(
+            listOf("Default Tasks.org description"),
+            alarm.getProperties<Description>(Property.DESCRIPTION).map { it.value }
+        )
+        val triggers = alarm.getProperties<Trigger>(Property.TRIGGER)
+        assertEquals(1, triggers.size)
+        assertEquals(java.time.Duration.ofSeconds(0), triggers.first().duration)
+        assertNotNull(alarm.getProperty<net.fortuna.ical4j.model.property.XProperty>("X-CUSTOM-PROP").getOrNull())
+    }
+
+    @Test
     fun `Trigger with relative duration`() {
         val input = Entity(ContentValues())
         input.addSubValue(

--- a/synctools/src/test/kotlin/at/bitfire/synctools/util/UtilsTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/util/UtilsTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.synctools.util
+
+import at.bitfire.synctools.util.Utils.containsIgnoreCase
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UtilsTest {
+
+    @Test
+    fun `containsIgnoreCase with exact case match`() {
+        assertTrue(setOf("TRIGGER").containsIgnoreCase("TRIGGER"))
+    }
+
+    @Test
+    fun `containsIgnoreCase with lowercase value`() {
+        assertTrue(setOf("TRIGGER").containsIgnoreCase("trigger"))
+    }
+
+    @Test
+    fun `containsIgnoreCase with mixed-case value`() {
+        assertTrue(setOf("TRIGGER").containsIgnoreCase("Trigger"))
+    }
+
+    @Test
+    fun `containsIgnoreCase with no match`() {
+        assertFalse(setOf("TRIGGER").containsIgnoreCase("ACTION"))
+    }
+
+    @Test
+    fun `containsIgnoreCase with empty set`() {
+        assertFalse(emptySet<String>().containsIgnoreCase("TRIGGER"))
+    }
+
+}


### PR DESCRIPTION
### Purpose

jtx Board: filter known properties from the `OTHER` when building a `VALARM`. Hopefully fixes #2688.

### Short description

- Introduced `KNOWN_ALARM_PROPERTIES` to track recognized alarm properties.
- Implemented filtering logic to exclude known properties from the `OTHER` category.
- Added corresponding test coverage.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.