### PR TITLE
[SyncManager] Move `deleteMember` to `WebDavCollection`

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/remote/TestWebDavCollection.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/remote/TestWebDavCollection.kt
@@ -5,5 +5,11 @@
 package at.bitfire.davdroid.resource.remote
 
 import at.bitfire.dav4jvm.ktor.DavCollection
+import io.ktor.client.HttpClient
+import io.ktor.http.Url
 
-class TestWebDavCollection(davCollection: DavCollection) : BaseWebDavCollection(davCollection)
+class TestWebDavCollection(httpClient: HttpClient, url: Url) : BaseWebDavCollection(httpClient, url) {
+
+    override val davCollection = DavCollection(httpClient, url)
+
+}

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/CalendarSyncManagerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/CalendarSyncManagerTest.kt
@@ -27,6 +27,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import io.ktor.client.engine.mock.toByteArray
+import io.ktor.http.Url
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import okio.Buffer
@@ -144,7 +145,7 @@ class CalendarSyncManagerTest {
         syncResult = mockk(),
         localCalendar = mockk(),
         collectionInfo = mockk(),
-        remoteCollection = CalDavCollection(mockk()),
+        remoteCollection = CalDavCollection(mockk(), Url("https://example.com/dav/")),
         resync = mockk(),
         settings = SyncSettingsFixtures.default()
     )

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/JtxSyncManagerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/JtxSyncManagerTest.kt
@@ -6,7 +6,6 @@ package at.bitfire.davdroid.sync
 
 import android.content.ContentProviderClient
 import android.content.Context
-import at.bitfire.dav4jvm.ktor.DavCalendar
 import at.bitfire.davdroid.accounts.LegacyAccount
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service
@@ -103,7 +102,7 @@ class JtxSyncManagerTest {
             syncResult = SyncResult(),
             localCollection = localJtxCollection,
             collectionInfo = dbCollection,
-            remoteCollection = CalDavCollection(DavCalendar(httpClient, dbCollection.url)),
+            remoteCollection = CalDavCollection(httpClient, dbCollection.url),
             resync = null,
             settings = SyncSettingsFixtures.default()
         )

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncManagerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncManagerTest.kt
@@ -7,7 +7,6 @@ package at.bitfire.davdroid.sync
 import android.content.Context
 import androidx.core.app.NotificationManagerCompat
 import androidx.hilt.work.HiltWorkerFactory
-import at.bitfire.dav4jvm.ktor.DavCollection
 import at.bitfire.dav4jvm.ktor.PropStat
 import at.bitfire.dav4jvm.ktor.Response
 import at.bitfire.dav4jvm.ktor.Response.HrefRelation
@@ -544,7 +543,7 @@ class SyncManagerTest {
         syncResult,
         localCollection,
         collection,
-        spyk(TestWebDavCollection(DavCollection(client, collection.url))),
+        spyk(TestWebDavCollection(client, collection.url)),
         SyncSettingsFixtures.default()
     )
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollection.kt
@@ -15,9 +15,7 @@ import at.bitfire.dav4jvm.property.webdav.WebDAV
 import at.bitfire.davdroid.resource.SyncState
 import io.ktor.client.HttpClient
 import io.ktor.http.HttpHeaders
-import io.ktor.http.URLBuilder
 import io.ktor.http.Url
-import io.ktor.http.appendPathSegments
 import io.ktor.http.headers
 import io.ktor.util.appendAll
 import at.bitfire.dav4jvm.property.caldav.MaxResourceSize as CalDavMaxResourceSize
