### PR TITLE
[UI] Debug info: clarify wording of 5xx "contact server support" message

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoScreen.kt
@@ -127,16 +127,7 @@ fun DebugInfoScreen(
                     cause.statusCode == 403 -> AnnotatedString(stringResource(R.string.debug_info_http_403_description))
                     cause.statusCode == 404 -> AnnotatedString(stringResource(R.string.debug_info_http_404_description))
                     cause.statusCode == 405 -> AnnotatedString(stringResource(R.string.debug_info_http_405_description))
-                    cause.isServerError -> {
-                        val domain = UrlUtils.hostToDomain(remoteResource?.toUrlOrNull()?.host)
-                        val appName = stringResource(R.string.app_name).htmlEncode()
-                        AnnotatedString.fromHtml(
-                            if (domain != null)
-                                stringResource(R.string.debug_info_http_5xx_description, domain.htmlEncode(), appName)
-                            else
-                                stringResource(R.string.debug_info_http_5xx_description_no_domain, appName)
-                        )
-                    }
+                    cause.isServerError -> serverErrorMessage(UrlUtils.hostToDomain(remoteResource?.toUrlOrNull()?.host))
                     else -> AnnotatedString(stringResource(R.string.debug_info_unexpected_error))
                 }
             else
@@ -416,6 +407,18 @@ private fun FindHelpCard(modifier: Modifier = Modifier) {
 }
 
 @Composable
