### PR TITLE
[SyncManager] Extract/reorganize some methods

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/SyncState.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/SyncState.kt
@@ -4,6 +4,8 @@
 
 package at.bitfire.davdroid.resource
 
+import at.bitfire.dav4jvm.ktor.Response
+import at.bitfire.dav4jvm.property.caldav.GetCTag
 import at.bitfire.dav4jvm.property.webdav.SyncToken
 import org.json.JSONException
 import org.json.JSONObject
@@ -57,3 +59,13 @@ data class SyncState(
     }
 
 }
+
+/**
+ * Extracts the [SyncState] (`sync-token` or `CTag`) reported by this response, if any.
+ */
+fun Response.syncState(): SyncState? =
+    this[SyncToken::class.java]?.token?.let {
+        SyncState(SyncState.Type.SYNC_TOKEN, it)
+    } ?: this[GetCTag::class.java]?.cTag?.let {
+        SyncState(SyncState.Type.CTAG, it)
+    }

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
@@ -27,6 +27,7 @@ import at.bitfire.davdroid.resource.LocalCalendar
 import at.bitfire.davdroid.resource.LocalEvent
 import at.bitfire.davdroid.resource.LocalResource
 import at.bitfire.davdroid.resource.SyncState
+import at.bitfire.davdroid.resource.syncState
 import at.bitfire.davdroid.util.DavUtils
 import at.bitfire.davdroid.util.DavUtils.lastSegment
 import at.bitfire.synctools.exception.InvalidResourceException
@@ -130,7 +131,7 @@ class CalendarSyncManager @AssistedInject constructor(
             }
 
             logger.info("Calendar supports Collection Sync: $hasCollectionSync")
-            syncState(response)
+            response.syncState()
         }
 
     override fun syncAlgorithm() =

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
@@ -31,6 +31,7 @@ import at.bitfire.davdroid.resource.LocalContact
 import at.bitfire.davdroid.resource.LocalGroup
 import at.bitfire.davdroid.resource.LocalResource
 import at.bitfire.davdroid.resource.SyncState
+import at.bitfire.davdroid.resource.syncState
 import at.bitfire.davdroid.resource.workaround.ContactDirtyVerifier
 import at.bitfire.davdroid.sync.groups.CategoriesStrategy
 import at.bitfire.davdroid.sync.groups.VCard4Strategy
@@ -191,7 +192,7 @@ class ContactsSyncManager @AssistedInject constructor(
             logger.info("Address book supports vCard4: $hasVCard4")
             logger.info("Address book supports Collection Sync: $hasCollectionSync")
 
-            syncState(response)
+            response.syncState()
         }
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
@@ -26,6 +26,7 @@ import at.bitfire.davdroid.di.qualifier.SyncTransferSemaphore
 import at.bitfire.davdroid.resource.LocalJtxCollection
 import at.bitfire.davdroid.resource.LocalJtxObject
 import at.bitfire.davdroid.resource.LocalResource
+import at.bitfire.davdroid.resource.syncState
 import at.bitfire.davdroid.util.DavUtils
 import at.bitfire.davdroid.util.DavUtils.lastSegment
 import at.bitfire.synctools.exception.InvalidResourceException
@@ -108,7 +109,7 @@ class JtxSyncManager @AssistedInject constructor(
                 logger.info("Collection accepts resources up to ${Formatter.formatFileSize(context, maxSize)}")
             }
 