@@ -73,8 +71,7 @@ abstract class BaseWebDavCollection(
         ifScheduleTag: String?,
         additionalHeaders: Map<String, String>
     ) {
-        val memberUrl = URLBuilder(url).appendPathSegments(fileName, encodeSlash = true).build()
-        DavResource(httpClient, memberUrl).delete(
+        DavResource(httpClient, url.member(fileName)).delete(
             additionalHeaders = headers {
                 if (ifETag != null) {
                     // only delete specific version

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollection.kt
@@ -4,7 +4,8 @@
 
 package at.bitfire.davdroid.resource.remote
 
-import at.bitfire.dav4jvm.ktor.DavCollection
+import at.bitfire.dav4jvm.QuotedStringUtils
+import at.bitfire.dav4jvm.ktor.DavResource
 import at.bitfire.dav4jvm.ktor.selfResponse
 import at.bitfire.dav4jvm.property.caldav.CalDAV
 import at.bitfire.dav4jvm.property.carddav.CardDAV
@@ -12,6 +13,13 @@ import at.bitfire.dav4jvm.property.carddav.SupportedAddressData
 import at.bitfire.dav4jvm.property.webdav.SupportedReportSet
 import at.bitfire.dav4jvm.property.webdav.WebDAV
 import at.bitfire.davdroid.resource.SyncState
+import io.ktor.client.HttpClient
+import io.ktor.http.HttpHeaders
+import io.ktor.http.URLBuilder
+import io.ktor.http.Url
+import io.ktor.http.appendPathSegments
+import io.ktor.http.headers
+import io.ktor.util.appendAll
 import at.bitfire.dav4jvm.property.caldav.MaxResourceSize as CalDavMaxResourceSize
 import at.bitfire.dav4jvm.property.carddav.MaxResourceSize as CardDavMaxResourceSize
 
@@ -19,7 +27,8 @@ import at.bitfire.dav4jvm.property.carddav.MaxResourceSize as CardDavMaxResource
  * Common implementation of [WebDavCollection] for [CalDavCollection] and [CardDavCollection].
  */
 abstract class BaseWebDavCollection(
-    override val davCollection: DavCollection
+    protected val httpClient: HttpClient,
+    protected val url: Url
 ) : WebDavCollection {
 
     override suspend fun queryCapabilities(): WebDavCollection.QueryCapabilitiesResult {
@@ -52,5 +61,26 @@ abstract class BaseWebDavCollection(
 
     override suspend fun querySyncState(): SyncState? =
         davCollection.propfind(depth = 0, CalDAV.GetCTag, WebDAV.SyncToken).selfResponse()?.syncState()
+
+    override suspend fun deleteMember(
+        fileName: String,
+        ifETag: String?,
+        ifScheduleTag: String?,
+        additionalHeaders: Map<String, String>
+    ) {
+        val memberUrl = URLBuilder(url).appendPathSegments(fileName, encodeSlash = true).build()
+        DavResource(httpClient, memberUrl).delete(
+            additionalHeaders = headers {
+                if (ifETag != null)
+                // only delete specific version
+                    append(HttpHeaders.IfMatch, QuotedStringUtils.asQuotedString(ifETag))
+                if (ifScheduleTag != null)
+                // only delete specific version
+                    append(HttpHeaders.IfScheduleTagMatch, QuotedStringUtils.asQuotedString(ifScheduleTag))
+
+                appendAll(additionalHeaders)
+            }
+        ) {}
+    }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollection.kt
@@ -31,6 +31,8 @@ abstract class BaseWebDavCollection(
     protected val url: Url
 ) : WebDavCollection {
 
+    // read/query
+
     override suspend fun queryCapabilities(): WebDavCollection.QueryCapabilitiesResult {
         val response = davCollection.propfind(
             depth = 0,
@@ -62,6 +64,9 @@ abstract class BaseWebDavCollection(
     override suspend fun querySyncState(): SyncState? =
         davCollection.propfind(depth = 0, CalDAV.GetCTag, WebDAV.SyncToken).selfResponse()?.syncState()
 
+
+    // delete
+
     override suspend fun deleteMember(
         fileName: String,
         ifETag: String?,
@@ -71,16 +76,20 @@ abstract class BaseWebDavCollection(
         val memberUrl = URLBuilder(url).appendPathSegments(fileName, encodeSlash = true).build()
         DavResource(httpClient, memberUrl).delete(
             additionalHeaders = headers {
-                if (ifETag != null)
-                // only delete specific version
+                if (ifETag != null) {
+                    // only delete specific version
                     append(HttpHeaders.IfMatch, QuotedStringUtils.asQuotedString(ifETag))
-                if (ifScheduleTag != null)
-                // only delete specific version
+                }
+                if (ifScheduleTag != null) {
+                    // only delete specific version
                     append(HttpHeaders.IfScheduleTagMatch, QuotedStringUtils.asQuotedString(ifScheduleTag))
+                }
 
                 appendAll(additionalHeaders)
             }
-        ) {}
+        ) {
+            // don't do anything special on success
+        }
     }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/CalDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/CalDavCollection.kt
@@ -5,8 +5,14 @@
 package at.bitfire.davdroid.resource.remote
 
 import at.bitfire.dav4jvm.ktor.DavCalendar
+import io.ktor.client.HttpClient
+import io.ktor.http.Url
 
 /**
  * Remote CalDAV collection, as used for calendars, jtx board collections and task lists.
  */
-class CalDavCollection(override val davCollection: DavCalendar) : BaseWebDavCollection(davCollection)
+class CalDavCollection(httpClient: HttpClient, url: Url) : BaseWebDavCollection(httpClient, url) {
+
+    override val davCollection = DavCalendar(httpClient, url)
+
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/CardDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/CardDavCollection.kt
@@ -5,8 +5,14 @@
 package at.bitfire.davdroid.resource.remote
 
 import at.bitfire.dav4jvm.ktor.DavAddressBook
+import io.ktor.client.HttpClient
+import io.ktor.http.Url
 
 /**
  * Remote CardDAV collection, as used for address books.
  */
-class CardDavCollection(override val davCollection: DavAddressBook) : BaseWebDavCollection(davCollection)
+class CardDavCollection(httpClient: HttpClient, url: Url) : BaseWebDavCollection(httpClient, url) {
+
+    override val davCollection = DavAddressBook(httpClient, url)
+
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/UrlExtensions.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/UrlExtensions.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.resource.remote
+
+import io.ktor.http.URLBuilder
+import io.ktor.http.Url
+import io.ktor.http.appendPathSegments
+
+/**
+ * Returns the URL of a member (non-collection resource) with the given file name inside this collection URL.
+ *
+ * [fileName] is treated as a single, unencoded (decoded) file name — it's percent-encoded when appended,
+ * including a literal `/` (which would otherwise be interpreted as an additional path segment).
+ *
+ * @param fileName unencoded file name of the member
+ *
+ * @return URL of the member
+ */
+internal fun Url.member(fileName: String): Url =
+    URLBuilder(this).appendPathSegments(fileName, encodeSlash = true).build()

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/WebDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/WebDavCollection.kt
@@ -17,6 +17,9 @@ interface WebDavCollection {
 
     val davCollection: DavCollection
 
+
+    // read/query
+
     /**
      * Queries the collection's current capabilities. Also fetches the [SyncState]
      * in the same PROPFIND request to save a network round-trip.
@@ -46,6 +49,9 @@ interface WebDavCollection {
      * Queries the collection's current [SyncState] (`sync-token` or `CTag`).
      */
     suspend fun querySyncState(): SyncState?
+
+
+    // delete
 
     /**
      * Deletes a member (non-collection resource) of this collection (HTTP `DELETE`).

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/WebDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/WebDavCollection.kt
@@ -47,4 +47,19 @@ interface WebDavCollection {
      */
     suspend fun querySyncState(): SyncState?
 
+    /**
+     * Deletes a member (non-collection resource) of this collection (HTTP `DELETE`).
+     *
+     * @param fileName          file name of the member to delete
+     * @param ifETag            if given, sets `If-Match` so that the deletion only succeeds if the member's ETag matches
+     * @param ifScheduleTag     if given, sets `If-Schedule-Tag-Match` so that the deletion only succeeds if the member's Schedule-Tag matches
+     * @param additionalHeaders further headers to send (for instance `Push-Dont-Notify`)
+     */
+    suspend fun deleteMember(
+        fileName: String,
+        ifETag: String? = null,
+        ifScheduleTag: String? = null,
+        additionalHeaders: Map<String, String> = emptyMap()
+    )
+
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
@@ -7,7 +7,6 @@ package at.bitfire.davdroid.sync
 import android.accounts.AccountManager
 import android.content.ContentProviderClient
 import android.provider.ContactsContract
-import at.bitfire.dav4jvm.ktor.DavAddressBook
 import at.bitfire.davdroid.accounts.AccountId
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service
@@ -102,7 +101,7 @@ class AddressBookSyncer @AssistedInject constructor(
                 provider = provider,
                 localAddressBook = addressBook,
                 collectionInfo = collection,
-                remoteCollection = CardDavCollection(DavAddressBook(httpClient, collection.url)),
+                remoteCollection = CardDavCollection(httpClient, collection.url),
                 resync = resync,
                 syncFrameworkUpload = syncFrameworkUpload,
                 settings = settings

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncer.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncer.kt
@@ -5,7 +5,6 @@
 package at.bitfire.davdroid.sync
 
 import android.content.ContentProviderClient
-import at.bitfire.dav4jvm.ktor.DavCalendar
 import at.bitfire.davdroid.accounts.AccountId
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service
@@ -81,7 +80,7 @@ class CalendarSyncer @AssistedInject constructor(
             syncResult = syncResult,
             localCalendar = localCollection,
             collectionInfo = remoteCollectionInfo,
-            remoteCollection = CalDavCollection(DavCalendar(httpClient, remoteCollectionInfo.url)),
+            remoteCollection = CalDavCollection(httpClient, remoteCollectionInfo.url),
             resync = resync,
             settings = settings
         )

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncer.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncer.kt
@@ -5,7 +5,6 @@
 package at.bitfire.davdroid.sync
 
 import android.content.ContentProviderClient
-import at.bitfire.dav4jvm.ktor.DavCalendar
 import at.bitfire.davdroid.accounts.AccountId
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service
@@ -78,7 +77,7 @@ class JtxSyncer @AssistedInject constructor(
             syncResult = syncResult,
             localCollection = localCollection,
             collectionInfo = remoteCollectionInfo,
-            remoteCollection = CalDavCollection(DavCalendar(httpClient, remoteCollectionInfo.url)),
+            remoteCollection = CalDavCollection(httpClient, remoteCollectionInfo.url),
             resync = resync,
             settings = settings
         )

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -263,15 +263,14 @@ abstract class SyncManager<LocalType : LocalResource>(
                     val lastETag = if (lastScheduleTag == null) local.eTag else null
                     logger.info("$fileName has been deleted locally -> deleting from server (ETag $lastETag / schedule-tag $lastScheduleTag)")
 
-                    val url = URLBuilder(collectionInfo.url).appendPathSegments(fileName, encodeSlash = true).build()
-                    val remote = DavResource(httpClient, url)
-                    url.withExceptionContext {
+                    memberUrl(fileName).withExceptionContext {
                         try {
-                            remote.delete(
+                            remoteCollection.deleteMember(
+                                fileName = fileName,
                                 ifETag = lastETag,
                                 ifScheduleTag = lastScheduleTag,
-                                headers = pushDontNotifyHeader,
-                            ) {}
+                                additionalHeaders = pushDontNotifyHeader,
+                            )
                             numDeleted++
                         } catch (_: HttpException) {
                             logger.warning("Couldn't delete $fileName from server; ignoring (may be downloaded again)")
@@ -877,30 +876,9 @@ abstract class SyncManager<LocalType : LocalResource>(
     }
 
     /**
-     * A wrapper for making `DELETE` requests with conditional headers.
-     * @param ifETag If one is given, the `If-Match` header will have this value.
-     * @param ifScheduleTag If one is given, the `If-Schedule-Tag-Match` header will have this value.
-     * @param headers Any other headers to append to the request.
-     * @param callback Will be called with the request's response.
+     * URL of a member (non-collection resource) of the remote collection, for debugging/exception context only.
      */
-    private suspend fun DavResource.delete(
-        ifETag: String? = null,
-        ifScheduleTag: String? = null,
-        headers: Map<String, String> = emptyMap(),
-        callback: suspend (HttpResponse) -> Unit
-    ) {
-        delete(
-            additionalHeaders = headers {
-                if (ifETag != null)
-                    append(HttpHeaders.IfMatch, QuotedStringUtils.asQuotedString(ifETag))
-                if (ifScheduleTag != null)
-                    append(HttpHeaders.IfScheduleTagMatch, QuotedStringUtils.asQuotedString(ifScheduleTag))
-
-                // Append all custom headers
-                appendAll(headers)
-            },
-            callback = callback
-        )
-    }
+    private fun memberUrl(fileName: String): Url =
+        URLBuilder(collectionInfo.url).appendPathSegments(fileName, encodeSlash = true).build()
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -39,6 +39,7 @@ import at.bitfire.davdroid.resource.LocalCollection
 import at.bitfire.davdroid.resource.LocalResource
 import at.bitfire.davdroid.resource.SyncState
 import at.bitfire.davdroid.resource.remote.WebDavCollection
+import at.bitfire.davdroid.resource.remote.member
 import at.bitfire.davdroid.sync.account.InvalidAccountException
 import at.bitfire.synctools.storage.LocalStorageException
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -263,7 +264,7 @@ abstract class SyncManager<LocalType : LocalResource>(
                     val lastETag = if (lastScheduleTag == null) local.eTag else null
                     logger.info("$fileName has been deleted locally -> deleting from server (ETag $lastETag / schedule-tag $lastScheduleTag)")
 
-                    memberUrl(fileName).withExceptionContext {
+                    collectionInfo.url.member(fileName).withExceptionContext {
                         try {
                             remoteCollection.deleteMember(
                                 fileName = fileName,
@@ -874,11 +875,5 @@ abstract class SyncManager<LocalType : LocalResource>(
             callback = callback
         )
     }
-
-    /**
-     * URL of a member (non-collection resource) of the remote collection, for debugging/exception context only.
-     */
-    private fun memberUrl(fileName: String): Url =
-        URLBuilder(collectionInfo.url).appendPathSegments(fileName, encodeSlash = true).build()
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -47,9 +47,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
-import io.ktor.http.URLBuilder
 import io.ktor.http.Url
-import io.ktor.http.appendPathSegments
 import io.ktor.http.content.OutgoingContent
 import io.ktor.http.headers
 import io.ktor.util.appendAll
@@ -333,7 +331,7 @@ abstract class SyncManager<LocalType : LocalResource>(
         val upload = generateUpload(local, capabilities)
 
         val fileName = existingFileName ?: upload.suggestedFileName
-        val uploadUrl = URLBuilder(collectionInfo.url).appendPathSegments(fileName, encodeSlash = true).build()
+        val uploadUrl = collectionInfo.url.member(fileName)
         val remote = DavResource(httpClient, uploadUrl)
 
         try {

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/TaskSyncer.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/TaskSyncer.kt
@@ -5,7 +5,6 @@
 package at.bitfire.davdroid.sync
 
 import android.content.ContentProviderClient
-import at.bitfire.dav4jvm.ktor.DavCalendar
 import at.bitfire.davdroid.accounts.AccountId
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service
@@ -85,7 +84,7 @@ class TaskSyncer @AssistedInject constructor(
             syncResult = syncResult,
             localCollection = localCollection,
             collectionInfo = remoteCollectionInfo,
-            remoteCollection = CalDavCollection(DavCalendar(httpClient, remoteCollectionInfo.url)),
+            remoteCollection = CalDavCollection(httpClient, remoteCollectionInfo.url),
             resync = resync,
             settings = settings
         )

--- a/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollectionTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollectionTest.kt
@@ -9,7 +9,9 @@ import at.bitfire.davdroid.resource.SyncState
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.HttpRequestData
 import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
 import io.ktor.http.headersOf
@@ -28,8 +30,17 @@ class BaseWebDavCollectionTest {
         val engine = MockEngine { _ ->
             respond(xmlResponse, HttpStatusCode.MultiStatus, headersOf(HttpHeaders.ContentType, "text/xml"))
         }
-        return object : BaseWebDavCollection(DavCollection(HttpClient(engine), url)) {}
+        return collection(engine)
     }
+
+    private fun collection(engine: MockEngine): BaseWebDavCollection {
+        val httpClient = HttpClient(engine)
+        return object : BaseWebDavCollection(httpClient, url) {
+            override val davCollection = DavCollection(httpClient, url)
+        }
+    }
+
+    // read/query
 
     @Test
     fun `queryCapabilities() with no self-response returns defaults`() = runTest {
@@ -248,6 +259,64 @@ class BaseWebDavCollectionTest {
         ).querySyncState()
 
         assertEquals(SyncState(SyncState.Type.SYNC_TOKEN, "http://example.com/ns/sync/token123"), syncState)
+    }
+
+    // delete
+
+    @Test
+    fun `deleteMember() sends DELETE to the member URL`() = runTest {
+        var request: HttpRequestData? = null
+        val engine = MockEngine { req ->
+            request = req
+            respond("", HttpStatusCode.NoContent)
+        }
+
+        collection(engine).deleteMember("some-file.ics")
+
+        assertEquals(HttpMethod.Delete, request?.method)
+        assertEquals(Url("https://example.com/dav/some-file.ics"), request?.url)
+    }
+
+    @Test
+    fun `deleteMember() sets If-Match when ifETag is given`() = runTest {
+        var request: HttpRequestData? = null
+        val engine = MockEngine { req ->
+            request = req
+            respond("", HttpStatusCode.NoContent)
+        }
+
+        collection(engine).deleteMember("some-file.ics", ifETag = "some-etag")
+
+        assertEquals("\"some-etag\"", request?.headers?.get(HttpHeaders.IfMatch))
+    }
+
+    @Test
+    fun `deleteMember() sets If-Schedule-Tag-Match when ifScheduleTag is given`() = runTest {
+        var request: HttpRequestData? = null
+        val engine = MockEngine { req ->
+            request = req
+            respond("", HttpStatusCode.NoContent)
+        }
+
+        collection(engine).deleteMember("some-file.ics", ifScheduleTag = "some-schedule-tag")
+
+        assertEquals("\"some-schedule-tag\"", request?.headers?.get(HttpHeaders.IfScheduleTagMatch))
+    }
+
+    @Test
+    fun `deleteMember() passes through additionalHeaders`() = runTest {
+        var request: HttpRequestData? = null
+        val engine = MockEngine { req ->
+            request = req
+            respond("", HttpStatusCode.NoContent)
+        }
+
+        collection(engine).deleteMember(
+            "some-file.ics",
+            additionalHeaders = mapOf("Push-Dont-Notify" to "\"some-subscription\"")
+        )
+
+        assertEquals("\"some-subscription\"", request?.headers?.get("Push-Dont-Notify"))
     }
 
 }

--- a/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/UrlExtensionsTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/UrlExtensionsTest.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.resource.remote
+
+import io.ktor.http.Url
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UrlExtensionsTest {
+
+    @Test
+    fun `member() appends the file name as a path segment`() {
+        val url = Url("https://example.com/dav/")
+        assertEquals(Url("https://example.com/dav/some-file.ics"), url.member("some-file.ics"))
+    }
+
+    @Test
+    fun `member() encodes a literal slash in the file name`() {
+        val url = Url("https://example.com/dav/")
+        assertEquals("/dav/has%2Fslash.ics", url.member("has/slash.ics").encodedPath)
+    }
+
+}


### PR DESCRIPTION
### Purpose

Next part of #2755. This one moves the member `DELETE` out of `SyncManager` and into `resource.remote`.

### Short description

- **`CalDavCollection`/`CardDavCollection` now construct their own `davCollection` from an `httpClient` + `url` instead of receiving it.**
- Added `WebDavCollection.deleteMember()`; `BaseWebDavCollection` implements it (builds the member URL with slash-encoding, sets `If-Match`/`If-Schedule-Tag-Match`, sends the `DELETE`).
- `SyncManager.processLocallyDeleted()` now calls `remoteCollection.deleteMember(...)` instead of building a raw `DavResource` itself; removed the now-unused private `DavResource.delete()` extension.
- Added unit tests for `deleteMember()` in `BaseWebDavCollectionTest`; fixed test call sites broken by the constructor change.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have self-reviewed the PR.
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.