### PR TITLE
[SyncManager] Move multi-get into `WebDavCollection`

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/remote/TestWebDavCollection.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/remote/TestWebDavCollection.kt
@@ -7,9 +7,16 @@ package at.bitfire.davdroid.resource.remote
 import at.bitfire.dav4jvm.ktor.DavCollection
 import io.ktor.client.HttpClient
 import io.ktor.http.Url
+import kotlinx.coroutines.flow.Flow
 
 class TestWebDavCollection(httpClient: HttpClient, url: Url) : BaseWebDavCollection(httpClient, url) {
 
     override val davCollection = DavCollection(httpClient, url)
+
+    override fun multiget(
+        urls: List<Url>,
+        capabilities: WebDavCollection.Capabilities
+    ): Flow<WebDavCollection.MultiGetItem> =
+        throw NotImplementedError()
 
 }

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncManagerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncManagerTest.kt
@@ -19,6 +19,7 @@ import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.repository.DavSyncStatsRepository
 import at.bitfire.davdroid.resource.SyncState
 import at.bitfire.davdroid.resource.remote.TestWebDavCollection
+import at.bitfire.davdroid.resource.remote.WebDavCollection
 import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.sync.account.TestAccount
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -36,6 +37,7 @@ import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
 import io.mockk.mockk
 import io.mockk.spyk
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -154,7 +156,7 @@ class SyncManagerTest {
         coVerify(exactly = 1) { syncManager.remoteCollection.queryCapabilities() }
         assertFalse(syncManager.didGenerateUpload)
         assertTrue(syncManager.didListAllRemote)
-        assertFalse(syncManager.didDownloadRemote)
+        assertTrue(syncManager.processedDownloads.isEmpty())
         assertFalse(syncManager.syncResult.hasError)
         assertTrue(collection.entries.isEmpty())
     }
@@ -195,7 +197,7 @@ class SyncManagerTest {
         coVerify(exactly = 1) { syncManager.remoteCollection.queryCapabilities() }
         assertTrue(syncManager.didGenerateUpload)
         assertTrue(syncManager.didListAllRemote)
-        assertFalse(syncManager.didDownloadRemote)
+        assertTrue(syncManager.processedDownloads.isEmpty())
         assertFalse(syncManager.syncResult.hasError)
         assertEquals(1, collection.entries.size)
         assertEquals("etag-from-put", collection.entries.first().eTag)
@@ -233,14 +235,12 @@ class SyncManagerTest {
                             ))
                     ), HrefRelation.MEMBER)
             )
-
-            assertDownloadRemote = mapOf(Pair(Url("$BASE_URL/existing-file.txt"), "etag-from-put"))
         }
         syncManager.performSync()
 
         assertTrue(syncManager.didGenerateUpload)
         assertTrue(syncManager.didListAllRemote)
-        assertFalse(syncManager.didDownloadRemote)
+        assertTrue(syncManager.processedDownloads.isEmpty())
         assertFalse(syncManager.syncResult.hasError)
         assertEquals(1, collection.entries.size)
         assertEquals("etag-from-put", collection.entries.first().eTag)
@@ -278,14 +278,24 @@ class SyncManagerTest {
                             ))
                     ), HrefRelation.MEMBER)
             )
-
-            assertDownloadRemote = mapOf(Pair(Url("$BASE_URL/existing-file.txt"), "etag-from-propfind"))
         }
+        every { syncManager.remoteCollection.multiget(any(), any()) } returns flowOf(
+            WebDavCollection.MultiGetItem(Url("$BASE_URL/existing-file.txt"), "etag-from-propfind", content = "ignored")
+        )
         syncManager.performSync()
 
         assertTrue(syncManager.didGenerateUpload)
         assertTrue(syncManager.didListAllRemote)
-        assertTrue(syncManager.didDownloadRemote)
+        assertEquals(
+            listOf(
+                WebDavCollection.MultiGetItem(
+                    Url("$BASE_URL/existing-file.txt"),
+                    "etag-from-propfind",
+                    content = "ignored"
+                )
+            ),
+            syncManager.processedDownloads
+        )
         assertFalse(syncManager.syncResult.hasError)
         assertEquals(1, collection.entries.size)
         assertEquals("etag-from-propfind", collection.entries.first().eTag)
@@ -323,14 +333,28 @@ class SyncManagerTest {
                             ))
                     ), HrefRelation.MEMBER)
             )
-
-            assertDownloadRemote = mapOf(Pair(Url("$BASE_URL/existing-file.txt"), "changed-etag-from-server"))
         }
+        every { syncManager.remoteCollection.multiget(any(), any()) } returns flowOf(
+            WebDavCollection.MultiGetItem(
+                Url("$BASE_URL/existing-file.txt"),
+                "changed-etag-from-server",
+                content = "ignored"
+            )
+        )
         syncManager.performSync()
 
         assertTrue(syncManager.didGenerateUpload)
         assertTrue(syncManager.didListAllRemote)
-        assertTrue(syncManager.didDownloadRemote)
+        assertEquals(
+            listOf(
+                WebDavCollection.MultiGetItem(
+                    Url("$BASE_URL/existing-file.txt"),
+                    "changed-etag-from-server",
+                    content = "ignored"
+                )
+            ),
+            syncManager.processedDownloads
+        )
         assertFalse(syncManager.syncResult.hasError)
         assertEquals(1, collection.entries.size)
         assertEquals("changed-etag-from-server", collection.entries.first().eTag)
@@ -367,7 +391,7 @@ class SyncManagerTest {
 
         assertFalse(syncManager.didGenerateUpload)
         assertTrue(syncManager.didListAllRemote)
-        assertFalse(syncManager.didDownloadRemote)
+        assertTrue(syncManager.processedDownloads.isEmpty())
         assertFalse(syncManager.syncResult.hasError)
         assertEquals(1, collection.entries.size)
         assertEquals("MemberETag1", collection.entries.first().eTag)
@@ -394,14 +418,24 @@ class SyncManagerTest {
                             ))
                     ), HrefRelation.MEMBER)
             )
-
-            assertDownloadRemote = mapOf(Pair(Url("$BASE_URL/new-member.txt"), "NewMemberETag1"))
         }
+        every { syncManager.remoteCollection.multiget(any(), any()) } returns flowOf(
+            WebDavCollection.MultiGetItem(Url("$BASE_URL/new-member.txt"), "NewMemberETag1", content = "ignored")
+        )
         syncManager.performSync()
 
         assertFalse(syncManager.didGenerateUpload)
         assertTrue(syncManager.didListAllRemote)
-        assertTrue(syncManager.didDownloadRemote)
+        assertEquals(
+            listOf(
+                WebDavCollection.MultiGetItem(
+                    Url("$BASE_URL/new-member.txt"),
+                    "NewMemberETag1",
+                    content = "ignored"
+                )
+            ),
+            syncManager.processedDownloads
+        )
         assertFalse(syncManager.syncResult.hasError)
         assertEquals(1, collection.entries.size)
         assertEquals("NewMemberETag1", collection.entries.first().eTag)
@@ -432,14 +466,24 @@ class SyncManagerTest {
                             ))
                     ), HrefRelation.MEMBER)
             )
-
-            assertDownloadRemote = mapOf(Pair(Url("$BASE_URL/downloaded-member.txt"), "MemberETag2"))
         }
+        every { syncManager.remoteCollection.multiget(any(), any()) } returns flowOf(
+            WebDavCollection.MultiGetItem(Url("$BASE_URL/downloaded-member.txt"), "MemberETag2", content = "ignored")
+        )
         syncManager.performSync()
 
         assertFalse(syncManager.didGenerateUpload)
         assertTrue(syncManager.didListAllRemote)
-        assertTrue(syncManager.didDownloadRemote)
+        assertEquals(
+            listOf(
+                WebDavCollection.MultiGetItem(
+                    Url("$BASE_URL/downloaded-member.txt"),
+                    "MemberETag2",
+                    content = "ignored"
+                )
+            ),
+            syncManager.processedDownloads
+        )
         assertFalse(syncManager.syncResult.hasError)
         assertEquals(1, collection.entries.size)
         assertEquals("MemberETag2", collection.entries.first().eTag)
@@ -460,7 +504,7 @@ class SyncManagerTest {
 
         assertFalse(syncManager.didGenerateUpload)
         assertTrue(syncManager.didListAllRemote)
-        assertFalse(syncManager.didDownloadRemote)
+        assertTrue(syncManager.processedDownloads.isEmpty())
         assertFalse(syncManager.syncResult.hasError)
         assertTrue(collection.entries.isEmpty())
     }
