### PR TITLE
[SyncManager] Move upload PUT logic into `WebDavCollection`

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollection.kt
@@ -8,14 +8,18 @@ import at.bitfire.dav4jvm.QuotedStringUtils
 import at.bitfire.dav4jvm.ktor.DavResource
 import at.bitfire.dav4jvm.ktor.selfResponse
 import at.bitfire.dav4jvm.property.caldav.CalDAV
+import at.bitfire.dav4jvm.property.caldav.ScheduleTag
 import at.bitfire.dav4jvm.property.carddav.CardDAV
 import at.bitfire.dav4jvm.property.carddav.SupportedAddressData
+import at.bitfire.dav4jvm.property.webdav.GetETag
 import at.bitfire.dav4jvm.property.webdav.SupportedReportSet
 import at.bitfire.dav4jvm.property.webdav.WebDAV
 import at.bitfire.davdroid.resource.SyncState
 import io.ktor.client.HttpClient
+import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
 import io.ktor.http.Url
+import io.ktor.http.content.OutgoingContent
 import io.ktor.http.headers
 import io.ktor.util.appendAll
 import at.bitfire.dav4jvm.property.caldav.MaxResourceSize as CalDavMaxResourceSize
@@ -63,6 +67,52 @@ abstract class BaseWebDavCollection(
         davCollection.propfind(depth = 0, CalDAV.GetCTag, WebDAV.SyncToken).selfResponse()?.syncState()
 
 
+    // create
+
+    override suspend fun createMember(
+        fileName: String,
+        content: OutgoingContent,
+        additionalHeaders: Map<String, String>
+    ): WebDavCollection.PutMemberResult =
+        putMember(
+            fileName,
+            content,
+            additionalHeaders = headers {
+                // fail if a member with that file name already exists
+                append(HttpHeaders.IfNoneMatch, "*")
+
+                appendAll(additionalHeaders)
+            }
+        )
+
+
+    // update
+
+    override suspend fun updateMember(
+        fileName: String,
+        content: OutgoingContent,
+        ifETag: String?,
+        ifScheduleTag: String?,
+        additionalHeaders: Map<String, String>
+    ): WebDavCollection.PutMemberResult =
+        putMember(
+            fileName,
+            content,
+            additionalHeaders = headers {
+                if (ifETag != null) {
+                    // only update specific version
+                    append(HttpHeaders.IfMatch, QuotedStringUtils.asQuotedString(ifETag))
+                }
+                if (ifScheduleTag != null) {
+                    // only update specific version
+                    append(HttpHeaders.IfScheduleTagMatch, QuotedStringUtils.asQuotedString(ifScheduleTag))
+                }
+
+                appendAll(additionalHeaders)
+            }
+        )
+
+
     // delete
 
     override suspend fun deleteMember(
@@ -88,5 +138,20 @@ abstract class BaseWebDavCollection(
             // don't do anything special on success
         }
     }
+
+
+    // request helpers
+
+    private suspend fun putMember(
+        fileName: String,
+        content: OutgoingContent,
+        additionalHeaders: Headers
+    ): WebDavCollection.PutMemberResult =
+        DavResource(httpClient, url.member(fileName)).put(content, additionalHeaders) { response ->
+            WebDavCollection.PutMemberResult(
+                eTag = GetETag.fromHttpResponse(response)?.eTag,
+                scheduleTag = ScheduleTag.fromHttpResponse(response)?.scheduleTag
+            )
+        }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollection.kt
@@ -33,6 +33,25 @@ abstract class BaseWebDavCollection(
     protected val url: Url
 ) : WebDavCollection {
 
+    // create
+
+    override suspend fun createMember(
+        fileName: String,
+        content: OutgoingContent,
+        additionalHeaders: Map<String, String>
+    ): WebDavCollection.PutMemberResult =
+        putMember(
+            fileName,
+            content,
+            additionalHeaders = headers {
+                // fail if a member with that file name already exists
+                append(HttpHeaders.IfNoneMatch, "*")
+
+                appendAll(additionalHeaders)
+            }
+        )
+
+
     // read/query
 
     override suspend fun queryCapabilities(): WebDavCollection.QueryCapabilitiesResult {
@@ -65,25 +84,6 @@ abstract class BaseWebDavCollection(
 
     override suspend fun querySyncState(): SyncState? =
         davCollection.propfind(depth = 0, CalDAV.GetCTag, WebDAV.SyncToken).selfResponse()?.syncState()
-
-
-    // create
-
-    override suspend fun createMember(
-        fileName: String,
-        content: OutgoingContent,
-        additionalHeaders: Map<String, String>
-    ): WebDavCollection.PutMemberResult =
-        putMember(
-            fileName,
-            content,
-            additionalHeaders = headers {
-                // fail if a member with that file name already exists
-                append(HttpHeaders.IfNoneMatch, "*")
-
-                appendAll(additionalHeaders)
-            }
-        )
 
 
     // update

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/WebDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/WebDavCollection.kt
@@ -18,6 +18,32 @@ interface WebDavCollection {
 
     val davCollection: DavCollection
 
+    // create
+
+    /**
+     * Creates a new member (non-collection resource) of this collection (HTTP `PUT`).
+     * Fails if a member with that file name already exists (`If-None-Match: *`).
+     *
+     * @param fileName          file name of the member to create
+     * @param content           content to upload
+     * @param additionalHeaders further headers to send (for instance `Push-Dont-Notify`)
+     *
+     * @return the new member's ETag / Schedule-Tag, if returned by the server
+     *
+     * @throws at.bitfire.dav4jvm.ktor.exception.PreconditionFailedException if a member with that file name already exists
+     * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on other HTTP errors
+     */
+    suspend fun createMember(
+        fileName: String,
+        content: OutgoingContent,
+        additionalHeaders: Map<String, String> = emptyMap()
+    ): PutMemberResult
+
+    data class PutMemberResult(
+        val eTag: String? = null,
+        val scheduleTag: String? = null
+    )
+
 
     // read/query
 
@@ -56,28 +82,6 @@ interface WebDavCollection {
     suspend fun querySyncState(): SyncState?
 
 
-    // create
-
-    /**
-     * Creates a new member (non-collection resource) of this collection (HTTP `PUT`).
-     * Fails if a member with that file name already exists (`If-None-Match: *`).
-     *
-     * @param fileName          file name of the member to create
-     * @param content           content to upload
-     * @param additionalHeaders further headers to send (for instance `Push-Dont-Notify`)
-     *
-     * @return the new member's ETag / Schedule-Tag, if returned by the server
-     *
-     * @throws at.bitfire.dav4jvm.ktor.exception.PreconditionFailedException if a member with that file name already exists
-     * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on other HTTP errors
-     */
-    suspend fun createMember(
-        fileName: String,
-        content: OutgoingContent,
-        additionalHeaders: Map<String, String> = emptyMap()
-    ): PutMemberResult
-
-
     // update
 
     /**
@@ -102,11 +106,6 @@ interface WebDavCollection {
         ifScheduleTag: String? = null,
         additionalHeaders: Map<String, String> = emptyMap()
     ): PutMemberResult
-
-    data class PutMemberResult(
-        val eTag: String? = null,
-        val scheduleTag: String? = null
-    )
 
 
     // delete

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/WebDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/WebDavCollection.kt
@@ -6,6 +6,7 @@ package at.bitfire.davdroid.resource.remote
 
 import at.bitfire.dav4jvm.ktor.DavCollection
 import at.bitfire.davdroid.resource.SyncState
+import io.ktor.http.content.OutgoingContent
 
 /**
  * Provides remote collection access as required for [at.bitfire.davdroid.sync.SyncManager].
@@ -49,6 +50,52 @@ interface WebDavCollection {
      * Queries the collection's current [SyncState] (`sync-token` or `CTag`).
      */
     suspend fun querySyncState(): SyncState?
+
+
+    // create
+
+    /**
+     * Creates a new member (non-collection resource) of this collection (HTTP `PUT`).
+     * Fails if a member with that file name already exists (`If-None-Match: *`).
+     *
+     * @param fileName          file name of the member to create
+     * @param content           content to upload
+     * @param additionalHeaders further headers to send (for instance `Push-Dont-Notify`)
+     *
+     * @return the new member's ETag / Schedule-Tag, if returned by the server
+     */
+    suspend fun createMember(
+        fileName: String,
+        content: OutgoingContent,
+        additionalHeaders: Map<String, String> = emptyMap()
+    ): PutMemberResult
+
+
+    // update
+
+    /**
+     * Updates an existing member (non-collection resource) of this collection (HTTP `PUT`).
+     *
+     * @param fileName          file name of the member to update
+     * @param content           new content to upload
+     * @param ifETag            if given, sets `If-Match` so that the update only succeeds if the member's ETag matches
+     * @param ifScheduleTag     if given, sets `If-Schedule-Tag-Match` so that the update only succeeds if the member's Schedule-Tag matches
+     * @param additionalHeaders further headers to send (for instance `Push-Dont-Notify`)
+     *
+     * @return the updated member's ETag / Schedule-Tag, if returned by the server
+     */
+    suspend fun updateMember(
+        fileName: String,
+        content: OutgoingContent,
+        ifETag: String? = null,
+        ifScheduleTag: String? = null,
+        additionalHeaders: Map<String, String> = emptyMap()
+    ): PutMemberResult
+
+    data class PutMemberResult(
+        val eTag: String? = null,
+        val scheduleTag: String? = null
+    )
 
 
     // delete

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/WebDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/WebDavCollection.kt
@@ -24,6 +24,8 @@ interface WebDavCollection {
     /**
      * Queries the collection's current capabilities. Also fetches the [SyncState]
      * in the same PROPFIND request to save a network round-trip.
+     *
+     * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP errors
      */
     suspend fun queryCapabilities(): QueryCapabilitiesResult
 
@@ -48,6 +50,8 @@ interface WebDavCollection {
 
     /**
      * Queries the collection's current [SyncState] (`sync-token` or `CTag`).
+     *
+     * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP errors
      */
     suspend fun querySyncState(): SyncState?
 
@@ -63,6 +67,9 @@ interface WebDavCollection {
      * @param additionalHeaders further headers to send (for instance `Push-Dont-Notify`)
      *
      * @return the new member's ETag / Schedule-Tag, if returned by the server
+     *
+     * @throws at.bitfire.dav4jvm.ktor.exception.PreconditionFailedException if a member with that file name already exists
+     * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on other HTTP errors
      */
     suspend fun createMember(
         fileName: String,
@@ -83,6 +90,10 @@ interface WebDavCollection {
      * @param additionalHeaders further headers to send (for instance `Push-Dont-Notify`)
      *
      * @return the updated member's ETag / Schedule-Tag, if returned by the server
+     *
+     * @throws at.bitfire.dav4jvm.ktor.exception.PreconditionFailedException if ifETag or ifScheduleTag is given and
+     *   doesn't match the member's current state (also if the file doesn't exist on the server)
+     * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on other HTTP errors
      */
     suspend fun updateMember(
         fileName: String,
@@ -107,6 +118,10 @@ interface WebDavCollection {
      * @param ifETag            if given, sets `If-Match` so that the deletion only succeeds if the member's ETag matches
      * @param ifScheduleTag     if given, sets `If-Schedule-Tag-Match` so that the deletion only succeeds if the member's Schedule-Tag matches
      * @param additionalHeaders further headers to send (for instance `Push-Dont-Notify`)
+     *
+     * @throws at.bitfire.dav4jvm.ktor.exception.PreconditionFailedException if ifETag or ifScheduleTag is given and
+     *   doesn't match the member's current state (also if the file doesn't exist on the server)
+     * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP errors
      */
     suspend fun deleteMember(
         fileName: String,

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -332,10 +332,20 @@ abstract class SyncManager<LocalType : LocalResource>(
                     // create new resource on server
                     logger.log(Level.INFO, "Uploading new resource {0} -> {1}", arrayOf<Any?>(local.id, fileName))
 
-                    val result = remoteCollection.createMember(fileName, upload.content, pushDontNotifyHeader)
+                    val result = remoteCollection.createMember(
+                        fileName = fileName,
+                        content = upload.content,
+                        additionalHeaders = pushDontNotifyHeader
+                    )
 
                     // success (no exception thrown)
-                    onSuccessfulUpload(local, fileName, result.eTag, result.scheduleTag, upload.onSuccessContext)
+                    onSuccessfulUpload(
+                        local = local,
+                        newFileName = fileName,
+                        eTag = result.eTag,
+                        scheduleTag = result.scheduleTag,
+                        context = upload.onSuccessContext
+                    )
 
                 } else {
                     // update resource on server
@@ -349,15 +359,21 @@ abstract class SyncManager<LocalType : LocalResource>(
                     )
 
                     val result = remoteCollection.updateMember(
-                        fileName,
-                        upload.content,
-                        ifETag,
-                        ifScheduleTag,
-                        pushDontNotifyHeader
+                        fileName = fileName,
+                        content = upload.content,
+                        ifETag = ifETag,
+                        ifScheduleTag = ifScheduleTag,
+                        additionalHeaders = pushDontNotifyHeader
                     )
 
                     // success (no exception thrown)
-                    onSuccessfulUpload(local, fileName, result.eTag, result.scheduleTag, upload.onSuccessContext)
+                    onSuccessfulUpload(
+                        local = local,
+                        newFileName = fileName,
+                        eTag = result.eTag,
+                        scheduleTag = result.scheduleTag,
+                        context = upload.onSuccessContext
+                    )
                 }
             }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -10,7 +10,6 @@ import android.os.RemoteException
 import androidx.annotation.VisibleForTesting
 import at.bitfire.dav4jvm.Error
 import at.bitfire.dav4jvm.QuotedStringUtils
-import at.bitfire.dav4jvm.ktor.DavResource
 import at.bitfire.dav4jvm.ktor.MultiStatusItem
 import at.bitfire.dav4jvm.ktor.Response
 import at.bitfire.dav4jvm.ktor.exception.ConflictException
@@ -23,7 +22,6 @@ import at.bitfire.dav4jvm.ktor.exception.PreconditionFailedException
 import at.bitfire.dav4jvm.ktor.exception.ServiceUnavailableException
 import at.bitfire.dav4jvm.ktor.exception.UnauthorizedException
 import at.bitfire.dav4jvm.ktor.responsesWithRelation
-import at.bitfire.dav4jvm.property.caldav.ScheduleTag
 import at.bitfire.dav4jvm.property.webdav.GetETag
 import at.bitfire.dav4jvm.property.webdav.ResourceType
 import at.bitfire.dav4jvm.property.webdav.SyncToken
@@ -44,13 +42,8 @@ import at.bitfire.davdroid.sync.account.InvalidAccountException
 import at.bitfire.synctools.storage.LocalStorageException
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.ktor.client.HttpClient
-import io.ktor.client.statement.HttpResponse
-import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
-import io.ktor.http.content.OutgoingContent
-import io.ktor.http.headers
-import io.ktor.util.appendAll
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -332,7 +325,6 @@ abstract class SyncManager<LocalType : LocalResource>(
 
         val fileName = existingFileName ?: upload.suggestedFileName
         val uploadUrl = collectionInfo.url.member(fileName)
-        val remote = DavResource(httpClient, uploadUrl)
 
         try {
             uploadUrl.withExceptionContext {
@@ -340,20 +332,10 @@ abstract class SyncManager<LocalType : LocalResource>(
                     // create new resource on server
                     logger.log(Level.INFO, "Uploading new resource {0} -> {1}", arrayOf<Any?>(local.id, fileName))
 
-                    var newETag: String? = null
-                    var newScheduleTag: String? = null
-                    remote.put(
-                        upload.content,
-                        ifNoneMatch = true,     // fails if there's already a resource with that name
-                        callback = { response ->
-                            newETag = GetETag.fromHttpResponse(response)?.eTag
-                            newScheduleTag = ScheduleTag.fromHttpResponse(response)?.scheduleTag
-                        },
-                        headers = pushDontNotifyHeader
-                    )
+                    val result = remoteCollection.createMember(fileName, upload.content, pushDontNotifyHeader)
 
                     // success (no exception thrown)
-                    onSuccessfulUpload(local, fileName, newETag, newScheduleTag, upload.onSuccessContext)
+                    onSuccessfulUpload(local, fileName, result.eTag, result.scheduleTag, upload.onSuccessContext)
 
                 } else {
                     // update resource on server
@@ -366,21 +348,16 @@ abstract class SyncManager<LocalType : LocalResource>(
                         arrayOf<Any?>(local.id, fileName, ifETag, ifScheduleTag)
                     )
 
-                    var updatedETag: String? = null
-                    var updatedScheduleTag: String? = null
-                    remote.put(
+                    val result = remoteCollection.updateMember(
+                        fileName,
                         upload.content,
-                        ifETag = ifETag,
-                        ifScheduleTag = ifScheduleTag,
-                        callback = { response ->
-                            updatedETag = GetETag.fromHttpResponse(response)?.eTag
-                            updatedScheduleTag = ScheduleTag.fromHttpResponse(response)?.scheduleTag
-                        },
-                        headers = pushDontNotifyHeader
+                        ifETag,
+                        ifScheduleTag,
+                        pushDontNotifyHeader
                     )
 
                     // success (no exception thrown)
-                    onSuccessfulUpload(local, fileName, updatedETag, updatedScheduleTag, upload.onSuccessContext)
+                    onSuccessfulUpload(local, fileName, result.eTag, result.scheduleTag, upload.onSuccessContext)
                 }
             }
 
@@ -836,42 +813,5 @@ abstract class SyncManager<LocalType : LocalResource>(
         )
 
     protected abstract fun notifyInvalidResourceTitle(): String
-
-    /**
-     * A wrapper for making `PUT` requests with conditional headers.
-     * @param content The content to send in the PUT request.
-     * @param ifETag If one is given, the `If-Match` header will have this value.
-     * @param ifScheduleTag If one is given, the `If-Schedule-Tag-Match` header will have this value.
-     * @param ifNoneMatch If `true`, the `If-None-Match` header will be set to `*`.
-     * @param headers Any other headers to append to the request.
-     * @param callback Will be called with the request's response.
-     */
-    private suspend fun DavResource.put(
-        content: OutgoingContent,
-        ifETag: String? = null,
-        ifScheduleTag: String? = null,
-        ifNoneMatch: Boolean = false,
-        headers: Map<String, String> = emptyMap(),
-        callback: suspend (HttpResponse) -> Unit
-    ) {
-        put(
-            content,
-            additionalHeaders = headers {
-                if (ifETag != null)
-                // only overwrite specific version
-                    append(HttpHeaders.IfMatch, QuotedStringUtils.asQuotedString(ifETag))
-                if (ifScheduleTag != null)
-                // only overwrite specific version
-                    append(HttpHeaders.IfScheduleTagMatch, QuotedStringUtils.asQuotedString(ifScheduleTag))
-                if (ifNoneMatch)
-                // don't overwrite anything existing
-                    append(HttpHeaders.IfNoneMatch, "*")
-
-                // Append all custom headers
-                appendAll(headers)
-            },
-            callback = callback
-        )
-    }
 
 }

--- a/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollectionTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollectionTest.kt
@@ -42,6 +42,74 @@ class BaseWebDavCollectionTest {
         }
     }
 
+
+    // create
+
+    @Test
+    fun `createMember() sends PUT to the member URL`() = runTest {
+        var request: HttpRequestData? = null
+        val engine = MockEngine { req ->
+            request = req
+            respond("", HttpStatusCode.Created)
+        }
+
+        collection(engine).createMember("some-file.ics", TextContent("BEGIN:VCALENDAR", ContentType.Text.Plain))
+
+        assertEquals(HttpMethod.Put, request?.method)
+        assertEquals(Url("https://example.com/dav/some-file.ics"), request?.url)
+    }
+
+    @Test
+    fun `createMember() sets If-None-Match`() = runTest {
+        var request: HttpRequestData? = null
+        val engine = MockEngine { req ->
+            request = req
+            respond("", HttpStatusCode.Created)
+        }
+
+        collection(engine).createMember("some-file.ics", TextContent("BEGIN:VCALENDAR", ContentType.Text.Plain))
+
+        assertEquals("*", request?.headers?.get(HttpHeaders.IfNoneMatch))
+    }
+
+    @Test
+    fun `createMember() passes through additionalHeaders`() = runTest {
+        var request: HttpRequestData? = null
+        val engine = MockEngine { req ->
+            request = req
+            respond("", HttpStatusCode.Created)
+        }
+
+        collection(engine).createMember(
+            "some-file.ics",
+            TextContent("BEGIN:VCALENDAR", ContentType.Text.Plain),
+            additionalHeaders = mapOf("Push-Dont-Notify" to "\"some-subscription\"")
+        )
+
+        assertEquals("\"some-subscription\"", request?.headers?.get("Push-Dont-Notify"))
+    }
+
+    @Test
+    fun `createMember() returns ETag and Schedule-Tag from response`() = runTest {
+        val engine = MockEngine {
+            respond(
+                "",
+                HttpStatusCode.Created,
+                headersOf(
+                    HttpHeaders.ETag to listOf("\"new-etag\""),
+                    HttpHeaders.ScheduleTag to listOf("\"new-schedule-tag\"")
+                )
+            )
+        }
+
+        val result =
+            collection(engine).createMember("some-file.ics", TextContent("BEGIN:VCALENDAR", ContentType.Text.Plain))
+
+        assertEquals("new-etag", result.eTag)
+        assertEquals("new-schedule-tag", result.scheduleTag)
+    }
+
+
     // read/query
 
     @Test
@@ -261,72 +329,6 @@ class BaseWebDavCollectionTest {
         ).querySyncState()
 
         assertEquals(SyncState(SyncState.Type.SYNC_TOKEN, "http://example.com/ns/sync/token123"), syncState)
-    }
-
-    // create
-
-    @Test
-    fun `createMember() sends PUT to the member URL`() = runTest {
-        var request: HttpRequestData? = null
-        val engine = MockEngine { req ->
-            request = req
-            respond("", HttpStatusCode.Created)
-        }
-
-        collection(engine).createMember("some-file.ics", TextContent("BEGIN:VCALENDAR", ContentType.Text.Plain))
-
-        assertEquals(HttpMethod.Put, request?.method)
-        assertEquals(Url("https://example.com/dav/some-file.ics"), request?.url)
-    }
-
-    @Test
-    fun `createMember() sets If-None-Match`() = runTest {
-        var request: HttpRequestData? = null
-        val engine = MockEngine { req ->
-            request = req
-            respond("", HttpStatusCode.Created)
-        }
-
-        collection(engine).createMember("some-file.ics", TextContent("BEGIN:VCALENDAR", ContentType.Text.Plain))
-
-        assertEquals("*", request?.headers?.get(HttpHeaders.IfNoneMatch))
-    }
-
-    @Test
-    fun `createMember() passes through additionalHeaders`() = runTest {
-        var request: HttpRequestData? = null
-        val engine = MockEngine { req ->
-            request = req
-            respond("", HttpStatusCode.Created)
-        }
-
-        collection(engine).createMember(
-            "some-file.ics",
-            TextContent("BEGIN:VCALENDAR", ContentType.Text.Plain),
-            additionalHeaders = mapOf("Push-Dont-Notify" to "\"some-subscription\"")
-        )
-
-        assertEquals("\"some-subscription\"", request?.headers?.get("Push-Dont-Notify"))
-    }
-
-    @Test
-    fun `createMember() returns ETag and Schedule-Tag from response`() = runTest {
-        val engine = MockEngine {
-            respond(
-                "",
-                HttpStatusCode.Created,
-                headersOf(
-                    HttpHeaders.ETag to listOf("\"new-etag\""),
-                    HttpHeaders.ScheduleTag to listOf("\"new-schedule-tag\"")
-                )
-            )
-        }
-
-        val result =
-            collection(engine).createMember("some-file.ics", TextContent("BEGIN:VCALENDAR", ContentType.Text.Plain))
-
-        assertEquals("new-etag", result.eTag)
-        assertEquals("new-schedule-tag", result.scheduleTag)
     }
 
 

--- a/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollectionTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollectionTest.kt
@@ -10,10 +10,12 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.request.HttpRequestData
+import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
+import io.ktor.http.content.TextContent
 import io.ktor.http.headersOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -260,6 +262,175 @@ class BaseWebDavCollectionTest {
 
         assertEquals(SyncState(SyncState.Type.SYNC_TOKEN, "http://example.com/ns/sync/token123"), syncState)
     }
+
+    // create
+
+    @Test
+    fun `createMember() sends PUT to the member URL`() = runTest {
+        var request: HttpRequestData? = null
+        val engine = MockEngine { req ->
+            request = req
+            respond("", HttpStatusCode.Created)
+        }
+
+        collection(engine).createMember("some-file.ics", TextContent("BEGIN:VCALENDAR", ContentType.Text.Plain))
+
+        assertEquals(HttpMethod.Put, request?.method)
+        assertEquals(Url("https://example.com/dav/some-file.ics"), request?.url)
+    }
+
+    @Test
+    fun `createMember() sets If-None-Match`() = runTest {
+        var request: HttpRequestData? = null
+        val engine = MockEngine { req ->
+            request = req
+            respond("", HttpStatusCode.Created)
+        }
+
+        collection(engine).createMember("some-file.ics", TextContent("BEGIN:VCALENDAR", ContentType.Text.Plain))
+
+        assertEquals("*", request?.headers?.get(HttpHeaders.IfNoneMatch))
+    }
+
+    @Test
+    fun `createMember() passes through additionalHeaders`() = runTest {
+        var request: HttpRequestData? = null
+        val engine = MockEngine { req ->
+            request = req
+            respond("", HttpStatusCode.Created)
+        }
+
+        collection(engine).createMember(
+            "some-file.ics",
+            TextContent("BEGIN:VCALENDAR", ContentType.Text.Plain),
+            additionalHeaders = mapOf("Push-Dont-Notify" to "\"some-subscription\"")
+        )
+
+        assertEquals("\"some-subscription\"", request?.headers?.get("Push-Dont-Notify"))
+    }
+
+    @Test
+    fun `createMember() returns ETag and Schedule-Tag from response`() = runTest {
+        val engine = MockEngine {
+            respond(
+                "",
+                HttpStatusCode.Created,
+                headersOf(
+                    HttpHeaders.ETag to listOf("\"new-etag\""),
+                    HttpHeaders.ScheduleTag to listOf("\"new-schedule-tag\"")
+                )
+            )
+        }
+
+        val result =
+            collection(engine).createMember("some-file.ics", TextContent("BEGIN:VCALENDAR", ContentType.Text.Plain))
+
+        assertEquals("new-etag", result.eTag)
+        assertEquals("new-schedule-tag", result.scheduleTag)
+    }
+
+
+    // update
+
+    @Test
+    fun `updateMember() sends PUT to the member URL`() = runTest {
+        var request: HttpRequestData? = null
+        val engine = MockEngine { req ->
+            request = req
+            respond("", HttpStatusCode.NoContent)
+        }
+
+        collection(engine).updateMember("some-file.ics", TextContent("BEGIN:VCALENDAR", ContentType.Text.Plain))
+
+        assertEquals(HttpMethod.Put, request?.method)
+        assertEquals(Url("https://example.com/dav/some-file.ics"), request?.url)
+    }
+
+    @Test
+    fun `updateMember() sets If-Match when ifETag is given`() = runTest {
+        var request: HttpRequestData? = null
+        val engine = MockEngine { req ->
+            request = req
+            respond("", HttpStatusCode.NoContent)
+        }
+
+        collection(engine).updateMember(
+            "some-file.ics",
+            TextContent("BEGIN:VCALENDAR", ContentType.Text.Plain),
+            ifETag = "some-etag"
+        )
+
+        assertEquals("\"some-etag\"", request?.headers?.get(HttpHeaders.IfMatch))
+    }
+
+    @Test
+    fun `updateMember() sets If-Schedule-Tag-Match when ifScheduleTag is given`() = runTest {
+        var request: HttpRequestData? = null
+        val engine = MockEngine { req ->
+            request = req
+            respond("", HttpStatusCode.NoContent)
+        }
+
+        collection(engine).updateMember(
+            "some-file.ics",
+            TextContent("BEGIN:VCALENDAR", ContentType.Text.Plain),
+            ifScheduleTag = "some-schedule-tag"
+        )
+
+        assertEquals("\"some-schedule-tag\"", request?.headers?.get(HttpHeaders.IfScheduleTagMatch))
+    }
+
+    @Test
+    fun `updateMember() sets no precondition headers when no tags are given`() = runTest {
+        var request: HttpRequestData? = null
+        val engine = MockEngine { req ->
+            request = req
+            respond("", HttpStatusCode.NoContent)
+        }
+
+        collection(engine).updateMember("some-file.ics", TextContent("BEGIN:VCALENDAR", ContentType.Text.Plain))
+
+        assertNull(request?.headers?.get(HttpHeaders.IfMatch))
+        assertNull(request?.headers?.get(HttpHeaders.IfScheduleTagMatch))
+    }
+
+    @Test
+    fun `updateMember() passes through additionalHeaders`() = runTest {
+        var request: HttpRequestData? = null
+        val engine = MockEngine { req ->
+            request = req
+            respond("", HttpStatusCode.NoContent)
+        }
+
+        collection(engine).updateMember(
+            "some-file.ics",
+            TextContent("BEGIN:VCALENDAR", ContentType.Text.Plain),
+            additionalHeaders = mapOf("Push-Dont-Notify" to "\"some-subscription\"")
+        )
+
+        assertEquals("\"some-subscription\"", request?.headers?.get("Push-Dont-Notify"))
+    }
+
+    @Test
+    fun `updateMember() returns ETag and Schedule-Tag from response`() = runTest {
+        val engine = MockEngine {
+            respond(
+                "",
+                HttpStatusCode.NoContent,
+                headersOf(
+                    HttpHeaders.ETag to listOf("\"updated-etag\""),
+                    HttpHeaders.ScheduleTag to listOf("\"updated-schedule-tag\"")
+                )
+            )
+        }
+
+        val result =
+            collection(engine).updateMember("some-file.ics", TextContent("BEGIN:VCALENDAR", ContentType.Text.Plain))
+
+        assertEquals("updated-etag", result.eTag)
+        assertEquals("updated-schedule-tag", result.scheduleTag)
+    }
+
 
     // delete
 


### PR DESCRIPTION
### Purpose

Move create/update member operations out of `SyncManager` and into `WebDavCollection`.

Part of https://github.com/bitfireAT/davx5-ose/issues/2755

### Short description

- Added `createMember()` and `updateMember()` to `WebDavCollection`, implemented in `BaseWebDavCollection`, replacing the ad-hoc `DavResource.put()` extension that used to live in `SyncManager`.
- `SyncManager` now calls `remoteCollection.createMember()`/`updateMember()` instead of building the PUT request itself; conditional headers (`If-None-Match`, `If-Match`, `If-Schedule-Tag-Match`) and Push-Dont-Notify header handling are preserved.
- Switched `onSuccessfulUpload` calls to named arguments for clarity.
- Added `@throws` documentation to `WebDavCollection` methods.
- Added unit tests for `createMember`/`updateMember` in `BaseWebDavCollectionTest`.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.