### PR TITLE
[SyncManager] Move querySyncState() responsibility to WebDavCollection

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/SyncState.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/SyncState.kt
@@ -4,8 +4,6 @@
 
 package at.bitfire.davdroid.resource
 
-import at.bitfire.dav4jvm.ktor.Response
-import at.bitfire.dav4jvm.property.caldav.GetCTag
 import at.bitfire.dav4jvm.property.webdav.SyncToken
 import org.json.JSONException
 import org.json.JSONObject
@@ -59,13 +57,3 @@ data class SyncState(
     }
 
 }
-
-/**
- * Extracts the [SyncState] (`sync-token` or `CTag`) reported by this response, if any.
- */
-fun Response.syncState(): SyncState? =
-    this[SyncToken::class.java]?.token?.let {
-        SyncState(SyncState.Type.SYNC_TOKEN, it)
-    } ?: this[GetCTag::class.java]?.cTag?.let {
-        SyncState(SyncState.Type.CTAG, it)
-    }

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollection.kt
@@ -11,7 +11,7 @@ import at.bitfire.dav4jvm.property.carddav.CardDAV
 import at.bitfire.dav4jvm.property.carddav.SupportedAddressData
 import at.bitfire.dav4jvm.property.webdav.SupportedReportSet
 import at.bitfire.dav4jvm.property.webdav.WebDAV
-import at.bitfire.davdroid.resource.syncState
+import at.bitfire.davdroid.resource.SyncState
 import at.bitfire.dav4jvm.property.caldav.MaxResourceSize as CalDavMaxResourceSize
 import at.bitfire.dav4jvm.property.carddav.MaxResourceSize as CardDavMaxResourceSize
 
@@ -19,7 +19,7 @@ import at.bitfire.dav4jvm.property.carddav.MaxResourceSize as CardDavMaxResource
  * Common implementation of [WebDavCollection] for [CalDavCollection] and [CardDavCollection].
  */
 abstract class BaseWebDavCollection(
-    open override val davCollection: DavCollection
+    override val davCollection: DavCollection
 ) : WebDavCollection {
 
     override suspend fun queryCapabilities(): WebDavCollection.QueryCapabilitiesResult {
@@ -49,5 +49,8 @@ abstract class BaseWebDavCollection(
             )
         )
     }
+
+    override suspend fun querySyncState(): SyncState? =
+        davCollection.propfind(depth = 0, CalDAV.GetCTag, WebDAV.SyncToken).selfResponse()?.syncState()
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/ResponseExtensions.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/ResponseExtensions.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.resource.remote
+
+import at.bitfire.dav4jvm.ktor.Response
+import at.bitfire.dav4jvm.property.caldav.GetCTag
+import at.bitfire.dav4jvm.property.webdav.SyncToken
+import at.bitfire.davdroid.resource.SyncState
+
+/**
+ * Extracts the [SyncState] (`sync-token` or `CTag`) reported by this response, if any.
+ */
+internal fun Response.syncState(): SyncState? =
+    this[SyncToken::class.java]?.token?.let {
+        SyncState(SyncState.Type.SYNC_TOKEN, it)
+    } ?: this[GetCTag::class.java]?.cTag?.let {
+        SyncState(SyncState.Type.CTAG, it)
+    }

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/WebDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/WebDavCollection.kt
@@ -42,4 +42,9 @@ interface WebDavCollection {
         val supportsVCard4: Boolean = false
     )
 
+    /**
+     * Queries the collection's current [SyncState] (`sync-token` or `CTag`).
+     */
+    suspend fun querySyncState(): SyncState?
+
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -23,8 +23,6 @@ import at.bitfire.dav4jvm.ktor.exception.PreconditionFailedException
 import at.bitfire.dav4jvm.ktor.exception.ServiceUnavailableException
 import at.bitfire.dav4jvm.ktor.exception.UnauthorizedException
 import at.bitfire.dav4jvm.ktor.responsesWithRelation
-import at.bitfire.dav4jvm.ktor.selfResponse
-import at.bitfire.dav4jvm.property.caldav.CalDAV
 import at.bitfire.dav4jvm.property.caldav.ScheduleTag
 import at.bitfire.dav4jvm.property.webdav.GetETag
 import at.bitfire.dav4jvm.property.webdav.ResourceType
@@ -41,7 +39,6 @@ import at.bitfire.davdroid.resource.LocalCollection
 import at.bitfire.davdroid.resource.LocalResource
 import at.bitfire.davdroid.resource.SyncState
 import at.bitfire.davdroid.resource.remote.WebDavCollection
