### PR TITLE
Unify DAO method naming and convert easy blocking calls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,15 @@ Android library. The sync engine, database layer, and Jetpack Compose UI for DAV
 
 **Repository pattern** — DAOs (in `db/`) are always wrapped by a repository in `repository/`. UI code and sync managers talk to repositories, never to DAOs directly.
 
+**DAO/repository naming convention** — applies to both DAO methods (`db/`) and their repository wrappers (
+`repository/`):
+
+- Suspending functions have **no suffix** (e.g. `get`, `insert`) — never `...Async`.
+- Non-suspending (blocking) functions have a **`Blocking`** suffix (e.g. `getBlocking`, `insertBlocking`).
+- Functions returning `Flow` have a **`Flow`** suffix (e.g. `getAllFlow`).
+- Functions returning `PagingSource` use a **`page`/`pageXxx`** prefix instead of a suffix (e.g.
+  `pageByServiceAndType`), mirroring how `Flow`-returning functions are marked.
+
 **ViewModel pattern** — Each Compose screen has a `@HiltViewModel` in `ui/`. Keep business logic out of Composables; Composables observe state from the ViewModel.
 
 **Startup actions** — App-initialization hooks implement the `StartupAction` interface and are registered via set-based

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/db/HomeSetDaoTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/db/HomeSetDaoTest.kt
@@ -33,14 +33,14 @@ class HomeSetDaoTest {
         hiltRule.inject()
         dao = db.homeSetDao()
 
-        serviceId = db.serviceDao().insertOrReplace(
+        serviceId = db.serviceDao().insertOrReplaceBlocking(
             Service(id=0, accountName="test", type= Service.TYPE_CALDAV, principal = null)
         )
     }
 
     @After
     fun tearDown() {
-        db.serviceDao().deleteAll()
+        db.serviceDao().deleteAllBlocking()
     }
 
 
@@ -50,17 +50,17 @@ class HomeSetDaoTest {
         val entry1 = HomeSet(id=0, serviceId=serviceId, personal=true, url="https://example.com/1".toUrl())
         val insertId1 = dao.insertOrUpdateByUrlBlocking(entry1)
         assertEquals(1L, insertId1)
-        assertEquals(entry1.copy(id = 1L), dao.getById(1))
+        assertEquals(entry1.copy(id = 1L), dao.getByIdBlocking(1))
 
         val updatedEntry1 = HomeSet(id=0, serviceId=serviceId, personal=true, url="https://example.com/1".toUrl(), displayName="Updated Entry")
         val updateId1 = dao.insertOrUpdateByUrlBlocking(updatedEntry1)
         assertEquals(1L, updateId1)
-        assertEquals(updatedEntry1.copy(id = 1L), dao.getById(1))
+        assertEquals(updatedEntry1.copy(id = 1L), dao.getByIdBlocking(1))
 
         val entry2 = HomeSet(id=0, serviceId=serviceId, personal=true, url= "https://example.com/2".toUrl())
         val insertId2 = dao.insertOrUpdateByUrlBlocking(entry2)
         assertEquals(2L, insertId2)
-        assertEquals(entry2.copy(id = 2L), dao.getById(2))
+        assertEquals(entry2.copy(id = 2L), dao.getByIdBlocking(2))
     }
 
     @Test
@@ -78,7 +78,7 @@ class HomeSetDaoTest {
                     )
                 }
         }
-        assertEquals(1, dao.getByService(serviceId).size)
+        assertEquals(1, dao.getByServiceBlocking(serviceId).size)
     }
 
     @Test
@@ -88,10 +88,10 @@ class HomeSetDaoTest {
 
         val insertId1 = dao.insertOrUpdateByUrlBlocking(entry1)
         assertEquals(1L, insertId1)
-        assertEquals(entry1, dao.getById(1L))
+        assertEquals(entry1, dao.getByIdBlocking(1L))
 
-        dao.delete(entry1)
-        assertEquals(null, dao.getById(1L))
+        dao.deleteBlocking(entry1)
+        assertEquals(null, dao.getByIdBlocking(1L))
     }
 
 }

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/db/PrincipalDaoTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/db/PrincipalDaoTest.kt
@@ -8,9 +8,9 @@ import android.database.sqlite.SQLiteConstraintException
 import at.bitfire.davdroid.util.DavUtils.toUrl
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import io.mockk.coVerify
 import io.mockk.junit4.MockKRule
 import io.mockk.spyk
-import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -48,41 +48,41 @@ class PrincipalDaoTest {
     @Test
     fun insertOrUpdate_insertsIfNotExisting() = runTest {
         val principal = Principal(serviceId = service.id, url = url, displayName = "principal")
-        val id = principalDao.insertOrUpdateBlocking(service.id, principal)
+        val id = principalDao.insertOrUpdate(service.id, principal)
         assertTrue(id > 0)
 
         val stored = principalDao.getBlocking(id)
         assertEquals("principal", stored.displayName)
-        verify(exactly = 0) { principalDao.updateBlocking(any()) }
+        coVerify(exactly = 0) { principalDao.update(any()) }
     }
 
     @Test
     fun insertOrUpdate_doesNotUpdateIfDisplayNameIsEqual() = runTest {
         val principalOld = Principal(serviceId = service.id, url = url, displayName = "principalOld")
-        val idOld = principalDao.insertOrUpdateBlocking(service.id, principalOld)
+        val idOld = principalDao.insertOrUpdate(service.id, principalOld)
 
         val principalNew = Principal(serviceId = service.id, url = url, displayName = "principalOld")
-        val idNew = principalDao.insertOrUpdateBlocking(service.id, principalNew)
+        val idNew = principalDao.insertOrUpdate(service.id, principalNew)
 
         assertEquals(idOld, idNew)
         val stored = principalDao.getBlocking(idOld)
         assertEquals("principalOld", stored.displayName)
-        verify(exactly = 0) { principalDao.updateBlocking(any()) }
+        coVerify(exactly = 0) { principalDao.update(any()) }
     }
 
     @Test
     fun insertOrUpdate_updatesIfDisplayNameIsDifferent() = runTest {
         val principalOld = Principal(serviceId = service.id, url = url, displayName = "principalOld")
-        val idOld = principalDao.insertOrUpdateBlocking(service.id, principalOld)
+        val idOld = principalDao.insertOrUpdate(service.id, principalOld)
 
         val principalNew = Principal(serviceId = service.id, url = url, displayName = "principalNew")
-        val idNew = principalDao.insertOrUpdateBlocking(service.id, principalNew)
+        val idNew = principalDao.insertOrUpdate(service.id, principalNew)
 
         assertEquals(idOld, idNew)
 
         val updated = principalDao.getBlocking(idOld)
         assertEquals("principalNew", updated.displayName)
-        verify(exactly = 1) { principalDao.updateBlocking(any()) }
+        coVerify(exactly = 1) { principalDao.update(any()) }
     }
 
     @Test(expected = SQLiteConstraintException::class)
@@ -90,7 +90,7 @@ class PrincipalDaoTest {
         // throws on non-existing service
         val url = "https://example.com/dav/principal".toUrl()
         val principal1 = Principal(serviceId = 999, url = url, displayName = "p1")
-        principalDao.insertOrUpdateBlocking(999, principal1)
+        principalDao.insertOrUpdate(999, principal1)
     }
 
 }

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/db/PrincipalDaoTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/db/PrincipalDaoTest.kt
@@ -42,47 +42,47 @@ class PrincipalDaoTest {
         principalDao = spyk(db.principalDao())
 
         service = Service(id = 1, accountName = "account", type = "webdav")
-        db.serviceDao().insertOrReplace(service)
+        db.serviceDao().insertOrReplaceBlocking(service)
     }
 
     @Test
     fun insertOrUpdate_insertsIfNotExisting() = runTest {
         val principal = Principal(serviceId = service.id, url = url, displayName = "principal")
-        val id = principalDao.insertOrUpdate(service.id, principal)
+        val id = principalDao.insertOrUpdateBlocking(service.id, principal)
         assertTrue(id > 0)
 
-        val stored = principalDao.get(id)
+        val stored = principalDao.getBlocking(id)
         assertEquals("principal", stored.displayName)
-        verify(exactly = 0) { principalDao.update(any()) }
+        verify(exactly = 0) { principalDao.updateBlocking(any()) }
     }
 
     @Test
     fun insertOrUpdate_doesNotUpdateIfDisplayNameIsEqual() = runTest {
         val principalOld = Principal(serviceId = service.id, url = url, displayName = "principalOld")
-        val idOld = principalDao.insertOrUpdate(service.id, principalOld)
+        val idOld = principalDao.insertOrUpdateBlocking(service.id, principalOld)
 
         val principalNew = Principal(serviceId = service.id, url = url, displayName = "principalOld")
-        val idNew = principalDao.insertOrUpdate(service.id, principalNew)
+        val idNew = principalDao.insertOrUpdateBlocking(service.id, principalNew)
 
         assertEquals(idOld, idNew)
-        val stored = principalDao.get(idOld)
+        val stored = principalDao.getBlocking(idOld)
         assertEquals("principalOld", stored.displayName)
-        verify(exactly = 0) { principalDao.update(any()) }
+        verify(exactly = 0) { principalDao.updateBlocking(any()) }
     }
 
     @Test
     fun insertOrUpdate_updatesIfDisplayNameIsDifferent() = runTest {
         val principalOld = Principal(serviceId = service.id, url = url, displayName = "principalOld")
-        val idOld = principalDao.insertOrUpdate(service.id, principalOld)
+        val idOld = principalDao.insertOrUpdateBlocking(service.id, principalOld)
 
         val principalNew = Principal(serviceId = service.id, url = url, displayName = "principalNew")
-        val idNew = principalDao.insertOrUpdate(service.id, principalNew)
+        val idNew = principalDao.insertOrUpdateBlocking(service.id, principalNew)
 
         assertEquals(idOld, idNew)
 
-        val updated = principalDao.get(idOld)
+        val updated = principalDao.getBlocking(idOld)
         assertEquals("principalNew", updated.displayName)
-        verify(exactly = 1) { principalDao.update(any()) }
+        verify(exactly = 1) { principalDao.updateBlocking(any()) }
     }
 
     @Test(expected = SQLiteConstraintException::class)
