### PR TITLE
Create `davCollection` in `Syncer` instead of `SyncManager`

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/CalendarSyncManagerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/CalendarSyncManagerTest.kt
@@ -5,7 +5,6 @@
 package at.bitfire.davdroid.sync
 
 import android.Manifest
-import android.accounts.Account
 import android.content.ContentProviderClient
 import android.content.Context
 import android.content.Entity
@@ -14,7 +13,6 @@ import android.provider.CalendarContract.Calendars
 import android.provider.CalendarContract.Events
 import androidx.core.content.contentValuesOf
 import androidx.test.rule.GrantPermissionRule
-import at.bitfire.davdroid.accounts.AccountId
 import at.bitfire.davdroid.accounts.LegacyAccount
 import at.bitfire.davdroid.accounts.toAndroidAccount
 import at.bitfire.davdroid.resource.LocalCalendar
@@ -141,7 +139,8 @@ class CalendarSyncManagerTest {
         httpClient = mockk(),
         syncResult = mockk(),
         localCalendar = mockk(),
-        collection = mockk(),
+        collectionInfo = mockk(),
+        davCollection = mockk(),
         resync = mockk(),
         settings = SyncSettingsFixtures.default()
     )

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/JtxSyncManagerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/JtxSyncManagerTest.kt
@@ -6,6 +6,7 @@ package at.bitfire.davdroid.sync
 
 import android.content.ContentProviderClient
 import android.content.Context
+import at.bitfire.dav4jvm.ktor.DavCalendar
 import at.bitfire.davdroid.accounts.LegacyAccount
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service
@@ -94,12 +95,14 @@ class JtxSyncManagerTest {
             url = "https://example.com".toUrl()
         )
         localJtxCollection = runBlocking { localJtxCollectionStore.create(provider, dbCollection) }
+        val httpClient = httpClientBuilder.build()
         syncManager = jtxSyncManagerFactory.jtxSyncManager(
             accountId = accountId,
-            httpClient = httpClientBuilder.build(),
+            httpClient = httpClient,
             syncResult = SyncResult(),
             localCollection = localJtxCollection,
-            collection = dbCollection,
+            collectionInfo = dbCollection,
+            davCollection = DavCalendar(httpClient, dbCollection.url),
             resync = null,
             settings = SyncSettingsFixtures.default()
         )

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncManagerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncManagerTest.kt
@@ -7,6 +7,7 @@ package at.bitfire.davdroid.sync
 import android.content.Context
 import androidx.core.app.NotificationManagerCompat
 import androidx.hilt.work.HiltWorkerFactory
+import at.bitfire.dav4jvm.ktor.DavCollection
 import at.bitfire.dav4jvm.ktor.PropStat
 import at.bitfire.dav4jvm.ktor.Response
 import at.bitfire.dav4jvm.ktor.Response.HrefRelation