+private fun serverErrorMessage(domain: String?): AnnotatedString {
+    val appName = stringResource(R.string.app_name).htmlEncode()
+    val description = stringResource(R.string.debug_info_http_5xx_description).htmlEncode()
+    val contactSupport =
+        if (domain != null)
+            stringResource(R.string.debug_info_http_5xx_contact_support, domain.htmlEncode(), appName)
+        else
+            stringResource(R.string.debug_info_http_5xx_contact_support_no_domain, appName)
+    return AnnotatedString.fromHtml("$description\n\n$contactSupport")
+}
+
+@Composable
 @Preview
 fun DebugInfoScreen_Preview() {
     DebugInfoScreen(
@@ -443,13 +446,7 @@ fun DebugInfoScreen_5xxError_Preview() {
         showModelCause = true,
         modelCauseTitle = "Server Error",
         modelCauseSubtitle = "503 Service Unavailable",
-        modelCauseMessage = AnnotatedString.fromHtml(
-            stringResource(
-                R.string.debug_info_http_5xx_description,
-                "example.com",
-                stringResource(R.string.app_name)
-            )
-        ),
+        modelCauseMessage = serverErrorMessage(domain = "example.com"),
         localResource = "local-resource-string",
         canViewResource = true,
         remoteResource = "https://example.com/dav/",

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoScreen.kt
@@ -16,7 +16,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.rounded.LiveHelp
 import androidx.compose.material.icons.rounded.Adb
 import androidx.compose.material.icons.rounded.BugReport
-import androidx.compose.material.icons.rounded.Info
+import androidx.compose.material.icons.rounded.CloudOff
 import androidx.compose.material.icons.rounded.PrivacyTip
 import androidx.compose.material.icons.rounded.Share
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -44,9 +44,12 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.text.htmlEncode
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import at.bitfire.dav4jvm.ktor.UrlUtils
 import at.bitfire.dav4jvm.ktor.exception.DavException
 import at.bitfire.dav4jvm.ktor.exception.HttpException
+import at.bitfire.dav4jvm.ktor.toUrlOrNull
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.accounts.AccountId
 import at.bitfire.davdroid.log.DebugDirectory
@@ -76,15 +79,17 @@ fun DebugInfoScreen(
 ) {
     val model: DebugInfoViewModel = hiltViewModel(
         creationCallback = { factory: DebugInfoViewModel.Factory ->
-            factory.createWithDetails(DebugInfoViewModel.DebugInfoDetails(
-                accountId = accountId,
-                syncDataType = syncDataType,
-                cause = cause,
-                localResource = localResource,
-                remoteResource = remoteResource,
-                debugLogFileName = debugLogFileName,
-                timestamp = timestamp
-            ))
+            factory.createWithDetails(
+                DebugInfoViewModel.DebugInfoDetails(
+                    accountId = accountId,
+                    syncDataType = syncDataType,
+                    cause = cause,
+                    localResource = localResource,
+                    remoteResource = remoteResource,
+                    debugLogFileName = debugLogFileName,
+                    timestamp = timestamp
+                )
+            )
         }
     )
 
@@ -116,18 +121,26 @@ fun DebugInfoScreen(
             else -> cause?.let { it::class.java.simpleName }
         } ?: "",
         modelCauseSubtitle = cause?.localizedMessage,
-        modelCauseMessage = stringResource(
+        modelCauseMessage =
             if (cause is HttpException)
                 when {
-                    cause.statusCode == 403 -> R.string.debug_info_http_403_description
-                    cause.statusCode == 404 -> R.string.debug_info_http_404_description
-                    cause.statusCode == 405 -> R.string.debug_info_http_405_description
-                    cause.isServerError -> R.string.debug_info_http_5xx_description
-                    else -> R.string.debug_info_unexpected_error
+                    cause.statusCode == 403 -> AnnotatedString(stringResource(R.string.debug_info_http_403_description))
+                    cause.statusCode == 404 -> AnnotatedString(stringResource(R.string.debug_info_http_404_description))
+                    cause.statusCode == 405 -> AnnotatedString(stringResource(R.string.debug_info_http_405_description))
+                    cause.isServerError -> {
+                        val domain = UrlUtils.hostToDomain(remoteResource?.toUrlOrNull()?.host)
+                        val appName = stringResource(R.string.app_name).htmlEncode()
+                        AnnotatedString.fromHtml(
+                            if (domain != null)
+                                stringResource(R.string.debug_info_http_5xx_description, domain.htmlEncode(), appName)
+                            else
+                                stringResource(R.string.debug_info_http_5xx_description_no_domain, appName)
+                        )
+                    }
+                    else -> AnnotatedString(stringResource(R.string.debug_info_unexpected_error))
                 }
             else
-                R.string.debug_info_unexpected_error
-        ),
+                AnnotatedString(stringResource(R.string.debug_info_unexpected_error)),
         localResource = localResource,
         canViewResource = canViewResource,
         remoteResource = remoteResource,
@@ -151,7 +164,7 @@ fun DebugInfoScreen(
     showModelCause: Boolean,
     modelCauseTitle: String,
     modelCauseSubtitle: String?,
-    modelCauseMessage: String?,
+    modelCauseMessage: AnnotatedString?,
     localResource: String?,
     canViewResource: Boolean,
     remoteResource: String?,
@@ -213,22 +226,22 @@ fun DebugInfoScreen(
                 if (!showDebugInfo || zipProgress)
                     ProgressBar()
 
+                if (showModelCause) {
+                    CardWithImage(
+                        title = modelCauseTitle,
+                        subtitle = modelCauseSubtitle,
+                        annotatedMessage = modelCauseMessage,
+                        icon = Icons.Rounded.CloudOff,
+                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp)
+                    )
+                }
+
                 CardWithImage(
                     title = stringResource(R.string.debug_info_privacy_warning_title),
                     message = stringResource(R.string.debug_info_privacy_warning_description),
                     icon = Icons.Rounded.PrivacyTip,
                     modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp)
                 )
-
-                if (showModelCause) {
-                    CardWithImage(
-                        title = modelCauseTitle,
-                        subtitle = modelCauseSubtitle,
-                        message = modelCauseMessage,
-                        icon = Icons.Rounded.Info,
-                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp)
-                    )
-                }
 
                 if (showDebugInfo)
                     CardWithImage(
@@ -412,10 +425,34 @@ fun DebugInfoScreen_Preview() {
         showModelCause = true,
         modelCauseTitle = "ModelCauseTitle",
         modelCauseSubtitle = "ModelCauseSubtitle",
-        modelCauseMessage = "ModelCauseMessage",
+        modelCauseMessage = AnnotatedString("ModelCauseMessage"),
         localResource = "local-resource-string",
         canViewResource = true,
         remoteResource = "remote-resource-string",
+        hasLogFile = true
+    )
+}
+
+@Composable
+@Preview
+fun DebugInfoScreen_5xxError_Preview() {
+    DebugInfoScreen(
+        error = null,
+        showDebugInfo = true,
+        zipProgress = false,
+        showModelCause = true,
+        modelCauseTitle = "Server Error",
+        modelCauseSubtitle = "503 Service Unavailable",
+        modelCauseMessage = AnnotatedString.fromHtml(
+            stringResource(
+                R.string.debug_info_http_5xx_description,
+                "example.com",
+                stringResource(R.string.app_name)
+            )
+        ),
+        localResource = "local-resource-string",
+        canViewResource = true,
+        remoteResource = "https://example.com/dav/",
         hasLogFile = true
     )
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoScreen.kt
@@ -414,11 +414,11 @@ private fun serverErrorMessage(domain: String?): AnnotatedString {
     val appName = stringResource(R.string.app_name).htmlEncode()
     val description = stringResource(R.string.debug_info_http_5xx_description).htmlEncode()
     val contactSupport =
-        if (domain != null)
+        if (!domain.isNullOrEmpty())
             stringResource(R.string.debug_info_http_5xx_contact_support, domain.htmlEncode(), appName)
         else
             stringResource(R.string.debug_info_http_5xx_contact_support_no_domain, appName)
-    return AnnotatedString.fromHtml("$description\n\n$contactSupport")
+    return AnnotatedString.fromHtml("$description $contactSupport")
 }
 
 @Composable

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoScreen.kt
@@ -127,7 +127,10 @@ fun DebugInfoScreen(
                     cause.statusCode == 403 -> AnnotatedString(stringResource(R.string.debug_info_http_403_description))
                     cause.statusCode == 404 -> AnnotatedString(stringResource(R.string.debug_info_http_404_description))
                     cause.statusCode == 405 -> AnnotatedString(stringResource(R.string.debug_info_http_405_description))
-                    cause.isServerError -> serverErrorMessage(UrlUtils.hostToDomain(remoteResource?.toUrlOrNull()?.host))
+                    cause.isServerError -> {
+                        val domain = UrlUtils.hostToDomain(remoteResource?.toUrlOrNull()?.host)
+                        serverErrorMessage(domain)
+                    }
                     else -> AnnotatedString(stringResource(R.string.debug_info_unexpected_error))
                 }
             else

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/composable/CardWithImage.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/composable/CardWithImage.kt
@@ -25,6 +25,8 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import at.bitfire.davdroid.R
@@ -38,6 +40,7 @@ fun CardWithImage(
     imageAlignment: Alignment = Alignment.Center,
     imageContentScale: ContentScale = ContentScale.Crop,
     message: String? = null,
+    annotatedMessage: AnnotatedString? = null,
     subtitle: String? = null,
     icon: ImageVector? = null,
     iconContentDescription: String? = null,
@@ -95,7 +98,15 @@ fun CardWithImage(
                         }
                     }
                 }
-                message?.let {
+                annotatedMessage?.let {
+                    Text(
+                        text = it,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 4.dp),
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                } ?: message?.let {
                     Text(
                         text = it,
                         modifier = Modifier
@@ -128,7 +139,7 @@ fun CardWithImage_Preview_WithIconAndSubtitleAndContent() {
         title = "Demo card",
         icon = Icons.Default.TabletAndroid,
         subtitle = "Subtitle",
-        message = "This is the message to be displayed under the title, but before the content."
+        annotatedMessage = AnnotatedString.fromHtml("This is the <b>message</b> to be displayed under the title, but before the content.")
     ) {
         Text("Content")
     }

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -512,7 +512,8 @@
     <string name="debug_info_http_403_description">The request has been denied by the server.</string>
     <string name="debug_info_http_404_description">The requested resource doesn\'t exist (anymore).</string>
     <string name="debug_info_http_405_description">The server doesn\'t allow the requested type of operation.</string>
-    <string name="debug_info_http_5xx_description">A server-side problem occurred. Please contact your server support.</string>
+    <string name="debug_info_http_5xx_description"><![CDATA[A problem occurred on your server. <b>Please contact the support team of <tt>%1$s</tt></b> (not %2$s).]]></string>
+    <string name="debug_info_http_5xx_description_no_domain"><![CDATA[A problem occurred on your server. <b>Please contact the support team of your provider</b> (not %1$s).]]></string>
     <string name="debug_info_unexpected_error">An unexpected error has occurred. View debug info for details.</string>
     <string name="debug_info_view_details">View details</string>
     <string name="debug_info_subtitle">Debug info have been collected</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -512,8 +512,9 @@
     <string name="debug_info_http_403_description">The request has been denied by the server.</string>
     <string name="debug_info_http_404_description">The requested resource doesn\'t exist (anymore).</string>
     <string name="debug_info_http_405_description">The server doesn\'t allow the requested type of operation.</string>
-    <string name="debug_info_http_5xx_description"><![CDATA[A problem occurred on your server. <b>Please contact the support team of <tt>%1$s</tt></b> (not %2$s).]]></string>
-    <string name="debug_info_http_5xx_description_no_domain"><![CDATA[A problem occurred on your server. <b>Please contact the support team of your provider</b> (not %1$s).]]></string>
+    <string name="debug_info_http_5xx_description">A problem occurred on the server.</string>
+    <string name="debug_info_http_5xx_contact_support"><![CDATA[<b>Please contact the support team of <tt>%1$s</tt></b> (not %2$s).]]></string>
+    <string name="debug_info_http_5xx_contact_support_no_domain"><![CDATA[<b>Please contact the support team of your provider</b> (not %1$s).]]></string>
     <string name="debug_info_unexpected_error">An unexpected error has occurred. View debug info for details.</string>
     <string name="debug_info_view_details">View details</string>
     <string name="debug_info_subtitle">Debug info have been collected</string>


### PR DESCRIPTION
### Purpose

Makes the 5xx debug info message clearer that it's the *server's* support that needs to be contacted, not DAVx5 support, and names the affected domain so it's obvious which server is meant. Fixes #2731.

### Short description

- Split `debug_info_http_5xx_description` into a short, unchanged base sentence plus new `debug_info_http_5xx_contact_support` / `debug_info_http_5xx_contact_support_no_domain` strings, so `ExceptionInfoDialog` (which also uses the base string) keeps working unmodified.
- `DebugInfoScreen` now builds the 5xx message via a shared `serverErrorMessage()` composable that names the failing server's domain (when it can be determined) and highlights the "contact support" part with bold/monospace formatting via `AnnotatedString.fromHtml`.
- Added `annotatedMessage` support to `CardWithImage` to render HTML-formatted messages.
- Added a `DebugInfoScreen_5xxError_Preview` preview for the new message.

## Screenshots

**New:** card on top, new message

<img width="403" height="448" alt="grafik" src="https://github.com/user-attachments/assets/65fdfb46-16ad-4a4f-98bd-1b34a0140cc6" />


**Old:**

<img width="403" height="448" alt="grafik" src="https://github.com/user-attachments/assets/f36fa3f0-90b6-48af-8655-89a787a2837f" />


### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have self-reviewed the PR.
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.