### PR TITLE
[SyncManager] Simplify `localCollection` argument

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/TestSyncManager.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/TestSyncManager.kt
@@ -34,17 +34,16 @@ class TestSyncManager @AssistedInject constructor(
     @Assisted accountId: AccountId,
     @Assisted httpClient: HttpClient,
     @Assisted syncResult: SyncResult,
-    @Assisted localCollection: LocalTestCollection,
+    @Assisted override val localCollection: LocalTestCollection,
     @Assisted collection: Collection,
     @Assisted settings: SyncSettings,
     @IoDispatcher ioDispatcher: CoroutineDispatcher,
     @SyncTransferSemaphore syncTransferSemaphore: Semaphore
-): SyncManager<LocalTestResource, LocalTestCollection, DavCollection>(
+): SyncManager<LocalTestResource, DavCollection>(
     accountId,
     httpClient,
     SyncDataType.EVENTS,
     syncResult,
-    localCollection,
     collection,
     resync = null,
     ioDispatcher,

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
@@ -64,19 +64,18 @@ class CalendarSyncManager @AssistedInject constructor(
     @Assisted accountId: AccountId,
     @Assisted httpClient: HttpClient,
     @Assisted syncResult: SyncResult,
-    @Assisted localCalendar: LocalCalendar,
+    @Assisted override val localCollection: LocalCalendar,
     @Assisted collection: Collection,
     @Assisted resync: ResyncType?,
     @Assisted settings: SyncSettings,
     @IoDispatcher ioDispatcher: CoroutineDispatcher,
     private val productIds: ProductIds,
     @SyncTransferSemaphore syncTransferSemaphore: Semaphore
-) : SyncManager<LocalEvent, LocalCalendar, DavCalendar>(
+) : SyncManager<LocalEvent, DavCalendar>(
     accountId,
     httpClient,
     SyncDataType.EVENTS,
     syncResult,
-    localCalendar,
     collection,
     resync,
     ioDispatcher,

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
@@ -105,7 +105,7 @@ class ContactsSyncManager @AssistedInject constructor(
     @Assisted httpClient: HttpClient,
     @Assisted syncResult: SyncResult,
     @Assisted val provider: ContentProviderClient,
-    @Assisted localAddressBook: LocalAddressBook,
+    @Assisted override val localCollection: LocalAddressBook,
     @Assisted collection: Collection,
     @Assisted resync: ResyncType?,
     @Assisted val syncFrameworkUpload: Boolean,
@@ -115,12 +115,11 @@ class ContactsSyncManager @AssistedInject constructor(
     private val productIds: ProductIds,
     private val resourceRetrieverFactory: ResourceRetriever.Factory,
     @SyncTransferSemaphore syncTransferSemaphore: Semaphore
-): SyncManager<LocalAddress, LocalAddressBook, DavAddressBook>(
+): SyncManager<LocalAddress, DavAddressBook>(
     accountId,
     httpClient,
     SyncDataType.CONTACTS,
     syncResult,
-    localAddressBook,
     collection,
     resync,
     ioDispatcher,
@@ -149,8 +148,8 @@ class ContactsSyncManager @AssistedInject constructor(
 
     private var hasVCard4 = false
     private val groupStrategy = when (settings.groupMethod) {
-        GroupMethod.GROUP_VCARDS -> VCard4Strategy(localAddressBook)
-        GroupMethod.CATEGORIES -> CategoriesStrategy(localAddressBook)
+        GroupMethod.GROUP_VCARDS -> VCard4Strategy(localCollection)
+        GroupMethod.CATEGORIES -> CategoriesStrategy(localCollection)
     }
 
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
@@ -59,19 +59,18 @@ class JtxSyncManager @AssistedInject constructor(
     @Assisted accountId: AccountId,
     @Assisted httpClient: HttpClient,
     @Assisted syncResult: SyncResult,
-    @Assisted localCollection: LocalJtxCollection,
+    @Assisted override val localCollection: LocalJtxCollection,
     @Assisted collection: Collection,
     @Assisted resync: ResyncType?,
     @Assisted settings: SyncSettings,
     @IoDispatcher ioDispatcher: CoroutineDispatcher,
     private val productIds: ProductIds,
     @SyncTransferSemaphore syncTransferSemaphore: Semaphore
-): SyncManager<LocalJtxObject, LocalJtxCollection, DavCalendar>(
+): SyncManager<LocalJtxObject, DavCalendar>(
     accountId,
     httpClient,
     SyncDataType.TASKS,
     syncResult,
-    localCollection,
     collection,
     resync,
     ioDispatcher,

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -75,24 +75,21 @@ import javax.net.ssl.SSLHandshakeException
  * Synchronizes a local collection with a remote collection.
  *
  * @param LocalType         type of local resources
- * @param CollectionType    type of local collection
  * @param RemoteType        type of remote collection
  *
  * @param accountId         [AccountId] of the account to synchronize
  * @param httpClient        HTTP client to use for network requests, already authenticated with credentials from the account
  * @param dataType          data type to synchronize
  * @param syncResult        receiver for result of the synchronization (will be updated by [performSync])
- * @param localCollection   local collection to synchronize (interface to content provider)
  * @param collection        collection info in the database
  * @param resync            whether re-synchronization is requested
  * @param settings          snapshot of the account settings relevant for this sync run
  */
-abstract class SyncManager<LocalType : LocalResource, out CollectionType : LocalCollection<LocalType>, RemoteType : DavCollection>(
+abstract class SyncManager<LocalType : LocalResource, RemoteType : DavCollection>(
     val accountId: AccountId,
     val httpClient: HttpClient,
     val dataType: SyncDataType,
     val syncResult: SyncResult,
-    val localCollection: CollectionType,
     val collection: Collection,
     val resync: ResyncType?,
     val ioDispatcher: CoroutineDispatcher,
@@ -131,6 +128,9 @@ abstract class SyncManager<LocalType : LocalResource, out CollectionType : Local
     @Inject
     lateinit var syncNotificationManagerFactory: SyncNotificationManager.Factory
 
+
+    /** local collection to synchronize (interface to content provider) */
+    protected abstract val localCollection: LocalCollection<LocalType>
 
     protected lateinit var davCollection: RemoteType
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
@@ -61,19 +61,18 @@ class TasksSyncManager @AssistedInject constructor(
     @Assisted accountId: AccountId,
     @Assisted httpClient: HttpClient,
     @Assisted syncResult: SyncResult,
-    @Assisted localCollection: LocalTaskList,
+    @Assisted override val localCollection: LocalTaskList,
     @Assisted collection: Collection,
     @Assisted resync: ResyncType?,
     @Assisted settings: SyncSettings,
     @IoDispatcher ioDispatcher: CoroutineDispatcher,
     private val productIds: ProductIds,
     @SyncTransferSemaphore syncTransferSemaphore: Semaphore
-): SyncManager<LocalTask, LocalTaskList, DavCalendar>(
+): SyncManager<LocalTask, DavCalendar>(
     accountId,
     httpClient,
     SyncDataType.TASKS,
     syncResult,
-    localCollection,
     collection,
     resync,
     ioDispatcher,


### PR DESCRIPTION
- `SyncManager`: remove `CollectionType` generic type and constructor arg, use abstract `LocalCollection` member instead
- `*SyncManager`: implement abstract member with specific class