### PR TITLE
[SyncManager] Split `syncRemote()` into `processListing()` / `processChanges()`

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/CalDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/CalDavCollection.kt
@@ -24,7 +24,8 @@ class CalDavCollection(httpClient: HttpClient, url: Url) : BaseWebDavCollection(
         capabilities: WebDavCollection.Capabilities
     ): Flow<WebDavCollection.MultiGetItem> =
         davCollection.multiget(urls).responsesWithRelation()
-            .filterSuccessfulMembers()
+            .filterMembers()
+            .filterSuccessful()
             .map {
                 it.response.asMultiGetItem { r -> r[CalendarData::class.java]?.iCalendar }
             }

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/CardDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/CardDavCollection.kt
@@ -34,7 +34,8 @@ class CardDavCollection(httpClient: HttpClient, url: Url) : BaseWebDavCollection
         }
 
         return davCollection.multiget(urls, contentType, vCardVersion).responsesWithRelation()
-            .filterSuccessfulMembers()
+            .filterMembers()
+            .filterSuccessful()
             .map {
                 it.response.asMultiGetItem { r -> r[AddressData::class.java]?.card }
             }

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/MultiStatusItemExtensions.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/MultiStatusItemExtensions.kt
@@ -10,25 +10,31 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
 import java.util.logging.Logger
 
+private val logger = Logger.getLogger("at.bitfire.davdroid.resource.remote.MultiStatusItemExtensions")
+
 /**
- * Filters this flow down to responses that
- *
- * - are members of the collection (not the collection's own response or an unrelated resource)
- * and successful.
+ * Filters this flow down to responses that are members of the collection (not the collection's
+ * own response or an unrelated resource).
  *
  * Logs a warning for every response that gets filtered out.
  */
-fun Flow<MultiStatusItem.Response>.filterSuccessfulMembers(): Flow<MultiStatusItem.Response> {
-    val logger = Logger.getLogger("at.bitfire.davdroid.resource.remote.MultiStatusItemExtensions")
-    return filter { item ->
-        val isMember = (item.relation == Response.HrefRelation.MEMBER)
+fun Flow<MultiStatusItem.Response>.filterMembers(): Flow<MultiStatusItem.Response> =
+    filter { item ->
+        val isMember = item.relation == Response.HrefRelation.MEMBER
         if (!isMember)
-                logger.warning("Ignoring non-member multi-get response: ${item.response.href}")
+            logger.warning("Ignoring non-member response: ${item.response.href}")
+        isMember
+    }
 
+/**
+ * Filters this flow down to successful responses.
+ *
+ * Logs a warning for every response that gets filtered out.
+ */
+fun Flow<MultiStatusItem.Response>.filterSuccessful(): Flow<MultiStatusItem.Response> =
+    filter { item ->
         val isSuccess = item.response.isSuccess()
         if (!isSuccess)
-            logger.warning("Ignoring non-successful (${item.response.status}) multi-get response: ${item.response.href}")
-
-        isMember && isSuccess
+            logger.warning("Ignoring non-successful (${item.response.status}) response: ${item.response.href}")
+        isSuccess
     }
-}

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/MultiStatusItemExtensions.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/MultiStatusItemExtensions.kt
@@ -6,8 +6,11 @@ package at.bitfire.davdroid.resource.remote
 
 import at.bitfire.dav4jvm.ktor.MultiStatusItem
 import at.bitfire.dav4jvm.ktor.Response
+import at.bitfire.dav4jvm.property.webdav.ResourceType
+import at.bitfire.dav4jvm.property.webdav.WebDAV
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNot
 import java.util.logging.Logger
 
 private val logger = Logger.getLogger("at.bitfire.davdroid.resource.remote.MultiStatusItemExtensions")
@@ -25,6 +28,15 @@ fun Flow<MultiStatusItem.Response>.filterMembers(): Flow<MultiStatusItem.Respons
             logger.warning("Ignoring non-member response: ${item.response.href}")
         isMember
     }
