### PR TITLE
Simplify `SyncException` handling

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
@@ -112,14 +112,14 @@ class CalendarSyncManager @AssistedInject constructor(
     }
 
     override suspend fun queryCapabilities(): SyncState? =
-        SyncException.wrapWithRemoteResource(collection.url) {
+        collection.url.withExceptionContext {
             val response = davCollection.propfind(
                 0,
                 CalDAV.MaxResourceSize,
                 WebDAV.SupportedReportSet,
                 CalDAV.GetCTag,
                 WebDAV.SyncToken
-            ).selfResponse() ?: return@wrapWithRemoteResource null
+            ).selfResponse() ?: return@withExceptionContext null
 
             response[MaxResourceSize::class.java]?.maxSize?.let { maxSize ->
                 logger.info("Calendar accepts events up to ${Formatter.formatFileSize(context, maxSize)}")
@@ -181,7 +181,7 @@ class CalendarSyncManager @AssistedInject constructor(
             ZonedDateTime.now().minusDays(pastDays.toLong()).toInstant()
         }
 
-        SyncException.wrapWithRemoteResource(collection.url) {
+        collection.url.withExceptionContext {
             logger.info("Querying events since $limitStart")
             emitAll(davCollection.calendarQuery(Component.VEVENT, limitStart, null))
         }
@@ -189,7 +189,7 @@ class CalendarSyncManager @AssistedInject constructor(
 
     override suspend fun downloadRemote(bunch: List<Url>) {
         logger.info("Downloading ${bunch.size} iCalendars: $bunch")
-        SyncException.wrapWithRemoteResource(collection.url) {
+        collection.url.withExceptionContext {
             davCollection.multiget(bunch).responses().collect { response ->
                 /*
                  * Real-world servers may return:
@@ -204,7 +204,7 @@ class CalendarSyncManager @AssistedInject constructor(
                  * - ignore responses without requested calendar data (should also ignore collections and hopefully unrelated resources), and
                  * - take the last segment of the href as the file name and assume that it's in the requested collection.
                  */
-                SyncException.wrapWithRemoteResource(response.href) wrapResource@{
+                response.href.withExceptionContext wrapResource@{
                     if (!response.isSuccess()) {
                         logger.warning("Ignoring non-successful multi-get response for ${response.href}")
                         return@wrapResource
@@ -271,7 +271,7 @@ class CalendarSyncManager @AssistedInject constructor(
         // create/update local event in calendar provider
         val local = localCollection.findByName(fileName)
         if (local != null) {
-            SyncException.wrapWithLocalResource(local) {
+            local.withExceptionContext {
                 logger.info("Updating $fileName in local calendar: $event")
                 local.update(androidEvent)
             }

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
@@ -167,7 +167,7 @@ class ContactsSyncManager @AssistedInject constructor(
     }
 
     override suspend fun queryCapabilities(): SyncState? {
-        return SyncException.wrapWithRemoteResource(collection.url) {
+        return collection.url.withExceptionContext {
             val response = davCollection.propfind(
                 0,
                 CardDAV.MaxResourceSize,
@@ -175,7 +175,7 @@ class ContactsSyncManager @AssistedInject constructor(
                 WebDAV.SupportedReportSet,
                 CalDAV.GetCTag,
                 WebDAV.SyncToken
-            ).selfResponse() ?: return@wrapWithRemoteResource null
+            ).selfResponse() ?: return@withExceptionContext null
 
             response[MaxResourceSize::class.java]?.maxSize?.let { maxSize ->
                 logger.info("Address book accepts vCards up to ${Formatter.formatFileSize(context, maxSize)}")
@@ -252,14 +252,14 @@ class ContactsSyncManager @AssistedInject constructor(
     }
 
     override fun listAllRemote(): Flow<MultiStatusItem> = flow {
-        SyncException.wrapWithRemoteResource(collection.url) {
+        collection.url.withExceptionContext {
             emitAll(davCollection.propfind(1, WebDAV.ResourceType, WebDAV.GetETag))
         }
     }
 
     override suspend fun downloadRemote(bunch: List<Url>) {
         logger.info("Downloading ${bunch.size} vCard(s): $bunch")
-        SyncException.wrapWithRemoteResource(collection.url) {
+        collection.url.withExceptionContext {
             val contentType: String?
             val version: String?
             when {
@@ -274,7 +274,7 @@ class ContactsSyncManager @AssistedInject constructor(
             }
             davCollection.multiget(bunch, contentType, version).responses().collect { response ->
                 // See CalendarSyncManager for more information about the multi-get response
-                SyncException.wrapWithRemoteResource(response.href) wrapResource@{
+                response.href.withExceptionContext wrapResource@{
                     if (!response.isSuccess()) {
                         logger.warning("Ignoring non-successful multi-get response for ${response.href}")
                         return@wrapResource
@@ -342,14 +342,14 @@ class ContactsSyncManager @AssistedInject constructor(
             if (newData.group) {
                 logger.info("Creating local group: $newData")
                 val newGroup = localCollection.addGroup(newData, fileName, eTag, LocalResource.FLAG_REMOTELY_PRESENT)
-                SyncException.wrapWithLocalResource(newGroup) {
+                newGroup.withExceptionContext {
                     updated = newGroup
                 }
 
             } else {
                 logger.info("Creating local contact: $newData")
                 val newContact = localCollection.addContact(newData, fileName, eTag, LocalResource.FLAG_REMOTELY_PRESENT)
-                SyncException.wrapWithLocalResource(newContact) {
+                newContact.withExceptionContext {
                     updated = newContact
                 }
             }
@@ -358,7 +358,7 @@ class ContactsSyncManager @AssistedInject constructor(
             // update existing local contact/group
             logger.info("Updating $fileName in local address book: $newData")
 
-            SyncException.wrapWithLocalResource(existing) {
+            existing.withExceptionContext {
                 if ((existing is LocalGroup && newData.group) || (existing is LocalContact && !newData.group)) {
                     // update contact / group
 
@@ -378,14 +378,14 @@ class ContactsSyncManager @AssistedInject constructor(
                     if (newData.group) {
                         logger.info("Creating local group (was contact before): $newData")
                         val newGroup = localCollection.addGroup(newData, fileName, eTag, LocalResource.FLAG_REMOTELY_PRESENT)
-                        SyncException.wrapWithLocalResource(newGroup) {
+                        newGroup.withExceptionContext {
                             updated = newGroup
                         }
 
                     } else {
                         logger.info("Creating local contact (was group before): $newData")
                         val newContact = localCollection.addContact(newData, fileName, eTag, LocalResource.FLAG_REMOTELY_PRESENT)
-                        SyncException.wrapWithLocalResource(newContact) {
+                        newContact.withExceptionContext {
                             updated = newContact
                         }
                     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
@@ -99,10 +99,10 @@ class JtxSyncManager @AssistedInject constructor(
     }
 
     override suspend fun queryCapabilities() =
-        SyncException.wrapWithRemoteResource(collection.url) {
+        collection.url.withExceptionContext {
             val response =
                 davCollection.propfind(0, CalDAV.GetCTag, CalDAV.MaxResourceSize, WebDAV.SyncToken).selfResponse()
-                    ?: return@wrapWithRemoteResource null
+                    ?: return@withExceptionContext null
 
             response[MaxResourceSize::class.java]?.maxSize?.let { maxSize ->
                 logger.info("Collection accepts resources up to ${Formatter.formatFileSize(context, maxSize)}")
@@ -147,7 +147,7 @@ class JtxSyncManager @AssistedInject constructor(
     override fun syncAlgorithm() = SyncAlgorithm.PROPFIND_REPORT
 
     override fun listAllRemote(): Flow<MultiStatusItem> = flow {
-        SyncException.wrapWithRemoteResource(collection.url) {
+        collection.url.withExceptionContext {
             if (localCollection.supportsVTODO) {
                 logger.info("Querying tasks")
                 emitAll(davCollection.calendarQuery("VTODO", null, null))
@@ -163,10 +163,10 @@ class JtxSyncManager @AssistedInject constructor(
     override suspend fun downloadRemote(bunch: List<Url>) {
         logger.info("Downloading ${bunch.size} iCalendars: $bunch")
         // multiple iCalendars, use calendar-multi-get
-        SyncException.wrapWithRemoteResource(collection.url) {
+        collection.url.withExceptionContext {
             davCollection.multiget(bunch).responses().collect { response ->
                 // See CalendarSyncManager for more information about the multi-get response
-                SyncException.wrapWithRemoteResource(response.href) wrapResource@{
+                response.href.withExceptionContext wrapResource@{
                     if (!response.isSuccess()) {
                         logger.warning("Ignoring non-successful multi-get response for ${response.href}")
                         return@wrapResource
@@ -227,7 +227,7 @@ class JtxSyncManager @AssistedInject constructor(
 
         val local = localCollection.findByName(fileName)
         if (local != null) {
-            SyncException.wrapWithLocalResource(local) {
+            local.withExceptionContext {
                 logger.info("Updating $fileName in local jtx collection: $component")
                 local.update(jtxEntityAndExceptions)
             }

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/ReadOnlyPolicy.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/ReadOnlyPolicy.kt
@@ -26,7 +26,7 @@ class ReadOnlyPolicy @Inject constructor(
         var modified = false
         collection.findDeleted().collect { local ->
             logger.warning("Restoring locally deleted resource (read-only collection!)")
-            SyncException.wrapWithLocalResource(local) {
+            local.withExceptionContext {
                 local.resetDeleted()
             }
             modified = true
@@ -50,7 +50,7 @@ class ReadOnlyPolicy @Inject constructor(
         var modified = false
         collection.findDirty().collect { local ->
             logger.warning("Resetting locally modified resource to ETag=null (read-only collection!)")
-            SyncException.wrapWithLocalResource(local) {
+            local.withExceptionContext {
                 local.clearDirty(
                     fileName = Optional.empty(),
                     eTag = null,

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncException.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncException.kt
@@ -11,23 +11,21 @@ import io.ktor.http.Url
  * A throwable together with the local/remote resource that was being processed
  * when it occurred, if any. Use
  *
- * - [LocalResource.withExceptionContext]/ [Url.withExceptionContext] to attach this
- * context while a resource is being processed, and
+ * - `withExceptionContext` to attach context when a resource is being processed, and
  * - [Throwable.unwrapContext] to retrieve it after catching an exception.
+ *
+ * If multiple `withExceptionContext` calls are nested, the innermost ones are unwrapped.
  */
 data class SyncExceptionContext(
     val cause: Throwable,
     val localResource: LocalResource? = null,
     val remoteResource: Url? = null
-) {
+)
 
-    /**
-     * Internal vehicle for propagating a [SyncExceptionContext] value up the call stack via
-     * normal exception handling. Not part of the public API.
-     */
-    internal class SyncException(val context: SyncExceptionContext) : Exception(context.cause)
-
-}
+/**
+ * The exception that actually carries the context. Only used internally.
+ */
+private class SyncException(val context: SyncExceptionContext) : Exception(context.cause)
 
 private suspend fun <T> wrapContext(
     buildContext: (SyncExceptionContext) -> SyncExceptionContext,
@@ -35,10 +33,10 @@ private suspend fun <T> wrapContext(
 ): T =
     try {
         body()
-    } catch (e: SyncExceptionContext.SyncException) {
-        throw SyncExceptionContext.SyncException(buildContext(e.context))
+    } catch (e: SyncException) {
+        throw SyncException(buildContext(e.context))
     } catch (e: Throwable) {
-        throw SyncExceptionContext.SyncException(buildContext(SyncExceptionContext(e)))
+        throw SyncException(buildContext(SyncExceptionContext(e)))
     }
 
 /**
@@ -90,7 +88,7 @@ suspend fun <T> Url?.withExceptionContext(body: suspend () -> T): T {
  * `withExceptionContext`, if available.
  */
 fun Throwable.unwrapContext(): SyncExceptionContext =
-    if (this is SyncExceptionContext.SyncException)
+    if (this is SyncException)
         context
     else
         SyncExceptionContext(this)

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncException.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncException.kt
@@ -16,6 +16,8 @@ import kotlinx.coroutines.CancellationException
  * - [Throwable.unwrapContext] to retrieve it after catching an exception.
  *
  * If multiple `withExceptionContext` calls are nested, the innermost ones are unwrapped.
+ *
+ * Methods of this class never wrap / touch [CancellationException] and [InterruptedException].
  */
 data class SyncExceptionContext(
     val cause: Throwable,
@@ -40,7 +42,7 @@ private suspend fun <T> wrapContext(
 
     } catch (e: Throwable) {
         when (e) {
-            // don't wrap cancellation (or legacy interruption) exceptions
+            // don't wrap cancellation (or interruption) exceptions
             is CancellationException,
             is InterruptedException ->
                 throw e

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncException.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncException.kt
@@ -6,6 +6,7 @@ package at.bitfire.davdroid.sync
 
 import at.bitfire.davdroid.resource.LocalResource
 import io.ktor.http.Url
+import io.ktor.utils.io.CancellationException
 
 /**
  * A throwable together with the local/remote resource that was being processed
@@ -28,15 +29,25 @@ data class SyncExceptionContext(
 private class SyncException(val context: SyncExceptionContext) : Exception(context.cause)
 
 private suspend fun <T> wrapContext(
-    buildContext: (SyncExceptionContext) -> SyncExceptionContext,
+    updateContext: (SyncExceptionContext) -> SyncExceptionContext,
     body: suspend () -> T
 ): T =
     try {
         body()
     } catch (e: SyncException) {
-        throw SyncException(buildContext(e.context))
+        // already SyncException, just update context
+        throw SyncException(updateContext(e.context))
+
     } catch (e: Throwable) {
-        throw SyncException(buildContext(SyncExceptionContext(e)))
+        when (e) {
+            // don't wrap cancellation (or legacy interruption) exceptions
+            is CancellationException,
+            is InterruptedException ->
+                throw e
+
+            else ->
+                throw SyncException(updateContext(SyncExceptionContext(e)))
+        }
     }
 
 /**
@@ -50,7 +61,7 @@ suspend fun <T> LocalResource?.withExceptionContext(body: suspend () -> T): T {
         body()
     else
         wrapContext(
-            buildContext = { oldContext ->
+            updateContext = { oldContext ->
                 // don't overwrite innermost local resource, if already set
                 if (oldContext.localResource == null)
                     oldContext.copy(localResource = local)
@@ -72,7 +83,7 @@ suspend fun <T> Url?.withExceptionContext(body: suspend () -> T): T {
         body()
     else
         wrapContext(
-            buildContext = { oldContext ->
+            updateContext = { oldContext ->
                 // don't overwrite innermost remote resource, if already set
                 if (oldContext.remoteResource == null)
                     oldContext.copy(remoteResource = remote)

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncException.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncException.kt
@@ -6,7 +6,7 @@ package at.bitfire.davdroid.sync
 
 import at.bitfire.davdroid.resource.LocalResource
 import io.ktor.http.Url
-import io.ktor.utils.io.CancellationException
+import kotlinx.coroutines.CancellationException
 
 /**
  * A throwable together with the local/remote resource that was being processed

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncException.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncException.kt
@@ -5,84 +5,92 @@
 package at.bitfire.davdroid.sync
 
 import at.bitfire.davdroid.resource.LocalResource
-import at.bitfire.davdroid.sync.SyncException.Companion.unwrap
-import at.bitfire.davdroid.sync.SyncException.Companion.wrapWithLocalResource
-import at.bitfire.davdroid.sync.SyncException.Companion.wrapWithRemoteResource
 import io.ktor.http.Url
 
 /**
- * Exception that wraps another notification together with potential information about
- * a local and/or remote resource that is related to the exception.
+ * A throwable together with the local/remote resource that was being processed
+ * when it occurred, if any. Use
+ *
+ * - [LocalResource.withExceptionContext]/ [Url.withExceptionContext] to attach this
+ * context while a resource is being processed, and
+ * - [Throwable.unwrapContext] to retrieve it after catching an exception.
  */
-class SyncException(cause: Throwable) : Exception(cause) {
+data class SyncExceptionContext(
+    val cause: Throwable,
+    val localResource: LocalResource? = null,
+    val remoteResource: Url? = null
+) {
 
     /**
-     * Context information extracted from a [SyncException] with [unwrap].
+     * Internal vehicle for propagating a [SyncExceptionContext] value up the call stack via
+     * normal exception handling. Not part of the public API.
      */
-    data class Unwrapped(
-        val cause: Throwable,
-        val localResource: LocalResource? = null,
-        val remoteResource: Url? = null
-    )
-
-    companion object {
-
-        private suspend fun <T> wrapContext(with: (SyncException) -> Unit, body: suspend () -> T): T =
-            try {
-                body()
-            } catch (e: SyncException) {
-                with(e)
-                throw e
-            } catch (e: Throwable) {
-                throw SyncException(e).also(with)
-            }
-
-        suspend fun <T> wrapWithLocalResource(localResource: LocalResource?, body: suspend () -> T): T =
-            if (localResource == null)
-                body()
-            else
-                wrapContext({ it.setLocalResourceIfNull(localResource) }, body)
-
-        suspend fun <T> wrapWithRemoteResource(remoteResource: Url?, body: suspend () -> T): T =
-            if (remoteResource == null)
-                body()
-            else
-                wrapContext({ it.setRemoteResourceIfNull(remoteResource) }, body)
-
-        fun unwrap(e: Throwable): Unwrapped =
-            if (e is SyncException)
-                Unwrapped(e.cause ?: e, e.localResource, e.remoteResource)
-            else
-                Unwrapped(e)
-
-    }
-
-
-    var localResource: LocalResource? = null
-        private set
-    var remoteResource: Url? = null
-        private set
-
-    /** Sets [localResource] unless already set, so the innermost (closest to the actual
-     *  failure) [wrapWithLocalResource] call wins when wraps are nested. */
-    fun setLocalResourceIfNull(local: LocalResource): SyncException {
-        if (localResource == null)
-            localResource = local
-
-        return this
-    }
-
-    /** Sets [remoteResource] unless already set, so the innermost (closest to the actual
-     *  failure) [wrapWithRemoteResource] call wins when wraps are nested. */
-    fun setRemoteResourceIfNull(remote: Url): SyncException {
-        if (remoteResource == null)
-            remoteResource = remote
-
-        return this
-    }
-
-    override fun toString(): String {
-        return "SyncException(localResource=$localResource, remoteResource=$remoteResource, cause=$cause)"
-    }
+    internal class SyncException(val context: SyncExceptionContext) : Exception(context.cause)
 
 }
+
+private suspend fun <T> wrapContext(
+    buildContext: (SyncExceptionContext) -> SyncExceptionContext,
+    body: suspend () -> T
+): T =
+    try {
+        body()
+    } catch (e: SyncExceptionContext.SyncException) {
+        throw SyncExceptionContext.SyncException(buildContext(e.context))
+    } catch (e: Throwable) {
+        throw SyncExceptionContext.SyncException(buildContext(SyncExceptionContext(e)))
+    }
+
+/**
+ * Runs [body], tagging any exception it throws with this local resource as context
+ * (unless a more deeply nested [withExceptionContext] already claimed it), recoverable later via
+ * [Throwable.unwrapContext].
+ */
+suspend fun <T> LocalResource?.withExceptionContext(body: suspend () -> T): T {
+    val local = this
+    return if (local == null)
+        body()
+    else
+        wrapContext(
+            buildContext = { oldContext ->
+                // don't overwrite innermost local resource, if already set
+                if (oldContext.localResource == null)
+                    oldContext.copy(localResource = local)
+                else
+                    oldContext
+            },
+            body = body
+        )
+}
+
+/**
+ * Runs [body], tagging any exception it throws with this remote resource URL as context
+ * (unless a more deeply nested [withExceptionContext] already claimed it), recoverable later via
+ * [Throwable.unwrapContext].
+ */
+suspend fun <T> Url?.withExceptionContext(body: suspend () -> T): T {
+    val remote = this
+    return if (remote == null)
+        body()
+    else
+        wrapContext(
+            buildContext = { oldContext ->
+                // don't overwrite innermost remote resource, if already set
+                if (oldContext.remoteResource == null)
+                    oldContext.copy(remoteResource = remote)
+                else
+                    oldContext
+            },
+            body = body
+        )
+}
+
+/**
+ * Extracts the original cause and any local/remote resource context recorded via
+ * `withExceptionContext`, if available.
+ */
+fun Throwable.unwrapContext(): SyncExceptionContext =
+    if (this is SyncExceptionContext.SyncException)
+        context
+    else
+        SyncExceptionContext(this)

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncException.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncException.kt
@@ -5,6 +5,9 @@
 package at.bitfire.davdroid.sync
 
 import at.bitfire.davdroid.resource.LocalResource
+import at.bitfire.davdroid.sync.SyncException.Companion.unwrap
+import at.bitfire.davdroid.sync.SyncException.Companion.wrapWithLocalResource
+import at.bitfire.davdroid.sync.SyncException.Companion.wrapWithRemoteResource
 import io.ktor.http.Url
 
 /**
@@ -13,46 +16,44 @@ import io.ktor.http.Url
  */
 class SyncException(cause: Throwable) : Exception(cause) {
 
+    /**
+     * Context information extracted from a [SyncException] with [unwrap].
+     */
+    data class Unwrapped(
+        val cause: Throwable,
+        val localResource: LocalResource? = null,
+        val remoteResource: Url? = null
+    )
+
     companion object {
 
-        // provide lambda wrappers for setting the local/remote resource
-
-        suspend fun <T> wrapWithLocalResource(localResource: LocalResource?, body: suspend () -> T): T {
+        private suspend fun <T> wrapContext(with: (SyncException) -> Unit, body: suspend () -> T): T =
             try {
-                return body()
+                body()
             } catch (e: SyncException) {
-                if (localResource != null)
-                    e.setLocalResourceIfNull(localResource)
+                with(e)
                 throw e
             } catch (e: Throwable) {
-                throw if (localResource != null)
-                    SyncException(e).setLocalResourceIfNull(localResource)
-                else
-                    e
+                throw SyncException(e).also(with)
             }
-        }
 
-        suspend fun <T> wrapWithRemoteResource(remoteResource: Url?, body: suspend () -> T): T {
-            try {
-                return body()
-            } catch (e: SyncException) {
-                if (remoteResource != null)
-                    e.setRemoteResourceIfNull(remoteResource)
-                throw e
-            } catch (e: Throwable) {
-                throw if (remoteResource != null)
-                    SyncException(e).setRemoteResourceIfNull(remoteResource)
-                else
-                    e
-            }
-        }
+        suspend fun <T> wrapWithLocalResource(localResource: LocalResource?, body: suspend () -> T): T =
+            if (localResource == null)
+                body()
+            else
+                wrapContext({ it.setLocalResourceIfNull(localResource) }, body)
 
-        fun unwrap(e: Throwable, contextReceiver: (SyncException) -> Unit) =
-            if (e is SyncException) {
-                contextReceiver(e)
-                e.cause!!
-            } else
-                e
+        suspend fun <T> wrapWithRemoteResource(remoteResource: Url?, body: suspend () -> T): T =
+            if (remoteResource == null)
+                body()
+            else
+                wrapContext({ it.setRemoteResourceIfNull(remoteResource) }, body)
+
+        fun unwrap(e: Throwable): Unwrapped =
+            if (e is SyncException)
+                Unwrapped(e.cause ?: e, e.localResource, e.remoteResource)
+            else
+                Unwrapped(e)
 
     }
 
@@ -62,6 +63,8 @@ class SyncException(cause: Throwable) : Exception(cause) {
     var remoteResource: Url? = null
         private set
 
+    /** Sets [localResource] unless already set, so the innermost (closest to the actual
+     *  failure) [wrapWithLocalResource] call wins when wraps are nested. */
     fun setLocalResourceIfNull(local: LocalResource): SyncException {
         if (localResource == null)
             localResource = local
@@ -69,6 +72,8 @@ class SyncException(cause: Throwable) : Exception(cause) {
         return this
     }
 
+    /** Sets [remoteResource] unless already set, so the innermost (closest to the actual
+     *  failure) [wrapWithRemoteResource] call wins when wraps are nested. */
     fun setRemoteResourceIfNull(remote: Url): SyncException {
         if (remoteResource == null)
             remoteResource = remote

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -265,7 +265,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
                 logger.info("Remote collection didn't change, no reason to sync")
 
         } catch (potentiallyWrappedException: Throwable) {
-            val ctx = SyncException.unwrap(potentiallyWrappedException)
+            val ctx = potentiallyWrappedException.unwrapContext()
 
             when (val e = ctx.cause) {
                 /* LocalStorageException with cause DeadObjectException may occur when syncing takes too long
@@ -338,7 +338,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
         // Remove locally deleted entries from server (if they have a name, i.e. if they were uploaded before),
         // but only if they don't have changed on the server. Then finally remove them from the local address book.
         localCollection.findDeleted().collect { local ->
-            SyncException.wrapWithLocalResource(local) {
+            local.withExceptionContext {
                 val fileName = local.fileName
                 if (fileName != null) {
                     val lastScheduleTag = local.scheduleTag
@@ -347,7 +347,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
 
                     val url = URLBuilder(collection.url).appendPathSegments(fileName, encodeSlash = true).build()
                     val remote = DavResource(httpClient, url)
-                    SyncException.wrapWithRemoteResource(url) {
+                    url.withExceptionContext {
                         try {
                             remote.delete(
                                 ifETag = lastETag,
@@ -387,7 +387,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
         var numUploaded = 0
 
         localCollection.findDirty().collect { local ->
-            SyncException.wrapWithLocalResource(local) {
+            local.withExceptionContext {
                 uploadDirty(local)
                 numUploaded++
             }
@@ -414,7 +414,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
         val remote = DavResource(httpClient, uploadUrl)
 
         try {
-            SyncException.wrapWithRemoteResource(uploadUrl) {
+            uploadUrl.withExceptionContext {
                 if (existingFileName == null || forceAsNew) {
                     // create new resource on server
                     logger.log(Level.INFO, "Uploading new resource {0} -> {1}", arrayOf<Any?>(local.id, fileName))
@@ -463,8 +463,8 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
                 }
             }
 
-        } catch (e: SyncException) {
-            when (val ex = e.cause) {
+        } catch (e: Throwable) {
+            when (val ex = e.unwrapContext().cause) {
                 is ForbiddenException -> {
                     // HTTP 403 Forbidden
                     // If and only if the upload failed because of missing permissions, treat it like 412.
@@ -626,7 +626,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
 
                         launch {
                             val local = localCollection.findByName(name)
-                            SyncException.wrapWithLocalResource(local) {
+                            local.withExceptionContext {
                                 if (local == null) {
                                     logger.info("$name has been added remotely, queueing download")
                                     batchDownloader.enqueue(response.href)
@@ -651,7 +651,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
                         // collection sync: resource has been deleted on remote server
                         launch {
                             localCollection.findByName(name)?.let { local ->
-                                SyncException.wrapWithLocalResource(local) {
+                                local.withExceptionContext {
                                     logger.info("$name has been deleted on server, deleting locally")
                                     local.deleteLocal()
                                 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -265,15 +265,9 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
                 logger.info("Remote collection didn't change, no reason to sync")
 
         } catch (potentiallyWrappedException: Throwable) {
-            var local: LocalResource? = null
-            var remote: Url? = null
+            val ctx = SyncException.unwrap(potentiallyWrappedException)
 
-            val e = SyncException.unwrap(potentiallyWrappedException) {
-                local = it.localResource
-                remote = it.remoteResource
-            }
-
-            when (e) {
+            when (val e = ctx.cause) {
                 /* LocalStorageException with cause DeadObjectException may occur when syncing takes too long
                 and process is demoted to cached. In this case, we re-throw to the base Syncer which will
                 treat it as a soft error and re-schedule the sync process. */
@@ -291,7 +285,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
 
                     // when a certificate is rejected by cert4android, the cause will be a CertificateException
                     if (e.cause !is CertificateException)
-                        handleException(e, local, remote)
+                        handleException(e, ctx.localResource, ctx.remoteResource)
                 }
 
                 // specific HTTP errors
@@ -304,7 +298,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
 
                 // all others
                 else ->
-                    handleException(e, local, remote)
+                    handleException(e, ctx.localResource, ctx.remoteResource)
             }
         }
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
@@ -101,10 +101,10 @@ class TasksSyncManager @AssistedInject constructor(
     }
 
     override suspend fun queryCapabilities() =
-        SyncException.wrapWithRemoteResource(collection.url) {
+        collection.url.withExceptionContext {
             val response =
                 davCollection.propfind(0, CalDAV.MaxResourceSize, CalDAV.GetCTag, WebDAV.SyncToken).selfResponse()
-                    ?: return@wrapWithRemoteResource null
+                    ?: return@withExceptionContext null
 
             response[MaxResourceSize::class.java]?.maxSize?.let { maxSize ->
                 logger.info("Calendar accepts tasks up to ${Formatter.formatFileSize(context, maxSize)}")
@@ -152,7 +152,7 @@ class TasksSyncManager @AssistedInject constructor(
     }
 
     override fun listAllRemote(): Flow<MultiStatusItem> = flow {
-        SyncException.wrapWithRemoteResource(collection.url) {
+        collection.url.withExceptionContext {
             logger.info("Querying tasks")
             emitAll(davCollection.calendarQuery("VTODO", null, null))
         }
@@ -161,10 +161,10 @@ class TasksSyncManager @AssistedInject constructor(
     override suspend fun downloadRemote(bunch: List<Url>) {
         logger.info("Downloading ${bunch.size} iCalendars: $bunch")
         // multiple iCalendars, use calendar-multi-get
-        SyncException.wrapWithRemoteResource(collection.url) {
+        collection.url.withExceptionContext {
             davCollection.multiget(bunch).responses().collect { response ->
                 // See CalendarSyncManager for more information about the multi-get response
-                SyncException.wrapWithRemoteResource(response.href) wrapResource@{
+                response.href.withExceptionContext wrapResource@{
                     if (!response.isSuccess()) {
                         logger.warning("Ignoring non-successful multi-get response for ${response.href}")
                         return@wrapResource
@@ -222,7 +222,7 @@ class TasksSyncManager @AssistedInject constructor(
         // update local task, if it exists
         val local = localCollection.findByName(fileName)
         if (local != null) {
-            SyncException.wrapWithLocalResource(local) {
+            local.withExceptionContext {
                 logger.info("Updating $fileName in local task list: $task")
                 local.update(dmfsTask)
             }

--- a/core/src/test/kotlin/at/bitfire/davdroid/sync/SyncExceptionTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/sync/SyncExceptionTest.kt
@@ -7,8 +7,10 @@ package at.bitfire.davdroid.sync
 import at.bitfire.davdroid.resource.LocalResource
 import io.ktor.http.Url
 import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
 import org.junit.Test
 
 class SyncExceptionTest {
@@ -87,6 +89,51 @@ class SyncExceptionTest {
         assertEquals(e, result.cause)
     }
 
+    @Test
+    fun testWithExceptionContext_CancellationException() = runTest {
+        val local = mockk<LocalResource>()
+        val e = CancellationException()
+
+        val result = assertThrown {
+            local.withExceptionContext {
+                throw e
+            }
+        }
+
+        assertSame(e, result)
+    }
+
+    @Test
+    fun testWithExceptionContext_CancellationException_Nested() = runTest {
+        val local = mockk<LocalResource>()
+        val remote = Url("https://example.com")
+        val e = CancellationException()
+
+        val result = assertThrown {
+            local.withExceptionContext {
+                remote.withExceptionContext {
+                    throw e
+                }
+            }
+        }
+
+        assertSame(e, result)
+    }
+
+    @Test
+    fun testWithExceptionContext_InterruptedException() = runTest {
+        val remote = Url("https://example.com")
+        val e = InterruptedException()
+
+        val result = assertThrown {
+            remote.withExceptionContext {
+                throw e
+            }
+        }
+
+        assertSame(e, result)
+    }
+
 
     @Test
     fun testUnwrapContext_PlainException() {
@@ -119,6 +166,19 @@ class SyncExceptionTest {
 
 
     // helpers
+
+    /**
+     * Runs [block], expecting it to throw, and returns the thrown [Throwable] as-is
+     * (without unwrapping it), to verify that it wasn't wrapped into a [SyncException].
+     */
+    suspend fun assertThrown(block: suspend () -> Unit): Throwable {
+        try {
+            block()
+        } catch (ex: Throwable) {
+            return ex
+        }
+        throw AssertionError("Expected an exception to be thrown")
+    }
 
     /**
      * Runs [block], expecting it to throw, and returns the [SyncExceptionContext]

--- a/core/src/test/kotlin/at/bitfire/davdroid/sync/SyncExceptionTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/sync/SyncExceptionTest.kt
@@ -14,14 +14,14 @@ import org.junit.Test
 class SyncExceptionTest {
 
     @Test
-    fun testWrapWithLocalResource_LocalResource_Exception() = runTest {
+    fun testWithExceptionContext_LocalResource_LocalResource() = runTest {
         val outer = mockk<LocalResource>()
         val inner = mockk<LocalResource>()
         val e = Exception()
 
-        val result = assertSyncException {
-            SyncException.wrapWithLocalResource(outer) {
-                SyncException.wrapWithLocalResource(inner) {
+        val result = assertWrapped {
+            outer.withExceptionContext {
+                inner.withExceptionContext {
                     throw e
                 }
             }
@@ -32,32 +32,14 @@ class SyncExceptionTest {
     }
 
     @Test
-    fun testWrapWithLocalResource_LocalResource_SyncException() = runTest {
-        val outer = mockk<LocalResource>()
-        val inner = mockk<LocalResource>()
-        val e = SyncException(Exception())
-
-        val result = assertSyncException {
-            SyncException.wrapWithLocalResource(outer) {
-                SyncException.wrapWithLocalResource(inner) {
-                    throw e
-                }
-            }
-        }
-
-        assertEquals(inner, result.localResource)
-        assertEquals(e, result)
-    }
-
-    @Test
-    fun testWrapWithLocalResource_RemoteResource_Exception() = runTest {
+    fun testWithExceptionContext_LocalResource_RemoteResource() = runTest {
         val local = mockk<LocalResource>()
-        val remote = mockk<Url>()
+        val remote = Url("https://example.com")
         val e = Exception()
 
-        val result = assertSyncException {
-            SyncException.wrapWithLocalResource(local) {
-                SyncException.wrapWithRemoteResource(remote) {
+        val result = assertWrapped {
+            local.withExceptionContext {
+                remote.withExceptionContext {
                     throw e
                 }
             }
@@ -69,34 +51,14 @@ class SyncExceptionTest {
     }
 
     @Test
-    fun testWrapWithLocalResource_RemoteResource_SyncException() = runTest {
-        val local = mockk<LocalResource>()
-        val remote = mockk<Url>()
-        val e = SyncException(Exception())
-
-        val result = assertSyncException {
-            SyncException.wrapWithLocalResource(local) {
-                SyncException.wrapWithRemoteResource(remote) {
-                    throw e
-                }
-            }
-        }
-
-        assertEquals(local, result.localResource)
-        assertEquals(remote, result.remoteResource)
-        assertEquals(e, result)
-    }
-
-
-    @Test
-    fun testWrapWithRemoteResource_LocalResource_Exception() = runTest {
-        val remote = mockk<Url>()
+    fun testWithExceptionContext_RemoteResource_LocalResource() = runTest {
+        val remote = Url("https://example.com")
         val local = mockk<LocalResource>()
         val e = Exception()
 
-        val result = assertSyncException {
-            SyncException.wrapWithRemoteResource(remote) {
-                SyncException.wrapWithLocalResource(local) {
+        val result = assertWrapped {
+            remote.withExceptionContext {
+                local.withExceptionContext {
                     throw e
                 }
             }
@@ -108,33 +70,14 @@ class SyncExceptionTest {
     }
 
     @Test
-    fun testWrapWithRemoteResource_LocalResource_SyncException() = runTest {
-        val remote = mockk<Url>()
-        val local = mockk<LocalResource>()
-        val e = SyncException(Exception())
-
-        val result = assertSyncException {
-            SyncException.wrapWithRemoteResource(remote) {
-                SyncException.wrapWithLocalResource(local) {
-                    throw e
-                }
-            }
-        }
-
-        assertEquals(local, result.localResource)
-        assertEquals(remote, result.remoteResource)
-        assertEquals(e, result)
-    }
-
-    @Test
-    fun testWrapWithRemoteResource_RemoteResource_Exception() = runTest {
-        val outer = mockk<Url>()
-        val inner = mockk<Url>()
+    fun testWithExceptionContext_RemoteResource_RemoteResource() = runTest {
+        val outer = Url("https://example.com/outer")
+        val inner = Url("https://example.com/inner")
         val e = Exception()
 
-        val result = assertSyncException {
-            SyncException.wrapWithRemoteResource(outer) {
-                SyncException.wrapWithRemoteResource(inner) {
+        val result = assertWrapped {
+            outer.withExceptionContext {
+                inner.withExceptionContext {
                     throw e
                 }
             }
@@ -144,59 +87,50 @@ class SyncExceptionTest {
         assertEquals(e, result.cause)
     }
 
-    @Test
-    fun testWrapWithRemoteResource_RemoteResource_SyncException() = runTest {
-        val outer = mockk<Url>()
-        val inner = mockk<Url>()
-        val e = SyncException(Exception())
-
-        val result = assertSyncException {
-            SyncException.wrapWithRemoteResource(outer) {
-                SyncException.wrapWithRemoteResource(inner) {
-                    throw e
-                }
-            }
-        }
-
-        assertEquals(inner, result.remoteResource)
-        assertEquals(e, result)
-    }
-
 
     @Test
-    fun testUnwrap_Exception() {
+    fun testUnwrapContext_PlainException() {
         val e = Exception()
 
-        val ctx = SyncException.unwrap(e)
+        val ctx = e.unwrapContext()
         assertEquals(e, ctx.cause)
         assertEquals(null, ctx.localResource)
         assertEquals(null, ctx.remoteResource)
     }
 
     @Test
-    fun testUnwrap_SyncException() {
+    fun testUnwrapContext_WrappedException() = runTest {
         val e = Exception()
         val local = mockk<LocalResource>()
         val remote = Url("https://example.com")
-        val wrapped = SyncException(e).setLocalResourceIfNull(local).setRemoteResourceIfNull(remote)
 
-        val ctx = SyncException.unwrap(wrapped)
-        assertEquals(e, ctx.cause)
-        assertEquals(local, ctx.localResource)
-        assertEquals(remote, ctx.remoteResource)
+        val result = assertWrapped {
+            local.withExceptionContext {
+                remote.withExceptionContext {
+                    throw e
+                }
+            }
+        }
+
+        assertEquals(e, result.cause)
+        assertEquals(local, result.localResource)
+        assertEquals(remote, result.remoteResource)
     }
 
 
     // helpers
 
-    suspend fun assertSyncException(block: suspend () -> Unit): SyncException {
+    /**
+     * Runs [block], expecting it to throw, and returns the [SyncExceptionContext]
+     * recovered from the thrown exception via [unwrapContext].
+     */
+    suspend fun assertWrapped(block: suspend () -> Unit): SyncExceptionContext {
         try {
             block()
-        } catch(ex: Throwable) {
-            if (ex is SyncException)
-                return ex
+        } catch (ex: Throwable) {
+            return ex.unwrapContext()
         }
-        throw AssertionError("Expected SyncException")
+        throw AssertionError("Expected an exception to be thrown")
     }
 
 }

--- a/core/src/test/kotlin/at/bitfire/davdroid/sync/SyncExceptionTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/sync/SyncExceptionTest.kt
@@ -9,8 +9,6 @@ import io.ktor.http.Url
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class SyncExceptionTest {
@@ -169,26 +167,23 @@ class SyncExceptionTest {
     fun testUnwrap_Exception() {
         val e = Exception()
 
-        var contextProvided = false
-        val unwrapped = SyncException.unwrap(e) {
-            contextProvided = true
-        }
-        assertEquals(e, unwrapped)
-        assertFalse(contextProvided)
+        val ctx = SyncException.unwrap(e)
+        assertEquals(e, ctx.cause)
+        assertEquals(null, ctx.localResource)
+        assertEquals(null, ctx.remoteResource)
     }
 
     @Test
     fun testUnwrap_SyncException() {
         val e = Exception()
-        val wrapped = SyncException(e)
+        val local = mockk<LocalResource>()
+        val remote = Url("https://example.com")
+        val wrapped = SyncException(e).setLocalResourceIfNull(local).setRemoteResourceIfNull(remote)
 
-        var contextProvided = false
-        val unwrapped = SyncException.unwrap(wrapped) {
-            assertEquals(wrapped, it)
-            contextProvided = true
-        }
-        assertEquals(e, unwrapped)
-        assertTrue(contextProvided)
+        val ctx = SyncException.unwrap(wrapped)
+        assertEquals(e, ctx.cause)
+        assertEquals(local, ctx.localResource)
+        assertEquals(remote, ctx.remoteResource)
     }
 
 


### PR DESCRIPTION
### Purpose

Replace the mutable, companion-object-based `SyncException` with a smaller, more idiomatic API for carrying local/remote resource context alongside sync failures.

### Short description

- `SyncExceptionContext`: immutable data class (`cause`, `localResource`, `remoteResource`) replacing `SyncException`'s mutable fields.
- `LocalResource?.withExceptionContext { }` / `Url?.withExceptionContext { }`: tag a block's exception with the resource being processed.
- `Throwable.unwrapContext()`: retrieve the recorded context after catching.
- Updated all call sites and rewrote `SyncExceptionTest` for the new API.
- The actual `SyncException` that carries the context (local/remote resource) is now a private implementation detail.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have self-reviewed the PR.
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