@@ -538,6 +539,7 @@ class SyncManagerTest {
         syncResult,
         localCollection,
         collection,
+        DavCollection(client, collection.url),
         SyncSettingsFixtures.default()
     )
 

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncerTest.kt
@@ -192,7 +192,7 @@ class SyncerTest {
         override suspend fun syncCollection(
             provider: ContentProviderClient,
             localCollection: LocalTestCollection,
-            remoteCollection: Collection
+            remoteCollectionInfo: Collection
         ) {
             throw NotImplementedError()
         }

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/TestSyncManager.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/TestSyncManager.kt
@@ -35,7 +35,7 @@ class TestSyncManager @AssistedInject constructor(
     @Assisted httpClient: HttpClient,
     @Assisted syncResult: SyncResult,
     @Assisted override val localCollection: LocalTestCollection,
-    @Assisted collection: Collection,
+    @Assisted collectionInfo: Collection,
     @Assisted override val davCollection: DavCollection,
     @Assisted settings: SyncSettings,
     @IoDispatcher ioDispatcher: CoroutineDispatcher,
@@ -45,7 +45,7 @@ class TestSyncManager @AssistedInject constructor(
     httpClient,
     SyncDataType.EVENTS,
     syncResult,
-    collection,
+    collectionInfo,
     resync = null,
     ioDispatcher,
     syncTransferSemaphore,
@@ -59,7 +59,7 @@ class TestSyncManager @AssistedInject constructor(
             httpClient: HttpClient,
             syncResult: SyncResult,
             localCollection: LocalTestCollection,
-            collection: Collection,
+            collectionInfo: Collection,
             davCollection: DavCollection,
             settings: SyncSettings
         ): TestSyncManager

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/TestSyncManager.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/TestSyncManager.kt
@@ -36,10 +36,11 @@ class TestSyncManager @AssistedInject constructor(
     @Assisted syncResult: SyncResult,
     @Assisted override val localCollection: LocalTestCollection,
     @Assisted collection: Collection,
+    @Assisted override val davCollection: DavCollection,
     @Assisted settings: SyncSettings,
     @IoDispatcher ioDispatcher: CoroutineDispatcher,
     @SyncTransferSemaphore syncTransferSemaphore: Semaphore
-): SyncManager<LocalTestResource, DavCollection>(
+) : SyncManager<LocalTestResource>(
     accountId,
     httpClient,
     SyncDataType.EVENTS,
@@ -59,13 +60,9 @@ class TestSyncManager @AssistedInject constructor(
             syncResult: SyncResult,
             localCollection: LocalTestCollection,
             collection: Collection,
+            davCollection: DavCollection,
             settings: SyncSettings
         ): TestSyncManager
-    }
-
-    override suspend fun prepare(): Boolean {
-        davCollection = DavCollection(httpClient, collection.url)
-        return true
     }
 
     var didQueryCapabilities = false

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
@@ -6,7 +6,6 @@ package at.bitfire.davdroid.resource
 
 import android.provider.CalendarContract.Calendars
 import android.provider.CalendarContract.Events
-import androidx.annotation.VisibleForTesting
 import androidx.core.content.contentValuesOf
 import at.bitfire.synctools.storage.BatchOperation
 import at.bitfire.synctools.storage.calendar.AndroidCalendar
@@ -57,7 +56,6 @@ class LocalCalendar @AssistedInject constructor(
             androidCalendar.writeSyncState(state.toString())
         }
 
-    @VisibleForTesting
     internal val recurringCalendar = AndroidRecurringCalendar(androidCalendar)
 
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
@@ -7,6 +7,7 @@ package at.bitfire.davdroid.sync
 import android.accounts.AccountManager
 import android.content.ContentProviderClient
 import android.provider.ContactsContract
+import at.bitfire.dav4jvm.ktor.DavAddressBook
 import at.bitfire.davdroid.accounts.AccountId
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service
@@ -77,7 +78,7 @@ class AddressBookSyncer @AssistedInject constructor(
      * Synchronizes an address book
      *
      * @param addressBook       local address book
-     * @param provideHttpClient returns HTTP client on demand
+     * @param provideHttpClient returns HTTP client on demand (no need to close)
      * @param provider          content provider to access android contacts
      * @param syncResult        stores hard and soft sync errors
      * @param collection        the database collection associated with this address book
@@ -93,16 +94,18 @@ class AddressBookSyncer @AssistedInject constructor(
         try {
             handleGroupMethodChange(addressBook, provider)
 
+            val httpClient = provideHttpClient()
             val syncManager = contactsSyncManagerFactory.contactsSyncManager(
-                accountId,
-                provideHttpClient(),
-                syncResult,
-                provider,
-                addressBook,
-                collection,
-                resync,
-                syncFrameworkUpload,
-                settings
+                accountId = accountId,
+                httpClient = httpClient,
+                syncResult = syncResult,
+                provider = provider,
+                localAddressBook = addressBook,
+                collection = collection,
+                davCollection = DavAddressBook(httpClient, collection.url),
+                resync = resync,
+                syncFrameworkUpload = syncFrameworkUpload,
+                settings = settings
             )
             syncManager.performSync()
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
@@ -61,7 +61,7 @@ class AddressBookSyncer @AssistedInject constructor(
     override suspend fun syncCollection(
         provider: ContentProviderClient,
         localCollection: LocalAddressBook,
-        remoteCollection: Collection
+        remoteCollectionInfo: Collection
     ) {
         logger.log(Level.INFO, "Synchronizing address book: {0}", arrayOf(localCollection.addressBookAccount.name))
         syncAddressBook(
@@ -70,7 +70,7 @@ class AddressBookSyncer @AssistedInject constructor(
             provideHttpClient = { httpClient },
             provider = provider,
             syncResult = syncResult,
-            collection = remoteCollection
+            collection = remoteCollectionInfo
         )
     }
 
@@ -101,7 +101,7 @@ class AddressBookSyncer @AssistedInject constructor(
                 syncResult = syncResult,
                 provider = provider,
                 localAddressBook = addressBook,
-                collection = collection,
+                collectionInfo = collection,
                 davCollection = DavAddressBook(httpClient, collection.url),
                 resync = resync,
                 syncFrameworkUpload = syncFrameworkUpload,

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
@@ -94,9 +94,10 @@ class AddressBookSyncer @AssistedInject constructor(
         try {
             handleGroupMethodChange(addressBook, provider)
 
+            val httpClient = provideHttpClient()
             val syncManager = contactsSyncManagerFactory.contactsSyncManager(
                 accountId = accountId,
-                httpClient = provideHttpClient(),
+                httpClient = httpClient,
                 syncResult = syncResult,
                 provider = provider,
                 localAddressBook = addressBook,

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
@@ -94,10 +94,9 @@ class AddressBookSyncer @AssistedInject constructor(
         try {
             handleGroupMethodChange(addressBook, provider)
 
-            val httpClient = provideHttpClient()
             val syncManager = contactsSyncManagerFactory.contactsSyncManager(
                 accountId = accountId,
-                httpClient = httpClient,
+                httpClient = provideHttpClient(),
                 syncResult = syncResult,
                 provider = provider,
                 localAddressBook = addressBook,

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
@@ -67,7 +67,7 @@ class AddressBookSyncer @AssistedInject constructor(
         syncAddressBook(
             accountId = accountId,
             addressBook = localCollection,
-            provideHttpClient = { httpClient },
+            httpClient = httpClient,
             provider = provider,
             syncResult = syncResult,
             collection = remoteCollectionInfo
@@ -78,7 +78,7 @@ class AddressBookSyncer @AssistedInject constructor(
      * Synchronizes an address book
      *
      * @param addressBook       local address book
-     * @param provideHttpClient returns HTTP client on demand (no need to close)
+     * @param httpClient        HTTP client to use for network requests
      * @param provider          content provider to access android contacts
      * @param syncResult        stores hard and soft sync errors
      * @param collection        the database collection associated with this address book
@@ -86,7 +86,7 @@ class AddressBookSyncer @AssistedInject constructor(
     private suspend fun syncAddressBook(
         accountId: AccountId,
         addressBook: LocalAddressBook,
-        provideHttpClient: () -> HttpClient,
+        httpClient: HttpClient,
         provider: ContentProviderClient,
         syncResult: SyncResult,
         collection: Collection
@@ -94,7 +94,6 @@ class AddressBookSyncer @AssistedInject constructor(
         try {
             handleGroupMethodChange(addressBook, provider)
 
-            val httpClient = provideHttpClient()
             val syncManager = contactsSyncManagerFactory.contactsSyncManager(
                 accountId = accountId,
                 httpClient = httpClient,

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
@@ -66,12 +66,13 @@ class CalendarSyncManager @AssistedInject constructor(
     @Assisted syncResult: SyncResult,
     @Assisted override val localCollection: LocalCalendar,
     @Assisted collection: Collection,
+    @Assisted override val davCollection: DavCalendar,
     @Assisted resync: ResyncType?,
     @Assisted settings: SyncSettings,
     @IoDispatcher ioDispatcher: CoroutineDispatcher,
     private val productIds: ProductIds,
     @SyncTransferSemaphore syncTransferSemaphore: Semaphore
-) : SyncManager<LocalEvent, DavCalendar>(
+) : SyncManager<LocalEvent>(
     accountId,
     httpClient,
     SyncDataType.EVENTS,
@@ -91,6 +92,7 @@ class CalendarSyncManager @AssistedInject constructor(
             syncResult: SyncResult,
             localCalendar: LocalCalendar,
             collection: Collection,
+            davCollection: DavCalendar,
             resync: ResyncType?,
             settings: SyncSettings
         ): CalendarSyncManager
@@ -98,8 +100,6 @@ class CalendarSyncManager @AssistedInject constructor(
 
 
     override suspend fun prepare(): Boolean {
-        davCollection = DavCalendar(httpClient, collection.url)
-
         // if there are dirty exceptions for events, mark their master events as dirty, too
         val recurringCalendar = localCollection.recurringCalendar
         recurringCalendar.processDeletedExceptions()

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
@@ -65,7 +65,7 @@ class CalendarSyncManager @AssistedInject constructor(
     @Assisted httpClient: HttpClient,
     @Assisted syncResult: SyncResult,
     @Assisted override val localCollection: LocalCalendar,
-    @Assisted collection: Collection,
+    @Assisted collectionInfo: Collection,
     @Assisted override val davCollection: DavCalendar,
     @Assisted resync: ResyncType?,
     @Assisted settings: SyncSettings,
@@ -77,7 +77,7 @@ class CalendarSyncManager @AssistedInject constructor(
     httpClient,
     SyncDataType.EVENTS,
     syncResult,
-    collection,
+    collectionInfo,
     resync,
     ioDispatcher,
     syncTransferSemaphore,
@@ -91,7 +91,7 @@ class CalendarSyncManager @AssistedInject constructor(
             httpClient: HttpClient,
             syncResult: SyncResult,
             localCalendar: LocalCalendar,
-            collection: Collection,
+            collectionInfo: Collection,
             davCollection: DavCalendar,
             resync: ResyncType?,
             settings: SyncSettings
@@ -112,7 +112,7 @@ class CalendarSyncManager @AssistedInject constructor(
     }
 
     override suspend fun queryCapabilities(): SyncState? =
-        collection.url.withExceptionContext {
+        collectionInfo.url.withExceptionContext {
             val response = davCollection.propfind(
                 0,
                 CalDAV.MaxResourceSize,
@@ -181,7 +181,7 @@ class CalendarSyncManager @AssistedInject constructor(
             ZonedDateTime.now().minusDays(pastDays.toLong()).toInstant()
         }
 
-        collection.url.withExceptionContext {
+        collectionInfo.url.withExceptionContext {
             logger.info("Querying events since $limitStart")
             emitAll(davCollection.calendarQuery(Component.VEVENT, limitStart, null))
         }
@@ -189,7 +189,7 @@ class CalendarSyncManager @AssistedInject constructor(
 
     override suspend fun downloadRemote(bunch: List<Url>) {
         logger.info("Downloading ${bunch.size} iCalendars: $bunch")
-        collection.url.withExceptionContext {
+        collectionInfo.url.withExceptionContext {
             davCollection.multiget(bunch).responses().collect { response ->
                 /*
                  * Real-world servers may return:

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncer.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncer.kt
@@ -5,8 +5,8 @@
 package at.bitfire.davdroid.sync
 
 import android.content.ContentProviderClient
+import at.bitfire.dav4jvm.ktor.DavCalendar
 import at.bitfire.davdroid.accounts.AccountId
-import at.bitfire.davdroid.accounts.AndroidAccountManager
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service
 import at.bitfire.davdroid.resource.LocalCalendar
@@ -75,13 +75,14 @@ class CalendarSyncer @AssistedInject constructor(
         )
 
         val syncManager = calendarSyncManagerFactory.calendarSyncManager(
-            accountId,
-            httpClient,
-            syncResult,
-            localCollection,
-            remoteCollection,
-            resync,
-            settings
+            accountId = accountId,
+            httpClient = httpClient,
+            syncResult = syncResult,
+            localCalendar = localCollection,
+            collection = remoteCollection,
+            davCollection = DavCalendar(httpClient, remoteCollection.url),
+            resync = resync,
+            settings = settings
         )
         syncManager.performSync()
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncer.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncer.kt
@@ -62,7 +62,7 @@ class CalendarSyncer @AssistedInject constructor(
     override suspend fun syncCollection(
         provider: ContentProviderClient,
         localCollection: LocalCalendar,
-        remoteCollection: Collection
+        remoteCollectionInfo: Collection
     ) {
         logger.log(
             Level.INFO,
@@ -79,8 +79,8 @@ class CalendarSyncer @AssistedInject constructor(
             httpClient = httpClient,
             syncResult = syncResult,
             localCalendar = localCollection,
-            collection = remoteCollection,
-            davCollection = DavCalendar(httpClient, remoteCollection.url),
+            collectionInfo = remoteCollectionInfo,
+            davCollection = DavCalendar(httpClient, remoteCollectionInfo.url),
             resync = resync,
             settings = settings
         )

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
@@ -107,6 +107,7 @@ class ContactsSyncManager @AssistedInject constructor(
     @Assisted val provider: ContentProviderClient,
     @Assisted override val localCollection: LocalAddressBook,
     @Assisted collection: Collection,
+    @Assisted override val davCollection: DavAddressBook,
     @Assisted resync: ResyncType?,
     @Assisted val syncFrameworkUpload: Boolean,
     @Assisted settings: SyncSettings,
@@ -115,7 +116,7 @@ class ContactsSyncManager @AssistedInject constructor(
     private val productIds: ProductIds,
     private val resourceRetrieverFactory: ResourceRetriever.Factory,
     @SyncTransferSemaphore syncTransferSemaphore: Semaphore
-): SyncManager<LocalAddress, DavAddressBook>(
+) : SyncManager<LocalAddress>(
     accountId,
     httpClient,
     SyncDataType.CONTACTS,
@@ -136,6 +137,7 @@ class ContactsSyncManager @AssistedInject constructor(
             provider: ContentProviderClient,
             localAddressBook: LocalAddressBook,
             collection: Collection,
+            davCollection: DavAddressBook,
             resync: ResyncType?,
             syncFrameworkUpload: Boolean,
             settings: SyncSettings
@@ -159,8 +161,6 @@ class ContactsSyncManager @AssistedInject constructor(
             if (!dirtyVerifier.get().prepareAddressBook(localCollection, isUpload = syncFrameworkUpload))
                 return false
         }
-
-        davCollection = DavAddressBook(httpClient, collection.url)
 
         logger.info("Contact group strategy: ${groupStrategy::class.java.simpleName}")
         return true

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
@@ -106,7 +106,7 @@ class ContactsSyncManager @AssistedInject constructor(
     @Assisted syncResult: SyncResult,
     @Assisted val provider: ContentProviderClient,
     @Assisted override val localCollection: LocalAddressBook,
-    @Assisted collection: Collection,
+    @Assisted collectionInfo: Collection,
     @Assisted override val davCollection: DavAddressBook,
     @Assisted resync: ResyncType?,
     @Assisted val syncFrameworkUpload: Boolean,
@@ -121,7 +121,7 @@ class ContactsSyncManager @AssistedInject constructor(
     httpClient,
     SyncDataType.CONTACTS,
     syncResult,
-    collection,
+    collectionInfo,
     resync,
     ioDispatcher,
     syncTransferSemaphore,
@@ -136,7 +136,7 @@ class ContactsSyncManager @AssistedInject constructor(
             syncResult: SyncResult,
             provider: ContentProviderClient,
             localAddressBook: LocalAddressBook,
-            collection: Collection,
+            collectionInfo: Collection,
             davCollection: DavAddressBook,
             resync: ResyncType?,
             syncFrameworkUpload: Boolean,
@@ -167,7 +167,7 @@ class ContactsSyncManager @AssistedInject constructor(
     }
 
     override suspend fun queryCapabilities(): SyncState? {
-        return collection.url.withExceptionContext {
+        return collectionInfo.url.withExceptionContext {
             val response = davCollection.propfind(
                 0,
                 CardDAV.MaxResourceSize,
@@ -252,14 +252,14 @@ class ContactsSyncManager @AssistedInject constructor(
     }
 
     override fun listAllRemote(): Flow<MultiStatusItem> = flow {
-        collection.url.withExceptionContext {
+        collectionInfo.url.withExceptionContext {
             emitAll(davCollection.propfind(1, WebDAV.ResourceType, WebDAV.GetETag))
         }
     }
 
     override suspend fun downloadRemote(bunch: List<Url>) {
         logger.info("Downloading ${bunch.size} vCard(s): $bunch")
-        collection.url.withExceptionContext {
+        collectionInfo.url.withExceptionContext {
             val contentType: String?
             val version: String?
             when {

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
@@ -61,12 +61,13 @@ class JtxSyncManager @AssistedInject constructor(
     @Assisted syncResult: SyncResult,
     @Assisted override val localCollection: LocalJtxCollection,
     @Assisted collection: Collection,
+    @Assisted override val davCollection: DavCalendar,
     @Assisted resync: ResyncType?,
     @Assisted settings: SyncSettings,
     @IoDispatcher ioDispatcher: CoroutineDispatcher,
     private val productIds: ProductIds,
     @SyncTransferSemaphore syncTransferSemaphore: Semaphore
-): SyncManager<LocalJtxObject, DavCalendar>(
+) : SyncManager<LocalJtxObject>(
     accountId,
     httpClient,
     SyncDataType.TASKS,
@@ -86,17 +87,12 @@ class JtxSyncManager @AssistedInject constructor(
             syncResult: SyncResult,
             localCollection: LocalJtxCollection,
             collection: Collection,
+            davCollection: DavCalendar,
             resync: ResyncType?,
             settings: SyncSettings
         ): JtxSyncManager
     }
 
-
-    override suspend fun prepare(): Boolean {
-        davCollection = DavCalendar(httpClient, collection.url)
-
-        return true
-    }
 
     override suspend fun queryCapabilities() =
         collection.url.withExceptionContext {

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
@@ -60,7 +60,7 @@ class JtxSyncManager @AssistedInject constructor(
     @Assisted httpClient: HttpClient,
     @Assisted syncResult: SyncResult,
     @Assisted override val localCollection: LocalJtxCollection,
-    @Assisted collection: Collection,
+    @Assisted collectionInfo: Collection,
     @Assisted override val davCollection: DavCalendar,
     @Assisted resync: ResyncType?,
     @Assisted settings: SyncSettings,
@@ -72,7 +72,7 @@ class JtxSyncManager @AssistedInject constructor(
     httpClient,
     SyncDataType.TASKS,
     syncResult,
-    collection,
+    collectionInfo,
     resync,
     ioDispatcher,
     syncTransferSemaphore,
@@ -86,7 +86,7 @@ class JtxSyncManager @AssistedInject constructor(
             httpClient: HttpClient,
             syncResult: SyncResult,
             localCollection: LocalJtxCollection,
-            collection: Collection,
+            collectionInfo: Collection,
             davCollection: DavCalendar,
             resync: ResyncType?,
             settings: SyncSettings
@@ -95,7 +95,7 @@ class JtxSyncManager @AssistedInject constructor(
 
 
     override suspend fun queryCapabilities() =
-        collection.url.withExceptionContext {
+        collectionInfo.url.withExceptionContext {
             val response =
                 davCollection.propfind(0, CalDAV.GetCTag, CalDAV.MaxResourceSize, WebDAV.SyncToken).selfResponse()
                     ?: return@withExceptionContext null
@@ -143,7 +143,7 @@ class JtxSyncManager @AssistedInject constructor(
     override fun syncAlgorithm() = SyncAlgorithm.PROPFIND_REPORT
 
     override fun listAllRemote(): Flow<MultiStatusItem> = flow {
-        collection.url.withExceptionContext {
+        collectionInfo.url.withExceptionContext {
             if (localCollection.supportsVTODO) {
                 logger.info("Querying tasks")
                 emitAll(davCollection.calendarQuery("VTODO", null, null))
@@ -159,7 +159,7 @@ class JtxSyncManager @AssistedInject constructor(
     override suspend fun downloadRemote(bunch: List<Url>) {
         logger.info("Downloading ${bunch.size} iCalendars: $bunch")
         // multiple iCalendars, use calendar-multi-get
-        collection.url.withExceptionContext {
+        collectionInfo.url.withExceptionContext {
             davCollection.multiget(bunch).responses().collect { response ->
                 // See CalendarSyncManager for more information about the multi-get response
                 response.href.withExceptionContext wrapResource@{

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncer.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncer.kt
@@ -5,8 +5,8 @@
 package at.bitfire.davdroid.sync
 
 import android.content.ContentProviderClient
+import at.bitfire.dav4jvm.ktor.DavCalendar
 import at.bitfire.davdroid.accounts.AccountId
-import at.bitfire.davdroid.accounts.AndroidAccountManager
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service
 import at.bitfire.davdroid.resource.LocalJtxCollection
@@ -72,13 +72,14 @@ class JtxSyncer @AssistedInject constructor(
         logger.info("Synchronizing jtx collection $localCollection")
 
         val syncManager = jtxSyncManagerFactory.jtxSyncManager(
-            accountId,
-            httpClient,
-            syncResult,
-            localCollection,
-            remoteCollection,
-            resync,
-            settings
+            accountId = accountId,
+            httpClient = httpClient,
+            syncResult = syncResult,
+            localCollection = localCollection,
+            collection = remoteCollection,
+            davCollection = DavCalendar(httpClient, remoteCollection.url),
+            resync = resync,
+            settings = settings
         )
         syncManager.performSync()
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncer.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncer.kt
@@ -67,7 +67,7 @@ class JtxSyncer @AssistedInject constructor(
     override suspend fun syncCollection(
         provider: ContentProviderClient,
         localCollection: LocalJtxCollection,
-        remoteCollection: Collection
+        remoteCollectionInfo: Collection
     ) {
         logger.info("Synchronizing jtx collection $localCollection")
 
@@ -76,8 +76,8 @@ class JtxSyncer @AssistedInject constructor(
             httpClient = httpClient,
             syncResult = syncResult,
             localCollection = localCollection,
-            collection = remoteCollection,
-            davCollection = DavCalendar(httpClient, remoteCollection.url),
+            collectionInfo = remoteCollectionInfo,
+            davCollection = DavCalendar(httpClient, remoteCollectionInfo.url),
             resync = resync,
             settings = settings
         )

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -76,7 +76,6 @@ import javax.net.ssl.SSLHandshakeException
  * Synchronizes a local collection with a remote collection.
  *
  * @param LocalType         type of local resources
- * @param RemoteType        type of remote collection
  *
  * @param accountId         [AccountId] of the account to synchronize
  * @param httpClient        HTTP client to use for network requests, already authenticated with credentials from the account

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -86,7 +86,7 @@ import javax.net.ssl.SSLHandshakeException
  * @param resync            whether re-synchronization is requested
  * @param settings          snapshot of the account settings relevant for this sync run
  */
-abstract class SyncManager<LocalType : LocalResource, RemoteType : DavCollection>(
+abstract class SyncManager<LocalType : LocalResource>(
     val accountId: AccountId,
     val httpClient: HttpClient,
     val dataType: SyncDataType,
@@ -133,7 +133,7 @@ abstract class SyncManager<LocalType : LocalResource, RemoteType : DavCollection
     /** local collection to synchronize (interface to content provider) */
     protected abstract val localCollection: LocalCollection<LocalType>
 
-    protected lateinit var davCollection: RemoteType
+    protected abstract val davCollection: DavCollection
 
     protected var hasCollectionSync = false
 
@@ -232,11 +232,11 @@ abstract class SyncManager<LocalType : LocalResource, RemoteType : DavCollection
 
 
     /**
-     * Prepares synchronization. Sets the lateinit property [davCollection].
+     * Prepares synchronization.
      *
      * @return whether synchronization shall be performed
      */
-    protected abstract suspend fun prepare(): Boolean
+    protected open suspend fun prepare(): Boolean = true
 
     /**
      * Queries the server for synchronization capabilities like specific report types,

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -82,7 +82,7 @@ import javax.net.ssl.SSLHandshakeException
  * @param httpClient        HTTP client to use for network requests, already authenticated with credentials from the account
  * @param dataType          data type to synchronize
  * @param syncResult        receiver for result of the synchronization (will be updated by [performSync])
- * @param collection        collection info in the database
+ * @param collectionInfo    remote collection info in the database
  * @param resync            whether re-synchronization is requested
  * @param settings          snapshot of the account settings relevant for this sync run
  */
@@ -91,7 +91,7 @@ abstract class SyncManager<LocalType : LocalResource>(
     val httpClient: HttpClient,
     val dataType: SyncDataType,
     val syncResult: SyncResult,
-    val collection: Collection,
+    val collectionInfo: Collection,
     val resync: ResyncType?,
     val ioDispatcher: CoroutineDispatcher,
     val syncTransferSemaphore: Semaphore,
@@ -145,7 +145,7 @@ abstract class SyncManager<LocalType : LocalResource>(
      * Push-Dont-Notify header, added to PUT and DELETE requests if subscription exists.
      */
     private val pushDontNotifyHeader by lazy {
-        collection.pushSubscription?.let { pushSubscription ->
+        collectionInfo.pushSubscription?.let { pushSubscription ->
             mapOf("Push-Dont-Notify" to QuotedStringUtils.asQuotedString(pushSubscription))
         } ?: emptyMap()
     }
@@ -160,7 +160,7 @@ abstract class SyncManager<LocalType : LocalResource>(
                 logger.info("No reason to synchronize, aborting")
                 return@withContext
             }
-            syncStatsRepository.logSyncTime(collection.id, dataType)
+            syncStatsRepository.logSyncTime(collectionInfo.id, dataType)
 
             logger.info("Querying server capabilities")
             var remoteSyncState = queryCapabilities()
@@ -275,7 +275,7 @@ abstract class SyncManager<LocalType : LocalResource>(
                     val lastETag = if (lastScheduleTag == null) local.eTag else null
                     logger.info("$fileName has been deleted locally -> deleting from server (ETag $lastETag / schedule-tag $lastScheduleTag)")
 
-                    val url = URLBuilder(collection.url).appendPathSegments(fileName, encodeSlash = true).build()
+                    val url = URLBuilder(collectionInfo.url).appendPathSegments(fileName, encodeSlash = true).build()
                     val remote = DavResource(httpClient, url)
                     url.withExceptionContext {
                         try {
@@ -340,7 +340,7 @@ abstract class SyncManager<LocalType : LocalResource>(
         val upload = generateUpload(local)
 
         val fileName = existingFileName ?: upload.suggestedFileName
-        val uploadUrl = URLBuilder(collection.url).appendPathSegments(fileName, encodeSlash = true).build()
+        val uploadUrl = URLBuilder(collectionInfo.url).appendPathSegments(fileName, encodeSlash = true).build()
         val remote = DavResource(httpClient, uploadUrl)
 
         try {
@@ -832,7 +832,7 @@ abstract class SyncManager<LocalType : LocalResource>(
         syncNotificationManager.notifyInvalidResource(
             dataType,
             localCollection.tag,
-            collection,
+            collectionInfo,
             e,
             fileName,
             notifyInvalidResourceTitle()

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
@@ -79,10 +79,13 @@ abstract class Syncer<StoreType: LocalDataStore<CollectionType>, CollectionType:
         syncNotificationManagerFactory.create(accountId)
     }
 
-    @WillCloseWhenClosed
-    val httpClient by lazy {
+    private val lazyHttpClient = lazy {
         httpClientBuilder.fromAccount(accountId).build()
     }
+
+    /** authenticated HTTP client to be used by subclasses */
+    @WillCloseWhenClosed
+    val httpClient by lazyHttpClient
 
     /**
      * Creates, updates and/or deletes local collections (calendars, address books, etc) according to
@@ -222,7 +225,7 @@ abstract class Syncer<StoreType: LocalDataStore<CollectionType>, CollectionType:
     }
 
     override fun close() {
-        if (::httpClient.isInitialized)
+        if (lazyHttpClient.isInitialized())
             httpClient.close()
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
@@ -222,7 +222,8 @@ abstract class Syncer<StoreType: LocalDataStore<CollectionType>, CollectionType:
     }
 
     override fun close() {
-        httpClient.close()
+        if (::httpClient.isInitialized)
+            httpClient.close()
     }
 
     /**

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
@@ -248,13 +248,13 @@ abstract class Syncer<StoreType: LocalDataStore<CollectionType>, CollectionType:
      *
      * @param provider The content provider client to access the local collection to be updated
      * @param localCollection The local collection to be synchronized
-     * @param remoteCollection The database collection representing the remote collection. Contains
+     * @param remoteCollectionInfo The database collection representing the remote collection. Contains
      * remote address of the collection to be synchronized.
      */
     abstract suspend fun syncCollection(
         provider: ContentProviderClient,
         localCollection: CollectionType,
-        remoteCollection: Collection
+        remoteCollectionInfo: Collection
     )
 
     /**

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/TaskSyncer.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/TaskSyncer.kt
@@ -5,8 +5,8 @@
 package at.bitfire.davdroid.sync
 
 import android.content.ContentProviderClient
+import at.bitfire.dav4jvm.ktor.DavCalendar
 import at.bitfire.davdroid.accounts.AccountId
-import at.bitfire.davdroid.accounts.AndroidAccountManager
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service
 import at.bitfire.davdroid.resource.LocalTaskList
@@ -79,13 +79,14 @@ class TaskSyncer @AssistedInject constructor(
         )
 
         val syncManager = tasksSyncManagerFactory.tasksSyncManager(
-            accountId,
-            httpClient,
-            syncResult,
-            localCollection,
-            remoteCollection,
-            resync,
-            settings
+            accountId = accountId,
+            httpClient = httpClient,
+            syncResult = syncResult,
+            localCollection = localCollection,
+            collection = remoteCollection,
+            davCollection = DavCalendar(httpClient, remoteCollection.url),
+            resync = resync,
+            settings = settings
         )
         syncManager.performSync()
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/TaskSyncer.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/TaskSyncer.kt
@@ -70,7 +70,7 @@ class TaskSyncer @AssistedInject constructor(
     override suspend fun syncCollection(
         provider: ContentProviderClient,
         localCollection: LocalTaskList,
-        remoteCollection: Collection
+        remoteCollectionInfo: Collection
     ) {
         logger.log(
             Level.INFO,
@@ -83,8 +83,8 @@ class TaskSyncer @AssistedInject constructor(
             httpClient = httpClient,
             syncResult = syncResult,
             localCollection = localCollection,
-            collection = remoteCollection,
-            davCollection = DavCalendar(httpClient, remoteCollection.url),
+            collectionInfo = remoteCollectionInfo,
+            davCollection = DavCalendar(httpClient, remoteCollectionInfo.url),
             resync = resync,
             settings = settings
         )

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
@@ -63,12 +63,13 @@ class TasksSyncManager @AssistedInject constructor(
     @Assisted syncResult: SyncResult,
     @Assisted override val localCollection: LocalTaskList,
     @Assisted collection: Collection,
+    @Assisted override val davCollection: DavCalendar,
     @Assisted resync: ResyncType?,
     @Assisted settings: SyncSettings,
     @IoDispatcher ioDispatcher: CoroutineDispatcher,
     private val productIds: ProductIds,
     @SyncTransferSemaphore syncTransferSemaphore: Semaphore
-): SyncManager<LocalTask, DavCalendar>(
+) : SyncManager<LocalTask>(
     accountId,
     httpClient,
     SyncDataType.TASKS,
@@ -88,17 +89,12 @@ class TasksSyncManager @AssistedInject constructor(
             syncResult: SyncResult,
             localCollection: LocalTaskList,
             collection: Collection,
+            davCollection: DavCalendar,
             resync: ResyncType?,
             settings: SyncSettings
         ): TasksSyncManager
     }
 
-
-    override suspend fun prepare(): Boolean {
-        davCollection = DavCalendar(httpClient, collection.url)
-
-        return true
-    }
 
     override suspend fun queryCapabilities() =
         collection.url.withExceptionContext {

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
@@ -62,7 +62,7 @@ class TasksSyncManager @AssistedInject constructor(
     @Assisted httpClient: HttpClient,
     @Assisted syncResult: SyncResult,
     @Assisted override val localCollection: LocalTaskList,
-    @Assisted collection: Collection,
+    @Assisted collectionInfo: Collection,
     @Assisted override val davCollection: DavCalendar,
     @Assisted resync: ResyncType?,
     @Assisted settings: SyncSettings,
@@ -74,7 +74,7 @@ class TasksSyncManager @AssistedInject constructor(
     httpClient,
     SyncDataType.TASKS,
     syncResult,
-    collection,
+    collectionInfo,
     resync,
     ioDispatcher,
     syncTransferSemaphore,
@@ -88,7 +88,7 @@ class TasksSyncManager @AssistedInject constructor(
             httpClient: HttpClient,
             syncResult: SyncResult,
             localCollection: LocalTaskList,
-            collection: Collection,
+            collectionInfo: Collection,
             davCollection: DavCalendar,
             resync: ResyncType?,
             settings: SyncSettings
@@ -97,7 +97,7 @@ class TasksSyncManager @AssistedInject constructor(
 
 
     override suspend fun queryCapabilities() =
-        collection.url.withExceptionContext {
+        collectionInfo.url.withExceptionContext {
             val response =
                 davCollection.propfind(0, CalDAV.MaxResourceSize, CalDAV.GetCTag, WebDAV.SyncToken).selfResponse()
                     ?: return@withExceptionContext null
@@ -148,7 +148,7 @@ class TasksSyncManager @AssistedInject constructor(
     }
 
     override fun listAllRemote(): Flow<MultiStatusItem> = flow {
-        collection.url.withExceptionContext {
+        collectionInfo.url.withExceptionContext {
             logger.info("Querying tasks")
             emitAll(davCollection.calendarQuery("VTODO", null, null))
         }
@@ -157,7 +157,7 @@ class TasksSyncManager @AssistedInject constructor(
     override suspend fun downloadRemote(bunch: List<Url>) {
         logger.info("Downloading ${bunch.size} iCalendars: $bunch")
         // multiple iCalendars, use calendar-multi-get
-        collection.url.withExceptionContext {
+        collectionInfo.url.withExceptionContext {
             davCollection.multiget(bunch).responses().collect { response ->
                 // See CalendarSyncManager for more information about the multi-get response
                 response.href.withExceptionContext wrapResource@{


### PR DESCRIPTION
### Purpose

`SyncManager` should sync an existing local collection with an existing remote collection — it shouldn't be responsible for creating the remote collection object itself. That's `Syncer`'s job.

Part of #2519.

### Short description

- `SyncManager` now takes `davCollection` as a constructor param (`abstract val davCollection: DavCollection`) instead of building it (`RemoteType`) in `prepare()`.
- Each `Syncer` subclass constructs its `DavCalendar`/`DavAddressBook` and passes it to the `SyncManager` factory.
- Dropped the `RemoteType` generic from `SyncManager`.
- Renamed `collection` → `collectionInfo` for clarity (it's DB info, not the remote collection itself).

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have self-reviewed the PR.
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.