-import at.bitfire.davdroid.resource.syncState
 import at.bitfire.davdroid.sync.account.InvalidAccountException
 import at.bitfire.synctools.storage.LocalStorageException
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -650,7 +647,7 @@ abstract class SyncManager<LocalType : LocalResource>(
         // get current sync state
         var currentSyncState = remoteSyncState
         if (modificationsPresent)
-            currentSyncState = querySyncState()
+            currentSyncState = remoteCollection.querySyncState()
 
         // list and process all entries at current sync state (which may be the same as or newer than remoteSyncState)
         logger.info("Processing remote entries")
@@ -665,9 +662,6 @@ abstract class SyncManager<LocalType : LocalResource>(
         logger.info("Saving sync state: $currentSyncState")
         localCollection.lastSyncState = currentSyncState
     }
-
-    private suspend fun querySyncState(): SyncState? =
-        remoteCollection.davCollection.propfind(0, CalDAV.GetCTag, WebDAV.SyncToken).selfResponse()?.syncState()
 
     protected abstract fun listAllRemote(): Flow<MultiStatusItem>
 

--- a/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollectionTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollectionTest.kt
@@ -199,4 +199,55 @@ class BaseWebDavCollectionTest {
         assertEquals(204800L, result.capabilities.maxCardResourceSize)
     }
 
+    @Test
+    fun `querySyncState() with no self-response returns null`() = runTest {
+        val syncState = collection(
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                    "<multistatus xmlns=\"DAV:\"/>"
+        ).querySyncState()
+
+        assertNull(syncState)
+    }
+
+    @Test
+    fun `querySyncState() with GetCTag returns sync state`() = runTest {
+        val syncState = collection(
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                    "<multistatus xmlns=\"DAV:\" xmlns:CS=\"http://calendarserver.org/ns/\">\n" +
+                    "  <response>\n" +
+                    "    <href>/dav/</href>\n" +
+                    "    <propstat>\n" +
+                    "      <prop>\n" +
+                    "        <CS:getctag>abc123</CS:getctag>\n" +
+                    "      </prop>\n" +
+                    "      <status>HTTP/1.1 200 OK</status>\n" +
+                    "    </propstat>\n" +
+                    "  </response>\n" +
+                    "</multistatus>"
+        ).querySyncState()
+
+        assertEquals(SyncState(SyncState.Type.CTAG, "abc123"), syncState)
+    }
+
+    @Test
+    fun `querySyncState() prefers SyncToken over GetCTag`() = runTest {
+        val syncState = collection(
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                    "<multistatus xmlns=\"DAV:\" xmlns:CS=\"http://calendarserver.org/ns/\">\n" +
+                    "  <response>\n" +
+                    "    <href>/dav/</href>\n" +
+                    "    <propstat>\n" +
+                    "      <prop>\n" +
+                    "        <sync-token>http://example.com/ns/sync/token123</sync-token>\n" +
+                    "        <CS:getctag>abc123</CS:getctag>\n" +
+                    "      </prop>\n" +
+                    "      <status>HTTP/1.1 200 OK</status>\n" +
+                    "    </propstat>\n" +
+                    "  </response>\n" +
+                    "</multistatus>"
+        ).querySyncState()
+
+        assertEquals(SyncState(SyncState.Type.SYNC_TOKEN, "http://example.com/ns/sync/token123"), syncState)
+    }
+
 }


### PR DESCRIPTION
### Purpose

Extracts `querySyncState()` into the shared `WebDavCollection`/`BaseWebDavCollection` abstraction, following the same pattern as the earlier `queryCapabilities()` extraction — removing the duplicated PROPFIND logic from `SyncManager`.

Part of https://github.com/bitfireAT/davx5-ose/issues/2755.

### Short description

- Added `querySyncState(): SyncState?` to the `WebDavCollection` interface, implemented in `BaseWebDavCollection` (PROPFIND for `CalDAV.GetCTag`/`WebDAV.SyncToken`).
- **Removed the now-redundant private `querySyncState()` from `SyncManager`**; it now calls `remoteCollection.querySyncState()`.
- Moved `Response.syncState()` out of `resource/SyncState.kt` into a new `resource/remote/ResponseExtensions.kt`, since it parses a remote/WebDAV `Response` type and its only caller is in that package.
- Added unit tests for `querySyncState()` in `BaseWebDavCollectionTest`, mirroring the existing `queryCapabilities()` sync-state tests.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.