@@ -477,7 +521,7 @@ class SyncManagerTest {
 
         assertFalse(syncManager.didGenerateUpload)
         assertFalse(syncManager.didListAllRemote)
-        assertFalse(syncManager.didDownloadRemote)
+        assertTrue(syncManager.processedDownloads.isEmpty())
         assertFalse(syncManager.syncResult.hasError)
         assertTrue(collection.entries.isEmpty())
     }

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/TestSyncManager.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/TestSyncManager.kt
@@ -17,14 +17,12 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import io.ktor.client.HttpClient
-import io.ktor.http.Url
 import io.ktor.http.content.ByteArrayContent
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.sync.Semaphore
-import org.junit.Assert.assertEquals
 
 class TestSyncManager @AssistedInject constructor(
     @Assisted accountId: AccountId,
@@ -87,25 +85,21 @@ class TestSyncManager @AssistedInject constructor(
         return listAllRemoteResult.asFlow().map { MultiStatusItem.Response(it.first, it.second) }
     }
 
-    var assertDownloadRemote = emptyMap<Url, String>()
-    var didDownloadRemote = false
-    override suspend fun downloadRemote(bunch: List<Url>, capabilities: WebDavCollection.Capabilities) {
-        didDownloadRemote = true
-        assertEquals(assertDownloadRemote.keys.toList(), bunch)
+    var processedDownloads = emptyList<WebDavCollection.MultiGetItem>()
+    override suspend fun processDownload(result: WebDavCollection.MultiGetItem) {
+        processedDownloads += result
 
-        for ((url, eTag) in assertDownloadRemote) {
-            val fileName = url.lastSegment
-            var localEntry = localCollection.entries.firstOrNull { it.fileName == fileName }
-            if (localEntry == null) {
-                val newEntry = LocalTestResource().also {
-                    it.fileName = fileName
-                }
-                localCollection.entries += newEntry
-                localEntry = newEntry
+        val fileName = result.url.lastSegment
+        var localEntry = localCollection.entries.firstOrNull { it.fileName == fileName }
+        if (localEntry == null) {
+            val newEntry = LocalTestResource().also {
+                it.fileName = fileName
             }
-            localEntry.eTag = eTag
-            localEntry.flags = LocalResource.FLAG_REMOTELY_PRESENT
+            localCollection.entries += newEntry
+            localEntry = newEntry
         }
+        localEntry.eTag = result.eTag
+        localEntry.flags = LocalResource.FLAG_REMOTELY_PRESENT
     }
 
     override suspend fun postProcess() {

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollection.kt
@@ -6,8 +6,6 @@ package at.bitfire.davdroid.resource.remote
 
 import at.bitfire.dav4jvm.QuotedStringUtils
 import at.bitfire.dav4jvm.ktor.DavResource
-import at.bitfire.dav4jvm.ktor.Response
-import at.bitfire.dav4jvm.ktor.exception.DavException
 import at.bitfire.dav4jvm.ktor.selfResponse
 import at.bitfire.dav4jvm.property.caldav.CalDAV
 import at.bitfire.dav4jvm.property.caldav.ScheduleTag
@@ -17,7 +15,6 @@ import at.bitfire.dav4jvm.property.webdav.GetETag
 import at.bitfire.dav4jvm.property.webdav.SupportedReportSet
 import at.bitfire.dav4jvm.property.webdav.WebDAV
 import at.bitfire.davdroid.resource.SyncState
-import at.bitfire.davdroid.sync.withExceptionContext
 import io.ktor.client.HttpClient
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
@@ -87,26 +84,6 @@ abstract class BaseWebDavCollection(
 
     override suspend fun querySyncState(): SyncState? =
         davCollection.propfind(depth = 0, CalDAV.GetCTag, WebDAV.SyncToken).selfResponse()?.syncState()
-
-    /**
-     * Turns one multi-get [response] into a [WebDavCollection.MultiGetItem], or `null` if the
-     * response was not successful or didn't contain the expected resource data.
-     *
-     * @param content the resource data already extracted from [response] (for instance calendar-data or address-data)
-     */
-    protected suspend fun buildMultiGetItem(response: Response, content: String?): WebDavCollection.MultiGetItem? =
-        response.href.withExceptionContext {
-            if (!response.isSuccess() || content == null)
-                return@withExceptionContext null
-            val eTag = response[GetETag::class.java]?.eTag
-                ?: throw DavException("Received multi-get response without ETag")
-            WebDavCollection.MultiGetItem(
-                url = response.href,
-                eTag = eTag,
-                scheduleTag = response[ScheduleTag::class.java]?.scheduleTag,
-                content = content
-            )
-        }
 
 
     // update

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollection.kt
@@ -6,6 +6,8 @@ package at.bitfire.davdroid.resource.remote
 
 import at.bitfire.dav4jvm.QuotedStringUtils
 import at.bitfire.dav4jvm.ktor.DavResource
+import at.bitfire.dav4jvm.ktor.Response
+import at.bitfire.dav4jvm.ktor.exception.DavException
 import at.bitfire.dav4jvm.ktor.selfResponse
 import at.bitfire.dav4jvm.property.caldav.CalDAV
 import at.bitfire.dav4jvm.property.caldav.ScheduleTag
@@ -15,6 +17,7 @@ import at.bitfire.dav4jvm.property.webdav.GetETag
 import at.bitfire.dav4jvm.property.webdav.SupportedReportSet
 import at.bitfire.dav4jvm.property.webdav.WebDAV
 import at.bitfire.davdroid.resource.SyncState
+import at.bitfire.davdroid.sync.withExceptionContext
 import io.ktor.client.HttpClient
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
@@ -84,6 +87,26 @@ abstract class BaseWebDavCollection(
 
     override suspend fun querySyncState(): SyncState? =
         davCollection.propfind(depth = 0, CalDAV.GetCTag, WebDAV.SyncToken).selfResponse()?.syncState()
+
+    /**
+     * Turns one multi-get [response] into a [WebDavCollection.MultiGetItem], or `null` if the
+     * response was not successful or didn't contain the expected resource data.
+     *
+     * @param content the resource data already extracted from [response] (for instance calendar-data or address-data)
+     */
+    protected suspend fun buildMultiGetItem(response: Response, content: String?): WebDavCollection.MultiGetItem? =
+        response.href.withExceptionContext {
+            if (!response.isSuccess() || content == null)
+                return@withExceptionContext null
+            val eTag = response[GetETag::class.java]?.eTag
+                ?: throw DavException("Received multi-get response without ETag")
+            WebDavCollection.MultiGetItem(
+                url = response.href,
+                eTag = eTag,
+                scheduleTag = response[ScheduleTag::class.java]?.scheduleTag,
+                content = content
+            )
+        }
 
 
     // update

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/CalDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/CalDavCollection.kt
@@ -27,6 +27,8 @@ class CalDavCollection(httpClient: HttpClient, url: Url) : BaseWebDavCollection(
     ): Flow<WebDavCollection.MultiGetItem> =
         davCollection.multiget(urls).responsesWithRelation()
             .filter { it.relation == Response.HrefRelation.MEMBER }
-            .mapNotNull { it.response.asMultiGetItem { r -> r[CalendarData::class.java]?.iCalendar } }
+            .mapNotNull {
+                it.response.asMultiGetItem { r -> r[CalendarData::class.java]?.iCalendar }
+            }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/CalDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/CalDavCollection.kt
@@ -5,8 +5,12 @@
 package at.bitfire.davdroid.resource.remote
 
 import at.bitfire.dav4jvm.ktor.DavCalendar
+import at.bitfire.dav4jvm.ktor.responses
+import at.bitfire.dav4jvm.property.caldav.CalendarData
 import io.ktor.client.HttpClient
 import io.ktor.http.Url
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.mapNotNull
 
 /**
  * Remote CalDAV collection, as used for calendars, jtx board collections and task lists.
@@ -14,5 +18,13 @@ import io.ktor.http.Url
 class CalDavCollection(httpClient: HttpClient, url: Url) : BaseWebDavCollection(httpClient, url) {
 
     override val davCollection = DavCalendar(httpClient, url)
+
+    override fun multiget(
+        urls: List<Url>,
+        capabilities: WebDavCollection.Capabilities
+    ): Flow<WebDavCollection.MultiGetItem> =
+        davCollection.multiget(urls).responses().mapNotNull { response ->
+            buildMultiGetItem(response, response[CalendarData::class.java]?.iCalendar)
+        }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/CalDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/CalDavCollection.kt
@@ -5,14 +5,12 @@
 package at.bitfire.davdroid.resource.remote
 
 import at.bitfire.dav4jvm.ktor.DavCalendar
-import at.bitfire.dav4jvm.ktor.Response
 import at.bitfire.dav4jvm.ktor.responsesWithRelation
 import at.bitfire.dav4jvm.property.caldav.CalendarData
 import io.ktor.client.HttpClient
 import io.ktor.http.Url
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.map
 
 /**
  * Remote CalDAV collection, as used for calendars, jtx board collections and task lists.
@@ -26,8 +24,8 @@ class CalDavCollection(httpClient: HttpClient, url: Url) : BaseWebDavCollection(
         capabilities: WebDavCollection.Capabilities
     ): Flow<WebDavCollection.MultiGetItem> =
         davCollection.multiget(urls).responsesWithRelation()
-            .filter { it.relation == Response.HrefRelation.MEMBER }
-            .mapNotNull {
+            .filterSuccessfulMembers()
+            .map {
                 it.response.asMultiGetItem { r -> r[CalendarData::class.java]?.iCalendar }
             }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/CalDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/CalDavCollection.kt
@@ -5,11 +5,13 @@
 package at.bitfire.davdroid.resource.remote
 
 import at.bitfire.dav4jvm.ktor.DavCalendar
-import at.bitfire.dav4jvm.ktor.responses
+import at.bitfire.dav4jvm.ktor.Response
+import at.bitfire.dav4jvm.ktor.responsesWithRelation
 import at.bitfire.dav4jvm.property.caldav.CalendarData
 import io.ktor.client.HttpClient
 import io.ktor.http.Url
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.mapNotNull
 
 /**
@@ -23,8 +25,8 @@ class CalDavCollection(httpClient: HttpClient, url: Url) : BaseWebDavCollection(
         urls: List<Url>,
         capabilities: WebDavCollection.Capabilities
     ): Flow<WebDavCollection.MultiGetItem> =
-        davCollection.multiget(urls).responses().mapNotNull { response ->
-            buildMultiGetItem(response, response[CalendarData::class.java]?.iCalendar)
-        }
+        davCollection.multiget(urls).responsesWithRelation()
+            .filter { it.relation == Response.HrefRelation.MEMBER }
+            .mapNotNull { it.response.asMultiGetItem { r -> r[CalendarData::class.java]?.iCalendar } }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/CardDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/CardDavCollection.kt
@@ -28,11 +28,18 @@ class CardDavCollection(httpClient: HttpClient, url: Url) : BaseWebDavCollection
         capabilities: WebDavCollection.Capabilities
     ): Flow<WebDavCollection.MultiGetItem> {
         val contentType = DavUtils.MEDIA_TYPE_VCARD.toString()
-        // 3.0 is the default version; don't request it explicitly because maybe some vCard3-only servers don't understand it
-        val version = if (capabilities.supportsVCard4) VCardVersion.V4_0.version else null
-        return davCollection.multiget(urls, contentType, version).responsesWithRelation()
+        val vCardVersion = if (capabilities.supportsVCard4)
+            VCardVersion.V4_0.version
+        else {
+            // 3.0 is the default version; don't request it explicitly because some vCard3-only servers may not understand it
+            null
+        }
+
+        return davCollection.multiget(urls, contentType, vCardVersion).responsesWithRelation()
             .filter { it.relation == Response.HrefRelation.MEMBER }
-            .mapNotNull { it.response.asMultiGetItem { r -> r[AddressData::class.java]?.card } }
+            .mapNotNull {
+                it.response.asMultiGetItem { r -> r[AddressData::class.java]?.card }
+            }
     }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/CardDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/CardDavCollection.kt
@@ -5,8 +5,14 @@
 package at.bitfire.davdroid.resource.remote
 
 import at.bitfire.dav4jvm.ktor.DavAddressBook
+import at.bitfire.dav4jvm.ktor.responses
+import at.bitfire.dav4jvm.property.carddav.AddressData
+import at.bitfire.davdroid.util.DavUtils
+import ezvcard.VCardVersion
 import io.ktor.client.HttpClient
 import io.ktor.http.Url
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.mapNotNull
 
 /**
  * Remote CardDAV collection, as used for address books.
@@ -14,5 +20,17 @@ import io.ktor.http.Url
 class CardDavCollection(httpClient: HttpClient, url: Url) : BaseWebDavCollection(httpClient, url) {
 
     override val davCollection = DavAddressBook(httpClient, url)
+
+    override fun multiget(
+        urls: List<Url>,
+        capabilities: WebDavCollection.Capabilities
+    ): Flow<WebDavCollection.MultiGetItem> {
+        val contentType = DavUtils.MEDIA_TYPE_VCARD.toString()
+        // 3.0 is the default version; don't request it explicitly because maybe some vCard3-only servers don't understand it
+        val version = if (capabilities.supportsVCard4) VCardVersion.V4_0.version else null
+        return davCollection.multiget(urls, contentType, version).responses().mapNotNull { response ->
+            buildMultiGetItem(response, response[AddressData::class.java]?.card)
+        }
+    }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/CardDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/CardDavCollection.kt
@@ -5,13 +5,15 @@
 package at.bitfire.davdroid.resource.remote
 
 import at.bitfire.dav4jvm.ktor.DavAddressBook
-import at.bitfire.dav4jvm.ktor.responses
+import at.bitfire.dav4jvm.ktor.Response
+import at.bitfire.dav4jvm.ktor.responsesWithRelation
 import at.bitfire.dav4jvm.property.carddav.AddressData
 import at.bitfire.davdroid.util.DavUtils
 import ezvcard.VCardVersion
 import io.ktor.client.HttpClient
 import io.ktor.http.Url
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.mapNotNull
 
 /**
@@ -28,9 +30,9 @@ class CardDavCollection(httpClient: HttpClient, url: Url) : BaseWebDavCollection
         val contentType = DavUtils.MEDIA_TYPE_VCARD.toString()
         // 3.0 is the default version; don't request it explicitly because maybe some vCard3-only servers don't understand it
         val version = if (capabilities.supportsVCard4) VCardVersion.V4_0.version else null
-        return davCollection.multiget(urls, contentType, version).responses().mapNotNull { response ->
-            buildMultiGetItem(response, response[AddressData::class.java]?.card)
-        }
+        return davCollection.multiget(urls, contentType, version).responsesWithRelation()
+            .filter { it.relation == Response.HrefRelation.MEMBER }
+            .mapNotNull { it.response.asMultiGetItem { r -> r[AddressData::class.java]?.card } }
     }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/CardDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/CardDavCollection.kt
@@ -5,7 +5,6 @@
 package at.bitfire.davdroid.resource.remote
 
 import at.bitfire.dav4jvm.ktor.DavAddressBook
-import at.bitfire.dav4jvm.ktor.Response
 import at.bitfire.dav4jvm.ktor.responsesWithRelation
 import at.bitfire.dav4jvm.property.carddav.AddressData
 import at.bitfire.davdroid.util.DavUtils
@@ -13,8 +12,7 @@ import ezvcard.VCardVersion
 import io.ktor.client.HttpClient
 import io.ktor.http.Url
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.map
 
 /**
  * Remote CardDAV collection, as used for address books.
@@ -36,8 +34,8 @@ class CardDavCollection(httpClient: HttpClient, url: Url) : BaseWebDavCollection
         }
 
         return davCollection.multiget(urls, contentType, vCardVersion).responsesWithRelation()
-            .filter { it.relation == Response.HrefRelation.MEMBER }
-            .mapNotNull {
+            .filterSuccessfulMembers()
+            .map {
                 it.response.asMultiGetItem { r -> r[AddressData::class.java]?.card }
             }
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/MultiStatusItemExtensions.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/MultiStatusItemExtensions.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.resource.remote
+
+import at.bitfire.dav4jvm.ktor.MultiStatusItem
+import at.bitfire.dav4jvm.ktor.Response
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
+import java.util.logging.Logger
+
+/**
+ * Filters this flow down to responses that
+ *
+ * - are members of the collection (not the collection's own response or an unrelated resource)
+ * and successful.
+ *
+ * Logs a warning for every response that gets filtered out.
+ */
+fun Flow<MultiStatusItem.Response>.filterSuccessfulMembers(): Flow<MultiStatusItem.Response> {
+    val logger = Logger.getLogger("at.bitfire.davdroid.resource.remote.MultiStatusItemExtensions")
+    return filter { item ->
+        val isMember = (item.relation == Response.HrefRelation.MEMBER)
+        if (!isMember)
+                logger.warning("Ignoring non-member multi-get response: ${item.response.href}")
+
+        val isSuccess = item.response.isSuccess()
+        if (!isSuccess)
+            logger.warning("Ignoring non-successful (${item.response.status}) multi-get response: ${item.response.href}")
+
+        isMember && isSuccess
+    }
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/ResponseExtensions.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/ResponseExtensions.kt
@@ -5,9 +5,13 @@
 package at.bitfire.davdroid.resource.remote
 
 import at.bitfire.dav4jvm.ktor.Response
+import at.bitfire.dav4jvm.ktor.exception.DavException
 import at.bitfire.dav4jvm.property.caldav.GetCTag
+import at.bitfire.dav4jvm.property.caldav.ScheduleTag
+import at.bitfire.dav4jvm.property.webdav.GetETag
 import at.bitfire.dav4jvm.property.webdav.SyncToken
 import at.bitfire.davdroid.resource.SyncState
+import at.bitfire.davdroid.sync.withExceptionContext
 
 /**
  * Extracts the [SyncState] (`sync-token` or `CTag`) reported by this response, if any.
@@ -18,3 +22,33 @@ internal fun Response.syncState(): SyncState? =
     } ?: this[GetCTag::class.java]?.cTag?.let {
         SyncState(SyncState.Type.CTAG, it)
     }
+
+/**
+ * Turns this multi-get response into a [WebDavCollection.MultiGetItem], or `null` if the
+ * response was not successful.
+ *
+ * Callers should only invoke this for responses whose [Response.HrefRelation] is `MEMBER`
+ * (a collection's self-response or unrelated responses naturally lack the requested content
+ * and shouldn't be passed here).
+ *
+ * @param getContent extracts the resource data from a (successful) response (for instance calendar-data or address-data)
+ *
+ * @throws DavException if the response is successful but doesn't contain the expected resource data or an ETag
+ */
+suspend fun Response.asMultiGetItem(getContent: (Response) -> String?): WebDavCollection.MultiGetItem? {
+    val response = this
+    return response.href.withExceptionContext {
+        if (!response.isSuccess())
+            return@withExceptionContext null
+        val content = getContent(response)
+            ?: throw DavException("Received multi-get response without data")
+        val eTag = response[GetETag::class.java]?.eTag
+            ?: throw DavException("Received multi-get response without ETag")
+        WebDavCollection.MultiGetItem(
+            url = response.href,
+            eTag = eTag,
+            scheduleTag = response[ScheduleTag::class.java]?.scheduleTag,
+            content = content
+        )
+    }
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/ResponseExtensions.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/ResponseExtensions.kt
@@ -14,32 +14,19 @@ import at.bitfire.davdroid.resource.SyncState
 import at.bitfire.davdroid.sync.withExceptionContext
 
 /**
- * Extracts the [SyncState] (`sync-token` or `CTag`) reported by this response, if any.
+ * Turns this multi-get response into a [WebDavCollection.MultiGetItem].
+ *
+ * @param getContent extracts the data (calendar-data or address-data) from this response
+ *
+ * @throws DavException if this response doesn't contain the expected resource data or an ETag
+ * @throws IllegalArgumentException if this response is not successful (callers must filter beforehand,
+ *   for instance to [Response.HrefRelation.MEMBER] responses only)
  */
-internal fun Response.syncState(): SyncState? =
-    this[SyncToken::class.java]?.token?.let {
-        SyncState(SyncState.Type.SYNC_TOKEN, it)
-    } ?: this[GetCTag::class.java]?.cTag?.let {
-        SyncState(SyncState.Type.CTAG, it)
-    }
-
-/**
- * Turns this multi-get response into a [WebDavCollection.MultiGetItem], or `null` if the
- * response was not successful.
- *
- * Callers should only invoke this for responses whose [Response.HrefRelation] is `MEMBER`
- * (a collection's self-response or unrelated responses naturally lack the requested content
- * and shouldn't be passed here).
- *
- * @param getContent extracts the resource data from a (successful) response (for instance calendar-data or address-data)
- *
- * @throws DavException if the response is successful but doesn't contain the expected resource data or an ETag
- */
-suspend fun Response.asMultiGetItem(getContent: (Response) -> String?): WebDavCollection.MultiGetItem? {
+suspend fun Response.asMultiGetItem(getContent: (Response) -> String?): WebDavCollection.MultiGetItem {
     val response = this
+    require(response.isSuccess()) { "asMultiGetItem() must only be called for successful responses" }
+
     return response.href.withExceptionContext {
-        if (!response.isSuccess())
-            return@withExceptionContext null
         val content = getContent(response)
             ?: throw DavException("Received multi-get response without data")
         val eTag = response[GetETag::class.java]?.eTag
@@ -52,3 +39,13 @@ suspend fun Response.asMultiGetItem(getContent: (Response) -> String?): WebDavCo
         )
     }
 }
+
+/**
+ * Extracts the [SyncState] (`sync-token` or `CTag`) reported by this response, if any.
+ */
+internal fun Response.syncState(): SyncState? =
+    this[SyncToken::class.java]?.token?.let {
+        SyncState(SyncState.Type.SYNC_TOKEN, it)
+    } ?: this[GetCTag::class.java]?.cTag?.let {
+        SyncState(SyncState.Type.CTAG, it)
+    }

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/ResponseExtensions.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/ResponseExtensions.kt
@@ -19,12 +19,11 @@ import at.bitfire.davdroid.sync.withExceptionContext
  * @param getContent extracts the data (calendar-data or address-data) from this response
  *
  * @throws DavException if this response doesn't contain the expected resource data or an ETag
- * @throws IllegalArgumentException if this response is not successful (callers must filter beforehand,
- *   for instance to [Response.HrefRelation.MEMBER] responses only)
+ * @throws IllegalArgumentException if this response is not successful (callers must filter beforehand)
  */
 suspend fun Response.asMultiGetItem(getContent: (Response) -> String?): WebDavCollection.MultiGetItem {
     val response = this
-    require(response.isSuccess()) { "asMultiGetItem() must only be called for successful responses" }
+    require(response.isSuccess()) { "Must only be called for successful responses" }
 
     return response.href.withExceptionContext {
         val content = getContent(response)

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/WebDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/WebDavCollection.kt
@@ -90,7 +90,7 @@ interface WebDavCollection {
      * @param urls          members to download (max. size depends on server limits, so this should be a reasonably sized batch)
      * @param capabilities  current capabilities of the collection (used by CardDAV to select the vCard version)
      *
-     * @throws at.bitfire.dav4jvm.ktor.exception.DavException if a successful response is missing its ETag
+     * @throws at.bitfire.dav4jvm.ktor.exception.DavException on invalid response (like missing ETag or content)
      * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP errors
      */
     fun multiget(urls: List<Url>, capabilities: Capabilities): Flow<MultiGetItem>

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/WebDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/WebDavCollection.kt
@@ -88,7 +88,7 @@ interface WebDavCollection {
      * responses that contain the expected resource data are emitted.
      *
      * @param urls          members to download (max. size depends on server limits, so this should be a reasonably sized batch)
-     * @param capabilities  current capabilities of the collection (used by CardDAV to select the vCard version)
+     * @param capabilities  current capabilities of the collection
      *
      * @throws at.bitfire.dav4jvm.ktor.exception.DavException on invalid response (like missing ETag or content)
      * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP errors

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/WebDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/WebDavCollection.kt
@@ -6,7 +6,9 @@ package at.bitfire.davdroid.resource.remote
 
 import at.bitfire.dav4jvm.ktor.DavCollection
 import at.bitfire.davdroid.resource.SyncState
+import io.ktor.http.Url
 import io.ktor.http.content.OutgoingContent
+import kotlinx.coroutines.flow.Flow
 
 /**
  * Provides remote collection access as required for [at.bitfire.davdroid.sync.SyncManager].
@@ -80,6 +82,25 @@ interface WebDavCollection {
      * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP errors
      */
     suspend fun querySyncState(): SyncState?
+
+    /**
+     * Downloads a batch of members via multi-get (CalDAV/CardDAV report). Only successful
+     * responses that contain the expected resource data are emitted.
+     *
+     * @param urls          members to download (max. size depends on server limits, so this should be a reasonably sized batch)
+     * @param capabilities  current capabilities of the collection (used by CardDAV to select the vCard version)
+     *
+     * @throws at.bitfire.dav4jvm.ktor.exception.DavException if a successful response is missing its ETag
+     * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP errors
+     */
+    fun multiget(urls: List<Url>, capabilities: Capabilities): Flow<MultiGetItem>
+
+    data class MultiGetItem(
+        val url: Url,
+        val eTag: String,
+        val scheduleTag: String? = null,
+        val content: String
+    )
 
 
     // update

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
@@ -6,11 +6,6 @@ package at.bitfire.davdroid.sync
 
 import at.bitfire.dav4jvm.ktor.DavCalendar
 import at.bitfire.dav4jvm.ktor.MultiStatusItem
-import at.bitfire.dav4jvm.ktor.exception.DavException
-import at.bitfire.dav4jvm.ktor.responses
-import at.bitfire.dav4jvm.property.caldav.CalendarData
-import at.bitfire.dav4jvm.property.caldav.ScheduleTag
-import at.bitfire.dav4jvm.property.webdav.GetETag
 import at.bitfire.davdroid.ProductIds
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.accounts.AccountId
@@ -36,7 +31,6 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import io.ktor.client.HttpClient
-import io.ktor.http.Url
 import io.ktor.http.content.TextContent
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
@@ -159,52 +153,19 @@ class CalendarSyncManager @AssistedInject constructor(
         }
     }
 
-    override suspend fun downloadRemote(bunch: List<Url>, capabilities: WebDavCollection.Capabilities) {
-        logger.info("Downloading ${bunch.size} iCalendars: $bunch")
-        collectionInfo.url.withExceptionContext {
-            remoteCollection.davCollection.multiget(bunch).responses().collect { response ->
-                /*
-                 * Real-world servers may return:
-                 *
-                 * - unrelated resources
-                 * - the collection itself
-                 * - the requested resources, but with a different collection URL (for instance, `/cal/1.ics` instead of `/shared-cal/1.ics`).
-                 *
-                 * So we:
-                 *
-                 * - ignore unsuccessful responses,
-                 * - ignore responses without requested calendar data (should also ignore collections and hopefully unrelated resources), and
-                 * - take the last segment of the href as the file name and assume that it's in the requested collection.
-                 */
-                response.href.withExceptionContext wrapResource@{
-                    if (!response.isSuccess()) {
-                        logger.warning("Ignoring non-successful multi-get response for ${response.href}")
-                        return@wrapResource
-                    }
-
-                    val iCal = response[CalendarData::class.java]?.iCalendar
-                    if (iCal == null) {
-                        logger.warning("Ignoring multi-get response without calendar-data")
-                        return@wrapResource
-                    }
-
-                    val eTag = response[GetETag::class.java]?.eTag
-                        ?: throw DavException("Received multi-get response without ETag")
-                    val scheduleTag = response[ScheduleTag::class.java]?.scheduleTag
-                    val fileName = response.href.lastSegment
-
-                    try {
-                        processICalendar(
-                            fileName = fileName,
-                            eTag = eTag,
-                            scheduleTag = scheduleTag,
-                            reader = StringReader(iCal)
-                        )
-                    } catch (e: InvalidResourceException) {
-                        logger.log(Level.WARNING, "Could not map event", e)
-                        notifyInvalidResource(e, fileName)
-                    }
-                }
+    override suspend fun processDownload(result: WebDavCollection.MultiGetItem) {
+        result.url.withExceptionContext {
+            val fileName = result.url.lastSegment
+            try {
+                processICalendar(
+                    fileName = fileName,
+                    eTag = result.eTag,
+                    scheduleTag = result.scheduleTag,
+                    reader = StringReader(result.content)
+                )
+            } catch (e: InvalidResourceException) {
+                logger.log(Level.WARNING, "Could not map event", e)
+                notifyInvalidResource(e, fileName)
             }
         }
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
@@ -7,10 +7,6 @@ package at.bitfire.davdroid.sync
 import android.content.ContentProviderClient
 import at.bitfire.dav4jvm.ktor.DavAddressBook
 import at.bitfire.dav4jvm.ktor.MultiStatusItem
-import at.bitfire.dav4jvm.ktor.exception.DavException
-import at.bitfire.dav4jvm.ktor.responses
-import at.bitfire.dav4jvm.property.carddav.AddressData
-import at.bitfire.dav4jvm.property.webdav.GetETag
 import at.bitfire.dav4jvm.property.webdav.WebDAV
 import at.bitfire.davdroid.ProductIds
 import at.bitfire.davdroid.R
@@ -42,7 +38,6 @@ import ezvcard.VCardVersion
 import ezvcard.io.CannotParseException
 import io.ktor.client.HttpClient
 import io.ktor.http.ContentType
-import io.ktor.http.Url
 import io.ktor.http.content.TextContent
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
@@ -223,55 +218,23 @@ class ContactsSyncManager @AssistedInject constructor(
         }
     }
 
-    override suspend fun downloadRemote(bunch: List<Url>, capabilities: WebDavCollection.Capabilities) {
-        logger.info("Downloading ${bunch.size} vCard(s): $bunch")
-        collectionInfo.url.withExceptionContext {
-            val contentType: String?
-            val version: String?
-            when {
-                capabilities.supportsVCard4 -> {
-                    contentType = DavUtils.MEDIA_TYPE_VCARD.toString()
-                    version = VCardVersion.V4_0.version
-                }
-                else -> {
-                    contentType = DavUtils.MEDIA_TYPE_VCARD.toString()
-                    version = null     // 3.0 is the default version; don't request 3.0 explicitly because maybe some vCard3-only servers don't understand it
-                }
-            }
-            remoteCollection.davCollection.multiget(bunch, contentType, version).responses().collect { response ->
-                // See CalendarSyncManager for more information about the multi-get response
-                response.href.withExceptionContext wrapResource@{
-                    if (!response.isSuccess()) {
-                        logger.warning("Ignoring non-successful multi-get response for ${response.href}")
-                        return@wrapResource
+    override suspend fun processDownload(result: WebDavCollection.MultiGetItem) {
+        result.url.withExceptionContext {
+            processCard(
+                fileName = result.url.lastSegment,
+                eTag = result.eTag,
+                reader = StringReader(result.content),
+                downloader = object : Contact.Downloader {
+                    override suspend fun download(url: String, accepts: String): ByteArray? {
+                        // retrieve external resource (like a photo) from a URL (not necessarily HTTP[S])
+                        val retriever = resourceRetrieverFactory.create(
+                            accountId,
+                            remoteCollection.davCollection.location.host
+                        )
+                        return retriever.retrieve(url)
                     }
-
-                    val card = response[AddressData::class.java]?.card
-                    if (card == null) {
-                        logger.warning("Ignoring multi-get response without address-data")
-                        return@wrapResource
-                    }
-
-                    val eTag = response[GetETag::class.java]?.eTag
-                        ?: throw DavException("Received multi-get response without ETag")
-
-                    processCard(
-                        fileName = response.href.lastSegment,
-                        eTag = eTag,
-                        reader = StringReader(card),
-                        downloader = object : Contact.Downloader {
-                            override suspend fun download(url: String, accepts: String): ByteArray? {
-                                // retrieve external resource (like a photo) from a URL (not necessarily HTTP[S])
-                                val retriever = resourceRetrieverFactory.create(
-                                    accountId,
-                                    remoteCollection.davCollection.location.host
-                                )
-                                return retriever.retrieve(url)
-                            }
-                        }
-                    )
                 }
-            }
+            )
         }
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
@@ -7,11 +7,6 @@ package at.bitfire.davdroid.sync
 import androidx.annotation.OpenForTesting
 import at.bitfire.dav4jvm.ktor.DavCalendar
 import at.bitfire.dav4jvm.ktor.MultiStatusItem
-import at.bitfire.dav4jvm.ktor.exception.DavException
-import at.bitfire.dav4jvm.ktor.responses
-import at.bitfire.dav4jvm.property.caldav.CalendarData
-import at.bitfire.dav4jvm.property.caldav.ScheduleTag
-import at.bitfire.dav4jvm.property.webdav.GetETag
 import at.bitfire.davdroid.ProductIds
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.accounts.AccountId
@@ -36,7 +31,6 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import io.ktor.client.HttpClient
-import io.ktor.http.Url
 import io.ktor.http.content.TextContent
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
@@ -142,36 +136,14 @@ class JtxSyncManager @AssistedInject constructor(
         }
     }
 
-    override suspend fun downloadRemote(bunch: List<Url>, capabilities: WebDavCollection.Capabilities) {
-        logger.info("Downloading ${bunch.size} iCalendars: $bunch")
-        // multiple iCalendars, use calendar-multi-get
-        collectionInfo.url.withExceptionContext {
-            remoteCollection.davCollection.multiget(bunch).responses().collect { response ->
-                // See CalendarSyncManager for more information about the multi-get response
-                response.href.withExceptionContext wrapResource@{
-                    if (!response.isSuccess()) {
-                        logger.warning("Ignoring non-successful multi-get response for ${response.href}")
-                        return@wrapResource
-                    }
-
-                    val iCal = response[CalendarData::class.java]?.iCalendar
-                    if (iCal == null) {
-                        logger.warning("Ignoring multi-get response without calendar-data")
-                        return@wrapResource
-                    }
-
-                    val eTag = response[GetETag::class.java]?.eTag
-                        ?: throw DavException("Received multi-get response without ETag")
-                    val scheduleTag = response[ScheduleTag::class.java]?.scheduleTag
-                    val fileName = response.href.lastSegment
-
-                    try {
-                        processICalObject(fileName, eTag, scheduleTag, StringReader(iCal))
-                    } catch (e: InvalidResourceException) {
-                        logger.log(Level.WARNING, "Error while processing jtx object", e)
-                        notifyInvalidResource(e, fileName)
-                    }
-                }
+    override suspend fun processDownload(result: WebDavCollection.MultiGetItem) {
+        result.url.withExceptionContext {
+            val fileName = result.url.lastSegment
+            try {
+                processICalObject(fileName, result.eTag, result.scheduleTag, StringReader(result.content))
+            } catch (e: InvalidResourceException) {
+                logger.log(Level.WARNING, "Error while processing jtx object", e)
+                notifyInvalidResource(e, fileName)
             }
         }
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -526,8 +526,10 @@ abstract class SyncManager<LocalType : LocalResource>(
                 launch {
                     syncTransferSemaphore.withPermit {
                         logger.info("Downloading ${batch.size} resources: $batch")
-                        remoteCollection.multiget(batch, capabilities).collect { result ->
-                            processDownload(result)
+                        collectionInfo.url.withExceptionContext {
+                            remoteCollection.multiget(batch, capabilities).collect { result ->
+                                processDownload(result)
+                            }
                         }
                     }
                 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -518,14 +518,17 @@ abstract class SyncManager<LocalType : LocalResource>(
      * list are downloaded and processed.
      *
      * @param remoteItems   Multi-Status items to process
-     * @param capabilities  current capabilities of the remote collection (passed on to [downloadRemote])
+     * @param capabilities  current capabilities of the remote collection (passed on to [WebDavCollection.multiget])
      */
     protected suspend fun syncRemote(remoteItems: Flow<MultiStatusItem>, capabilities: WebDavCollection.Capabilities) =
         coroutineScope {    // structured concurrency
             val batchDownloader = BatchDownloader { batch ->
                 launch {
                     syncTransferSemaphore.withPermit {
-                        downloadRemote(batch, capabilities)
+                        logger.info("Downloading ${batch.size} resources: $batch")
+                        remoteCollection.multiget(batch, capabilities).collect { result ->
+                            processDownload(result)
+                        }
                     }
                 }
             }
@@ -587,24 +590,10 @@ abstract class SyncManager<LocalType : LocalResource>(
         }
 
     /**
-     * Downloads and processes resources, given as a list of URLs. Will be called with a list
-     * of changed/new remote resources.
-     *
-     * Implementations should not use GET to fetch single resources, but always multi-get, even
-     * for single resources for these reasons:
-     *
-     *   1. GET can only be used without HTTP compression, because it may change the ETag.
-     *      multi-get sends the ETag in the XML body, so there's no problem with compression.
-     *   2. Some servers are wrongly configured to suppress the ETag header in the response.
-     *      With multi-get, the ETag is in the XML body, so it won't be affected by that.
-     *   3. If there are two methods to download resources (GET and multi-get), both methods
-     *      have to be implemented, tested and maintained. Given that multi-get is required
-     *      in any case, it's better to have only one method.
-     *   4. For users, it's strange behavior when DAVx5 can download multiple remote changes,
-     *      but not a single one (or vice versa). So only one method is more user-friendly.
-     *   5. March 2020: iCloud now crashes with HTTP 500 upon CardDAV GET requests.
+     * Processes a downloaded resource (retrieved via [WebDavCollection.multiget]): maps it to a
+     * local format and stores it into local storage.
      */
-    protected abstract suspend fun downloadRemote(bunch: List<Url>, capabilities: WebDavCollection.Capabilities)
+    protected abstract suspend fun processDownload(result: WebDavCollection.MultiGetItem)
 
     /**
      * Locally deletes entries which are

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
@@ -6,10 +6,6 @@ package at.bitfire.davdroid.sync
 
 import at.bitfire.dav4jvm.ktor.DavCalendar
 import at.bitfire.dav4jvm.ktor.MultiStatusItem
-import at.bitfire.dav4jvm.ktor.exception.DavException
-import at.bitfire.dav4jvm.ktor.responses
-import at.bitfire.dav4jvm.property.caldav.CalendarData
-import at.bitfire.dav4jvm.property.webdav.GetETag
 import at.bitfire.davdroid.ProductIds
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.accounts.AccountId
@@ -35,7 +31,6 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import io.ktor.client.HttpClient
-import io.ktor.http.Url
 import io.ktor.http.content.TextContent
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
@@ -137,36 +132,14 @@ class TasksSyncManager @AssistedInject constructor(
         }
     }
 
-    override suspend fun downloadRemote(bunch: List<Url>, capabilities: WebDavCollection.Capabilities) {
-        logger.info("Downloading ${bunch.size} iCalendars: $bunch")
-        // multiple iCalendars, use calendar-multi-get
-        collectionInfo.url.withExceptionContext {
-            remoteCollection.davCollection.multiget(bunch).responses().collect { response ->
-                // See CalendarSyncManager for more information about the multi-get response
-                response.href.withExceptionContext wrapResource@{
-                    if (!response.isSuccess()) {
-                        logger.warning("Ignoring non-successful multi-get response for ${response.href}")
-                        return@wrapResource
-                    }
-
-                    val iCal = response[CalendarData::class.java]?.iCalendar
-                    if (iCal == null) {
-                        logger.warning("Ignoring multi-get response without calendar-data")
-                        return@wrapResource
-                    }
-
-                    val eTag = response[GetETag::class.java]?.eTag
-                        ?: throw DavException("Received multi-get response without ETag")
-
-                    val fileName = response.href.lastSegment
-
-                    try {
-                        processVTodo(fileName, eTag, StringReader(iCal))
-                    } catch (e: InvalidResourceException) {
-                        logger.log(Level.WARNING, "Error while processing VTODO", e)
-                        notifyInvalidResource(e, fileName)
-                    }
-                }
+    override suspend fun processDownload(result: WebDavCollection.MultiGetItem) {
+        result.url.withExceptionContext {
+            val fileName = result.url.lastSegment
+            try {
+                processVTodo(fileName, result.eTag, StringReader(result.content))
+            } catch (e: InvalidResourceException) {
+                logger.log(Level.WARNING, "Error while processing VTODO", e)
+                notifyInvalidResource(e, fileName)
             }
         }
     }

--- a/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollectionTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollectionTest.kt
@@ -4,8 +4,15 @@
 
 package at.bitfire.davdroid.resource.remote
 
+import at.bitfire.dav4jvm.Property
 import at.bitfire.dav4jvm.ktor.DavCollection
+import at.bitfire.dav4jvm.ktor.PropStat
+import at.bitfire.dav4jvm.ktor.Response
+import at.bitfire.dav4jvm.ktor.exception.DavException
+import at.bitfire.dav4jvm.property.caldav.ScheduleTag
+import at.bitfire.dav4jvm.property.webdav.GetETag
 import at.bitfire.davdroid.resource.SyncState
+import at.bitfire.davdroid.sync.unwrapContext
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -17,16 +24,30 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
 import io.ktor.http.content.TextContent
 import io.ktor.http.headersOf
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class BaseWebDavCollectionTest {
 
     private val url = Url("https://example.com/dav/")
+
+    private class TestCollection(httpClient: HttpClient, url: Url) : BaseWebDavCollection(httpClient, url) {
+        override val davCollection = DavCollection(httpClient, url)
+        override fun multiget(
+            urls: List<Url>,
+            capabilities: WebDavCollection.Capabilities
+        ): Flow<WebDavCollection.MultiGetItem> =
+            throw NotImplementedError()
+
+        suspend fun testBuildMultiGetItem(response: Response, content: String?) = buildMultiGetItem(response, content)
+    }
 
     private fun collection(xmlResponse: String): BaseWebDavCollection {
         val engine = MockEngine { _ ->
@@ -35,12 +56,8 @@ class BaseWebDavCollectionTest {
         return collection(engine)
     }
 
-    private fun collection(engine: MockEngine): BaseWebDavCollection {
-        val httpClient = HttpClient(engine)
-        return object : BaseWebDavCollection(httpClient, url) {
-            override val davCollection = DavCollection(httpClient, url)
-        }
-    }
+    private fun collection(engine: MockEngine): BaseWebDavCollection =
+        TestCollection(HttpClient(engine), url)
 
 
     // create
@@ -329,6 +346,67 @@ class BaseWebDavCollectionTest {
         ).querySyncState()
 
         assertEquals(SyncState(SyncState.Type.SYNC_TOKEN, "http://example.com/ns/sync/token123"), syncState)
+    }
+
+
+    // multiget (buildMultiGetItem)
+
+    private fun response(status: HttpStatusCode?, properties: List<Property>) = Response(
+        url,
+        Url("https://example.com/dav/some-file.ics"),
+        status,
+        listOf(PropStat(properties, HttpStatusCode.OK))
+    )
+
+    @Test
+    fun `buildMultiGetItem() with successful response and content returns MultiGetItem`() = runTest {
+        val item = TestCollection(HttpClient(MockEngine { respond("") }), url).testBuildMultiGetItem(
+            response(null, listOf(GetETag("some-etag"), ScheduleTag("some-schedule-tag"))),
+            "BEGIN:VCALENDAR"
+        )
+
+        assertEquals(
+            WebDavCollection.MultiGetItem(
+                url = Url("https://example.com/dav/some-file.ics"),
+                eTag = "some-etag",
+                scheduleTag = "some-schedule-tag",
+                content = "BEGIN:VCALENDAR"
+            ),
+            item
+        )
+    }
+
+    @Test
+    fun `buildMultiGetItem() with unsuccessful response returns null`() = runTest {
+        val item = TestCollection(HttpClient(MockEngine { respond("") }), url).testBuildMultiGetItem(
+            response(HttpStatusCode.NotFound, listOf(GetETag("some-etag"))),
+            "BEGIN:VCALENDAR"
+        )
+
+        assertNull(item)
+    }
+
+    @Test
+    fun `buildMultiGetItem() with missing content returns null`() = runTest {
+        val item = TestCollection(HttpClient(MockEngine { respond("") }), url).testBuildMultiGetItem(
+            response(null, listOf(GetETag("some-etag"))),
+            null
+        )
+
+        assertNull(item)
+    }
+
+    @Test
+    fun `buildMultiGetItem() with missing ETag throws DavException`() = runTest {
+        val e = assertThrows(Throwable::class.java) {
+            runBlocking {
+                TestCollection(HttpClient(MockEngine { respond("") }), url).testBuildMultiGetItem(
+                    response(null, emptyList()),
+                    "BEGIN:VCALENDAR"
+                )
+            }
+        }
+        assertTrue(e.unwrapContext().cause is DavException)
     }
 
 

--- a/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollectionTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollectionTest.kt
@@ -4,15 +4,8 @@
 
 package at.bitfire.davdroid.resource.remote
 
-import at.bitfire.dav4jvm.Property
 import at.bitfire.dav4jvm.ktor.DavCollection
-import at.bitfire.dav4jvm.ktor.PropStat
-import at.bitfire.dav4jvm.ktor.Response
-import at.bitfire.dav4jvm.ktor.exception.DavException
-import at.bitfire.dav4jvm.property.caldav.ScheduleTag
-import at.bitfire.dav4jvm.property.webdav.GetETag
 import at.bitfire.davdroid.resource.SyncState
-import at.bitfire.davdroid.sync.unwrapContext
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -25,12 +18,10 @@ import io.ktor.http.Url
 import io.ktor.http.content.TextContent
 import io.ktor.http.headersOf
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -45,8 +36,6 @@ class BaseWebDavCollectionTest {
             capabilities: WebDavCollection.Capabilities
         ): Flow<WebDavCollection.MultiGetItem> =
             throw NotImplementedError()
-
-        suspend fun testBuildMultiGetItem(response: Response, content: String?) = buildMultiGetItem(response, content)
     }
 
     private fun collection(xmlResponse: String): BaseWebDavCollection {
@@ -346,67 +335,6 @@ class BaseWebDavCollectionTest {
         ).querySyncState()
 
         assertEquals(SyncState(SyncState.Type.SYNC_TOKEN, "http://example.com/ns/sync/token123"), syncState)
-    }
-
-
-    // multiget (buildMultiGetItem)
-
-    private fun response(status: HttpStatusCode?, properties: List<Property>) = Response(
-        url,
-        Url("https://example.com/dav/some-file.ics"),
-        status,
-        listOf(PropStat(properties, HttpStatusCode.OK))
-    )
-
-    @Test
-    fun `buildMultiGetItem() with successful response and content returns MultiGetItem`() = runTest {
-        val item = TestCollection(HttpClient(MockEngine { respond("") }), url).testBuildMultiGetItem(
-            response(null, listOf(GetETag("some-etag"), ScheduleTag("some-schedule-tag"))),
-            "BEGIN:VCALENDAR"
-        )
-
-        assertEquals(
-            WebDavCollection.MultiGetItem(
-                url = Url("https://example.com/dav/some-file.ics"),
-                eTag = "some-etag",
-                scheduleTag = "some-schedule-tag",
-                content = "BEGIN:VCALENDAR"
-            ),
-            item
-        )
-    }
-
-    @Test
-    fun `buildMultiGetItem() with unsuccessful response returns null`() = runTest {
-        val item = TestCollection(HttpClient(MockEngine { respond("") }), url).testBuildMultiGetItem(
-            response(HttpStatusCode.NotFound, listOf(GetETag("some-etag"))),
-            "BEGIN:VCALENDAR"
-        )
-
-        assertNull(item)
-    }
-
-    @Test
-    fun `buildMultiGetItem() with missing content returns null`() = runTest {
-        val item = TestCollection(HttpClient(MockEngine { respond("") }), url).testBuildMultiGetItem(
-            response(null, listOf(GetETag("some-etag"))),
-            null
-        )
-
-        assertNull(item)
-    }
-
-    @Test
-    fun `buildMultiGetItem() with missing ETag throws DavException`() = runTest {
-        val e = assertThrows(Throwable::class.java) {
-            runBlocking {
-                TestCollection(HttpClient(MockEngine { respond("") }), url).testBuildMultiGetItem(
-                    response(null, emptyList()),
-                    "BEGIN:VCALENDAR"
-                )
-            }
-        }
-        assertTrue(e.unwrapContext().cause is DavException)
     }
 
 

--- a/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/CalDavCollectionTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/CalDavCollectionTest.kt
@@ -12,8 +12,10 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
 import io.ktor.http.headersOf
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -61,7 +63,7 @@ class CalDavCollectionTest {
     }
 
     @Test
-    fun `multiget() ignores response without calendar-data`() = runTest {
+    fun `multiget() ignores the collection's own response`() = runTest {
         val items = collection(
             "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
                     "<multistatus xmlns=\"DAV:\">\n" +
@@ -78,6 +80,28 @@ class CalDavCollectionTest {
         ).multiget(listOf(Url("https://example.com/dav/calendar/")), WebDavCollection.Capabilities()).toList()
 
         assertTrue(items.isEmpty())
+    }
+
+    @Test
+    fun `multiget() throws when a member response lacks calendar-data`() = runTest {
+        val flow = collection(
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                    "<multistatus xmlns=\"DAV:\">\n" +
+                    "  <response>\n" +
+                    "    <href>/dav/calendar/event1.ics</href>\n" +
+                    "    <propstat>\n" +
+                    "      <prop>\n" +
+                    "        <getetag>\"event-etag\"</getetag>\n" +
+                    "      </prop>\n" +
+                    "      <status>HTTP/1.1 200 OK</status>\n" +
+                    "    </propstat>\n" +
+                    "  </response>\n" +
+                    "</multistatus>"
+        ).multiget(listOf(Url("https://example.com/dav/calendar/event1.ics")), WebDavCollection.Capabilities())
+
+        assertThrows(Throwable::class.java) {
+            runBlocking { flow.toList() }
+        }
     }
 
 }

--- a/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/CalDavCollectionTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/CalDavCollectionTest.kt
@@ -4,6 +4,7 @@
 
 package at.bitfire.davdroid.resource.remote
 
+import at.bitfire.synctools.test.assertThrows
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -12,10 +13,8 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
 import io.ktor.http.headersOf
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -99,9 +98,7 @@ class CalDavCollectionTest {
                     "</multistatus>"
         ).multiget(listOf(Url("https://example.com/dav/calendar/event1.ics")), WebDavCollection.Capabilities())
 
-        assertThrows(Throwable::class.java) {
-            runBlocking { flow.toList() }
-        }
+        assertThrows<Throwable> { flow.toList() }
     }
 
 }

--- a/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/CalDavCollectionTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/CalDavCollectionTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.resource.remote
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Url
+import io.ktor.http.headersOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CalDavCollectionTest {
+
+    private val url = Url("https://example.com/dav/calendar/")
+
+    private fun collection(xmlResponse: String): CalDavCollection {
+        val engine = MockEngine { _ ->
+            respond(xmlResponse, HttpStatusCode.MultiStatus, headersOf(HttpHeaders.ContentType, "text/xml"))
+        }
+        return CalDavCollection(HttpClient(engine), url)
+    }
+
+    @Test
+    fun `multiget() extracts calendar-data into MultiGetItem`() = runTest {
+        val items = collection(
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                    "<multistatus xmlns=\"DAV:\" xmlns:C=\"urn:ietf:params:xml:ns:caldav\">\n" +
+                    "  <response>\n" +
+                    "    <href>/dav/calendar/event1.ics</href>\n" +
+                    "    <propstat>\n" +
+                    "      <prop>\n" +
+                    "        <getetag>\"event-etag\"</getetag>\n" +
+                    "        <C:schedule-tag>\"event-schedule-tag\"</C:schedule-tag>\n" +
+                    "        <C:calendar-data>BEGIN:VCALENDAR\nEND:VCALENDAR</C:calendar-data>\n" +
+                    "      </prop>\n" +
+                    "      <status>HTTP/1.1 200 OK</status>\n" +
+                    "    </propstat>\n" +
+                    "  </response>\n" +
+                    "</multistatus>"
+        ).multiget(listOf(Url("https://example.com/dav/calendar/event1.ics")), WebDavCollection.Capabilities()).toList()
+
+        assertEquals(
+            listOf(
+                WebDavCollection.MultiGetItem(
+                    url = Url("https://example.com/dav/calendar/event1.ics"),
+                    eTag = "event-etag",
+                    scheduleTag = "event-schedule-tag",
+                    content = "BEGIN:VCALENDAR\nEND:VCALENDAR"
+                )
+            ),
+            items
+        )
+    }
+
+    @Test
+    fun `multiget() ignores response without calendar-data`() = runTest {
+        val items = collection(
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                    "<multistatus xmlns=\"DAV:\">\n" +
+                    "  <response>\n" +
+                    "    <href>/dav/calendar/</href>\n" +
+                    "    <propstat>\n" +
+                    "      <prop>\n" +
+                    "        <getetag>\"collection-etag\"</getetag>\n" +
+                    "      </prop>\n" +
+                    "      <status>HTTP/1.1 200 OK</status>\n" +
+                    "    </propstat>\n" +
+                    "  </response>\n" +
+                    "</multistatus>"
+        ).multiget(listOf(Url("https://example.com/dav/calendar/")), WebDavCollection.Capabilities()).toList()
+
+        assertTrue(items.isEmpty())
+    }
+
+}

--- a/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/CalDavCollectionTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/CalDavCollectionTest.kt
@@ -25,7 +25,7 @@ class CalDavCollectionTest {
 
     @Test
     fun `multiget() extracts calendar-data into MultiGetItem`() = runTest {
-        val items = collection(
+        val calendar = collection(
             """
             <?xml version="1.0" encoding="utf-8"?>
             <multistatus xmlns="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
@@ -43,7 +43,12 @@ class CalDavCollectionTest {
               </response>
             </multistatus>
             """.trimIndent()
-        ).multiget(listOf(Url("https://example.com/dav/calendar/event1.ics")), WebDavCollection.Capabilities()).toList()
+        )
+
+        val items = calendar.multiget(
+            listOf(Url("https://example.com/dav/calendar/event1.ics")),
+            WebDavCollection.Capabilities()
+        ).toList()
 
         assertEquals(
             listOf(
@@ -85,7 +90,7 @@ class CalDavCollectionTest {
 
     @Test
     fun `multiget() throws when a member response lacks calendar-data`() = runTest {
-        val flow = collection(
+        val calendar = collection(
             """
             <?xml version="1.0" encoding="utf-8"?>
             <multistatus xmlns="DAV:">
@@ -100,9 +105,15 @@ class CalDavCollectionTest {
               </response>
             </multistatus>
             """.trimIndent()
-        ).multiget(listOf(Url("https://example.com/dav/calendar/event1.ics")), WebDavCollection.Capabilities())
+        )
 
-        val e = assertThrows<Throwable> { flow.toList() }
+        val e = assertThrows<Throwable> {
+            calendar.multiget(
+                listOf(Url("https://example.com/dav/calendar/event1.ics")),
+                WebDavCollection.Capabilities()
+            ).toList()
+        }
+
         assertEquals("Received multi-get response without data", e.unwrapContext().cause.message)
     }
 

--- a/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/CalDavCollectionTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/CalDavCollectionTest.kt
@@ -4,6 +4,7 @@
 
 package at.bitfire.davdroid.resource.remote
 
+import at.bitfire.davdroid.sync.unwrapContext
 import at.bitfire.synctools.test.assertThrows
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -22,30 +23,26 @@ class CalDavCollectionTest {
 
     private val url = Url("https://example.com/dav/calendar/")
 
-    private fun collection(xmlResponse: String): CalDavCollection {
-        val engine = MockEngine { _ ->
-            respond(xmlResponse, HttpStatusCode.MultiStatus, headersOf(HttpHeaders.ContentType, "text/xml"))
-        }
-        return CalDavCollection(HttpClient(engine), url)
-    }
-
     @Test
     fun `multiget() extracts calendar-data into MultiGetItem`() = runTest {
         val items = collection(
-            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
-                    "<multistatus xmlns=\"DAV:\" xmlns:C=\"urn:ietf:params:xml:ns:caldav\">\n" +
-                    "  <response>\n" +
-                    "    <href>/dav/calendar/event1.ics</href>\n" +
-                    "    <propstat>\n" +
-                    "      <prop>\n" +
-                    "        <getetag>\"event-etag\"</getetag>\n" +
-                    "        <C:schedule-tag>\"event-schedule-tag\"</C:schedule-tag>\n" +
-                    "        <C:calendar-data>BEGIN:VCALENDAR\nEND:VCALENDAR</C:calendar-data>\n" +
-                    "      </prop>\n" +
-                    "      <status>HTTP/1.1 200 OK</status>\n" +
-                    "    </propstat>\n" +
-                    "  </response>\n" +
-                    "</multistatus>"
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <multistatus xmlns="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
+              <response>
+                <href>/dav/calendar/event1.ics</href>
+                <propstat>
+                  <prop>
+                    <getetag>"event-etag"</getetag>
+                    <C:schedule-tag>"event-schedule-tag"</C:schedule-tag>
+                    <C:calendar-data>BEGIN:VCALENDAR
+            END:VCALENDAR</C:calendar-data>
+                  </prop>
+                  <status>HTTP/1.1 200 OK</status>
+                </propstat>
+              </response>
+            </multistatus>
+            """.trimIndent()
         ).multiget(listOf(Url("https://example.com/dav/calendar/event1.ics")), WebDavCollection.Capabilities()).toList()
 
         assertEquals(
@@ -63,20 +60,25 @@ class CalDavCollectionTest {
 
     @Test
     fun `multiget() ignores the collection's own response`() = runTest {
-        val items = collection(
-            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
-                    "<multistatus xmlns=\"DAV:\">\n" +
-                    "  <response>\n" +
-                    "    <href>/dav/calendar/</href>\n" +
-                    "    <propstat>\n" +
-                    "      <prop>\n" +
-                    "        <getetag>\"collection-etag\"</getetag>\n" +
-                    "      </prop>\n" +
-                    "      <status>HTTP/1.1 200 OK</status>\n" +
-                    "    </propstat>\n" +
-                    "  </response>\n" +
-                    "</multistatus>"
-        ).multiget(listOf(Url("https://example.com/dav/calendar/")), WebDavCollection.Capabilities()).toList()
+        val calendar = collection(
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <multistatus xmlns="DAV:">
+              <response>
+                <href>/dav/calendar/</href>
+                <propstat>
+                  <prop>
+                    <getetag>"collection-etag"</getetag>
+                  </prop>
+                  <status>HTTP/1.1 200 OK</status>
+                </propstat>
+              </response>
+            </multistatus>
+            """.trimIndent()
+        )
+
+        val items = calendar.multiget(listOf(Url("https://example.com/dav/calendar/")), WebDavCollection.Capabilities())
+            .toList()
 
         assertTrue(items.isEmpty())
     }
@@ -84,21 +86,31 @@ class CalDavCollectionTest {
     @Test
     fun `multiget() throws when a member response lacks calendar-data`() = runTest {
         val flow = collection(
-            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
-                    "<multistatus xmlns=\"DAV:\">\n" +
-                    "  <response>\n" +
-                    "    <href>/dav/calendar/event1.ics</href>\n" +
-                    "    <propstat>\n" +
-                    "      <prop>\n" +
-                    "        <getetag>\"event-etag\"</getetag>\n" +
-                    "      </prop>\n" +
-                    "      <status>HTTP/1.1 200 OK</status>\n" +
-                    "    </propstat>\n" +
-                    "  </response>\n" +
-                    "</multistatus>"
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <multistatus xmlns="DAV:">
+              <response>
+                <href>/dav/calendar/event1.ics</href>
+                <propstat>
+                  <prop>
+                    <getetag>"event-etag"</getetag>
+                  </prop>
+                  <status>HTTP/1.1 200 OK</status>
+                </propstat>
+              </response>
+            </multistatus>
+            """.trimIndent()
         ).multiget(listOf(Url("https://example.com/dav/calendar/event1.ics")), WebDavCollection.Capabilities())
 
-        assertThrows<Throwable> { flow.toList() }
+        val e = assertThrows<Throwable> { flow.toList() }
+        assertEquals("Received multi-get response without data", e.unwrapContext().cause.message)
+    }
+
+    private fun collection(xmlResponse: String): CalDavCollection {
+        val engine = MockEngine { _ ->
+            respond(xmlResponse, HttpStatusCode.MultiStatus, headersOf(HttpHeaders.ContentType, "text/xml"))
+        }
+        return CalDavCollection(HttpClient(engine), url)
     }
 
 }

--- a/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/CardDavCollectionTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/CardDavCollectionTest.kt
@@ -4,6 +4,7 @@
 
 package at.bitfire.davdroid.resource.remote
 
+import at.bitfire.davdroid.sync.unwrapContext
 import at.bitfire.synctools.test.assertThrows
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -23,34 +24,26 @@ class CardDavCollectionTest {
 
     private val url = Url("https://example.com/dav/contacts/")
 
-    private fun minimalMultiStatus() = MockEngine { _ ->
-        respond(
-            "<?xml version=\"1.0\" encoding=\"utf-8\"?><multistatus xmlns=\"DAV:\"/>",
-            HttpStatusCode.MultiStatus,
-            headersOf(HttpHeaders.ContentType, "text/xml")
-        )
-    }
-
-    private suspend fun requestBody(engine: MockEngine) =
-        engine.requestHistory.last().body.toByteArray().toString(Charsets.UTF_8)
-
     @Test
     fun `multiget() extracts address-data into MultiGetItem`() = runTest {
         val engine = MockEngine { _ ->
             respond(
-                "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
-                        "<multistatus xmlns=\"DAV:\" xmlns:CARD=\"urn:ietf:params:xml:ns:carddav\">\n" +
-                        "  <response>\n" +
-                        "    <href>/dav/contacts/contact1.vcf</href>\n" +
-                        "    <propstat>\n" +
-                        "      <prop>\n" +
-                        "        <getetag>\"contact-etag\"</getetag>\n" +
-                        "        <CARD:address-data>BEGIN:VCARD\nEND:VCARD</CARD:address-data>\n" +
-                        "      </prop>\n" +
-                        "      <status>HTTP/1.1 200 OK</status>\n" +
-                        "    </propstat>\n" +
-                        "  </response>\n" +
-                        "</multistatus>",
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <multistatus xmlns="DAV:" xmlns:CARD="urn:ietf:params:xml:ns:carddav">
+                  <response>
+                    <href>/dav/contacts/contact1.vcf</href>
+                    <propstat>
+                      <prop>
+                        <getetag>"contact-etag"</getetag>
+                        <CARD:address-data>BEGIN:VCARD
+                END:VCARD</CARD:address-data>
+                      </prop>
+                      <status>HTTP/1.1 200 OK</status>
+                    </propstat>
+                  </response>
+                </multistatus>
+                """.trimIndent(),
                 HttpStatusCode.MultiStatus,
                 headersOf(HttpHeaders.ContentType, "text/xml")
             )
@@ -101,18 +94,20 @@ class CardDavCollectionTest {
     fun `multiget() throws when a member response lacks address-data`() = runTest {
         val engine = MockEngine { _ ->
             respond(
-                "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
-                        "<multistatus xmlns=\"DAV:\">\n" +
-                        "  <response>\n" +
-                        "    <href>/dav/contacts/contact1.vcf</href>\n" +
-                        "    <propstat>\n" +
-                        "      <prop>\n" +
-                        "        <getetag>\"contact-etag\"</getetag>\n" +
-                        "      </prop>\n" +
-                        "      <status>HTTP/1.1 200 OK</status>\n" +
-                        "    </propstat>\n" +
-                        "  </response>\n" +
-                        "</multistatus>",
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <multistatus xmlns="DAV:">
+                  <response>
+                    <href>/dav/contacts/contact1.vcf</href>
+                    <propstat>
+                      <prop>
+                        <getetag>"contact-etag"</getetag>
+                      </prop>
+                      <status>HTTP/1.1 200 OK</status>
+                    </propstat>
+                  </response>
+                </multistatus>
+                """.trimIndent(),
                 HttpStatusCode.MultiStatus,
                 headersOf(HttpHeaders.ContentType, "text/xml")
             )
@@ -123,7 +118,19 @@ class CardDavCollectionTest {
             WebDavCollection.Capabilities()
         )
 
-        assertThrows<Throwable> { flow.toList() }
+        val e = assertThrows<Throwable> { flow.toList() }
+        assertEquals("Received multi-get response without data", e.unwrapContext().cause.message)
     }
+
+    private fun minimalMultiStatus() = MockEngine { _ ->
+        respond(
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?><multistatus xmlns=\"DAV:\"/>",
+            HttpStatusCode.MultiStatus,
+            headersOf(HttpHeaders.ContentType, "text/xml")
+        )
+    }
+
+    private suspend fun requestBody(engine: MockEngine) =
+        engine.requestHistory.last().body.toByteArray().toString(Charsets.UTF_8)
 
 }

--- a/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/CardDavCollectionTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/CardDavCollectionTest.kt
@@ -4,6 +4,7 @@
 
 package at.bitfire.davdroid.resource.remote
 
+import at.bitfire.synctools.test.assertThrows
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -13,10 +14,8 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
 import io.ktor.http.headersOf
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -124,9 +123,7 @@ class CardDavCollectionTest {
             WebDavCollection.Capabilities()
         )
 
-        assertThrows(Throwable::class.java) {
-            runBlocking { flow.toList() }
-        }
+        assertThrows<Throwable> { flow.toList() }
     }
 
 }

--- a/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/CardDavCollectionTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/CardDavCollectionTest.kt
@@ -13,8 +13,10 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
 import io.ktor.http.headersOf
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -94,6 +96,37 @@ class CardDavCollectionTest {
 
         val body = requestBody(engine)
         assertTrue(body.contains("<CARD:address-data content-type=\"text/vcard\" />"))
+    }
+
+    @Test
+    fun `multiget() throws when a member response lacks address-data`() = runTest {
+        val engine = MockEngine { _ ->
+            respond(
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                        "<multistatus xmlns=\"DAV:\">\n" +
+                        "  <response>\n" +
+                        "    <href>/dav/contacts/contact1.vcf</href>\n" +
+                        "    <propstat>\n" +
+                        "      <prop>\n" +
+                        "        <getetag>\"contact-etag\"</getetag>\n" +
+                        "      </prop>\n" +
+                        "      <status>HTTP/1.1 200 OK</status>\n" +
+                        "    </propstat>\n" +
+                        "  </response>\n" +
+                        "</multistatus>",
+                HttpStatusCode.MultiStatus,
+                headersOf(HttpHeaders.ContentType, "text/xml")
+            )
+        }
+
+        val flow = CardDavCollection(HttpClient(engine), url).multiget(
+            listOf(Url("https://example.com/dav/contacts/contact1.vcf")),
+            WebDavCollection.Capabilities()
+        )
+
+        assertThrows(Throwable::class.java) {
+            runBlocking { flow.toList() }
+        }
     }
 
 }

--- a/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/CardDavCollectionTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/CardDavCollectionTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.resource.remote
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.toByteArray
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Url
+import io.ktor.http.headersOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CardDavCollectionTest {
+
+    private val url = Url("https://example.com/dav/contacts/")
+
+    private fun minimalMultiStatus() = MockEngine { _ ->
+        respond(
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?><multistatus xmlns=\"DAV:\"/>",
+            HttpStatusCode.MultiStatus,
+            headersOf(HttpHeaders.ContentType, "text/xml")
+        )
+    }
+
+    private suspend fun requestBody(engine: MockEngine) =
+        engine.requestHistory.last().body.toByteArray().toString(Charsets.UTF_8)
+
+    @Test
+    fun `multiget() extracts address-data into MultiGetItem`() = runTest {
+        val engine = MockEngine { _ ->
+            respond(
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                        "<multistatus xmlns=\"DAV:\" xmlns:CARD=\"urn:ietf:params:xml:ns:carddav\">\n" +
+                        "  <response>\n" +
+                        "    <href>/dav/contacts/contact1.vcf</href>\n" +
+                        "    <propstat>\n" +
+                        "      <prop>\n" +
+                        "        <getetag>\"contact-etag\"</getetag>\n" +
+                        "        <CARD:address-data>BEGIN:VCARD\nEND:VCARD</CARD:address-data>\n" +
+                        "      </prop>\n" +
+                        "      <status>HTTP/1.1 200 OK</status>\n" +
+                        "    </propstat>\n" +
+                        "  </response>\n" +
+                        "</multistatus>",
+                HttpStatusCode.MultiStatus,
+                headersOf(HttpHeaders.ContentType, "text/xml")
+            )
+        }
+
+        val items = CardDavCollection(HttpClient(engine), url).multiget(
+            listOf(Url("https://example.com/dav/contacts/contact1.vcf")),
+            WebDavCollection.Capabilities()
+        ).toList()
+
+        assertEquals(
+            listOf(
+                WebDavCollection.MultiGetItem(
+                    url = Url("https://example.com/dav/contacts/contact1.vcf"),
+                    eTag = "contact-etag",
+                    content = "BEGIN:VCARD\nEND:VCARD"
+                )
+            ),
+            items
+        )
+    }
+
+    @Test
+    fun `multiget() with supportsVCard4 requests vCard 4`() = runTest {
+        val engine = minimalMultiStatus()
+        CardDavCollection(HttpClient(engine), url).multiget(
+            listOf(Url("https://example.com/dav/contacts/contact1.vcf")),
+            WebDavCollection.Capabilities(supportsVCard4 = true)
+        ).toList()
+
+        val body = requestBody(engine)
+        assertTrue(body.contains("version=\"4.0\""))
+    }
+
+    @Test
+    fun `multiget() without supportsVCard4 doesn't request a specific version`() = runTest {
+        val engine = minimalMultiStatus()
+        CardDavCollection(HttpClient(engine), url).multiget(
+            listOf(Url("https://example.com/dav/contacts/contact1.vcf")),
+            WebDavCollection.Capabilities(supportsVCard4 = false)
+        ).toList()
+
+        val body = requestBody(engine)
+        assertTrue(body.contains("<CARD:address-data content-type=\"text/vcard\" />"))
+    }
+
+}

--- a/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/CardDavCollectionTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/CardDavCollectionTest.kt
@@ -49,7 +49,9 @@ class CardDavCollectionTest {
             )
         }
 
-        val items = CardDavCollection(HttpClient(engine), url).multiget(
+        val collection = CardDavCollection(HttpClient(engine), url)
+
+        val items = collection.multiget(
             listOf(Url("https://example.com/dav/contacts/contact1.vcf")),
             WebDavCollection.Capabilities()
         ).toList()
@@ -113,12 +115,15 @@ class CardDavCollectionTest {
             )
         }
 
-        val flow = CardDavCollection(HttpClient(engine), url).multiget(
-            listOf(Url("https://example.com/dav/contacts/contact1.vcf")),
-            WebDavCollection.Capabilities()
-        )
+        val collection = CardDavCollection(HttpClient(engine), url)
 
-        val e = assertThrows<Throwable> { flow.toList() }
+        val e = assertThrows<Throwable> {
+            collection.multiget(
+                listOf(Url("https://example.com/dav/contacts/contact1.vcf")),
+                WebDavCollection.Capabilities()
+            ).toList()
+        }
+
         assertEquals("Received multi-get response without data", e.unwrapContext().cause.message)
     }
 

--- a/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/MultiStatusItemExtensionsTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/MultiStatusItemExtensionsTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.resource.remote
+
+import at.bitfire.dav4jvm.ktor.MultiStatusItem
+import at.bitfire.dav4jvm.ktor.PropStat
+import at.bitfire.dav4jvm.ktor.Response
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Url
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MultiStatusItemExtensionsTest {
+
+    private val url = Url("https://example.com/dav/")
+
+    private fun item(status: HttpStatusCode?, relation: Response.HrefRelation) = MultiStatusItem.Response(
+        Response(
+            url,
+            Url("https://example.com/dav/some-file.ics"),
+            status,
+            listOf(PropStat(emptyList(), HttpStatusCode.OK))
+        ),
+        relation
+    )
+
+    @Test
+    fun `filterSuccessfulMembers() keeps a successful MEMBER response`() = runTest {
+        val kept = item(null, Response.HrefRelation.MEMBER)
+        val result = flowOf(kept).filterSuccessfulMembers().toList()
+
+        assertEquals(listOf(kept), result)
+    }
+
+    @Test
+    fun `filterSuccessfulMembers() filters out a SELF response`() = runTest {
+        val result = flowOf(item(null, Response.HrefRelation.SELF)).filterSuccessfulMembers().toList()
+
+        assertEquals(emptyList<MultiStatusItem.Response>(), result)
+    }
+
+    @Test
+    fun `filterSuccessfulMembers() filters out an unsuccessful MEMBER response`() = runTest {
+        val result =
+            flowOf(item(HttpStatusCode.NotFound, Response.HrefRelation.MEMBER)).filterSuccessfulMembers().toList()
+
+        assertEquals(emptyList<MultiStatusItem.Response>(), result)
+    }
+
+}

--- a/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/ResponseExtensionsTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/ResponseExtensionsTest.kt
@@ -7,7 +7,6 @@ package at.bitfire.davdroid.resource.remote
 import at.bitfire.dav4jvm.Property
 import at.bitfire.dav4jvm.ktor.PropStat
 import at.bitfire.dav4jvm.ktor.Response
-import at.bitfire.dav4jvm.ktor.exception.DavException
 import at.bitfire.dav4jvm.property.caldav.ScheduleTag
 import at.bitfire.dav4jvm.property.webdav.GetETag
 import at.bitfire.davdroid.sync.unwrapContext
@@ -16,7 +15,6 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ResponseExtensionsTest {
@@ -48,7 +46,7 @@ class ResponseExtensionsTest {
 
     @Test
     fun `asMultiGetItem() with unsuccessful response throws IllegalArgumentException`() = runTest {
-        assertThrows<IllegalArgumentException> {
+        assertThrows(IllegalArgumentException("asMultiGetItem() must only be called for successful responses")) {
             response(HttpStatusCode.NotFound, listOf(GetETag("some-etag"))).asMultiGetItem { "BEGIN:VCALENDAR" }
         }
     }
@@ -58,7 +56,7 @@ class ResponseExtensionsTest {
         val e = assertThrows<Throwable> {
             response(null, listOf(GetETag("some-etag"))).asMultiGetItem { null }
         }
-        assertTrue(e.unwrapContext().cause is DavException)
+        assertEquals("Received multi-get response without data", e.unwrapContext().cause.message)
     }
 
     @Test
@@ -66,7 +64,7 @@ class ResponseExtensionsTest {
         val e = assertThrows<Throwable> {
             response(null, emptyList()).asMultiGetItem { "BEGIN:VCALENDAR" }
         }
-        assertTrue(e.unwrapContext().cause is DavException)
+        assertEquals("Received multi-get response without ETag", e.unwrapContext().cause.message)
     }
 
 }

--- a/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/ResponseExtensionsTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/ResponseExtensionsTest.kt
@@ -11,12 +11,11 @@ import at.bitfire.dav4jvm.ktor.exception.DavException
 import at.bitfire.dav4jvm.property.caldav.ScheduleTag
 import at.bitfire.dav4jvm.property.webdav.GetETag
 import at.bitfire.davdroid.sync.unwrapContext
+import at.bitfire.synctools.test.assertThrows
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -49,29 +48,23 @@ class ResponseExtensionsTest {
 
     @Test
     fun `asMultiGetItem() with unsuccessful response throws IllegalArgumentException`() = runTest {
-        assertThrows(IllegalArgumentException::class.java) {
-            runBlocking {
-                response(HttpStatusCode.NotFound, listOf(GetETag("some-etag"))).asMultiGetItem { "BEGIN:VCALENDAR" }
-            }
+        assertThrows<IllegalArgumentException> {
+            response(HttpStatusCode.NotFound, listOf(GetETag("some-etag"))).asMultiGetItem { "BEGIN:VCALENDAR" }
         }
     }
 
     @Test
     fun `asMultiGetItem() with missing content throws DavException`() = runTest {
-        val e = assertThrows(Throwable::class.java) {
-            runBlocking {
-                response(null, listOf(GetETag("some-etag"))).asMultiGetItem { null }
-            }
+        val e = assertThrows<Throwable> {
+            response(null, listOf(GetETag("some-etag"))).asMultiGetItem { null }
         }
         assertTrue(e.unwrapContext().cause is DavException)
     }
 
     @Test
     fun `asMultiGetItem() with missing ETag throws DavException`() = runTest {
-        val e = assertThrows(Throwable::class.java) {
-            runBlocking {
-                response(null, emptyList()).asMultiGetItem { "BEGIN:VCALENDAR" }
-            }
+        val e = assertThrows<Throwable> {
+            response(null, emptyList()).asMultiGetItem { "BEGIN:VCALENDAR" }
         }
         assertTrue(e.unwrapContext().cause is DavException)
     }

--- a/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/ResponseExtensionsTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/ResponseExtensionsTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.resource.remote
+
+import at.bitfire.dav4jvm.Property
+import at.bitfire.dav4jvm.ktor.PropStat
+import at.bitfire.dav4jvm.ktor.Response
+import at.bitfire.dav4jvm.ktor.exception.DavException
+import at.bitfire.dav4jvm.property.caldav.ScheduleTag
+import at.bitfire.dav4jvm.property.webdav.GetETag
+import at.bitfire.davdroid.sync.unwrapContext
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Url
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ResponseExtensionsTest {
+
+    private val url = Url("https://example.com/dav/")
+
+    private fun response(status: HttpStatusCode?, properties: List<Property>) = Response(
+        url,
+        Url("https://example.com/dav/some-file.ics"),
+        status,
+        listOf(PropStat(properties, HttpStatusCode.OK))
+    )
+
+    @Test
+    fun `asMultiGetItem() with successful response and content returns MultiGetItem`() = runTest {
+        val item = response(null, listOf(GetETag("some-etag"), ScheduleTag("some-schedule-tag")))
+            .asMultiGetItem { "BEGIN:VCALENDAR" }
+
+        assertEquals(
+            WebDavCollection.MultiGetItem(
+                url = Url("https://example.com/dav/some-file.ics"),
+                eTag = "some-etag",
+                scheduleTag = "some-schedule-tag",
+                content = "BEGIN:VCALENDAR"
+            ),
+            item
+        )
+    }
+
+    @Test
+    fun `asMultiGetItem() with unsuccessful response returns null`() = runTest {
+        val item = response(HttpStatusCode.NotFound, listOf(GetETag("some-etag")))
+            .asMultiGetItem { "BEGIN:VCALENDAR" }
+
+        assertNull(item)
+    }
+
+    @Test
+    fun `asMultiGetItem() with missing content throws DavException`() = runTest {
+        val e = assertThrows(Throwable::class.java) {
+            runBlocking {
+                response(null, listOf(GetETag("some-etag"))).asMultiGetItem { null }
+            }
+        }
+        assertTrue(e.unwrapContext().cause is DavException)
+    }
+
+    @Test
+    fun `asMultiGetItem() with missing ETag throws DavException`() = runTest {
+        val e = assertThrows(Throwable::class.java) {
+            runBlocking {
+                response(null, emptyList()).asMultiGetItem { "BEGIN:VCALENDAR" }
+            }
+        }
+        assertTrue(e.unwrapContext().cause is DavException)
+    }
+
+}

--- a/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/ResponseExtensionsTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/ResponseExtensionsTest.kt
@@ -46,7 +46,7 @@ class ResponseExtensionsTest {
 
     @Test
     fun `asMultiGetItem() with unsuccessful response throws IllegalArgumentException`() = runTest {
-        assertThrows(IllegalArgumentException("asMultiGetItem() must only be called for successful responses")) {
+        assertThrows(IllegalArgumentException("Must only be called for successful responses")) {
             response(HttpStatusCode.NotFound, listOf(GetETag("some-etag"))).asMultiGetItem { "BEGIN:VCALENDAR" }
         }
     }

--- a/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/ResponseExtensionsTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/ResponseExtensionsTest.kt
@@ -46,24 +46,28 @@ class ResponseExtensionsTest {
 
     @Test
     fun `asMultiGetItem() with unsuccessful response throws IllegalArgumentException`() = runTest {
+        val response = response(HttpStatusCode.NotFound, listOf(GetETag("some-etag")))
+
         assertThrows(IllegalArgumentException("Must only be called for successful responses")) {
-            response(HttpStatusCode.NotFound, listOf(GetETag("some-etag"))).asMultiGetItem { "BEGIN:VCALENDAR" }
+            response.asMultiGetItem { "BEGIN:VCALENDAR" }
         }
     }
 
     @Test
     fun `asMultiGetItem() with missing content throws DavException`() = runTest {
-        val e = assertThrows<Throwable> {
-            response(null, listOf(GetETag("some-etag"))).asMultiGetItem { null }
-        }
+        val response = response(null, listOf(GetETag("some-etag")))
+
+        val e = assertThrows<Throwable> { response.asMultiGetItem { null } }
+
         assertEquals("Received multi-get response without data", e.unwrapContext().cause.message)
     }
 
     @Test
     fun `asMultiGetItem() with missing ETag throws DavException`() = runTest {
-        val e = assertThrows<Throwable> {
-            response(null, emptyList()).asMultiGetItem { "BEGIN:VCALENDAR" }
-        }
+        val response = response(null, emptyList())
+
+        val e = assertThrows<Throwable> { response.asMultiGetItem { "BEGIN:VCALENDAR" } }
+
         assertEquals("Received multi-get response without ETag", e.unwrapContext().cause.message)
     }
 

--- a/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/ResponseExtensionsTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/ResponseExtensionsTest.kt
@@ -16,7 +16,6 @@ import io.ktor.http.Url
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -49,11 +48,12 @@ class ResponseExtensionsTest {
     }
 
     @Test
-    fun `asMultiGetItem() with unsuccessful response returns null`() = runTest {
-        val item = response(HttpStatusCode.NotFound, listOf(GetETag("some-etag")))
-            .asMultiGetItem { "BEGIN:VCALENDAR" }
-
-        assertNull(item)
+    fun `asMultiGetItem() with unsuccessful response throws IllegalArgumentException`() = runTest {
+        assertThrows(IllegalArgumentException::class.java) {
+            runBlocking {
+                response(HttpStatusCode.NotFound, listOf(GetETag("some-etag"))).asMultiGetItem { "BEGIN:VCALENDAR" }
+            }
+        }
     }
 
     @Test

--- a/synctools/src/testFixtures/kotlin/at/bitfire/synctools/test/AssertHelpers.kt
+++ b/synctools/src/testFixtures/kotlin/at/bitfire/synctools/test/AssertHelpers.kt
@@ -80,6 +80,15 @@ suspend inline fun <reified T : Throwable> assertThrows(block: suspend () -> Uni
     throw AssertionError("Expected ${T::class.simpleName} to be thrown, but nothing was thrown")
 }
 
+/**
+ * Like [assertThrows], but also asserts that the thrown exception's message matches [expected]'s message.
+ */
+suspend inline fun <reified T : Throwable> assertThrows(expected: T, block: suspend () -> Unit): T {
+    val actual = assertThrows<T>(block)
+    assertEquals(expected.message, actual.message)
+    return actual
+}
+
 
 // provider-specific assert helpers
 

--- a/synctools/src/testFixtures/kotlin/at/bitfire/synctools/test/AssertHelpers.kt
+++ b/synctools/src/testFixtures/kotlin/at/bitfire/synctools/test/AssertHelpers.kt
@@ -62,6 +62,24 @@ fun assertExceptionsEqual(
     }
 }
 
+/**
+ * Runs [block] and asserts it throws a [T], returning it. Unlike [org.junit.Assert.assertThrows],
+ * accepts a suspending block.
+ *
+ * @throws AssertionError if [block] doesn't throw anything
+ * @throws Throwable whatever [block] throws, if it isn't a [T]
+ */
+suspend inline fun <reified T : Throwable> assertThrows(block: suspend () -> Unit): T {
+    try {
+        block()
+    } catch (e: Throwable) {
+        if (e is T)
+            return e
+        throw e
+    }
+    throw AssertionError("Expected ${T::class.simpleName} to be thrown, but nothing was thrown")
+}
+
 
 // provider-specific assert helpers
 


### PR DESCRIPTION
### Purpose

Continues moving remote-collection responsibilities out of `SyncManager` into `WebDavCollection`: multi-get execution and response parsing move out of the four sync manager subclasses, which now just implement `processDownload(item)`.

Part of https://github.com/bitfireAT/davx5-ose/issues/2755.

### Short description

> [!NOTE]
> **Net code reduction in production code.**
> Most new lines are increased test coverage.

- Add `WebDavCollection.multiget()` / `MultiGetItem`, with parsing in `CalDavCollection`/`CardDavCollection` via new `asMultiGetItem()`/`filterSuccessfulMembers()` extensions.
- Filter multi-get responses by `HrefRelation` + success before parsing; malformed member responses now throw instead of being silently ignored.
- Replace `SyncManager.downloadRemote()` with `processDownload(MultiGetItem)`, dropping now-redundant multi-get boilerplate from the 4 sync manager subclasses.
- Add/update unit tests accordingly.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have self-reviewed the PR.
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.