### PR TITLE
[sync] Fix endless upload loop when a locally modified resource was deleted on the server

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncManagerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncManagerTest.kt
@@ -4,7 +4,6 @@
 
 package at.bitfire.davdroid.sync
 
-import android.accounts.Account
 import android.content.Context
 import androidx.core.app.NotificationManagerCompat
 import androidx.hilt.work.HiltWorkerFactory
@@ -27,6 +26,7 @@ import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import io.ktor.client.HttpClient
 import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
 import io.ktor.http.headersOf
@@ -38,6 +38,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -103,6 +104,37 @@ class SyncManagerTest {
             headersOf(HttpHeaders.ContentType, "text/xml")
         )
     }
+
+    /**
+     * Enqueues a Multi-Status response for a PROPFIND on a single resource, as sent when DAVx5 checks
+     * whether the target of a failed conditional upload is still there.
+     */
+    private fun enqueuePropfindETag(href: String, eTag: String) {
+        mockEngineQueue.enqueue(
+            HttpStatusCode.MultiStatus,
+            "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n" +
+                    "<multistatus xmlns=\"DAV:\">\n" +
+                    "  <response>\n" +
+                    "    <href>$href</href>\n" +
+                    "    <propstat>\n" +
+                    "      <prop>\n" +
+                    "        <getetag>$eTag</getetag>\n" +
+                    "      </prop>\n" +
+                    "      <status>HTTP/1.1 200 OK</status>\n" +
+                    "    </propstat>\n" +
+                    "  </response>\n" +
+                    "</multistatus>",
+            headersOf(HttpHeaders.ContentType, "text/xml")
+        )
+    }
+
+    /** All PUT requests the mock engine has received, in order. */
+    private fun putRequests() =
+        mockEngineQueue.engine.requestHistory.filter { it.method == HttpMethod.Put }
+
+    /** All requests the mock engine has received for the given path (i.e. not the collection itself). */
+    private fun requestsFor(encodedPath: String) =
+        mockEngineQueue.engine.requestHistory.filter { it.url.encodedPath == encodedPath }
 
     @Before
     fun setUp() {
@@ -288,7 +320,7 @@ class SyncManagerTest {
     }
 
     @Test
-    fun testPerformSync_UploadModifiedMember_412PreconditionFailed() = runTest {
+    fun testPerformSync_UploadModifiedMember_412PreconditionFailed_ResourceStillThere() = runTest {
         val collection = LocalTestCollection().apply {
             lastSyncState = SyncState(SyncState.Type.CTAG, "old-ctag")
             entries += LocalTestResource().apply {
@@ -301,6 +333,9 @@ class SyncManagerTest {
 
         // PUT -> 412 Precondition Failed
         mockEngineQueue.enqueue(HttpStatusCode.PreconditionFailed)
+
+        // PROPFIND -> resource is still there, so it's a real edit conflict
+        enqueuePropfindETag("/existing-file.txt", "changed-etag-from-server")
 
         // modifications sent, so DAVx5 will query CTag again
         enqueueQueryCapabilities("ctag1")
@@ -330,6 +365,289 @@ class SyncManagerTest {
         assertFalse(syncManager.syncResult.hasError())
         assertEquals(1, collection.entries.size)
         assertEquals("changed-etag-from-server", collection.entries.first().eTag)
+
+        // real edit conflict: must not be uploaded a second time (would overwrite the server version)
+        assertEquals(1, putRequests().size)
+    }
+
+    @Test
+    fun testPerformSync_UploadModifiedMember_412PreconditionFailed_ResourceGone() = runTest {
+        // Some servers (like DAViCal) answer 412 instead of 404 when the resource is not there anymore,
+        // because a conditional request with If-Match must fail on a non-existing resource.
+        val collection = LocalTestCollection().apply {
+            lastSyncState = SyncState(SyncState.Type.CTAG, "old-ctag")
+            entries += LocalTestResource().apply {
+                fileName = "existing-file.txt"
+                eTag = "etag-of-the-resource-that-has-been-deleted-on-the-server"
+                dirty = true
+            }
+        }
+        enqueueQueryCapabilities("ctag1")
+
+        // PUT -> 412 Precondition Failed
+        mockEngineQueue.enqueue(HttpStatusCode.PreconditionFailed)
+
+        // PROPFIND -> 404 Not Found, so the resource is really gone
+        mockEngineQueue.enqueue(HttpStatusCode.NotFound)
+
+        // PUT (as new resource) -> 201 Created
+        mockEngineQueue.enqueue(HttpStatusCode.Created, headers = headersOf(HttpHeaders.ETag, "etag-from-put"))
+
+        // modifications sent, so DAVx5 will query CTag again
+        enqueueQueryCapabilities("ctag2")
+
+        val syncManager = syncManager(collection).apply {
+            listAllRemoteResult = listOf(
+                Pair(
+                    Response(
+                        Url("$BASE_URL/"),
+                        Url("$BASE_URL/existing-file.txt"),
+                        null,
+                        listOf(
+                            PropStat(
+                                listOf(
+                                    GetETag("etag-from-put")
+                                ),
+                                HttpStatusCode.OK
+                            )
+                        )
+                    ), HrefRelation.MEMBER
+                )
+            )
+        }
+        syncManager.performSync()
+
+        assertTrue(syncManager.didGenerateUpload)
+        assertTrue(syncManager.didListAllRemote)
+        assertFalse(syncManager.didDownloadRemote)
+        assertFalse(syncManager.syncResult.hasError())
+        assertEquals(1, collection.entries.size)
+        assertFalse(collection.entries.first().dirty)
+        assertEquals("etag-from-put", collection.entries.first().eTag)
+
+        // first PUT is conditional, second one creates the resource again
+        val puts = putRequests()
+        assertEquals(2, puts.size)
+        assertEquals(
+            "\"etag-of-the-resource-that-has-been-deleted-on-the-server\"",
+            puts[0].headers[HttpHeaders.IfMatch]
+        )
+        assertNull(puts[1].headers[HttpHeaders.IfMatch])
+        assertEquals("*", puts[1].headers[HttpHeaders.IfNoneMatch])
+    }
+
+    @Test
+    fun testPerformSync_UploadModifiedMember_409Conflict_ResourceGone() = runTest {
+        val collection = LocalTestCollection().apply {
+            lastSyncState = SyncState(SyncState.Type.CTAG, "old-ctag")
+            entries += LocalTestResource().apply {
+                fileName = "existing-file.txt"
+                eTag = "etag-of-the-resource-that-has-been-deleted-on-the-server"
+                dirty = true
+            }
+        }
+        enqueueQueryCapabilities("ctag1")
+
+        // PUT -> 409 Conflict
+        mockEngineQueue.enqueue(HttpStatusCode.Conflict)
+
+        // PROPFIND -> 404 Not Found, so the resource is really gone
+        mockEngineQueue.enqueue(HttpStatusCode.NotFound)
+
+        // PUT (as new resource) -> 201 Created
+        mockEngineQueue.enqueue(HttpStatusCode.Created, headers = headersOf(HttpHeaders.ETag, "etag-from-put"))
+
+        // modifications sent, so DAVx5 will query CTag again
+        enqueueQueryCapabilities("ctag2")
+
+        val syncManager = syncManager(collection).apply {
+            listAllRemoteResult = listOf(
+                Pair(
+                    Response(
+                        Url("$BASE_URL/"),
+                        Url("$BASE_URL/existing-file.txt"),
+                        null,
+                        listOf(
+                            PropStat(
+                                listOf(
+                                    GetETag("etag-from-put")
+                                ),
+                                HttpStatusCode.OK
+                            )
+                        )
+                    ), HrefRelation.MEMBER
+                )
+            )
+        }
+        syncManager.performSync()
+
+        assertFalse(syncManager.syncResult.hasError())
+        assertEquals(1, collection.entries.size)
+        assertFalse(collection.entries.first().dirty)
+        assertEquals("etag-from-put", collection.entries.first().eTag)
+        assertEquals(2, putRequests().size)
+    }
+
+    @Test
+    fun testPerformSync_UploadModifiedMember_412PreconditionFailed_ResourceStateUnknown() = runTest {
+        // When we can't determine whether the resource is still there, the safe behavior is kept:
+        // ignore the failed upload and let the resource be downloaded again.
+        val collection = LocalTestCollection().apply {
+            lastSyncState = SyncState(SyncState.Type.CTAG, "old-ctag")
+            entries += LocalTestResource().apply {
+                fileName = "existing-file.txt"
+                eTag = "etag-that-has-been-changed-on-server-in-the-meanwhile"
+                dirty = true
+            }
+        }
+        enqueueQueryCapabilities("ctag1")
+
+        // PUT -> 412 Precondition Failed
+        mockEngineQueue.enqueue(HttpStatusCode.PreconditionFailed)
+
+        // PROPFIND -> 500 Internal Server Error, so we don't know whether the resource is still there
+        mockEngineQueue.enqueue(HttpStatusCode.InternalServerError)
+
+        // modifications sent, so DAVx5 will query CTag again
+        enqueueQueryCapabilities("ctag1")
+
+        val syncManager = syncManager(collection).apply {
+            listAllRemoteResult = listOf(
+                Pair(
+                    Response(
+                        Url("$BASE_URL/"),
+                        Url("$BASE_URL/existing-file.txt"),
+                        null,
+                        listOf(
+                            PropStat(
+                                listOf(
+                                    GetETag("changed-etag-from-server")
+                                ),
+                                HttpStatusCode.OK
+                            )
+                        )
+                    ), HrefRelation.MEMBER
+                )
+            )
+
+            assertDownloadRemote = mapOf(Pair(Url("$BASE_URL/existing-file.txt"), "changed-etag-from-server"))
+        }
+        syncManager.performSync()
+
+        assertTrue(syncManager.didDownloadRemote)
+        assertFalse(syncManager.syncResult.hasError())
+        assertEquals(1, collection.entries.size)
+        assertEquals("changed-etag-from-server", collection.entries.first().eTag)
+        assertEquals(1, putRequests().size)
+    }
+
+    @Test
+    fun testPerformSync_UploadModifiedMember_412PreconditionFailed_ResourceReappeared() = runTest {
+        // The resource is gone when we ask, but back again when we upload it as a new resource.
+        val collection = LocalTestCollection().apply {
+            lastSyncState = SyncState(SyncState.Type.CTAG, "old-ctag")
+            entries += LocalTestResource().apply {
+                fileName = "existing-file.txt"
+                eTag = "etag-that-has-been-changed-on-server-in-the-meanwhile"
+                dirty = true
+            }
+        }
+        enqueueQueryCapabilities("ctag1")
+
+        // PUT -> 412 Precondition Failed
+        mockEngineQueue.enqueue(HttpStatusCode.PreconditionFailed)
+
+        // PROPFIND -> 404 Not Found
+        mockEngineQueue.enqueue(HttpStatusCode.NotFound)
+
+        // PUT (as new resource) -> 412 Precondition Failed, too (If-None-Match didn't match)
+        mockEngineQueue.enqueue(HttpStatusCode.PreconditionFailed)
+
+        // modifications sent, so DAVx5 will query CTag again
+        enqueueQueryCapabilities("ctag1")
+
+        val syncManager = syncManager(collection).apply {
+            listAllRemoteResult = listOf(
+                Pair(
+                    Response(
+                        Url("$BASE_URL/"),
+                        Url("$BASE_URL/existing-file.txt"),
+                        null,
+                        listOf(
+                            PropStat(
+                                listOf(
+                                    GetETag("changed-etag-from-server")
+                                ),
+                                HttpStatusCode.OK
+                            )
+                        )
+                    ), HrefRelation.MEMBER
+                )
+            )
+
+            assertDownloadRemote = mapOf(Pair(Url("$BASE_URL/existing-file.txt"), "changed-etag-from-server"))
+        }
+        syncManager.performSync()
+
+        assertTrue(syncManager.didDownloadRemote)
+        assertFalse(syncManager.syncResult.hasError())
+        assertEquals("changed-etag-from-server", collection.entries.first().eTag)
+
+        // the server is only asked once; the retry must not ask again (no endless recursion)
+        assertEquals(2, putRequests().size)
+        assertEquals(3, requestsFor("/existing-file.txt").size)
+    }
+
+    @Test
+    fun testPerformSync_UploadModifiedMember_404NotFound_UploadsAsNew() = runTest {
+        // Servers which answer 404 (instead of 412) don't have to be asked whether the resource is there.
+        val collection = LocalTestCollection().apply {
+            lastSyncState = SyncState(SyncState.Type.CTAG, "old-ctag")
+            entries += LocalTestResource().apply {
+                fileName = "existing-file.txt"
+                eTag = "etag-of-the-resource-that-has-been-deleted-on-the-server"
+                dirty = true
+            }
+        }
+        enqueueQueryCapabilities("ctag1")
+
+        // PUT -> 404 Not Found
+        mockEngineQueue.enqueue(HttpStatusCode.NotFound)
+
+        // PUT (as new resource) -> 201 Created
+        mockEngineQueue.enqueue(HttpStatusCode.Created, headers = headersOf(HttpHeaders.ETag, "etag-from-put"))
+
+        // modifications sent, so DAVx5 will query CTag again
+        enqueueQueryCapabilities("ctag2")
+
+        val syncManager = syncManager(collection).apply {
+            listAllRemoteResult = listOf(
+                Pair(
+                    Response(
+                        Url("$BASE_URL/"),
+                        Url("$BASE_URL/existing-file.txt"),
+                        null,
+                        listOf(
+                            PropStat(
+                                listOf(
+                                    GetETag("etag-from-put")
+                                ),
+                                HttpStatusCode.OK
+                            )
+                        )
+                    ), HrefRelation.MEMBER
+                )
+            )
+        }
+        syncManager.performSync()
+
+        assertFalse(syncManager.syncResult.hasError())
+        assertFalse(collection.entries.first().dirty)
+        assertEquals("etag-from-put", collection.entries.first().eTag)
+
+        // two PUTs and nothing else: no PROPFIND needed to find out that the resource is gone
+        assertEquals(2, putRequests().size)
+        assertEquals(2, requestsFor("/existing-file.txt").size)
     }
 
     @Test

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -487,11 +487,28 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
                 is ConflictException -> {
                     // HTTP 409 Conflict
                     // We can't interact with the user to resolve the conflict, so we treat 409 like 412.
+                    if (!forceAsNew && uploadTargetIsGone(remote)) {
+                        logger.info("Upload target is not there (anymore), trying as fresh upload")
+                        uploadDirty(local, forceAsNew = true)
+                        return
+                    }
                     logger.info("Edit conflict, ignoring")
                 }
                 is PreconditionFailedException -> {
-                    // HTTP 412 Precondition failed: Resource has been modified on the server in the meanwhile.
-                    // Ignore this condition so that the resource can be downloaded and reset again.
+                    // HTTP 412 Precondition failed: usually the resource has been modified on the server in the
+                    // meanwhile, so our If-Match/If-Schedule-Tag-Match didn't match. Ignore this condition so that
+                    // the resource can be downloaded and reset again.
+                    //
+                    // However some servers also answer 412 when the resource doesn't exist anymore at all, because
+                    // a conditional request with If-Match must fail on a non-existing resource (RFC 9110 13.1.1),
+                    // while others answer 404 in that case. So we have to ask the server whether the resource is
+                    // still there; otherwise the local resource would stay dirty and would be uploaded again in
+                    // every sync (endless loop).
+                    if (!forceAsNew && uploadTargetIsGone(remote)) {
+                        logger.info("Upload target is not there (anymore), trying as fresh upload")
+                        uploadDirty(local, forceAsNew = true)
+                        return
+                    }
                     logger.info("Resource has been modified on the server before upload, ignoring")
                 }
                 else -> throw e
@@ -750,6 +767,32 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
 
     private suspend fun querySyncState(): SyncState? =
         davCollection.propfind(0, CalDAV.GetCTag, WebDAV.SyncToken).selfResponse()?.let { syncState(it) }
+
+    /**
+     * Determines whether the target of a conditional upload is not there (anymore).
+     *
+     * Some servers (like DAViCal) answer 412 Precondition Failed when a request with `If-Match` is sent for a
+     * resource which doesn't exist anymore, as required by RFC 9110 13.1.1. Others answer 404 Not Found in that
+     * case. So when a conditional upload fails, we have to ask the server whether the resource is still there.
+     *
+     * @param remote  resource which was the target of the upload
+     *
+     * @return  *true* if the server says that the resource is not there (anymore); *false* if it's still there
+     *          or if it couldn't be determined (in this case, callers should keep the safe behavior)
+     */
+    private suspend fun uploadTargetIsGone(remote: DavResource): Boolean =
+        try {
+            val eTag = remote.propfind(0, WebDAV.GetETag).selfResponse()?.get(GetETag::class.java)?.eTag
+            logger.fine("Upload target ${remote.location} is still there (ETag $eTag)")
+            false
+        } catch (_: NotFoundException) {
+            true
+        } catch (_: GoneException) {
+            true
+        } catch (e: DavException) {
+            logger.log(Level.WARNING, "Couldn't determine whether ${remote.location} is still there", e)
+            false
+        }
 
     /**
      * Logs the exception, updates sync result and shows a notification to the user.


### PR DESCRIPTION
### Purpose

Fixes #2739: a resource that is modified locally and deleted on the server by another client is uploaded again in every sync, forever. Some servers (like DAViCal) answer 412 instead of 404 to our conditional `PUT`, because per RFC 9110 13.1.1 an `If-Match` against a non-existing resource must fail with 412. We treat every 412 as "modified on the server in the meanwhile" and ignore it, so the resource stays dirty — but it can never be downloaded, and `deleteNotPresentRemotely()` skips dirty rows, so nothing resolves it. Affects contacts and events, too.

### Short description

- Added `SyncManager.uploadTargetIsGone()`, which sends a `PROPFIND` to find out whether the upload target is still on the server.
- The 412 and 409 branches of `uploadDirty()` now use it: if the resource is gone, the upload is retried as a fresh upload (`forceAsNew`) — the same resolution we already apply when a server answers 404.
- If the resource is still there, or if the server doesn't give a clear answer, the previous behavior is kept, so a genuine edit conflict is still resolved in favor of the server version.

Related: [RFC 9110, section 13.1.1](https://www.rfc-editor.org/rfc/rfc9110#section-13.1.1).

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