-            syncState(response)
+            response.syncState()
         }
 
     override fun generateUpload(resource: LocalJtxObject): GeneratedResource {

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -181,85 +181,11 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
 
             if (modificationsPresent || syncRequired(remoteSyncState))
                 when (syncAlgorithm()) {
-                    SyncAlgorithm.PROPFIND_REPORT -> {
-                        logger.info("Sync algorithm: full listing as one result (PROPFIND/REPORT)")
-                        resetPresentRemotely()
+                    SyncAlgorithm.PROPFIND_REPORT ->
+                        syncPropfindReport(modificationsPresent, remoteSyncState)
 
-                        // get current sync state
-                        if (modificationsPresent)
-                            remoteSyncState = querySyncState()
-
-                        // list and process all entries at current sync state (which may be the same as or newer than remoteSyncState)
-                        logger.info("Processing remote entries")
-                        syncRemote { callback ->
-                            listAllRemote().forEachResponse(callback)
-                        }
-
-                        logger.info("Deleting entries which are not present remotely anymore")
-                        deleteNotPresentRemotely()
-
-                        logger.info("Post-processing")
-                        postProcess()
-
-                        logger.info("Saving sync state: $remoteSyncState")
-                        localCollection.lastSyncState = remoteSyncState
-                    }
-
-                    SyncAlgorithm.COLLECTION_SYNC -> {
-                        var syncState = localCollection.lastSyncState?.takeIf { it.type == SyncState.Type.SYNC_TOKEN }
-
-                        var initialSync = false
-                        if (syncState == null) {
-                            logger.info("Starting initial sync")
-                            initialSync = true
-                            resetPresentRemotely()
-                        } else if (syncState.initialSync == true) {
-                            logger.info("Continuing initial sync")
-                            initialSync = true
-                        }
-
-                        var furtherChanges = false
-                        do {
-                            logger.info("Listing changes since $syncState")
-                            syncRemote { callback ->
-                                try {
-                                    val result = listRemoteChanges(syncState, callback)
-                                    syncState = SyncState.fromSyncToken(result.first, initialSync)
-                                    furtherChanges = result.second
-                                } catch (e: HttpException) {
-                                    if (e.errors.contains(Error(WebDAV.ValidSyncToken))) {
-                                        logger.info("Sync token invalid, performing initial sync")
-                                        initialSync = true
-                                        resetPresentRemotely()
-
-                                        val result = listRemoteChanges(null, callback)
-                                        syncState = SyncState.fromSyncToken(result.first, initialSync)
-                                        furtherChanges = result.second
-                                    } else
-                                        throw e
-                                }
-                            }
-
-                            logger.info("Saving sync state: $syncState")
-                            localCollection.lastSyncState = syncState
-
-                            logger.info("Server has further changes: $furtherChanges")
-                        } while (furtherChanges)
-
-                        if (initialSync) {
-                            // initial sync is finished, remove all local resources which have not been listed by server
-                            logger.info("Deleting local resources which are not on server (anymore)")
-                            deleteNotPresentRemotely()
-
-                            // remove initial sync flag
-                            syncState!!.initialSync = false
-                            logger.info("Initial sync completed, saving sync state: $syncState")
-                            localCollection.lastSyncState = syncState
-                        }
-
-                        logger.info("Post-processing")
-                        postProcess()
-                    }
+                    SyncAlgorithm.COLLECTION_SYNC ->
+                        syncCollectionSync()
                 }
             else
                 logger.info("Remote collection didn't change, no reason to sync")
@@ -711,6 +637,31 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
 
     //region Sync algorithm-specific: PROPFIND/REPORT
 
+    private suspend fun syncPropfindReport(modificationsPresent: Boolean, remoteSyncState: SyncState?) {
+        logger.info("Sync algorithm: full listing as one result (PROPFIND/REPORT)")
+        resetPresentRemotely()
+
+        // get current sync state
+        var currentSyncState = remoteSyncState
+        if (modificationsPresent)
+            currentSyncState = querySyncState()
+
+        // list and process all entries at current sync state (which may be the same as or newer than remoteSyncState)
+        logger.info("Processing remote entries")
+        syncRemote { callback ->
+            listAllRemote().forEachResponse(callback)
+        }
+
+        logger.info("Deleting entries which are not present remotely anymore")
+        deleteNotPresentRemotely()
+
+        logger.info("Post-processing")
+        postProcess()
+
+        logger.info("Saving sync state: $currentSyncState")
+        localCollection.lastSyncState = currentSyncState
+    }
+
     private suspend fun querySyncState(): SyncState? =
         davCollection.propfind(0, CalDAV.GetCTag, WebDAV.SyncToken).selfResponse()?.syncState()
 
@@ -721,14 +672,70 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
 
     //region Sync algorithm-specific: collection-sync
 
+    private suspend fun syncCollectionSync() {
+        var syncState = localCollection.lastSyncState?.takeIf { it.type == SyncState.Type.SYNC_TOKEN }
+
+        var initialSync = false
+        if (syncState == null) {
+            logger.info("Starting initial sync")
+            initialSync = true
+            resetPresentRemotely()
+        } else if (syncState.initialSync == true) {
+            logger.info("Continuing initial sync")
+            initialSync = true
+        }
+
+        var furtherChanges = false
+        do {
+            logger.info("Listing changes since $syncState")
+            syncRemote { callback ->
+                try {
+                    val result = listRemoteChanges(syncState, callback)
+                    syncState = SyncState.fromSyncToken(result.first, initialSync)
+                    furtherChanges = result.second
+                } catch (e: HttpException) {
+                    if (e.errors.contains(Error(WebDAV.ValidSyncToken))) {
+                        logger.info("Sync token invalid, performing initial sync")
+                        initialSync = true
+                        resetPresentRemotely()
+
+                        val result = listRemoteChanges(null, callback)
+                        syncState = SyncState.fromSyncToken(result.first, initialSync)
+                        furtherChanges = result.second
+                    } else
+                        throw e
+                }
+            }
+
+            logger.info("Saving sync state: $syncState")
+            localCollection.lastSyncState = syncState
+
+            logger.info("Server has further changes: $furtherChanges")
+        } while (furtherChanges)
+
+        if (initialSync) {
+            // initial sync is finished, remove all local resources which have not been listed by server
+            logger.info("Deleting local resources which are not on server (anymore)")
+            deleteNotPresentRemotely()
+
+            // remove initial sync flag
+            syncState!!.initialSync = false
+            logger.info("Initial sync completed, saving sync state: $syncState")
+            localCollection.lastSyncState = syncState
+        }
+
+        logger.info("Post-processing")
+        postProcess()
+    }
+
     protected suspend fun listRemoteChanges(
-        syncState: SyncState?,
+        since: SyncState?,
         callback: MultiResponseCallback
     ): Pair<SyncToken, Boolean> {
         var furtherResults = false
 
         val report = davCollection.reportChanges(
-            syncState?.takeIf { syncState.type == SyncState.Type.SYNC_TOKEN }?.value,
+            since?.takeIf { since.type == SyncState.Type.SYNC_TOKEN }?.value,
             false, null,
             WebDAV.GetETag
         ).forEachResponse { response, relation ->

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -26,7 +26,6 @@ import at.bitfire.dav4jvm.ktor.exception.ServiceUnavailableException
 import at.bitfire.dav4jvm.ktor.exception.UnauthorizedException
 import at.bitfire.dav4jvm.ktor.selfResponse
 import at.bitfire.dav4jvm.property.caldav.CalDAV
-import at.bitfire.dav4jvm.property.caldav.GetCTag
 import at.bitfire.dav4jvm.property.caldav.ScheduleTag
 import at.bitfire.dav4jvm.property.webdav.GetETag
 import at.bitfire.dav4jvm.property.webdav.ResourceType
@@ -42,6 +41,7 @@ import at.bitfire.davdroid.repository.DavSyncStatsRepository
 import at.bitfire.davdroid.resource.LocalCollection
 import at.bitfire.davdroid.resource.LocalResource
 import at.bitfire.davdroid.resource.SyncState
+import at.bitfire.davdroid.resource.syncState
 import at.bitfire.davdroid.sync.account.InvalidAccountException
 import at.bitfire.synctools.storage.LocalStorageException
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -741,15 +741,8 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
 
     // sync helpers
 
-    protected fun syncState(dav: Response) =
-        dav[SyncToken::class.java]?.token?.let {
-            SyncState(SyncState.Type.SYNC_TOKEN, it)
-        } ?: dav[GetCTag::class.java]?.cTag?.let {
-            SyncState(SyncState.Type.CTAG, it)
-        }
-
     private suspend fun querySyncState(): SyncState? =
-        davCollection.propfind(0, CalDAV.GetCTag, WebDAV.SyncToken).selfResponse()?.let { syncState(it) }
+        davCollection.propfind(0, CalDAV.GetCTag, WebDAV.SyncToken).selfResponse()?.syncState()
 
     /**
      * Logs the exception, updates sync result and shows a notification to the user.

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -329,7 +329,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
      *
      * @return whether local resources have been processed so that a synchronization is always necessary
      */
-    protected open suspend fun processLocallyDeleted(): Boolean {
+    protected suspend fun processLocallyDeleted(): Boolean {
         if (localCollection.readOnly)
             return readOnlyPolicy.resetDeleted(localCollection)
 
@@ -404,7 +404,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
      * @param forceAsNew    whether the ETag (and Schedule-Tag) of [local] are ignored and the resource
      *                      is created as a new resource on the server
      */
-    protected open suspend fun uploadDirty(local: LocalType, forceAsNew: Boolean = false) {
+    protected suspend fun uploadDirty(local: LocalType, forceAsNew: Boolean = false) {
         val existingFileName = local.fileName
 
         val upload = generateUpload(local)
@@ -553,7 +553,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
      * @return whether data has been changed on the server, i.e. whether running the
      * sync algorithm is required
      */
-    protected open fun syncRequired(state: SyncState?): Boolean {
+    protected fun syncRequired(state: SyncState?): Boolean {
         if (resync != null)
             return true
 
@@ -588,7 +588,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
      *
      * Used together with [deleteNotPresentRemotely].
      */
-    protected open fun resetPresentRemotely() {
+    protected fun resetPresentRemotely() {
         val number = localCollection.markNotDirty(0)
         logger.info("Number of local non-dirty entries: $number")
     }
@@ -599,7 +599,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
      *
      * @param listRemote function to list remote resources (for instance, all since a certain sync-token)
      */
-    protected open suspend fun syncRemote(listRemote: suspend (MultiResponseCallback) -> Unit) =
+    protected suspend fun syncRemote(listRemote: suspend (MultiResponseCallback) -> Unit) =
         coroutineScope {    // structured concurrency
             val batchDownloader = BatchDownloader { batch ->
                 launch {
@@ -667,7 +667,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
 
     protected abstract fun listAllRemote(): Flow<MultiStatusItem>
 
-    protected open suspend fun listRemoteChanges(
+    protected suspend fun listRemoteChanges(
         syncState: SyncState?,
         callback: MultiResponseCallback
     ): Pair<SyncToken, Boolean> {
@@ -728,7 +728,7 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
      * Used together with [resetPresentRemotely] when a full listing has been received from
      * the server to locally delete resources which are not present remotely (anymore).
      */
-    protected open suspend fun deleteNotPresentRemotely() {
+    protected suspend fun deleteNotPresentRemotely() {
         val removed = localCollection.removeNotDirtyMarked(0)
         logger.info("Removed $removed local resources which are not present on the server anymore")
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -321,6 +321,9 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
      */
     protected abstract suspend fun queryCapabilities(): SyncState?
 
+
+    //region Processing of locally dirty/deleted items
+
     /**
      * Processes locally deleted entries. This can mean:
      *
@@ -536,6 +539,8 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
         local.clearDirty(Optional.of(newFileName), eTag, scheduleTag)
     }
 
+    //endregion
+
 
     /**
      * Determines whether a sync is required because there were changes on the server.
@@ -665,41 +670,6 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
             batchDownloader.flush()
         }
 
-    protected abstract fun listAllRemote(): Flow<MultiStatusItem>
-
-    protected suspend fun listRemoteChanges(
-        syncState: SyncState?,
-        callback: MultiResponseCallback
-    ): Pair<SyncToken, Boolean> {
-        var furtherResults = false
-
-        val report = davCollection.reportChanges(
-            syncState?.takeIf { syncState.type == SyncState.Type.SYNC_TOKEN }?.value,
-            false, null,
-            WebDAV.GetETag
-        ).forEachResponse { response, relation ->
-            when (relation) {
-                Response.HrefRelation.SELF ->
-                    furtherResults = response.status == HttpStatusCode.InsufficientStorage
-
-                Response.HrefRelation.MEMBER ->
-                    callback(response, relation)
-
-                else ->
-                    logger.fine("Unexpected sync-collection response: $response")
-            }
-        }
-
-        var syncToken: SyncToken? = null
-        report.filterIsInstance<SyncToken>().firstOrNull()?.let {
-            syncToken = it
-        }
-        if (syncToken == null)
-            throw DavException("Received sync-collection response without sync-token")
-
-        return Pair(syncToken, furtherResults)
-    }
-
     /**
      * Downloads and processes resources, given as a list of URLs. Will be called with a list
      * of changed/new remote resources.
@@ -739,10 +709,55 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
     protected abstract suspend fun postProcess()
 
 
-    // sync helpers
+    //region Sync algorithm-specific: PROPFIND/REPORT
 
     private suspend fun querySyncState(): SyncState? =
         davCollection.propfind(0, CalDAV.GetCTag, WebDAV.SyncToken).selfResponse()?.syncState()
+
+    protected abstract fun listAllRemote(): Flow<MultiStatusItem>
+
+    //endregion
+
+
+    //region Sync algorithm-specific: collection-sync
+
+    protected suspend fun listRemoteChanges(
+        syncState: SyncState?,
+        callback: MultiResponseCallback
+    ): Pair<SyncToken, Boolean> {
+        var furtherResults = false
+
+        val report = davCollection.reportChanges(
+            syncState?.takeIf { syncState.type == SyncState.Type.SYNC_TOKEN }?.value,
+            false, null,
+            WebDAV.GetETag
+        ).forEachResponse { response, relation ->
+            when (relation) {
+                Response.HrefRelation.SELF ->
+                    furtherResults = response.status == HttpStatusCode.InsufficientStorage
+
+                Response.HrefRelation.MEMBER ->
+                    callback(response, relation)
+
+                else ->
+                    logger.fine("Unexpected sync-collection response: $response")
+            }
+        }
+
+        var syncToken: SyncToken? = null
+        report.filterIsInstance<SyncToken>().firstOrNull()?.let {
+            syncToken = it
+        }
+        if (syncToken == null)
+            throw DavException("Received sync-collection response without sync-token")
+
+        return Pair(syncToken, furtherResults)
+    }
+
+    //endregion
+
+
+    // sync helpers
 
     /**
      * Logs the exception, updates sync result and shows a notification to the user.

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
@@ -24,6 +24,7 @@ import at.bitfire.davdroid.di.qualifier.SyncTransferSemaphore
 import at.bitfire.davdroid.resource.LocalResource
 import at.bitfire.davdroid.resource.LocalTask
 import at.bitfire.davdroid.resource.LocalTaskList
+import at.bitfire.davdroid.resource.syncState
 import at.bitfire.davdroid.util.DavUtils
 import at.bitfire.davdroid.util.DavUtils.lastSegment
 import at.bitfire.synctools.exception.InvalidResourceException
@@ -110,7 +111,7 @@ class TasksSyncManager @AssistedInject constructor(
                 logger.info("Calendar accepts tasks up to ${Formatter.formatFileSize(context, maxSize)}")
             }
 
-            syncState(response)
+            response.syncState()
         }
 
     override fun syncAlgorithm() = SyncAlgorithm.PROPFIND_REPORT


### PR DESCRIPTION
### Purpose

Improves the readability of `SyncManager` by reorganizing existing code into clearer regions and extracting inline logic into named methods.

Related to / preparation of #2519. In a later phase, we can extract functionality into separate classes.
**Should be merged before #2739 and #2691 are addressed** because they can then be implemented with less risk.

### Short description

> [!NOTE]
> This PR is purely mechanical — no behavior, control flow, or logic was changed.

- Extracted sync-state extraction (`GetCTag`/`SyncToken` → `SyncState`) into a `Response.syncState()` extension function.
- Removed unnecessary `open` modifiers from `SyncManager` methods that aren't overridden anywhere.
- Moved sync algorithm-specific methods into separate commented regions.
- Extracted the `SyncAlgorithm.PROPFIND_REPORT` and `SyncAlgorithm.COLLECTION_SYNC` branch bodies out of `performSync()`'s `when` block into two new private methods (`syncPropfindReport()`, `syncCollectionSync()`).

No functional changes are included — this is code movement and structuring only.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.