+
+/**
+ * Filters this flow down to responses that are not collections.
+ *
+ * Only filters anything if [WebDAV.ResourceType] is present in the response.
+ * **Make sure to request [WebDAV.ResourceType] if you want this filter to actually filter anything.**
+ */
+fun Flow<MultiStatusItem.Response>.filterNotCollections(): Flow<MultiStatusItem.Response> =
+    filterNot { item -> item.response[ResourceType::class.java]?.types?.contains(WebDAV.Collection) == true }
 
 /**
  * Filters this flow down to successful responses.

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -23,7 +23,6 @@ import at.bitfire.dav4jvm.ktor.exception.ServiceUnavailableException
 import at.bitfire.dav4jvm.ktor.exception.UnauthorizedException
 import at.bitfire.dav4jvm.ktor.responsesWithRelation
 import at.bitfire.dav4jvm.property.webdav.GetETag
-import at.bitfire.dav4jvm.property.webdav.ResourceType
 import at.bitfire.dav4jvm.property.webdav.SyncToken
 import at.bitfire.dav4jvm.property.webdav.WebDAV
 import at.bitfire.davdroid.R
@@ -40,6 +39,7 @@ import at.bitfire.davdroid.resource.LocalResource
 import at.bitfire.davdroid.resource.SyncState
 import at.bitfire.davdroid.resource.remote.WebDavCollection
 import at.bitfire.davdroid.resource.remote.filterMembers
+import at.bitfire.davdroid.resource.remote.filterNotCollections
 import at.bitfire.davdroid.resource.remote.filterSuccessful
 import at.bitfire.davdroid.resource.remote.member
 import at.bitfire.davdroid.sync.account.InvalidAccountException
@@ -52,7 +52,6 @@ import io.ktor.http.Url
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
-import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.transform
@@ -583,7 +582,8 @@ abstract class SyncManager<LocalType : LocalResource>(
     }
 
     /**
-     * Processes a full listing of remote members (PROPFIND/REPORT sync algorithm).
+     * Processes a full listing of remote members (PROPFIND/REPORT sync algorithm) with
+     * `Depth: 1`.
      *
      * Only new or changed members are queued for download. (Members that have vanished
      * are cleaned up separately by [deleteNotPresentRemotely] once the whole listing has
@@ -599,6 +599,8 @@ abstract class SyncManager<LocalType : LocalResource>(
         remoteItems.responsesWithRelation()
             // filter successful member responses
             .filterMembers()
+            // we requested Depth: 1, but may still receive collections which are direct members
+            .filterNotCollections()
             .filterSuccessful()
             // filter the items we want to download
             .mapNotNull { item ->
@@ -740,8 +742,8 @@ abstract class SyncManager<LocalType : LocalResource>(
         remoteItems.responsesWithRelation()
             // filter member resources
             .filterMembers()
-            // we requested sync-level=1, but may still receive collections which are direct members
-            .filterNot { item -> item.response[ResourceType::class.java]?.types?.contains(WebDAV.Collection) == true }
+            // we requested Depth: 1, but may still receive collections which are direct members
+            .filterNotCollections()
             // filter the items we want to download
             .mapNotNull { item ->
                 val response = item.response

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -600,8 +600,11 @@ abstract class SyncManager<LocalType : LocalResource>(
             // filter successful member responses
             .filterMembers()
             .filterSuccessful()
-            // filter the items we want to download – marks members as remotely present as side effect
-            .mapNotNull { item -> decideDownload(item.response) }
+            // filter the items we want to download
+            .mapNotNull { item ->
+                // marks remotely present members as side effect
+                decideDownload(item.response)
+            }
             // download items in batches concurrently
             .batchMap(MULTIGET_BATCH_SIZE) { batch -> downloadMembers(batch, capabilities) }
             // process and store downloaded items
@@ -739,18 +742,19 @@ abstract class SyncManager<LocalType : LocalResource>(
             .filterMembers()
             // we requested sync-level=1, but may still receive collections which are direct members
             .filterNot { item -> item.response[ResourceType::class.java]?.types?.contains(WebDAV.Collection) == true }
-            /* filter the items we want to download – two side effects:
-               1. remotely removed members are deleted locally
-               2. locally mark remotely present members (done in decideDownload) */
+            // filter the items we want to download
             .mapNotNull { item ->
                 val response = item.response
                 when {
                     // 2xx means "new/changed member"
-                    response.isSuccess() ->
+                    response.isSuccess() -> {
+                        // marks remotely present members as side effect
                         decideDownload(response)
+                    }
 
                     // 404 means "removed member"
                     response.status == HttpStatusCode.NotFound -> {
+                        // locally deletes remotely removed members as side effect
                         deleteRemovedMember(response.hrefName())
                         null
                     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -39,6 +39,8 @@ import at.bitfire.davdroid.resource.LocalCollection
 import at.bitfire.davdroid.resource.LocalResource
 import at.bitfire.davdroid.resource.SyncState
 import at.bitfire.davdroid.resource.remote.WebDavCollection
+import at.bitfire.davdroid.resource.remote.filterMembers
+import at.bitfire.davdroid.resource.remote.filterSuccessful
 import at.bitfire.davdroid.resource.remote.member
 import at.bitfire.davdroid.sync.account.InvalidAccountException
 import at.bitfire.davdroid.util.batchMap
@@ -527,108 +529,6 @@ abstract class SyncManager<LocalType : LocalResource>(
     }
 
     /**
-     * Calls a function to list remote resources. All resources from the returned
-     * list are downloaded and processed.
-     *
-     * Batches download concurrently, but local storage access stays sequential, since thread-safety
-     * of [LocalCollection] is not explicitly guaranteed.
-     *
-     * @param remoteItems   Multi-Status items to process
-     * @param capabilities  current capabilities of the remote collection (passed on to [WebDavCollection.multiget])
-     */
-    protected suspend fun syncRemote(remoteItems: Flow<MultiStatusItem>, capabilities: WebDavCollection.Capabilities) {
-        remoteItems.responsesWithRelation()
-            // we only want members and no known collections
-            .filter { (response, relation) ->
-                relation == Response.HrefRelation.MEMBER &&
-                        response[ResourceType::class.java]?.types?.contains(WebDAV.Collection) != true
-            }
-            // filter the items we want to download – delete remotely removed members as side effect
-            .mapNotNull { (response, _) -> processMember(response) }
-            // download items in batches concurrently
-            .batchMap(MULTIGET_BATCH_SIZE) { batch -> downloadMembers(batch, capabilities) }
-            // process downloaded items
-            .collect { result -> processDownload(result) }
-    }
-
-    /**
-     * Decides what to do with one remote member response:
-     *
-     * 1. marks it as remotely present and queues it for download (by returning
-     * its URL), or
-     * 2. deletes it locally if it has vanished on the server.
-     *
-     * **Attention:** This method is a basically a mapping filter (filters
-     * member [Response]s that need to be downloaded) with side effects
-     * (marks as locally present or deletes locally).
-     *
-     * @return the member's URL if it needs to be (re)downloaded, `null` otherwise
-     */
-    private suspend fun processMember(response: Response): Url? {
-        val name = response.hrefName()
-        return when {
-            response.isSuccess() -> {
-                logger.fine("Found remote resource: $name")
-
-                val local = localCollection.findByName(name)
-                local.withExceptionContext {
-                    if (local == null) {
-                        logger.info("$name has been added remotely, queueing download")
-                        response.href   // return URL to download
-                    } else {
-                        val localETag = local.eTag
-                        val remoteETag = response[GetETag::class.java]?.eTag
-                            ?: throw DavException("Server didn't provide ETag")
-
-                        // mark as remotely present, so that this resource won't be deleted at the end
-                        local.updateFlags(LocalResource.FLAG_REMOTELY_PRESENT)
-
-                        if (localETag == remoteETag) {
-                            logger.info("$name has not been changed on server (ETag still $remoteETag)")
-                            null    // return null → "don't download"
-                        } else {
-                            logger.info("$name has been changed on server (current ETag=$remoteETag, last known ETag=$localETag)")
-                            response.href   // return URL to download
-                        }
-                    }
-                }
-            }
-
-            response.status == HttpStatusCode.NotFound -> {
-                // collection sync: resource has been deleted on remote server
-                localCollection.findByName(name)?.let { local ->
-                    local.withExceptionContext {
-                        logger.info("$name has been deleted on server, deleting locally")
-                        local.deleteLocal()
-                    }
-                }
-                null    // return null → "don't download"
-            }
-
-            else -> {
-                logger.warning("Ignoring member status: ${response.href} (${response.status})")
-                null    // return null → "don't download"
-            }
-        }
-    }
-
-    /**
-     * Downloads one batch of members via [WebDavCollection.multiget], bounded by
-     * [syncMultigetSemaphore] and tagged with [collectionInfo]'s URL for error context.
-     */
-    private fun downloadMembers(
-        batch: List<Url>,
-        capabilities: WebDavCollection.Capabilities
-    ): Flow<WebDavCollection.MultiGetItem> = flow {
-        syncMultigetSemaphore.withPermit {
-            logger.info("Downloading ${batch.size} resources: $batch")
-            collectionInfo.url.withExceptionContext {
-                emitAll(remoteCollection.multiget(batch, capabilities))
-            }
-        }
-    }
-
-    /**
      * Processes a downloaded resource (retrieved via [WebDavCollection.multiget]): maps it to a
      * local format and stores it into local storage.
      */
@@ -670,7 +570,7 @@ abstract class SyncManager<LocalType : LocalResource>(
 
         // list and process all entries at current sync state (which may be the same as or newer than remoteSyncState)
         logger.info("Processing remote entries")
-        syncRemote(listAllRemote(), capabilities)
+        processListing(listAllRemote(), capabilities)
 
         logger.info("Deleting entries which are not present remotely anymore")
         deleteNotPresentRemotely()
@@ -680,6 +580,26 @@ abstract class SyncManager<LocalType : LocalResource>(
 
         logger.info("Saving sync state: $currentSyncState")
         localCollection.lastSyncState = currentSyncState
+    }
+
+    /**
+     * Processes a full listing of remote members (PROPFIND/REPORT sync algorithm). Only new or
+     * changed members are queued for download — members that have vanished are cleaned up
+     * separately by [deleteNotPresentRemotely] once the whole listing has been processed.
+     *
+     * @param remoteItems   Multi-Status items to process
+     * @param capabilities  current capabilities of the remote collection (passed on to [WebDavCollection.multiget])
+     */
+    private suspend fun processListing(
+        remoteItems: Flow<MultiStatusItem>,
+        capabilities: WebDavCollection.Capabilities
+    ) {
+        remoteItems.responsesWithRelation()
+            .filterMembers()
+            .filterSuccessful()
+            .mapNotNull { item -> decideDownload(item.response) }
+            .batchMap(MULTIGET_BATCH_SIZE) { batch -> downloadMembers(batch, capabilities) }
+            .collect { result -> processDownload(result) }
     }
 
     protected abstract fun listAllRemote(): Flow<MultiStatusItem>
@@ -704,9 +624,9 @@ abstract class SyncManager<LocalType : LocalResource>(
 
         do {
             logger.info("Listing changes since $syncState")
-            var (listingFlow, changesResult) = listRemoteChanges(syncState)
+            var (changesFlow, changesResult) = listRemoteChanges(syncState)
             try {
-                syncRemote(listingFlow, capabilities)
+                processChanges(changesFlow, capabilities)
             } catch (e: HttpException) {
                 if (e.errors.contains(Error(WebDAV.ValidSyncToken))) {
                     logger.info("Sync token invalid, performing initial sync")
@@ -714,9 +634,9 @@ abstract class SyncManager<LocalType : LocalResource>(
                     resetPresentRemotely()
 
                     val (retryFlow, retryResult) = listRemoteChanges(null)
-                    listingFlow = retryFlow
+                    changesFlow = retryFlow
                     changesResult = retryResult
-                    syncRemote(listingFlow, capabilities)
+                    processChanges(changesFlow, capabilities)
                 } else
                     throw e
             }
@@ -760,7 +680,7 @@ abstract class SyncManager<LocalType : LocalResource>(
      *
      * @param since sync state to list the changes since; `null` for an initial sync
      */
-    protected fun listRemoteChanges(since: SyncState?): Pair<Flow<MultiStatusItem>, SyncCollectionResult> {
+    private fun listRemoteChanges(since: SyncState?): Pair<Flow<MultiStatusItem>, SyncCollectionResult> {
         val result = SyncCollectionResult()
         val flow = remoteCollection.davCollection.reportChanges(
             syncToken = since?.takeIf { since.type == SyncState.Type.SYNC_TOKEN }?.value,
@@ -791,6 +711,109 @@ abstract class SyncManager<LocalType : LocalResource>(
             }
         }
         return flow to result
+    }
+
+    /**
+     * Processes changes reported by a `sync-collection` REPORT (collection-sync algorithm). Each
+     * member response either represents a new/changed member (queued for download) or a 404
+     * signalling that the member has been deleted on the server (deleted locally).
+     *
+     * @param remoteItems   Multi-Status items to process
+     * @param capabilities  current capabilities of the remote collection (passed on to [WebDavCollection.multiget])
+     */
+    private suspend fun processChanges(
+        remoteItems: Flow<MultiStatusItem>,
+        capabilities: WebDavCollection.Capabilities
+    ) {
+        remoteItems.responsesWithRelation()
+            .filterMembers()
+            // ignore sub-collections (e.g. nested calendars/address books)
+            .filter { item -> item.response[ResourceType::class.java]?.types?.contains(WebDAV.Collection) != true }
+            .mapNotNull { item ->
+                val response = item.response
+                when {
+                    response.isSuccess() -> decideDownload(response)
+                    response.status == HttpStatusCode.NotFound -> {
+                        deleteVanishedMember(response)
+                        null
+                    }
+                    else -> {
+                        logger.warning("Ignoring member status: ${response.href} (${response.status})")
+                        null
+                    }
+                }
+            }
+            .batchMap(MULTIGET_BATCH_SIZE) { batch -> downloadMembers(batch, capabilities) }
+            .collect { result -> processDownload(result) }
+    }
+
+    /**
+     * Deletes a member locally after the server reported it as deleted (404 in a `sync-collection`
+     * REPORT response).
+     */
+    private suspend fun deleteVanishedMember(response: Response) {
+        val name = response.hrefName()
+        localCollection.findByName(name)?.let { local ->
+            local.withExceptionContext {
+                logger.info("$name has been deleted on server, deleting locally")
+                local.deleteLocal()
+            }
+        }
+    }
+
+    //endregion
+
+
+    //region Processing shared by sync algorithms
+
+    /**
+     * Decides whether a member response represents a new or changed resource that needs to be
+     * (re)downloaded, and marks it as remotely present so it won't be deleted by
+     * [deleteNotPresentRemotely].
+     *
+     * @return the member's URL if it needs to be (re)downloaded, `null` otherwise
+     */
+    private suspend fun decideDownload(response: Response): Url? {
+        val name = response.hrefName()
+        logger.fine("Found remote resource: $name")
+
+        val local = localCollection.findByName(name)
+        return local.withExceptionContext {
+            if (local == null) {
+                logger.info("$name has been added remotely, queueing download")
+                response.href
+            } else {
+                val remoteETag = response[GetETag::class.java]?.eTag
+                    ?: throw DavException("Server didn't provide ETag")
+
+                // mark as remotely present, so that this resource won't be deleted at the end
+                local.updateFlags(LocalResource.FLAG_REMOTELY_PRESENT)
+
+                if (local.eTag == remoteETag) {
+                    logger.info("$name has not been changed on server (ETag still $remoteETag)")
+                    null
+                } else {
+                    logger.info("$name has been changed on server (current ETag=$remoteETag, last known ETag=${local.eTag})")
+                    response.href
+                }
+            }
+        }
+    }
+
+    /**
+     * Downloads one batch of members via [WebDavCollection.multiget], bounded by
+     * [syncMultigetSemaphore] and tagged with [collectionInfo]'s URL for error context.
+     */
+    private fun downloadMembers(
+        batch: List<Url>,
+        capabilities: WebDavCollection.Capabilities
+    ): Flow<WebDavCollection.MultiGetItem> = flow {
+        syncMultigetSemaphore.withPermit {
+            logger.info("Downloading ${batch.size} resources: $batch")
+            collectionInfo.url.withExceptionContext {
+                emitAll(remoteCollection.multiget(batch, capabilities))
+            }
+        }
     }
 
     //endregion

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -52,7 +52,7 @@ import io.ktor.http.Url
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
-import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.transform
@@ -583,23 +583,29 @@ abstract class SyncManager<LocalType : LocalResource>(
     }
 
     /**
-     * Processes a full listing of remote members (PROPFIND/REPORT sync algorithm). Only new or
-     * changed members are queued for download — members that have vanished are cleaned up
-     * separately by [deleteNotPresentRemotely] once the whole listing has been processed.
+     * Processes a full listing of remote members (PROPFIND/REPORT sync algorithm).
+     *
+     * Only new or changed members are queued for download. (Members that have vanished
+     * are cleaned up separately by [deleteNotPresentRemotely] once the whole listing has
+     * been processed).
      *
      * @param remoteItems   Multi-Status items to process
-     * @param capabilities  current capabilities of the remote collection (passed on to [WebDavCollection.multiget])
+     * @param capabilities  current capabilities of the remote collection
      */
     private suspend fun processListing(
         remoteItems: Flow<MultiStatusItem>,
         capabilities: WebDavCollection.Capabilities
     ) {
         remoteItems.responsesWithRelation()
+            // filter successful member responses
             .filterMembers()
             .filterSuccessful()
+            // filter the items we want to download – marks members as remotely present as side effect
             .mapNotNull { item -> decideDownload(item.response) }
+            // download items in batches concurrently
             .batchMap(MULTIGET_BATCH_SIZE) { batch -> downloadMembers(batch, capabilities) }
-            .collect { result -> processDownload(result) }
+            // process and store downloaded items
+            .collect { item -> processDownload(item) }
     }
 
     protected abstract fun listAllRemote(): Flow<MultiStatusItem>
@@ -686,7 +692,8 @@ abstract class SyncManager<LocalType : LocalResource>(
             syncToken = since?.takeIf { since.type == SyncState.Type.SYNC_TOKEN }?.value,
             infiniteDepth = false,
             limit = null,
-            WebDAV.GetETag
+            WebDAV.GetETag,     // we need the ETag for every item
+            WebDAV.ResourceType // we want to ignore sub-collections, so we need to know which items are collections
         ).transform { item ->
             when (item) {
                 is MultiStatusItem.Response -> when (item.relation) {
@@ -714,45 +721,56 @@ abstract class SyncManager<LocalType : LocalResource>(
     }
 
     /**
-     * Processes changes reported by a `sync-collection` REPORT (collection-sync algorithm). Each
-     * member response either represents a new/changed member (queued for download) or a 404
-     * signalling that the member has been deleted on the server (deleted locally).
+     * Processes changes reported by a `sync-collection` REPORT (collection-sync algorithm)
+     * with `Depth: 1`. Each member response either represents
+     *
+     * - a new/changed member → queue for download, or
+     * - a 404 response signaling that the member has been deleted on the server → delete locally.
      *
      * @param remoteItems   Multi-Status items to process
-     * @param capabilities  current capabilities of the remote collection (passed on to [WebDavCollection.multiget])
+     * @param capabilities  current capabilities of the remote collection
      */
     private suspend fun processChanges(
         remoteItems: Flow<MultiStatusItem>,
         capabilities: WebDavCollection.Capabilities
     ) {
         remoteItems.responsesWithRelation()
+            // filter member resources
             .filterMembers()
-            // ignore sub-collections (e.g. nested calendars/address books)
-            .filter { item -> item.response[ResourceType::class.java]?.types?.contains(WebDAV.Collection) != true }
+            // we requested sync-level=1, but may still receive collections which are direct members
+            .filterNot { item -> item.response[ResourceType::class.java]?.types?.contains(WebDAV.Collection) == true }
+            /* filter the items we want to download – two side effects:
+               1. remotely removed members are deleted locally
+               2. locally mark remotely present members (done in decideDownload) */
             .mapNotNull { item ->
                 val response = item.response
                 when {
-                    response.isSuccess() -> decideDownload(response)
+                    // 2xx means "new/changed member"
+                    response.isSuccess() ->
+                        decideDownload(response)
+
+                    // 404 means "removed member"
                     response.status == HttpStatusCode.NotFound -> {
-                        deleteVanishedMember(response)
+                        deleteRemovedMember(response.hrefName())
                         null
                     }
+
                     else -> {
-                        logger.warning("Ignoring member status: ${response.href} (${response.status})")
+                        logger.warning("Ignoring response for ${response.href} (${response.status})")
                         null
                     }
                 }
             }
+            // download items in batches concurrently
             .batchMap(MULTIGET_BATCH_SIZE) { batch -> downloadMembers(batch, capabilities) }
-            .collect { result -> processDownload(result) }
+            // process and store downloaded items
+            .collect { item -> processDownload(item) }
     }
 
     /**
-     * Deletes a member locally after the server reported it as deleted (404 in a `sync-collection`
-     * REPORT response).
+     * Locally deletes a member after the server reported it as deleted remotely.
      */
-    private suspend fun deleteVanishedMember(response: Response) {
-        val name = response.hrefName()
+    private suspend fun deleteRemovedMember(name: String) {
         localCollection.findByName(name)?.let { local ->
             local.withExceptionContext {
                 logger.info("$name has been deleted on server, deleting locally")

--- a/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/MultiStatusItemExtensionsTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/MultiStatusItemExtensionsTest.kt
@@ -4,9 +4,12 @@
 
 package at.bitfire.davdroid.resource.remote
 
+import at.bitfire.dav4jvm.Property
 import at.bitfire.dav4jvm.ktor.MultiStatusItem
 import at.bitfire.dav4jvm.ktor.PropStat
 import at.bitfire.dav4jvm.ktor.Response
+import at.bitfire.dav4jvm.property.webdav.ResourceType
+import at.bitfire.dav4jvm.property.webdav.WebDAV
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
 import kotlinx.coroutines.flow.flowOf
@@ -19,12 +22,16 @@ class MultiStatusItemExtensionsTest {
 
     private val url = Url("https://example.com/dav/")
 
-    private fun item(status: HttpStatusCode?, relation: Response.HrefRelation) = MultiStatusItem.Response(
+    private fun item(
+        status: HttpStatusCode?,
+        relation: Response.HrefRelation,
+        properties: List<Property> = emptyList()
+    ) = MultiStatusItem.Response(
         Response(
             url,
             Url("https://example.com/dav/some-file.ics"),
             status,
-            listOf(PropStat(emptyList(), HttpStatusCode.OK))
+            listOf(PropStat(properties, HttpStatusCode.OK))
         ),
         relation
     )
@@ -40,6 +47,26 @@ class MultiStatusItemExtensionsTest {
     @Test
     fun `filterMembers() filters out a SELF response`() = runTest {
         val result = flowOf(item(null, Response.HrefRelation.SELF)).filterMembers().toList()
+
+        assertEquals(emptyList<MultiStatusItem.Response>(), result)
+    }
+
+    @Test
+    fun `filterNotCollections() keeps a non-collection response`() = runTest {
+        val kept = item(null, Response.HrefRelation.MEMBER)
+        val result = flowOf(kept).filterNotCollections().toList()
+
+        assertEquals(listOf(kept), result)
+    }
+
+    @Test
+    fun `filterNotCollections() filters out a collection response`() = runTest {
+        val collection = item(
+            null,
+            Response.HrefRelation.MEMBER,
+            properties = listOf(ResourceType(setOf(WebDAV.Collection)))
+        )
+        val result = flowOf(collection).filterNotCollections().toList()
 
         assertEquals(emptyList<MultiStatusItem.Response>(), result)
     }

--- a/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/MultiStatusItemExtensionsTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/MultiStatusItemExtensionsTest.kt
@@ -30,24 +30,32 @@ class MultiStatusItemExtensionsTest {
     )
 
     @Test
-    fun `filterSuccessfulMembers() keeps a successful MEMBER response`() = runTest {
+    fun `filterMembers() keeps a MEMBER response`() = runTest {
         val kept = item(null, Response.HrefRelation.MEMBER)
-        val result = flowOf(kept).filterSuccessfulMembers().toList()
+        val result = flowOf(kept).filterMembers().toList()
 
         assertEquals(listOf(kept), result)
     }
 
     @Test
-    fun `filterSuccessfulMembers() filters out a SELF response`() = runTest {
-        val result = flowOf(item(null, Response.HrefRelation.SELF)).filterSuccessfulMembers().toList()
+    fun `filterMembers() filters out a SELF response`() = runTest {
+        val result = flowOf(item(null, Response.HrefRelation.SELF)).filterMembers().toList()
 
         assertEquals(emptyList<MultiStatusItem.Response>(), result)
     }
 
     @Test
-    fun `filterSuccessfulMembers() filters out an unsuccessful MEMBER response`() = runTest {
+    fun `filterSuccessful() keeps a successful response`() = runTest {
+        val kept = item(null, Response.HrefRelation.MEMBER)
+        val result = flowOf(kept).filterSuccessful().toList()
+
+        assertEquals(listOf(kept), result)
+    }
+
+    @Test
+    fun `filterSuccessful() filters out an unsuccessful response`() = runTest {
         val result =
-            flowOf(item(HttpStatusCode.NotFound, Response.HrefRelation.MEMBER)).filterSuccessfulMembers().toList()
+            flowOf(item(HttpStatusCode.NotFound, Response.HrefRelation.MEMBER)).filterSuccessful().toList()
 
         assertEquals(emptyList<MultiStatusItem.Response>(), result)
     }


### PR DESCRIPTION
Part of https://github.com/bitfireAT/davx5-ose/issues/2755.

### Purpose

`syncRemote()` handled both sync algorithms (full PROPFIND/REPORT listing and incremental collection-sync) with one function, even though only collection-sync ever sees 404 "member deleted" responses.

Splitting it makes each algorithm's response handling explicit.

### Short description

- **Split `syncRemote()` into `processListing()` (PROPFIND/REPORT) and `processChanges()` (collection-sync); each now only handles the response cases relevant to its algorithm.**
- Moved the logic shared by both (`decideDownload()`, `downloadMembers()`) into a new "Processing shared by sync algorithms" region.
- `reportChanges()` now explicitly requests `WebDAV.ResourceType` (previously `processChanges` filtered on it without requesting it, so sub-collections were never actually excluded from collection-sync).

**Out of scope / for future PR:** extract the remote collection queries (`listAllRemote()`/`listRemoteChanges()`) into `WebDavCollection`. Even further in the future: extract sync algorithms into separate classes (strategy pattern).