@@ -90,7 +90,7 @@ class PrincipalDaoTest {
         // throws on non-existing service
         val url = "https://example.com/dav/principal".toUrl()
         val principal1 = Principal(serviceId = 999, url = url, displayName = "p1")
-        principalDao.insertOrUpdate(999, principal1)
+        principalDao.insertOrUpdateBlocking(999, principal1)
     }
 
 }

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/db/SyncStatsDaoTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/db/SyncStatsDaoTest.kt
@@ -30,12 +30,14 @@ class SyncStatsDaoTest {
     fun setUp() {
         hiltRule.inject()
 
-        val serviceId = db.serviceDao().insertOrReplace(Service(
+        val serviceId = db.serviceDao().insertOrReplaceBlocking(
+            Service(
             id = 0,
             accountName = "test@example.com",
             type = Service.TYPE_CALDAV
         ))
-        collectionId = db.collectionDao().insert(Collection(
+        collectionId = db.collectionDao().insertBlocking(
+            Collection(
             id = 0,
             serviceId = serviceId,
             type = Collection.TYPE_CALENDAR,
@@ -45,7 +47,7 @@ class SyncStatsDaoTest {
 
     @After
     fun tearDown() {
-        db.serviceDao().deleteAll()
+        db.serviceDao().deleteAllBlocking()
     }
 
     @Test

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/db/WebDavDocumentDaoTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/db/WebDavDocumentDaoTest.kt
@@ -73,7 +73,7 @@ class WebDavDocumentDaoTest {
                 ), result.map { it.name })
             }
         } finally {
-            mountDao.deleteAsync(mount)
+            mountDao.delete(mount)
         }
     }
 

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStoreTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStoreTest.kt
@@ -68,10 +68,10 @@ class LocalAddressBookStoreTest {
         service = Service(
             id = 200,
             accountName = account.name,
-            type = Service.Companion.TYPE_CARDDAV,
+            type = Service.TYPE_CARDDAV,
             principal = null
         )
-        db.serviceDao().insertOrReplace(service)
+        db.serviceDao().insertOrReplaceBlocking(service)
         addressBookAccount = Account(
             "MrRobert@example.com",
             addressBookAccountType

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStoreTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStoreTest.kt
@@ -22,6 +22,7 @@ import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
 import io.mockk.mockk
 import io.mockk.mockkObject
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -133,7 +134,7 @@ class LocalAddressBookStoreTest {
 
 
     @Test
-    fun test_create_createAccountReturnsNull() {
+    fun test_create_createAccountReturnsNull() = runTest {
         val collection = mockk<Collection>(relaxed = true) {
             every { serviceId } returns service.id
             every { id } returns 1
@@ -147,7 +148,7 @@ class LocalAddressBookStoreTest {
     }
 
     @Test
-    fun test_create_ReadOnly() {
+    fun test_create_ReadOnly() = runTest {
         val collection = mockk<Collection>(relaxed = true) {
             every { serviceId } returns service.id
             every { id } returns 1
@@ -160,7 +161,7 @@ class LocalAddressBookStoreTest {
     }
 
     @Test
-    fun test_create_ReadWrite() {
+    fun test_create_ReadWrite() = runTest {
         val collection = mockk<Collection>(relaxed = true) {
             every { serviceId } returns service.id
             every { id } returns 1

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/servicedetection/CollectionsWithoutHomeSetRefresherTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/servicedetection/CollectionsWithoutHomeSetRefresherTest.kt
@@ -155,10 +155,10 @@ class CollectionsWithoutHomeSetRefresherTest {
             )
         )
 
-        assertEquals(0, db.principalDao().getByServiceBlocking(service.id).size)
+        assertEquals(0, db.principalDao().getByService(service.id).size)
         refresherFactory.create(service, client).refreshCollectionsWithoutHomeSet()
 
-        val principals = db.principalDao().getByServiceBlocking(service.id)
+        val principals = db.principalDao().getByService(service.id)
         assertEquals(1, principals.size)
         assertEquals("$BASE_URL$PATH_CARDDAV$SUBPATH_PRINCIPAL".toUrl(), principals[0].url)
         assertEquals(null, principals[0].displayName)

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/servicedetection/CollectionsWithoutHomeSetRefresherTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/servicedetection/CollectionsWithoutHomeSetRefresherTest.kt
@@ -91,10 +91,10 @@ class CollectionsWithoutHomeSetRefresherTest {
         hiltRule.inject()
         client = HttpClient(buildMockEngine())
 
-        val serviceId = db.serviceDao().insertOrReplace(
+        val serviceId = db.serviceDao().insertOrReplaceBlocking(
             Service(id = 0, accountName = "test", type = Service.TYPE_CARDDAV, principal = null)
         )
-        service = db.serviceDao().get(serviceId)!!
+        service = db.serviceDao().getBlocking(serviceId)!!
     }
 
     @After
@@ -107,7 +107,7 @@ class CollectionsWithoutHomeSetRefresherTest {
 
     @Test
     fun refreshCollectionsWithoutHomeSet_updatesExistingCollection() = runTest {
-        val collectionId = db.collectionDao().insertOrUpdateByUrl(
+        val collectionId = db.collectionDao().insertOrUpdateByUrlBlocking(
             Collection(
                 0, service.id, null, null,
                 Collection.TYPE_ADDRESSBOOK,
@@ -126,13 +126,13 @@ class CollectionsWithoutHomeSetRefresherTest {
                 displayName = "My Contacts",
                 description = "My Contacts Description"
             ),
-            db.collectionDao().get(collectionId)
+            db.collectionDao().getBlocking(collectionId)
         )
     }
 
     @Test
     fun refreshCollectionsWithoutHomeSet_deletesInaccessibleCollectionsWithoutHomeSet() = runTest {
-        val collectionId = db.collectionDao().insertOrUpdateByUrl(
+        val collectionId = db.collectionDao().insertOrUpdateByUrlBlocking(
             Collection(
                 0, service.id, null, null,
                 Collection.TYPE_ADDRESSBOOK,
@@ -142,12 +142,12 @@ class CollectionsWithoutHomeSetRefresherTest {
 
         refresherFactory.create(service, client).refreshCollectionsWithoutHomeSet()
 
-        assertEquals(null, db.collectionDao().get(collectionId))
+        assertEquals(null, db.collectionDao().getBlocking(collectionId))
     }
 
     @Test
     fun refreshCollectionsWithoutHomeSet_addsOwnerUrls() = runTest {
-        val collectionId = db.collectionDao().insertOrUpdateByUrl(
+        val collectionId = db.collectionDao().insertOrUpdateByUrlBlocking(
             Collection(
                 0, service.id, null, null,
                 Collection.TYPE_ADDRESSBOOK,
@@ -155,16 +155,16 @@ class CollectionsWithoutHomeSetRefresherTest {
             )
         )
 
-        assertEquals(0, db.principalDao().getByService(service.id).size)
+        assertEquals(0, db.principalDao().getByServiceBlocking(service.id).size)
         refresherFactory.create(service, client).refreshCollectionsWithoutHomeSet()
 
-        val principals = db.principalDao().getByService(service.id)
+        val principals = db.principalDao().getByServiceBlocking(service.id)
         assertEquals(1, principals.size)
         assertEquals("$BASE_URL$PATH_CARDDAV$SUBPATH_PRINCIPAL".toUrl(), principals[0].url)
         assertEquals(null, principals[0].displayName)
         assertEquals(
             principals[0].id,
-            db.collectionDao().get(collectionId)!!.ownerId
+            db.collectionDao().getBlocking(collectionId)!!.ownerId
         )
     }
 

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/servicedetection/HomeSetRefresherTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/servicedetection/HomeSetRefresherTest.kt
@@ -98,10 +98,10 @@ class HomeSetRefresherTest {
         hiltRule.inject()
         client = HttpClient(buildMockEngine())
 
-        val serviceId = db.serviceDao().insertOrReplace(
+        val serviceId = db.serviceDao().insertOrReplaceBlocking(
             Service(id = 0, accountName = "test", type = Service.TYPE_CARDDAV, principal = null)
         )
-        service = db.serviceDao().get(serviceId)!!
+        service = db.serviceDao().getBlocking(serviceId)!!
     }
 
     @After
@@ -114,7 +114,7 @@ class HomeSetRefresherTest {
 
     @Test
     fun refreshHomesetsAndTheirCollections_addsNewCollection() = runTest {
-        val homesetId = db.homeSetDao().insert(
+        val homesetId = db.homeSetDao().insertBlocking(
             HomeSet(id = 0, service.id, true, "$BASE_URL$PATH_CARDDAV$SUBPATH_ADDRESSBOOK_HOMESET_PERSONAL".toUrl())
         )
 
@@ -138,7 +138,7 @@ class HomeSetRefresherTest {
 
     @Test
     fun refreshHomesetsAndTheirCollections_updatesExistingCollection() = runTest {
-        val collectionId = db.collectionDao().insertOrUpdateByUrl(
+        val collectionId = db.collectionDao().insertOrUpdateByUrlBlocking(
             Collection(
                 0,
                 service.id,
@@ -164,13 +164,13 @@ class HomeSetRefresherTest {
                 displayName = "My Contacts",
                 description = "My Contacts Description"
             ),
-            db.collectionDao().get(collectionId)
+            db.collectionDao().getBlocking(collectionId)
         )
     }
 
     @Test
     fun refreshHomesetsAndTheirCollections_preservesCollectionFlags() = runTest {
-        val collectionId = db.collectionDao().insertOrUpdateByUrl(
+        val collectionId = db.collectionDao().insertOrUpdateByUrlBlocking(
             Collection(
                 0,
                 service.id,
@@ -200,17 +200,17 @@ class HomeSetRefresherTest {
                 forceReadOnly = true,
                 sync = true
             ),
-            db.collectionDao().get(collectionId)
+            db.collectionDao().getBlocking(collectionId)
         )
     }
 
     @Test
     fun refreshHomesetsAndTheirCollections_marksRemovedCollectionsAsHomeless() = runTest {
-        val homesetId = db.homeSetDao().insert(
+        val homesetId = db.homeSetDao().insertBlocking(
             HomeSet(id = 0, service.id, true, "$BASE_URL$PATH_CARDDAV$SUBPATH_ADDRESSBOOK_HOMESET_EMPTY".toUrl())
         )
 
-        val collectionId = db.collectionDao().insertOrUpdateByUrl(
+        val collectionId = db.collectionDao().insertOrUpdateByUrlBlocking(
             Collection(
                 0,
                 service.id,
@@ -223,16 +223,16 @@ class HomeSetRefresherTest {
 
         homeSetRefresherFactory.create(service, client).refreshHomesetsAndTheirCollections()
 
-        assertEquals(null, db.collectionDao().get(collectionId)!!.homeSetId)
+        assertEquals(null, db.collectionDao().getBlocking(collectionId)!!.homeSetId)
     }
 
     @Test
     fun refreshHomesetsAndTheirCollections_addsOwnerUrls() = runTest {
-        val homesetId = db.homeSetDao().insert(
+        val homesetId = db.homeSetDao().insertBlocking(
             HomeSet(id = 0, service.id, true, "$BASE_URL$PATH_CARDDAV$SUBPATH_ADDRESSBOOK_HOMESET_PERSONAL".toUrl())
         )
 
-        val collectionId = db.collectionDao().insertOrUpdateByUrl(
+        val collectionId = db.collectionDao().insertOrUpdateByUrlBlocking(
             Collection(
                 0,
                 service.id,
@@ -243,16 +243,16 @@ class HomeSetRefresherTest {
             )
         )
 
-        assertEquals(0, db.principalDao().getByService(service.id).size)
+        assertEquals(0, db.principalDao().getByServiceBlocking(service.id).size)
         homeSetRefresherFactory.create(service, client).refreshHomesetsAndTheirCollections()
 
-        val principals = db.principalDao().getByService(service.id)
+        val principals = db.principalDao().getByServiceBlocking(service.id)
         assertEquals(1, principals.size)
         assertEquals("$BASE_URL$PATH_CARDDAV$SUBPATH_PRINCIPAL".toUrl(), principals[0].url)
         assertEquals(null, principals[0].displayName)
         assertEquals(
             principals[0].id,
-            db.collectionDao().get(collectionId)!!.ownerId
+            db.collectionDao().getBlocking(collectionId)!!.ownerId
         )
     }
 

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/servicedetection/HomeSetRefresherTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/servicedetection/HomeSetRefresherTest.kt
@@ -243,10 +243,10 @@ class HomeSetRefresherTest {
             )
         )
 
-        assertEquals(0, db.principalDao().getByServiceBlocking(service.id).size)
+        assertEquals(0, db.principalDao().getByService(service.id).size)
         homeSetRefresherFactory.create(service, client).refreshHomesetsAndTheirCollections()
 
-        val principals = db.principalDao().getByServiceBlocking(service.id)
+        val principals = db.principalDao().getByService(service.id)
         assertEquals(1, principals.size)
         assertEquals("$BASE_URL$PATH_CARDDAV$SUBPATH_PRINCIPAL".toUrl(), principals[0].url)
         assertEquals(null, principals[0].displayName)

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/servicedetection/PrincipalsRefresherTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/servicedetection/PrincipalsRefresherTest.kt
@@ -106,7 +106,7 @@ class PrincipalsRefresherTest {
 
     @Test
     fun refreshPrincipals_inaccessiblePrincipal() = runTest {
-        val principalId = db.principalDao().insertBlocking(
+        val principalId = db.principalDao().insert(
             Principal(
                 0, service.id,
                 "$BASE_URL$PATH_CARDDAV$SUBPATH_PRINCIPAL_INACCESSIBLE".toUrl(),
@@ -123,7 +123,7 @@ class PrincipalsRefresherTest {
 
         principalsRefresher.create(service, client).refreshPrincipals()
 
-        val principals = db.principalDao().getByServiceBlocking(service.id)
+        val principals = db.principalDao().getByService(service.id)
         assertEquals(1, principals.size)
         assertEquals("$BASE_URL$PATH_CARDDAV$SUBPATH_PRINCIPAL_INACCESSIBLE".toUrl(), principals[0].url)
         assertEquals(null, principals[0].displayName)
@@ -131,7 +131,7 @@ class PrincipalsRefresherTest {
 
     @Test
     fun refreshPrincipals_updatesPrincipal() = runTest {
-        val principalId = db.principalDao().insertBlocking(
+        val principalId = db.principalDao().insert(
             Principal(
                 0, service.id,
                 "$BASE_URL$PATH_CARDDAV$SUBPATH_PRINCIPAL".toUrl(),
@@ -148,7 +148,7 @@ class PrincipalsRefresherTest {
 
         principalsRefresher.create(service, client).refreshPrincipals()
 
-        val principals = db.principalDao().getByServiceBlocking(service.id)
+        val principals = db.principalDao().getByService(service.id)
         assertEquals(1, principals.size)
         assertEquals("$BASE_URL$PATH_CARDDAV$SUBPATH_PRINCIPAL".toUrl(), principals[0].url)
         assertEquals("Mr. Wobbles", principals[0].displayName)
@@ -156,7 +156,7 @@ class PrincipalsRefresherTest {
 
     @Test
     fun refreshPrincipals_deletesPrincipalsWithoutCollections() = runTest {
-        db.principalDao().insertBlocking(
+        db.principalDao().insert(
             Principal(
                 0, service.id,
                 "$BASE_URL$PATH_CARDDAV$SUBPATH_PRINCIPAL_WITHOUT_COLLECTIONS/".toUrl()
@@ -165,7 +165,7 @@ class PrincipalsRefresherTest {
 
         principalsRefresher.create(service, client).refreshPrincipals()
 
-        assertEquals(0, db.principalDao().getByServiceBlocking(service.id).size)
+        assertEquals(0, db.principalDao().getByService(service.id).size)
     }
 
 }

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/servicedetection/PrincipalsRefresherTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/servicedetection/PrincipalsRefresherTest.kt
@@ -92,10 +92,10 @@ class PrincipalsRefresherTest {
         hiltRule.inject()
         client = HttpClient(buildMockEngine())
 
-        val serviceId = db.serviceDao().insertOrReplace(
+        val serviceId = db.serviceDao().insertOrReplaceBlocking(
             Service(id = 0, accountName = "test", type = Service.TYPE_CARDDAV, principal = null)
         )
-        service = db.serviceDao().get(serviceId)!!
+        service = db.serviceDao().getBlocking(serviceId)!!
     }
 
     @After
@@ -106,14 +106,14 @@ class PrincipalsRefresherTest {
 
     @Test
     fun refreshPrincipals_inaccessiblePrincipal() = runTest {
-        val principalId = db.principalDao().insert(
+        val principalId = db.principalDao().insertBlocking(
             Principal(
                 0, service.id,
                 "$BASE_URL$PATH_CARDDAV$SUBPATH_PRINCIPAL_INACCESSIBLE".toUrl(),
                 null
             )
         )
-        db.collectionDao().insertOrUpdateByUrl(
+        db.collectionDao().insertOrUpdateByUrlBlocking(
             Collection(
                 0, service.id, null, principalId,
                 Collection.TYPE_ADDRESSBOOK,
@@ -123,7 +123,7 @@ class PrincipalsRefresherTest {
 
         principalsRefresher.create(service, client).refreshPrincipals()
 
-        val principals = db.principalDao().getByService(service.id)
+        val principals = db.principalDao().getByServiceBlocking(service.id)
         assertEquals(1, principals.size)
         assertEquals("$BASE_URL$PATH_CARDDAV$SUBPATH_PRINCIPAL_INACCESSIBLE".toUrl(), principals[0].url)
         assertEquals(null, principals[0].displayName)
@@ -131,14 +131,14 @@ class PrincipalsRefresherTest {
 
     @Test
     fun refreshPrincipals_updatesPrincipal() = runTest {
-        val principalId = db.principalDao().insert(
+        val principalId = db.principalDao().insertBlocking(
             Principal(
                 0, service.id,
                 "$BASE_URL$PATH_CARDDAV$SUBPATH_PRINCIPAL".toUrl(),
                 null
             )
         )
-        db.collectionDao().insertOrUpdateByUrl(
+        db.collectionDao().insertOrUpdateByUrlBlocking(
             Collection(
                 0, service.id, null, principalId,
                 Collection.TYPE_ADDRESSBOOK,
@@ -148,7 +148,7 @@ class PrincipalsRefresherTest {
 
         principalsRefresher.create(service, client).refreshPrincipals()
 
-        val principals = db.principalDao().getByService(service.id)
+        val principals = db.principalDao().getByServiceBlocking(service.id)
         assertEquals(1, principals.size)
         assertEquals("$BASE_URL$PATH_CARDDAV$SUBPATH_PRINCIPAL".toUrl(), principals[0].url)
         assertEquals("Mr. Wobbles", principals[0].displayName)
@@ -156,7 +156,7 @@ class PrincipalsRefresherTest {
 
     @Test
     fun refreshPrincipals_deletesPrincipalsWithoutCollections() = runTest {
-        db.principalDao().insert(
+        db.principalDao().insertBlocking(
             Principal(
                 0, service.id,
                 "$BASE_URL$PATH_CARDDAV$SUBPATH_PRINCIPAL_WITHOUT_COLLECTIONS/".toUrl()
@@ -165,7 +165,7 @@ class PrincipalsRefresherTest {
 
         principalsRefresher.create(service, client).refreshPrincipals()
 
-        assertEquals(0, db.principalDao().getByService(service.id).size)
+        assertEquals(0, db.principalDao().getByServiceBlocking(service.id).size)
     }
 
 }

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/servicedetection/ServiceRefresherTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/servicedetection/ServiceRefresherTest.kt
@@ -91,10 +91,10 @@ class ServiceRefresherTest {
         hiltRule.inject()
         client = HttpClient(buildMockEngine())
 
-        val serviceId = db.serviceDao().insertOrReplace(
+        val serviceId = db.serviceDao().insertOrReplaceBlocking(
             Service(id = 0, accountName = "test", type = Service.TYPE_CARDDAV, principal = null)
         )
-        service = db.serviceDao().get(serviceId)!!
+        service = db.serviceDao().getBlocking(serviceId)!!
     }
 
     @After
@@ -110,7 +110,7 @@ class ServiceRefresherTest {
         serviceRefresherFactory.create(service, client)
             .discoverHomesets(baseUrl)
 
-        val savedHomesets = db.homeSetDao().getByService(service.id)
+        val savedHomesets = db.homeSetDao().getByServiceBlocking(service.id)
         assertEquals(2, savedHomesets.size)
 
         // Home set from current-user-principal

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration17Test.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration17Test.kt
@@ -67,12 +67,12 @@ class AccountSettingsMigration17Test {
                 accountManager.setAndVerifyUserData(addressBookAccount, localAddressBookUserDataUrl, url)
 
                 // and is known in database
-                db.serviceDao().insertOrReplace(
+                db.serviceDao().insertOrReplaceBlocking(
                     Service(
                         id = 1, accountName = account.name, type = Service.TYPE_CARDDAV, principal = null
                     )
                 )
-                db.collectionDao().insert(
+                db.collectionDao().insertBlocking(
                     Collection(
                         id = 100,
                         serviceId = 1,

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration18Test.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration18Test.kt
@@ -90,13 +90,15 @@ class AccountSettingsMigration18Test {
     fun testMigrate_AddressBook_ValidCollection() {
         val account = Account("test", "test")
 
-        db.serviceDao().insertOrReplace(Service(
+        db.serviceDao().insertOrReplaceBlocking(
+            Service(
             id = 10,
             accountName = account.name,
             type = Service.TYPE_CARDDAV,
             principal = null
         ))
-        db.collectionDao().insertOrUpdateByUrl(Collection(
+        db.collectionDao().insertOrUpdateByUrlBlocking(
+            Collection(
             id = 100,
             serviceId = 10,
             url = "http://example.com".toUrl(),

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration20Test.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration20Test.kt
@@ -87,8 +87,17 @@ class AccountSettingsMigration20Test {
         // set up legacy address-book with URL, but without collection ID
         val url = "https://example.com/"
 
-        db.serviceDao().insertOrReplace(Service(id = 1, accountName = account.name, type = Service.TYPE_CARDDAV, principal = null))
-        val collectionId = db.collectionDao().insert(Collection(
+        db.serviceDao()
+            .insertOrReplaceBlocking(
+                Service(
+                    id = 1,
+                    accountName = account.name,
+                    type = Service.TYPE_CARDDAV,
+                    principal = null
+                )
+            )
+        val collectionId = db.collectionDao().insertBlocking(
+            Collection(
             serviceId = 1,
             type = Collection.Companion.TYPE_ADDRESSBOOK,
             url = url.toUrl()
@@ -116,8 +125,16 @@ class AccountSettingsMigration20Test {
         // set up legacy calendar with URL, but without collection ID
         val url = "https://example.com/"
 
-        db.serviceDao().insertOrReplace(Service(id = 1, accountName = account.name, type = Service.TYPE_CALDAV, principal = null))
-        val collectionId = db.collectionDao().insert(
+        db.serviceDao()
+            .insertOrReplaceBlocking(
+                Service(
+                    id = 1,
+                    accountName = account.name,
+                    type = Service.TYPE_CALDAV,
+                    principal = null
+                )
+            )
+        val collectionId = db.collectionDao().insertBlocking(
             Collection(
                 serviceId = 1,
                 type = Collection.Companion.TYPE_CALENDAR,

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/JtxSyncManagerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/JtxSyncManagerTest.kt
@@ -4,7 +4,6 @@
 
 package at.bitfire.davdroid.sync
 
-import android.accounts.Account
 import android.content.ContentProviderClient
 import android.content.Context
 import at.bitfire.davdroid.accounts.LegacyAccount
@@ -23,6 +22,7 @@ import at.techbee.jtx.JtxContract
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -93,7 +93,7 @@ class JtxSyncManagerTest {
             type = Collection.TYPE_CALENDAR,
             url = "https://example.com".toUrl()
         )
-        localJtxCollection = localJtxCollectionStore.create(provider, dbCollection)
+        localJtxCollection = runBlocking { localJtxCollectionStore.create(provider, dbCollection) }
         syncManager = jtxSyncManagerFactory.jtxSyncManager(
             accountId = accountId,
             httpClient = httpClientBuilder.build(),

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncerTest.kt
@@ -126,7 +126,7 @@ class SyncerTest {
     fun testCreateLocalCollections() = runTest {
         val localCollection = mockk<LocalTestCollection>()
         val dbCollection = mockk<Collection>()
-        every { dataStore.create(provider, dbCollection) } returns localCollection
+        coEvery { dataStore.create(provider, dbCollection) } returns localCollection
 
         // Should return list of newly created local collections
         val result = syncer.createLocalCollections(provider, listOf(dbCollection))
@@ -197,7 +197,7 @@ class SyncerTest {
             throw NotImplementedError()
         }
 
-        override fun create(
+        override suspend fun create(
             client: ContentProviderClient,
             fromCollection: Collection
         ): LocalTestCollection? {

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/account/AccountsCleanupWorkerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/account/AccountsCleanupWorkerTest.kt
@@ -77,8 +77,16 @@ class AccountsCleanupWorkerTest {
     @Test
     fun testCleanUpServices_noAccount() {
         // Insert service that reference to invalid account
-        db.serviceDao().insertOrReplace(Service(id = 1, accountName = "test", type = Service.TYPE_CALDAV, principal = null))
-        assertNotNull(db.serviceDao().get(1))
+        db.serviceDao()
+            .insertOrReplaceBlocking(
+                Service(
+                    id = 1,
+                    accountName = "test",
+                    type = Service.TYPE_CALDAV,
+                    principal = null
+                )
+            )
+        assertNotNull(db.serviceDao().getBlocking(1))
 
         // Create worker and run the method
         val worker = TestListenableWorkerBuilder<AccountsCleanupWorker>(context)
@@ -87,18 +95,34 @@ class AccountsCleanupWorkerTest {
         worker.cleanUpServices()
 
         // Verify that service is deleted
-        assertNull(db.serviceDao().get(1))
+        assertNull(db.serviceDao().getBlocking(1))
     }
 
     @Test
     fun testCleanUpServices_oneAccount() {
         TestAccount.provide { existingAccount ->
             // Insert services, one that reference the existing account and one that references an invalid account
-            db.serviceDao().insertOrReplace(Service(id = 1, accountName = existingAccount.name, type = Service.TYPE_CALDAV, principal = null))
-            assertNotNull(db.serviceDao().get(1))
+            db.serviceDao()
+                .insertOrReplaceBlocking(
+                    Service(
+                        id = 1,
+                        accountName = existingAccount.name,
+                        type = Service.TYPE_CALDAV,
+                        principal = null
+                    )
+                )
+            assertNotNull(db.serviceDao().getBlocking(1))
 
-            db.serviceDao().insertOrReplace(Service(id = 2, accountName = "not existing", type = Service.TYPE_CARDDAV, principal = null))
-            assertNotNull(db.serviceDao().get(2))
+            db.serviceDao()
+                .insertOrReplaceBlocking(
+                    Service(
+                        id = 2,
+                        accountName = "not existing",
+                        type = Service.TYPE_CARDDAV,
+                        principal = null
+                    )
+                )
+            assertNotNull(db.serviceDao().getBlocking(2))
 
             // Create worker and run the method
             val worker = TestListenableWorkerBuilder<AccountsCleanupWorker>(context)
@@ -107,8 +131,8 @@ class AccountsCleanupWorkerTest {
             worker.cleanUpServices()
 
             // Verify that one service is deleted and the other one is kept
-            assertNotNull(db.serviceDao().get(1))
-            assertNull(db.serviceDao().get(2))
+            assertNotNull(db.serviceDao().getBlocking(1))
+            assertNull(db.serviceDao().getBlocking(2))
         }
     }
 
@@ -156,8 +180,8 @@ class AccountsCleanupWorkerTest {
 
     private fun createTestService(): Service {
         val service = Service(id=0, accountName="test", type=Service.TYPE_CARDDAV, principal = null)
-        val serviceId = db.serviceDao().insertOrReplace(service)
-        return db.serviceDao().get(serviceId)!!
+        val serviceId = db.serviceDao().insertOrReplaceBlocking(service)
+        return db.serviceDao().getBlocking(serviceId)!!
     }
 
 }

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/webdav/operation/MoveDocumentOperationTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/webdav/operation/MoveDocumentOperationTest.kt
@@ -72,7 +72,7 @@ class MoveDocumentOperationTest {
 
     @After
     fun tearDown() {
-        runBlocking { mountDao.deleteAsync(mount) }
+        runBlocking { mountDao.delete(mount) }
     }
 
 

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/webdav/operation/QueryChildDocumentsOperationTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/webdav/operation/QueryChildDocumentsOperationTest.kt
@@ -75,7 +75,7 @@ class QueryChildDocumentsOperationTest {
     @After
     fun tearDown() {
         runBlocking {
-            db.webDavMountDao().deleteAsync(mount)
+            db.webDavMountDao().delete(mount)
         }
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/db/CollectionDao.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/CollectionDao.kt
@@ -35,9 +35,6 @@ interface CollectionDao {
     @Query("SELECT * FROM collection WHERE serviceId=:serviceId AND homeSetId IS :homeSetId")
     suspend fun getByServiceAndHomeset(serviceId: Long, homeSetId: Long?): List<Collection>
 
-    @Query("SELECT * FROM collection WHERE serviceId=:serviceId AND type=:type ORDER BY displayName COLLATE NOCASE, url COLLATE NOCASE")
-    fun getByServiceAndTypeBlocking(serviceId: Long, @CollectionType type: String): List<Collection>
-
     @Query("SELECT * FROM collection WHERE pushTopic=:topic AND sync")
     suspend fun getSyncableByPushTopic(topic: String): Collection?
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/db/CollectionDao.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/CollectionDao.kt
@@ -18,10 +18,10 @@ import kotlinx.coroutines.flow.Flow
 interface CollectionDao {
 
     @Query("SELECT * FROM collection WHERE id=:id")
-    fun getBlocking(id: Long): Collection?
+    suspend fun get(id: Long): Collection?
 
     @Query("SELECT * FROM collection WHERE id=:id")
-    suspend fun get(id: Long): Collection?
+    fun getBlocking(id: Long): Collection?
 
     @Query("SELECT * FROM collection WHERE id=:id")
     fun getFlow(id: Long): Flow<Collection?>
@@ -33,7 +33,7 @@ interface CollectionDao {
     fun getByServiceBlocking(serviceId: Long): List<Collection>
 
     @Query("SELECT * FROM collection WHERE serviceId=:serviceId AND homeSetId IS :homeSetId")
-    fun getByServiceAndHomesetBlocking(serviceId: Long, homeSetId: Long?): List<Collection>
+    suspend fun getByServiceAndHomeset(serviceId: Long, homeSetId: Long?): List<Collection>
 
     @Query("SELECT * FROM collection WHERE serviceId=:serviceId AND type=:type ORDER BY displayName COLLATE NOCASE, url COLLATE NOCASE")
     fun getByServiceAndTypeBlocking(serviceId: Long, @CollectionType type: String): List<Collection>
@@ -101,10 +101,10 @@ interface CollectionDao {
     suspend fun getPushRegisteredAndNotSyncable(serviceId: Long): List<Collection>
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
-    fun insertBlocking(collection: Collection): Long
+    suspend fun insert(collection: Collection): Long
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
-    suspend fun insert(collection: Collection): Long
+    fun insertBlocking(collection: Collection): Long
 
     @Update
     fun updateBlocking(collection: Collection)

--- a/core/src/main/kotlin/at/bitfire/davdroid/db/CollectionDao.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/CollectionDao.kt
@@ -18,10 +18,10 @@ import kotlinx.coroutines.flow.Flow
 interface CollectionDao {
 
     @Query("SELECT * FROM collection WHERE id=:id")
-    fun get(id: Long): Collection?
+    fun getBlocking(id: Long): Collection?
 
     @Query("SELECT * FROM collection WHERE id=:id")
-    suspend fun getAsync(id: Long): Collection?
+    suspend fun get(id: Long): Collection?
 
     @Query("SELECT * FROM collection WHERE id=:id")
     fun getFlow(id: Long): Flow<Collection?>
@@ -33,17 +33,17 @@ interface CollectionDao {
     fun getByServiceBlocking(serviceId: Long): List<Collection>
 
     @Query("SELECT * FROM collection WHERE serviceId=:serviceId AND homeSetId IS :homeSetId")
-    fun getByServiceAndHomeset(serviceId: Long, homeSetId: Long?): List<Collection>
+    fun getByServiceAndHomesetBlocking(serviceId: Long, homeSetId: Long?): List<Collection>
 
     @Query("SELECT * FROM collection WHERE serviceId=:serviceId AND type=:type ORDER BY displayName COLLATE NOCASE, url COLLATE NOCASE")
-    fun getByServiceAndType(serviceId: Long, @CollectionType type: String): List<Collection>
+    fun getByServiceAndTypeBlocking(serviceId: Long, @CollectionType type: String): List<Collection>
 
     @Query("SELECT * FROM collection WHERE pushTopic=:topic AND sync")
     suspend fun getSyncableByPushTopic(topic: String): Collection?
 
     @Suppress("unused")     // for build variant
     @Query("SELECT * FROM collection WHERE sync")
-    fun getSyncCollections(): List<Collection>
+    fun getSyncCollectionsBlocking(): List<Collection>
 
     @Query("SELECT pushVapidKey FROM collection WHERE serviceId=:serviceId AND pushVapidKey IS NOT NULL LIMIT 1")
     suspend fun getFirstVapidKey(serviceId: Long): String?
@@ -56,7 +56,7 @@ interface CollectionDao {
 
     @Query("SELECT COUNT(*) FROM collection WHERE sync")
     suspend fun countSyncEnabled(): Int
-    
+
     @Query("SELECT COUNT(*) FROM collection WHERE supportsWebPush AND pushTopic IS NOT NULL and sync")
     suspend fun countSyncEnabledPushCapable(): Int
 
@@ -70,22 +70,22 @@ interface CollectionDao {
     fun pageByServiceAndType(serviceId: Long, @CollectionType type: String): PagingSource<Int, Collection>
 
     @Query("SELECT * FROM collection WHERE serviceId=:serviceId AND sync")
-    fun getByServiceAndSync(serviceId: Long): List<Collection>
+    fun getByServiceAndSyncBlocking(serviceId: Long): List<Collection>
 
     @Query("SELECT collection.* FROM collection, homeset WHERE collection.serviceId=:serviceId AND type=:type AND homeSetId=homeset.id AND homeset.personal ORDER BY collection.displayName COLLATE NOCASE, collection.url COLLATE NOCASE")
     fun pagePersonalByServiceAndType(serviceId: Long, @CollectionType type: String): PagingSource<Int, Collection>
 
     @Query("SELECT * FROM collection WHERE serviceId=:serviceId AND url=:url")
-    fun getByServiceAndUrl(serviceId: Long, url: String): Collection?
+    fun getByServiceAndUrlBlocking(serviceId: Long, url: String): Collection?
 
     @Query("SELECT * FROM collection WHERE serviceId=:serviceId AND type='${Collection.TYPE_CALENDAR}' AND supportsVEVENT AND sync ORDER BY displayName COLLATE NOCASE, url COLLATE NOCASE")
-    fun getSyncCalendars(serviceId: Long): List<Collection>
+    fun getSyncCalendarsBlocking(serviceId: Long): List<Collection>
 
     @Query("SELECT * FROM collection WHERE serviceId=:serviceId AND type='${Collection.TYPE_CALENDAR}' AND (supportsVTODO OR supportsVJOURNAL) AND sync ORDER BY displayName COLLATE NOCASE, url COLLATE NOCASE")
-    fun getSyncJtxCollections(serviceId: Long): List<Collection>
+    fun getSyncJtxCollectionsBlocking(serviceId: Long): List<Collection>
 
     @Query("SELECT * FROM collection WHERE serviceId=:serviceId AND type='${Collection.TYPE_CALENDAR}' AND supportsVTODO AND sync ORDER BY displayName COLLATE NOCASE, url COLLATE NOCASE")
-    fun getSyncTaskLists(serviceId: Long): List<Collection>
+    fun getSyncTaskListsBlocking(serviceId: Long): List<Collection>
 
     /**
      * Get a list of collections that are both sync enabled and push capable (supportsWebPush and
@@ -101,13 +101,13 @@ interface CollectionDao {
     suspend fun getPushRegisteredAndNotSyncable(serviceId: Long): List<Collection>
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
-    fun insert(collection: Collection): Long
+    fun insertBlocking(collection: Collection): Long
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
-    suspend fun insertAsync(collection: Collection): Long
+    suspend fun insert(collection: Collection): Long
 
     @Update
-    fun update(collection: Collection)
+    fun updateBlocking(collection: Collection)
 
     @Query("UPDATE collection SET forceReadOnly=:forceReadOnly WHERE id=:id")
     suspend fun updateForceReadOnly(id: Long, forceReadOnly: Boolean)
@@ -133,15 +133,15 @@ interface CollectionDao {
      * @return ID of the row, that has been inserted or updated. -1 If the insert fails due to other reasons.
      */
     @Transaction
-    fun insertOrUpdateByUrl(collection: Collection): Long = getByServiceAndUrl(
+    fun insertOrUpdateByUrlBlocking(collection: Collection): Long = getByServiceAndUrlBlocking(
         collection.serviceId,
         collection.url.toString()
     )?.let { localCollection ->
-        update(collection.copy(id = localCollection.id))
+        updateBlocking(collection.copy(id = localCollection.id))
         localCollection.id
-    } ?: insert(collection)
+    } ?: insertBlocking(collection)
 
     @Delete
-    fun delete(collection: Collection)
+    fun deleteBlocking(collection: Collection)
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/db/HomeSetDao.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/HomeSetDao.kt
@@ -21,7 +21,13 @@ interface HomeSetDao {
     fun getByIdBlocking(homesetId: Long): HomeSet?
 
     @Query("SELECT * FROM homeset WHERE serviceId=:serviceId AND url=:url")
+    suspend fun getByUrl(serviceId: Long, url: String): HomeSet?
+
+    @Query("SELECT * FROM homeset WHERE serviceId=:serviceId AND url=:url")
     fun getByUrlBlocking(serviceId: Long, url: String): HomeSet?
+
+    @Query("SELECT * FROM homeset WHERE serviceId=:serviceId")
+    suspend fun getByService(serviceId: Long): List<HomeSet>
 
     @Query("SELECT * FROM homeset WHERE serviceId=:serviceId")
     fun getByServiceBlocking(serviceId: Long): List<HomeSet>
@@ -44,7 +50,13 @@ interface HomeSetDao {
     fun getBindableByServiceFlow(serviceId: Long): Flow<List<HomeSet>>
 
     @Insert
+    suspend fun insert(homeSet: HomeSet): Long
+
+    @Insert
     fun insertBlocking(homeSet: HomeSet): Long
+
+    @Update
+    suspend fun update(homeset: HomeSet)
 
     @Update
     fun updateBlocking(homeset: HomeSet)
@@ -61,11 +73,21 @@ interface HomeSetDao {
      * @return ID of the row that has been inserted or updated. -1 If the insert fails due to other reasons.
      */
     @Transaction
+    suspend fun insertOrUpdateByUrl(homeSet: HomeSet): Long =
+        getByUrl(homeSet.serviceId, homeSet.url.toString())?.let { existingHomeset ->
+            update(homeSet.copy(id = existingHomeset.id))
+            existingHomeset.id
+        } ?: insert(homeSet)
+
+    @Transaction
     fun insertOrUpdateByUrlBlocking(homeSet: HomeSet): Long =
         getByUrlBlocking(homeSet.serviceId, homeSet.url.toString())?.let { existingHomeset ->
             updateBlocking(homeSet.copy(id = existingHomeset.id))
             existingHomeset.id
         } ?: insertBlocking(homeSet)
+
+    @Delete
+    suspend fun delete(homeset: HomeSet)
 
     @Delete
     fun deleteBlocking(homeset: HomeSet)

--- a/core/src/main/kotlin/at/bitfire/davdroid/db/HomeSetDao.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/HomeSetDao.kt
@@ -18,13 +18,13 @@ import kotlinx.coroutines.flow.Flow
 interface HomeSetDao {
 
     @Query("SELECT * FROM homeset WHERE id=:homesetId")
-    fun getById(homesetId: Long): HomeSet?
+    fun getByIdBlocking(homesetId: Long): HomeSet?
 
     @Query("SELECT * FROM homeset WHERE serviceId=:serviceId AND url=:url")
-    fun getByUrl(serviceId: Long, url: String): HomeSet?
+    fun getByUrlBlocking(serviceId: Long, url: String): HomeSet?
 
     @Query("SELECT * FROM homeset WHERE serviceId=:serviceId")
-    fun getByService(serviceId: Long): List<HomeSet>
+    fun getByServiceBlocking(serviceId: Long): List<HomeSet>
 
     @Query("SELECT * FROM homeset WHERE serviceId=(SELECT id FROM service WHERE accountName=:accountName AND type=:serviceType) AND privBind ORDER BY displayName, url COLLATE NOCASE")
     fun getBindableByAccountAndServiceTypeFlow(accountName: String, @ServiceType serviceType: String): Flow<List<HomeSet>>
@@ -44,10 +44,10 @@ interface HomeSetDao {
     fun getBindableByServiceFlow(serviceId: Long): Flow<List<HomeSet>>
 
     @Insert
-    fun insert(homeSet: HomeSet): Long
+    fun insertBlocking(homeSet: HomeSet): Long
 
     @Update
-    fun update(homeset: HomeSet)
+    fun updateBlocking(homeset: HomeSet)
 
     /**
      * If a homeset with the given service ID and URL already exists, it is updated with the other fields.
@@ -62,12 +62,12 @@ interface HomeSetDao {
      */
     @Transaction
     fun insertOrUpdateByUrlBlocking(homeSet: HomeSet): Long =
-        getByUrl(homeSet.serviceId, homeSet.url.toString())?.let { existingHomeset ->
-            update(homeSet.copy(id = existingHomeset.id))
+        getByUrlBlocking(homeSet.serviceId, homeSet.url.toString())?.let { existingHomeset ->
+            updateBlocking(homeSet.copy(id = existingHomeset.id))
             existingHomeset.id
-        } ?: insert(homeSet)
+        } ?: insertBlocking(homeSet)
 
     @Delete
-    fun delete(homeset: HomeSet)
+    fun deleteBlocking(homeset: HomeSet)
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/db/PrincipalDao.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/PrincipalDao.kt
@@ -15,31 +15,31 @@ import io.ktor.http.Url
 interface PrincipalDao {
 
     @Query("SELECT * FROM principal WHERE id=:id")
-    fun get(id: Long): Principal
+    fun getBlocking(id: Long): Principal
 
     @Query("SELECT * FROM principal WHERE id=:id")
-    suspend fun getAsync(id: Long): Principal
+    suspend fun get(id: Long): Principal
 
     @Query("SELECT * FROM principal WHERE serviceId=:serviceId")
-    fun getByService(serviceId: Long): List<Principal>
+    fun getByServiceBlocking(serviceId: Long): List<Principal>
 
     @Query("SELECT * FROM principal WHERE serviceId=:serviceId AND url=:url")
-    fun getByUrl(serviceId: Long, url: Url): Principal?
+    fun getByUrlBlocking(serviceId: Long, url: Url): Principal?
 
     /**
      * Gets all principals who do not own any collections
      */
     @Query("SELECT * FROM principal WHERE principal.id NOT IN (SELECT ownerId FROM collection WHERE ownerId IS NOT NULL)")
-    fun getAllWithoutCollections(): List<Principal>
+    fun getAllWithoutCollectionsBlocking(): List<Principal>
 
     @Insert
-    fun insert(principal: Principal): Long
+    fun insertBlocking(principal: Principal): Long
 
     @Update
-    fun update(principal: Principal)
+    fun updateBlocking(principal: Principal)
 
     @Delete
-    fun delete(principal: Principal)
+    fun deleteBlocking(principal: Principal)
 
     /**
      * Inserts, updates or just gets existing principal if its display name has not
@@ -48,17 +48,17 @@ interface PrincipalDao {
      * @param principal Principal to be inserted or updated
      * @return ID of the newly inserted or already existing principal
      */
-    fun insertOrUpdate(serviceId: Long, principal: Principal): Long {
+    fun insertOrUpdateBlocking(serviceId: Long, principal: Principal): Long {
         // Try to get existing principal by URL
-        val oldPrincipal = getByUrl(serviceId, principal.url)
+        val oldPrincipal = getByUrlBlocking(serviceId, principal.url)
 
         // Insert new principal if not existing
         if (oldPrincipal == null)
-            return insert(principal)
+            return insertBlocking(principal)
 
         // Otherwise update the existing principal
         if (principal.displayName != oldPrincipal.displayName)
-            update(principal.copy(id = oldPrincipal.id))
+            updateBlocking(principal.copy(id = oldPrincipal.id))
 
         // In any case return the id of the principal
         return oldPrincipal.id

--- a/core/src/main/kotlin/at/bitfire/davdroid/db/PrincipalDao.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/PrincipalDao.kt
@@ -8,6 +8,7 @@ import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
+import androidx.room.Transaction
 import androidx.room.Update
 import io.ktor.http.Url
 
@@ -48,6 +49,7 @@ interface PrincipalDao {
      * @param principal Principal to be inserted or updated
      * @return ID of the newly inserted or already existing principal
      */
+    @Transaction
     suspend fun insertOrUpdate(serviceId: Long, principal: Principal): Long {
         // Try to get existing principal by URL
         val oldPrincipal = getByUrl(serviceId, principal.url)

--- a/core/src/main/kotlin/at/bitfire/davdroid/db/PrincipalDao.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/PrincipalDao.kt
@@ -15,31 +15,31 @@ import io.ktor.http.Url
 interface PrincipalDao {
 
     @Query("SELECT * FROM principal WHERE id=:id")
-    fun getBlocking(id: Long): Principal
-
-    @Query("SELECT * FROM principal WHERE id=:id")
     suspend fun get(id: Long): Principal
 
+    @Query("SELECT * FROM principal WHERE id=:id")
+    fun getBlocking(id: Long): Principal
+
     @Query("SELECT * FROM principal WHERE serviceId=:serviceId")
-    fun getByServiceBlocking(serviceId: Long): List<Principal>
+    suspend fun getByService(serviceId: Long): List<Principal>
 
     @Query("SELECT * FROM principal WHERE serviceId=:serviceId AND url=:url")
-    fun getByUrlBlocking(serviceId: Long, url: Url): Principal?
+    suspend fun getByUrl(serviceId: Long, url: Url): Principal?
 
     /**
      * Gets all principals who do not own any collections
      */
     @Query("SELECT * FROM principal WHERE principal.id NOT IN (SELECT ownerId FROM collection WHERE ownerId IS NOT NULL)")
-    fun getAllWithoutCollectionsBlocking(): List<Principal>
+    suspend fun getAllWithoutCollections(): List<Principal>
 
     @Insert
-    fun insertBlocking(principal: Principal): Long
+    suspend fun insert(principal: Principal): Long
 
     @Update
-    fun updateBlocking(principal: Principal)
+    suspend fun update(principal: Principal)
 
     @Delete
-    fun deleteBlocking(principal: Principal)
+    suspend fun delete(principal: Principal)
 
     /**
      * Inserts, updates or just gets existing principal if its display name has not
@@ -48,17 +48,17 @@ interface PrincipalDao {
      * @param principal Principal to be inserted or updated
      * @return ID of the newly inserted or already existing principal
      */
-    fun insertOrUpdateBlocking(serviceId: Long, principal: Principal): Long {
+    suspend fun insertOrUpdate(serviceId: Long, principal: Principal): Long {
         // Try to get existing principal by URL
-        val oldPrincipal = getByUrlBlocking(serviceId, principal.url)
+        val oldPrincipal = getByUrl(serviceId, principal.url)
 
         // Insert new principal if not existing
         if (oldPrincipal == null)
-            return insertBlocking(principal)
+            return insert(principal)
 
         // Otherwise update the existing principal
         if (principal.displayName != oldPrincipal.displayName)
-            updateBlocking(principal.copy(id = oldPrincipal.id))
+            update(principal.copy(id = oldPrincipal.id))
 
         // In any case return the id of the principal
         return oldPrincipal.id

--- a/core/src/main/kotlin/at/bitfire/davdroid/db/ServiceDao.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/ServiceDao.kt
@@ -46,10 +46,10 @@ interface ServiceDao {
     suspend fun getIdsByAccount(accountName: String): List<Long>
 
     @Query("SELECT * FROM service WHERE id=:id")
-    fun getBlocking(id: Long): Service?
+    suspend fun get(id: Long): Service?
 
     @Query("SELECT * FROM service WHERE id=:id")
-    suspend fun get(id: Long): Service?
+    fun getBlocking(id: Long): Service?
 
     @Query("SELECT * FROM service")
     suspend fun getAll(): List<Service>

--- a/core/src/main/kotlin/at/bitfire/davdroid/db/ServiceDao.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/ServiceDao.kt
@@ -43,22 +43,22 @@ interface ServiceDao {
     }
 
     @Query("SELECT id FROM service WHERE accountName=:accountName")
-    suspend fun getIdsByAccountAsync(accountName: String): List<Long>
+    suspend fun getIdsByAccount(accountName: String): List<Long>
 
     @Query("SELECT * FROM service WHERE id=:id")
-    fun get(id: Long): Service?
+    fun getBlocking(id: Long): Service?
 
     @Query("SELECT * FROM service WHERE id=:id")
-    suspend fun getAsync(id: Long): Service?
+    suspend fun get(id: Long): Service?
 
     @Query("SELECT * FROM service")
     suspend fun getAll(): List<Service>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insertOrReplace(service: Service): Long
+    fun insertOrReplaceBlocking(service: Service): Long
 
     @Query("DELETE FROM service")
-    fun deleteAll()
+    fun deleteAllBlocking()
 
     @Query("DELETE FROM service WHERE accountName=:accountName")
     suspend fun deleteByAccount(accountName: String)
@@ -70,7 +70,7 @@ interface ServiceDao {
     }
 
     @Query("DELETE FROM service WHERE accountName NOT IN (:accountNames)")
-    fun deleteExceptAccounts(accountNames: Array<String>)
+    fun deleteExceptAccountsBlocking(accountNames: Array<String>)
 
     @Query("UPDATE service SET accountName=:newName WHERE accountName=:oldName")
     suspend fun renameAccount(oldName: String, newName: String)

--- a/core/src/main/kotlin/at/bitfire/davdroid/db/WebDavMountDao.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/WebDavMountDao.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.Flow
 interface WebDavMountDao {
 
     @Delete
-    suspend fun deleteAsync(mount: WebDavMount)
+    suspend fun delete(mount: WebDavMount)
 
     @Query("SELECT * FROM webdav_mount ORDER BY name, url")
     suspend fun getAll(): List<WebDavMount>

--- a/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/repository/DavCollectionRepository.kt
@@ -127,7 +127,7 @@ class DavCollectionRepository @Inject constructor(
             displayName = displayName,
             description = description
         )
-        dao.insertAsync(collection)
+        dao.insert(collection)
     }
 
     /**
@@ -181,7 +181,7 @@ class DavCollectionRepository @Inject constructor(
             supportsVTODO = supportVTODO,
             supportsVJOURNAL = supportVJOURNAL
         )
-        dao.insertAsync(collection)
+        dao.insert(collection)
 
         // Trigger service detection (because the collection may actually have other properties than the ones we have inserted).
         // Some servers are known to change the supported components (VEVENT, …) after creation.
@@ -219,22 +219,22 @@ class DavCollectionRepository @Inject constructor(
 
     suspend fun getSyncableByTopic(topic: String) = dao.getSyncableByPushTopic(topic)
 
-    fun get(id: Long) = dao.get(id)
-    suspend fun getAsync(id: Long) = dao.getAsync(id)
+    fun get(id: Long) = dao.getBlocking(id)
+    suspend fun getAsync(id: Long) = dao.get(id)
 
     fun getFlow(id: Long) = dao.getFlow(id)
 
     suspend fun getByService(serviceId: Long) = dao.getByService(serviceId)
 
-    fun getByServiceAndUrl(serviceId: Long, url: String) = dao.getByServiceAndUrl(serviceId, url)
+    fun getByServiceAndUrl(serviceId: Long, url: String) = dao.getByServiceAndUrlBlocking(serviceId, url)
 
-    fun getByServiceAndSync(serviceId: Long) = dao.getByServiceAndSync(serviceId)
+    fun getByServiceAndSync(serviceId: Long) = dao.getByServiceAndSyncBlocking(serviceId)
 
-    fun getSyncCalendars(serviceId: Long) = dao.getSyncCalendars(serviceId)
+    fun getSyncCalendars(serviceId: Long) = dao.getSyncCalendarsBlocking(serviceId)
 
-    fun getSyncJtxCollections(serviceId: Long) = dao.getSyncJtxCollections(serviceId)
+    fun getSyncJtxCollections(serviceId: Long) = dao.getSyncJtxCollectionsBlocking(serviceId)
 
-    fun getSyncTaskLists(serviceId: Long) = dao.getSyncTaskLists(serviceId)
+    fun getSyncTaskLists(serviceId: Long) = dao.getSyncTaskListsBlocking(serviceId)
 
     /** Returns all collections that are both selected for synchronization and push-capable. */
     suspend fun getPushCapableAndSyncable(serviceId: Long) = dao.getPushCapableSyncCollections(serviceId)
@@ -257,7 +257,7 @@ class DavCollectionRepository @Inject constructor(
     fun insertOrUpdateByUrlRememberSync(newCollection: Collection) {
         db.runInTransaction {
             // remember locally set flags
-            val oldCollection = dao.getByServiceAndUrl(newCollection.serviceId, newCollection.url.toString())
+            val oldCollection = dao.getByServiceAndUrlBlocking(newCollection.serviceId, newCollection.url.toString())
             val newCollectionWithFlags =
                 if (oldCollection != null)
                     newCollection.copy(sync = oldCollection.sync, forceReadOnly = oldCollection.forceReadOnly)
@@ -273,7 +273,7 @@ class DavCollectionRepository @Inject constructor(
      * Creates or updates the existing collection if it exists (URL)
      */
     fun insertOrUpdateByUrl(collection: Collection) {
-        dao.insertOrUpdateByUrl(collection)
+        dao.insertOrUpdateByUrlBlocking(collection)
     }
 
     /**
@@ -321,7 +321,7 @@ class DavCollectionRepository @Inject constructor(
      * Deletes the collection locally
      */
     fun delete(collection: Collection) {
-        dao.delete(collection)
+        dao.deleteBlocking(collection)
     }
 
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/repository/DavHomeSetRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/repository/DavHomeSetRepository.kt
@@ -23,14 +23,17 @@ class DavHomeSetRepository @Inject constructor(
 
     fun getByIdBlocking(id: Long) = dao.getByIdBlocking(id)
 
-    fun getByServiceBlocking(serviceId: Long) = dao.getByServiceBlocking(serviceId)
+    suspend fun getByService(serviceId: Long) = dao.getByService(serviceId)
 
     fun getCalendarHomeSetsFlow(accountId: AccountId) =
         dao.getBindableByAccountAndServiceTypeFlow(accountId, Service.TYPE_CALDAV)
 
+    suspend fun insertOrUpdateByUrl(homeSet: HomeSet): Long =
+        dao.insertOrUpdateByUrl(homeSet)
+
     fun insertOrUpdateByUrlBlocking(homeSet: HomeSet): Long =
         dao.insertOrUpdateByUrlBlocking(homeSet)
 
-    fun deleteBlocking(homeSet: HomeSet) = dao.deleteBlocking(homeSet)
+    suspend fun delete(homeSet: HomeSet) = dao.delete(homeSet)
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/repository/DavHomeSetRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/repository/DavHomeSetRepository.kt
@@ -21,8 +21,6 @@ class DavHomeSetRepository @Inject constructor(
 
     fun getBindableByServiceFlow(serviceId: Long) = dao.getBindableByServiceFlow(serviceId)
 
-    fun getByIdBlocking(id: Long) = dao.getByIdBlocking(id)
-
     suspend fun getByService(serviceId: Long) = dao.getByService(serviceId)
 
     fun getCalendarHomeSetsFlow(accountId: AccountId) =

--- a/core/src/main/kotlin/at/bitfire/davdroid/repository/DavHomeSetRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/repository/DavHomeSetRepository.kt
@@ -21,9 +21,9 @@ class DavHomeSetRepository @Inject constructor(
 
     fun getBindableByServiceFlow(serviceId: Long) = dao.getBindableByServiceFlow(serviceId)
 
-    fun getByIdBlocking(id: Long) = dao.getById(id)
+    fun getByIdBlocking(id: Long) = dao.getByIdBlocking(id)
 
-    fun getByServiceBlocking(serviceId: Long) = dao.getByService(serviceId)
+    fun getByServiceBlocking(serviceId: Long) = dao.getByServiceBlocking(serviceId)
 
     fun getCalendarHomeSetsFlow(accountId: AccountId) =
         dao.getBindableByAccountAndServiceTypeFlow(accountId, Service.TYPE_CALDAV)
@@ -31,6 +31,6 @@ class DavHomeSetRepository @Inject constructor(
     fun insertOrUpdateByUrlBlocking(homeSet: HomeSet): Long =
         dao.insertOrUpdateByUrlBlocking(homeSet)
 
-    fun deleteBlocking(homeSet: HomeSet) = dao.delete(homeSet)
+    fun deleteBlocking(homeSet: HomeSet) = dao.deleteBlocking(homeSet)
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/repository/DavServiceRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/repository/DavServiceRepository.kt
@@ -21,8 +21,8 @@ class DavServiceRepository @Inject constructor(
 
     // Read
 
-    fun getBlocking(id: Long): Service? = dao.get(id)
-    suspend fun get(id: Long): Service? = dao.getAsync(id)
+    fun getBlocking(id: Long): Service? = dao.getBlocking(id)
+    suspend fun get(id: Long): Service? = dao.get(id)
 
     suspend fun getAll(): List<Service> = dao.getAll()
 
@@ -55,7 +55,7 @@ class DavServiceRepository @Inject constructor(
     // Create & update
 
     fun insertOrReplaceBlocking(service: Service) =
-        dao.insertOrReplace(service)
+        dao.insertOrReplaceBlocking(service)
 
     suspend fun renameAccount(oldName: String, newName: String) =
         dao.renameAccount(oldName, newName)
@@ -63,7 +63,7 @@ class DavServiceRepository @Inject constructor(
 
     // Delete
 
-    fun deleteAllBlocking() = dao.deleteAll()
+    fun deleteAllBlocking() = dao.deleteAllBlocking()
 
     suspend fun deleteByAccount(accountId: AccountId) =
         dao.deleteByAccount(accountId)

--- a/core/src/main/kotlin/at/bitfire/davdroid/repository/DavServiceRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/repository/DavServiceRepository.kt
@@ -21,8 +21,8 @@ class DavServiceRepository @Inject constructor(
 
     // Read
 
-    fun getBlocking(id: Long): Service? = dao.getBlocking(id)
     suspend fun get(id: Long): Service? = dao.get(id)
+    fun getBlocking(id: Long): Service? = dao.getBlocking(id)
 
     suspend fun getAll(): List<Service> = dao.getAll()
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/repository/PrincipalRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/repository/PrincipalRepository.kt
@@ -14,6 +14,6 @@ class PrincipalRepository @Inject constructor(
 
     private val dao = db.principalDao()
 
-    fun getBlocking(id: Long): Principal = dao.get(id)
+    fun getBlocking(id: Long): Principal = dao.getBlocking(id)
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
@@ -89,8 +89,9 @@ class LocalAddressBookStore @Inject constructor(
             /* return */ null
     }
 
-    override fun create(client: ContentProviderClient, fromCollection: Collection): LocalAddressBook? {
-        val service = serviceRepository.getBlocking(fromCollection.serviceId) ?: throw IllegalArgumentException("Couldn't fetch DB service from collection")
+    override suspend fun create(client: ContentProviderClient, fromCollection: Collection): LocalAddressBook? {
+        val service = serviceRepository.get(fromCollection.serviceId)
+            ?: throw IllegalArgumentException("Couldn't fetch DB service from collection")
         val account = Account(service.accountName, context.getString(R.string.account_type))
 
         val name = accountName(fromCollection)

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendarStore.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendarStore.kt
@@ -49,8 +49,9 @@ class LocalCalendarStore @Inject constructor(
             /* return */ null
     }
 
-    override fun create(client: ContentProviderClient, fromCollection: Collection): LocalCalendar {
-        val service = serviceRepository.getBlocking(fromCollection.serviceId) ?: throw IllegalArgumentException("Couldn't fetch DB service from collection")
+    override suspend fun create(client: ContentProviderClient, fromCollection: Collection): LocalCalendar {
+        val service = serviceRepository.get(fromCollection.serviceId)
+            ?: throw IllegalArgumentException("Couldn't fetch DB service from collection")
         val account = Account(service.accountName, context.getString(R.string.account_type))
 
         // If the collection doesn't have a color, use a default color.

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalDataStore.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalDataStore.kt
@@ -44,7 +44,7 @@ interface LocalDataStore<T: LocalCollection<*>> {
      *
      * @return the new local collection, or `null` if creation failed
      */
-    fun create(client: ContentProviderClient, fromCollection: Collection): T?
+    suspend fun create(client: ContentProviderClient, fromCollection: Collection): T?
 
     /**
      * Returns all local collections of the data store, including those which don't have a corresponding remote

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollectionStore.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollectionStore.kt
@@ -46,7 +46,8 @@ class LocalJtxCollectionStore @Inject constructor(
     }
 
     override fun create(client: ContentProviderClient, fromCollection: Collection): LocalJtxCollection {
-        val service = serviceDao.get(fromCollection.serviceId) ?: throw IllegalArgumentException("Couldn't fetch DB service from collection")
+        val service = serviceDao.getBlocking(fromCollection.serviceId)
+            ?: throw IllegalArgumentException("Couldn't fetch DB service from collection")
         val account = Account(service.accountName, context.getString(R.string.account_type))
 
         // If the collection doesn't have a color, use a default color.

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollectionStore.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollectionStore.kt
@@ -45,8 +45,8 @@ class LocalJtxCollectionStore @Inject constructor(
             /* return */ null
     }
 
-    override fun create(client: ContentProviderClient, fromCollection: Collection): LocalJtxCollection {
-        val service = serviceDao.getBlocking(fromCollection.serviceId)
+    override suspend fun create(client: ContentProviderClient, fromCollection: Collection): LocalJtxCollection {
+        val service = serviceDao.get(fromCollection.serviceId)
             ?: throw IllegalArgumentException("Couldn't fetch DB service from collection")
         val account = Account(service.accountName, context.getString(R.string.account_type))
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskListStore.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskListStore.kt
@@ -57,7 +57,8 @@ class LocalTaskListStore @AssistedInject constructor(
     }
 
     override fun create(client: ContentProviderClient, fromCollection: Collection): LocalTaskList {
-        val service = serviceDao.get(fromCollection.serviceId) ?: throw IllegalArgumentException("Couldn't fetch DB service from collection")
+        val service = serviceDao.getBlocking(fromCollection.serviceId)
+            ?: throw IllegalArgumentException("Couldn't fetch DB service from collection")
         val account = Account(service.accountName, context.getString(R.string.account_type))
 
         logger.info("Adding local task list: $fromCollection")

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskListStore.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskListStore.kt
@@ -56,8 +56,8 @@ class LocalTaskListStore @AssistedInject constructor(
             /* return */ null
     }
 
-    override fun create(client: ContentProviderClient, fromCollection: Collection): LocalTaskList {
-        val service = serviceDao.getBlocking(fromCollection.serviceId)
+    override suspend fun create(client: ContentProviderClient, fromCollection: Collection): LocalTaskList {
+        val service = serviceDao.get(fromCollection.serviceId)
             ?: throw IllegalArgumentException("Couldn't fetch DB service from collection")
         val account = Account(service.accountName, context.getString(R.string.account_type))
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/servicedetection/CollectionsWithoutHomeSetRefresher.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/servicedetection/CollectionsWithoutHomeSetRefresher.kt
@@ -42,7 +42,8 @@ class CollectionsWithoutHomeSetRefresher @AssistedInject constructor(
      * It queries each stored collection with a homeSetId of "null" and either updates or deletes (if inaccessible or unusable) them.
      */
     internal suspend fun refreshCollectionsWithoutHomeSet() {
-        val withoutHomeSet = db.collectionDao().getByServiceAndHomeset(service.id, null).associateBy { it.url }.toMutableMap()
+        val withoutHomeSet =
+            db.collectionDao().getByServiceAndHomesetBlocking(service.id, null).associateBy { it.url }.toMutableMap()
         for ((url, localCollection) in withoutHomeSet) try {
             val collectionProperties = ServiceDetectionUtils.collectionQueryProperties(service.type)
             DavResource(httpClient, url).propfind(0, *collectionProperties).responses().collect { response ->
@@ -60,7 +61,7 @@ class CollectionsWithoutHomeSetRefresher @AssistedInject constructor(
                         ownerId = response[Owner::class.java]?.href     // save the principal id (collection owner)
                             ?.let { response.href.resolve(it) }
                             ?.let { principalUrl -> Principal.fromServiceAndUrl(service, principalUrl) }
-                            ?.let { principal -> db.principalDao().insertOrUpdate(service.id, principal) }
+                            ?.let { principal -> db.principalDao().insertOrUpdateBlocking(service.id, principal) }
                     ))
                 } ?: collectionRepository.delete(localCollection)
             }

--- a/core/src/main/kotlin/at/bitfire/davdroid/servicedetection/CollectionsWithoutHomeSetRefresher.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/servicedetection/CollectionsWithoutHomeSetRefresher.kt
@@ -43,7 +43,7 @@ class CollectionsWithoutHomeSetRefresher @AssistedInject constructor(
      */
     internal suspend fun refreshCollectionsWithoutHomeSet() {
         val withoutHomeSet =
-            db.collectionDao().getByServiceAndHomesetBlocking(service.id, null).associateBy { it.url }.toMutableMap()
+            db.collectionDao().getByServiceAndHomeset(service.id, null).associateBy { it.url }.toMutableMap()
         for ((url, localCollection) in withoutHomeSet) try {
             val collectionProperties = ServiceDetectionUtils.collectionQueryProperties(service.type)
             DavResource(httpClient, url).propfind(0, *collectionProperties).responses().collect { response ->
@@ -61,7 +61,7 @@ class CollectionsWithoutHomeSetRefresher @AssistedInject constructor(
                         ownerId = response[Owner::class.java]?.href     // save the principal id (collection owner)
                             ?.let { response.href.resolve(it) }
                             ?.let { principalUrl -> Principal.fromServiceAndUrl(service, principalUrl) }
-                            ?.let { principal -> db.principalDao().insertOrUpdateBlocking(service.id, principal) }
+                            ?.let { principal -> db.principalDao().insertOrUpdate(service.id, principal) }
                     ))
                 } ?: collectionRepository.delete(localCollection)
             }

--- a/core/src/main/kotlin/at/bitfire/davdroid/servicedetection/HomeSetRefresher.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/servicedetection/HomeSetRefresher.kt
@@ -57,14 +57,14 @@ class HomeSetRefresher @AssistedInject constructor(
      * and a null value for it's home-set. Refreshing of collections without home-sets is then handled by [CollectionsWithoutHomeSetRefresher.refreshCollectionsWithoutHomeSet].
      */
     internal suspend fun refreshHomesetsAndTheirCollections() {
-        val homesets = homeSetRepository.getByServiceBlocking(service.id).associateBy { it.url }.toMutableMap()
+        val homesets = homeSetRepository.getByService(service.id).associateBy { it.url }.toMutableMap()
         for ((homeSetUrl, localHomeset) in homesets) {
             logger.fine("Listing home set $homeSetUrl")
 
             // To find removed collections in this homeset: create a queue from existing collections and remove every collection that
             // is successfully rediscovered. If there are collections left, after processing is done, these are marked as "without home-set".
             val localHomesetCollections = db.collectionDao()
-                .getByServiceAndHomesetBlocking(service.id, localHomeset.id)
+                .getByServiceAndHomeset(service.id, localHomeset.id)
                 .associateBy { it.url }
                 .toMutableMap()
 
@@ -76,7 +76,7 @@ class HomeSetRefresher @AssistedInject constructor(
                     .collect { (response, relation) ->
                         if (relation == Response.HrefRelation.SELF) {
                             // this response is about the home set itself
-                            homeSetRepository.insertOrUpdateByUrlBlocking(
+                            homeSetRepository.insertOrUpdateByUrl(
                                 localHomeset.copy(
                                     displayName = response[DisplayName::class.java]?.displayName,
                                     privBind = response[CurrentUserPrivilegeSet::class.java]?.mayBind != false
@@ -93,7 +93,7 @@ class HomeSetRefresher @AssistedInject constructor(
                             ownerId = response[Owner::class.java]?.href  // save the principal id (collection owner)
                                 ?.let { response.href.resolve(it) }
                                 ?.let { principalUrl -> Principal.fromServiceAndUrl(service, principalUrl) }
-                                ?.let { principal -> db.principalDao().insertOrUpdateBlocking(service.id, principal) }
+                                ?.let { principal -> db.principalDao().insertOrUpdate(service.id, principal) }
                         )
                         logger.fine("Found collection: $collection")
 
@@ -107,7 +107,7 @@ class HomeSetRefresher @AssistedInject constructor(
             } catch (e: HttpException) {
                 // delete home set locally if it was not accessible (40x)
                 if (e.statusCode in arrayOf(403, 404, 410))
-                    homeSetRepository.deleteBlocking(localHomeset)
+                    homeSetRepository.delete(localHomeset)
             }
 
             // Mark leftover (not rediscovered) collections from queue as "without home-set" (remove association)

--- a/core/src/main/kotlin/at/bitfire/davdroid/servicedetection/HomeSetRefresher.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/servicedetection/HomeSetRefresher.kt
@@ -64,7 +64,7 @@ class HomeSetRefresher @AssistedInject constructor(
             // To find removed collections in this homeset: create a queue from existing collections and remove every collection that
             // is successfully rediscovered. If there are collections left, after processing is done, these are marked as "without home-set".
             val localHomesetCollections = db.collectionDao()
-                .getByServiceAndHomeset(service.id, localHomeset.id)
+                .getByServiceAndHomesetBlocking(service.id, localHomeset.id)
                 .associateBy { it.url }
                 .toMutableMap()
 
@@ -93,7 +93,7 @@ class HomeSetRefresher @AssistedInject constructor(
                             ownerId = response[Owner::class.java]?.href  // save the principal id (collection owner)
                                 ?.let { response.href.resolve(it) }
                                 ?.let { principalUrl -> Principal.fromServiceAndUrl(service, principalUrl) }
-                                ?.let { principal -> db.principalDao().insertOrUpdate(service.id, principal) }
+                                ?.let { principal -> db.principalDao().insertOrUpdateBlocking(service.id, principal) }
                         )
                         logger.fine("Found collection: $collection")
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/servicedetection/PrincipalsRefresher.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/servicedetection/PrincipalsRefresher.kt
@@ -48,7 +48,7 @@ class PrincipalsRefresher @AssistedInject constructor(
      */
     suspend fun refreshPrincipals() {
         // Refresh principals (collection owner urls)
-        val principals = db.principalDao().getByService(service.id)
+        val principals = db.principalDao().getByServiceBlocking(service.id)
         for (oldPrincipal in principals) {
             val principalUrl = oldPrincipal.url
             logger.fine("Querying principal $principalUrl")
@@ -59,7 +59,7 @@ class PrincipalsRefresher @AssistedInject constructor(
                     .collect { response ->
                         Principal.fromDavResponse(service.id, response)?.let { principal ->
                             logger.fine("Got principal: $principal")
-                            db.principalDao().insertOrUpdate(service.id, principal)
+                            db.principalDao().insertOrUpdateBlocking(service.id, principal)
                         }
                     }
             } catch (e: HttpException) {
@@ -68,8 +68,8 @@ class PrincipalsRefresher @AssistedInject constructor(
         }
 
         // Delete principals which don't own any collections
-        db.principalDao().getAllWithoutCollections().forEach { principal ->
-            db.principalDao().delete(principal)
+        db.principalDao().getAllWithoutCollectionsBlocking().forEach { principal ->
+            db.principalDao().deleteBlocking(principal)
         }
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/servicedetection/PrincipalsRefresher.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/servicedetection/PrincipalsRefresher.kt
@@ -48,7 +48,7 @@ class PrincipalsRefresher @AssistedInject constructor(
      */
     suspend fun refreshPrincipals() {
         // Refresh principals (collection owner urls)
-        val principals = db.principalDao().getByServiceBlocking(service.id)
+        val principals = db.principalDao().getByService(service.id)
         for (oldPrincipal in principals) {
             val principalUrl = oldPrincipal.url
             logger.fine("Querying principal $principalUrl")
@@ -59,7 +59,7 @@ class PrincipalsRefresher @AssistedInject constructor(
                     .collect { response ->
                         Principal.fromDavResponse(service.id, response)?.let { principal ->
                             logger.fine("Got principal: $principal")
-                            db.principalDao().insertOrUpdateBlocking(service.id, principal)
+                            db.principalDao().insertOrUpdate(service.id, principal)
                         }
                     }
             } catch (e: HttpException) {
@@ -68,8 +68,8 @@ class PrincipalsRefresher @AssistedInject constructor(
         }
 
         // Delete principals which don't own any collections
-        db.principalDao().getAllWithoutCollectionsBlocking().forEach { principal ->
-            db.principalDao().deleteBlocking(principal)
+        db.principalDao().getAllWithoutCollections().forEach { principal ->
+            db.principalDao().delete(principal)
         }
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/servicedetection/ServiceRefresher.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/servicedetection/ServiceRefresher.kt
@@ -118,7 +118,7 @@ class ServiceRefresher @AssistedInject constructor(
                         principal.location.resolve(homeSetHref)?.let { homesetUrl ->
                             val resolvedHomeSetUrl = homesetUrl.withTrailingSlash()
                             if (!alreadySavedHomeSets.contains(resolvedHomeSetUrl)) {
-                                homeSetRepository.insertOrUpdateByUrlBlocking(
+                                homeSetRepository.insertOrUpdateByUrl(
                                     // HomeSet is considered personal if this is the outer recursion call,
                                     // This is because we assume the first call to query the current-user-principal
                                     // Note: This is not be be confused with the DAV:owner attribute. Home sets can be owned by

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/account/AccountsCleanupWorker.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/account/AccountsCleanupWorker.kt
@@ -65,9 +65,9 @@ class AccountsCleanupWorker @AssistedInject constructor(
         logger.info("Cleaning up accounts. Currently existing accounts: ${accounts.contentToString()}")
         val serviceDao = db.serviceDao()
         if (accounts.isEmpty())
-            serviceDao.deleteAll()
+            serviceDao.deleteAllBlocking()
         else
-            serviceDao.deleteExceptAccounts(accounts.map { it.name }.toTypedArray())
+            serviceDao.deleteExceptAccountsBlocking(accounts.map { it.name }.toTypedArray())
     }
 
     /**

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/AccountsViewModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/AccountsViewModel.kt
@@ -150,7 +150,7 @@ class AccountsViewModel @AssistedInject constructor(
         accounts
             .sortedWith { a, b -> collator.compare(a.name, b.name) }
             .map { account ->
-                val services = db.serviceDao().getIdsByAccountAsync(account.name)
+                val services = db.serviceDao().getIdsByAccount(account.name)
                 val progress = when {
                     workInfos.any { info ->
                         info.state == WorkInfo.State.RUNNING && (

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionScreenViewModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionScreenViewModel.kt
@@ -138,7 +138,7 @@ class CollectionScreenViewModel @AssistedInject constructor(
     private val principalDao = db.principalDao()
     val owner: Flow<String?> = collection.map { collection ->
         collection?.ownerId?.let { ownerId ->
-            val principal = principalDao.getAsync(ownerId)
+            val principal = principalDao.get(ownerId)
             principal.displayName ?: principal.url.lastSegment
         }
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/WebDavMountRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/WebDavMountRepository.kt
@@ -66,7 +66,7 @@ class WebDavMountRepository @Inject constructor(
 
     suspend fun delete(mount: WebDavMount) {
         // remove mount from database
-        mountDao.deleteAsync(mount)
+        mountDao.delete(mount)
 
         // remove credentials, too
         CredentialsStore(context).setCredentials(mount.id, null)


### PR DESCRIPTION
### Purpose

DAO methods had inconsistent naming for whether they were `suspend` or not (some blocking methods had no suffix, some suspend methods were suffixed `Async`), making it hard to spot accidental blocking DB calls. This PR establishes and applies a clear convention, then uses it to convert the calls that were easy to make suspend:

- DAO methods are suspending by default. (No `...Async` suffix.)
- Blocking calls have the `...Blocking` suffix.
- Flow-returning methods have the `...Flow` suffix.

### Short description

- **Naming convention**: suspend methods get no suffix, blocking methods get a `Blocking` suffix, `Flow`-returning methods get a `Flow` suffix, `PagingSource`-returning methods use a `page`/`pageXxx` prefix. Documented in `AGENTS.md`. This step is a **pure rename** across DAOs/repositories/call sites — no change to suspend-ness or execution.
- Easy calls (no rewriting required) are switched from blocking to suspend:
  - Group A: new suspend DAO/repo methods, and call sites **switched from blocking to suspend**:
    - `CollectionDao.getByServiceAndHomeset`
    - `HomeSetDao.getByUrl`
    - `HomeSetDao.getByService`
    - `HomeSetDao.insert`
    - `HomeSetDao.update`
    - `HomeSetDao.insertOrUpdateByUrl`
    - `HomeSetDao.delete`
    - `PrincipalDao.getByService`
    - `PrincipalDao.getByUrl`
    - `PrincipalDao.getAllWithoutCollections`
    - `PrincipalDao.insert`
    - `PrincipalDao.update`
    - `PrincipalDao.delete`
    - `PrincipalDao.insertOrUpdate` (**also add missing `@Transaction`**)
    - `DavHomeSetRepository.getByService`
    - `DavHomeSetRepository.insertOrUpdateByUrl`
    - `DavHomeSetRepository.delete`
    - consumed by `PrincipalsRefresher.refreshPrincipals()`, `CollectionsWithoutHomeSetRefresher.refreshCollectionsWithoutHomeSet()`, `HomeSetRefresher.refreshHomesetsAndTheirCollections()`, and `ServiceRefresher.discoverHomesets()`, which were already `suspend` but called blocking DB methods directly.
  - **Group B** — interface + implementations made suspend:
    - `LocalDataStore.create()`
    - `LocalAddressBookStore.create()`
    - `LocalCalendarStore.create()`
    - `LocalTaskListStore.create()`
    - `LocalJtxCollectionStore.create()`
    - since the only caller (`Syncer.createLocalCollections`) was already suspend.
- **Cleanup**: removed DAO/repository `Blocking` methods left with no callers after the above conversions, including two pre-existing orphaned ones (`CollectionDao.getByServiceAndTypeBlocking`, `DavHomeSetRepository.getByIdBlocking`) found during a final audit.

> [!NOTE]
> The only changes that affect *how code executes* (blocking → suspend) are the Group A and Group B items listed above — this PR contains no logic changes. Everything else in this diff (39 files) is a mechanical rename with no change to suspend-ness or execution.

### Note on diff size

Part of the line-count increase comes from an auto-formatter expanding. The rest of the increase is genuine: new suspend DAO/repository method declarations in `HomeSetDao.kt` (Group A) and the `AGENTS.md` documentation addition. All other changed files show equal (or near-equal) insertions/deletions — pure 1:1 renames.