### PR TITLE
[SyncManager] Extract `listChanges`

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollection.kt
@@ -6,22 +6,31 @@ package at.bitfire.davdroid.resource.remote
 
 import at.bitfire.dav4jvm.QuotedStringUtils
 import at.bitfire.dav4jvm.ktor.DavResource
+import at.bitfire.dav4jvm.ktor.MultiStatusItem
+import at.bitfire.dav4jvm.ktor.Response
 import at.bitfire.dav4jvm.ktor.selfResponse
 import at.bitfire.dav4jvm.property.caldav.CalDAV
 import at.bitfire.dav4jvm.property.caldav.ScheduleTag
 import at.bitfire.dav4jvm.property.carddav.CardDAV
 import at.bitfire.dav4jvm.property.carddav.SupportedAddressData
 import at.bitfire.dav4jvm.property.webdav.GetETag
+import at.bitfire.dav4jvm.property.webdav.ResourceType
 import at.bitfire.dav4jvm.property.webdav.SupportedReportSet
+import at.bitfire.dav4jvm.property.webdav.SyncToken
 import at.bitfire.dav4jvm.property.webdav.WebDAV
 import at.bitfire.davdroid.resource.SyncState
 import io.ktor.client.HttpClient
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
 import io.ktor.http.content.OutgoingContent
 import io.ktor.http.headers
 import io.ktor.util.appendAll
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.map
+import java.util.logging.Logger
 import at.bitfire.dav4jvm.property.caldav.MaxResourceSize as CalDavMaxResourceSize
 import at.bitfire.dav4jvm.property.carddav.MaxResourceSize as CardDavMaxResourceSize
 
@@ -32,6 +41,8 @@ abstract class BaseWebDavCollection(
     protected val httpClient: HttpClient,
     protected val url: Url
 ) : WebDavCollection {
+
+    private val logger get() = Logger.getLogger(javaClass.name)
 
     // create
 
@@ -84,6 +95,50 @@ abstract class BaseWebDavCollection(
 
     override suspend fun querySyncState(): SyncState? =
         davCollection.propfind(depth = 0, CalDAV.GetCTag, WebDAV.SyncToken).selfResponse()?.syncState()
+
+    override fun listChanges(since: SyncState?): Flow<CollectionSyncItem> =
+        davCollection.reportChanges(
+            syncToken = since?.takeIf { it.type == SyncState.Type.SYNC_TOKEN }?.value,
+            infiniteDepth = false,
+            limit = null,
+            WebDAV.GetETag,     // we need the ETag for every changed member
+            WebDAV.ResourceType // we want to ignore sub-collections, so we need to know which items are collections
+        ).map { item -> classifyItem(item) }.filterNotNull()
+
+    private fun classifyItem(item: MultiStatusItem): CollectionSyncItem? =
+        when (item) {
+            is MultiStatusItem.Response -> when (item.relation) {
+                Response.HrefRelation.SELF ->
+                    CollectionSyncItem.FurtherChanges.takeIf { item.response.status == HttpStatusCode.InsufficientStorage }
+
+                Response.HrefRelation.MEMBER -> {
+                    val response = item.response
+                    when {
+                        // we requested Depth: 1, but may still receive collections which are direct members
+                        response[ResourceType::class.java]?.types?.contains(WebDAV.Collection) == true -> null
+
+                        response.isSuccess() ->
+                            CollectionSyncItem.ChangedMember(InternalMemberState(response.href, response.requireETag()))
+
+                        response.status == HttpStatusCode.NotFound ->
+                            CollectionSyncItem.RemovedMember(response.href)
+
+                        else -> {
+                            logger.warning("Ignoring response for ${response.href} (${response.status})")
+                            null
+                        }
+                    }
+                }
+
+                else -> {
+                    logger.warning("Unexpected sync-collection response: ${item.response}")
+                    null
+                }
+            }
+
+            is MultiStatusItem.ExtraProperty ->
+                (item.property as? SyncToken)?.let { CollectionSyncItem.SyncToken(it) }
+        }
 
 
     // update

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/CollectionSyncItem.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/CollectionSyncItem.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.resource.remote
+
+import io.ktor.http.Url
+
+/**
+ * One item reported by a `sync-collection` REPORT (RFC 6578), as returned by [WebDavCollection.listChanges].
+ */
+sealed class CollectionSyncItem {
+
+    /** The `sync-token` reported for this `sync-collection` REPORT. */
+    data class SyncToken(val token: at.bitfire.dav4jvm.property.webdav.SyncToken) : CollectionSyncItem()
+
+    /** Signals that the result set was truncated (507 on the request-URI) and more changes follow. */
+    data object FurtherChanges : CollectionSyncItem()
+
+    /** A member that was added or changed (2xx response). */
+    data class ChangedMember(val memberState: InternalMemberState) : CollectionSyncItem()
+
+    /** A member that was removed (404 response). Only the href is available, no ETag. */
+    data class RemovedMember(val href: Url) : CollectionSyncItem()
+
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/WebDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/WebDavCollection.kt
@@ -101,7 +101,8 @@ interface WebDavCollection {
     fun listFilteredMembers(): Flow<InternalMemberState>
 
     /**
-     * Lists changes since [since] via `sync-collection` REPORT (RFC 6578), with `Depth: 1`.
+     * Lists changes since [since] via `sync-collection` REPORT (RFC 6578), with a
+     * `sync-level` of 1 (one).
      *
      * Must only be called when [Capabilities.canCollectionSync] is `true`; behavior is undefined
      * (server will likely respond with an error) otherwise.

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/WebDavCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/remote/WebDavCollection.kt
@@ -101,6 +101,21 @@ interface WebDavCollection {
     fun listFilteredMembers(): Flow<InternalMemberState>
 
     /**
+     * Lists changes since [since] via `sync-collection` REPORT (RFC 6578), with `Depth: 1`.
+     *
+     * Must only be called when [Capabilities.canCollectionSync] is `true`; behavior is undefined
+     * (server will likely respond with an error) otherwise.
+     *
+     * @param since sync state to list changes since; `null` for an initial sync
+     *
+     * @throws at.bitfire.dav4jvm.ktor.exception.DavException on WebDAV errors, for instance
+     *   when a changed member is listed without ETag
+     * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on other HTTP errors (for instance,
+     *   if the sync-token is invalid)
+     */
+    fun listChanges(since: SyncState?): Flow<CollectionSyncItem>
+
+    /**
      * Downloads a batch of members via multi-get (CalDAV/CardDAV report). Only successful
      * responses that contain the expected resource data are emitted.
      *

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -10,8 +10,6 @@ import android.os.RemoteException
 import androidx.annotation.VisibleForTesting
 import at.bitfire.dav4jvm.Error
 import at.bitfire.dav4jvm.QuotedStringUtils
-import at.bitfire.dav4jvm.ktor.MultiStatusItem
-import at.bitfire.dav4jvm.ktor.Response
 import at.bitfire.dav4jvm.ktor.exception.ConflictException
 import at.bitfire.dav4jvm.ktor.exception.DavException
 import at.bitfire.dav4jvm.ktor.exception.ForbiddenException
@@ -21,7 +19,6 @@ import at.bitfire.dav4jvm.ktor.exception.NotFoundException
 import at.bitfire.dav4jvm.ktor.exception.PreconditionFailedException
 import at.bitfire.dav4jvm.ktor.exception.ServiceUnavailableException
 import at.bitfire.dav4jvm.ktor.exception.UnauthorizedException
-import at.bitfire.dav4jvm.ktor.responsesWithRelation
 import at.bitfire.dav4jvm.property.webdav.SyncToken
 import at.bitfire.dav4jvm.property.webdav.WebDAV
 import at.bitfire.davdroid.R
@@ -36,18 +33,16 @@ import at.bitfire.davdroid.repository.DavSyncStatsRepository
 import at.bitfire.davdroid.resource.LocalCollection
 import at.bitfire.davdroid.resource.LocalResource
 import at.bitfire.davdroid.resource.SyncState
+import at.bitfire.davdroid.resource.remote.CollectionSyncItem
 import at.bitfire.davdroid.resource.remote.InternalMemberState
 import at.bitfire.davdroid.resource.remote.WebDavCollection
-import at.bitfire.davdroid.resource.remote.filterMembers
-import at.bitfire.davdroid.resource.remote.filterNotCollections
 import at.bitfire.davdroid.resource.remote.member
-import at.bitfire.davdroid.resource.remote.requireETag
 import at.bitfire.davdroid.sync.account.InvalidAccountException
+import at.bitfire.davdroid.util.DavUtils.lastSegment
 import at.bitfire.davdroid.util.batchMap
 import at.bitfire.synctools.storage.LocalStorageException
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.ktor.client.HttpClient
-import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
@@ -55,7 +50,6 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
@@ -284,11 +278,7 @@ abstract class SyncManager<LocalType : LocalResource>(
                         }
                     }
                 } else
-                    logger.log(
-                        Level.INFO,
-                        "Removing local record #{0} which has been deleted locally and was never uploaded",
-                        arrayOf(local.id)
-                    )
+                    logger.info("Removing local record ${local.id} which has been deleted locally and was never uploaded")
                 local.deleteLocal()
             }
         }
@@ -630,19 +620,15 @@ abstract class SyncManager<LocalType : LocalResource>(
 
         do {
             logger.info("Listing changes since $syncState")
-            var (changesFlow, changesResult) = listRemoteChanges(syncState)
-            try {
-                processChanges(changesFlow, capabilities)
+            val changesResult = try {
+                processChanges(remoteCollection.listChanges(syncState), capabilities)
             } catch (e: HttpException) {
                 if (e.errors.contains(Error(WebDAV.ValidSyncToken))) {
                     logger.info("Sync token invalid, performing initial sync")
                     initialSync = true
                     resetPresentRemotely()
 
-                    val (retryFlow, retryResult) = listRemoteChanges(null)
-                    changesFlow = retryFlow
-                    changesResult = retryResult
-                    processChanges(changesFlow, capabilities)
+                    processChanges(remoteCollection.listChanges(null), capabilities)
                 } else
                     throw e
             }
@@ -675,100 +661,60 @@ abstract class SyncManager<LocalType : LocalResource>(
     /**
      * Holds the sync-token / further-results reported by a `sync-collection` REPORT.
      */
-    protected class SyncCollectionResult {
-        var syncToken: SyncToken? = null
-        var furtherResults: Boolean = false
-    }
-
-    /**
-     * Builds a [Flow] of the member responses of a `sync-collection` REPORT (RFC 6578), together
-     * with a [SyncCollectionResult].
-     *
-     * @param since sync state to list the changes since; `null` for an initial sync
-     */
-    private fun listRemoteChanges(since: SyncState?): Pair<Flow<MultiStatusItem>, SyncCollectionResult> {
-        val result = SyncCollectionResult()
-        val flow = remoteCollection.davCollection.reportChanges(
-            syncToken = since?.takeIf { since.type == SyncState.Type.SYNC_TOKEN }?.value,
-            infiniteDepth = false,
-            limit = null,
-            WebDAV.GetETag,     // we need the ETag for every item
-            WebDAV.ResourceType // we want to ignore sub-collections, so we need to know which items are collections
-        ).transform { item ->
-            when (item) {
-                is MultiStatusItem.Response -> when (item.relation) {
-                    Response.HrefRelation.SELF -> {
-                        // incoming self response, update result
-                        result.furtherResults = item.response.status == HttpStatusCode.InsufficientStorage
-                    }
-
-                    Response.HrefRelation.MEMBER -> {
-                        // incoming (changed/deleted) member response, emit to flow
-                        emit(item)
-                    }
-
-                    else ->
-                        logger.warning("Unexpected sync-collection response: ${item.response}")
-                }
-
-                is MultiStatusItem.ExtraProperty -> {
-                    // incoming sync-token, update result
-                    (item.property as? SyncToken)?.let { result.syncToken = it }
-                }
-            }
-        }
-        return flow to result
-    }
+    protected data class SyncCollectionResult(
+        val syncToken: SyncToken? = null,
+        val furtherResults: Boolean = false
+    )
 
     /**
      * Processes changes reported by a `sync-collection` REPORT (collection-sync algorithm)
-     * with `Depth: 1`. Each member response either represents
+     * with `Depth: 1`. Each item either represents
      *
+     * - the sync-token or further-changes flag of the response → collected into the returned [SyncCollectionResult],
      * - a new/changed member → queue for download, or
-     * - a 404 response signaling that the member has been deleted on the server → delete locally.
+     * - a removed member → delete locally.
      *
-     * @param remoteItems   Multi-Status items to process
+     * @param remoteItems   items to process, as listed by [WebDavCollection.listChanges]
      * @param capabilities  current capabilities of the remote collection
+     *
+     * @return the sync-token / further-results reported for [remoteItems]
      */
     private suspend fun processChanges(
-        remoteItems: Flow<MultiStatusItem>,
+        remoteItems: Flow<CollectionSyncItem>,
         capabilities: WebDavCollection.Capabilities
-    ) {
-        remoteItems.responsesWithRelation()
-            // filter member resources
-            .filterMembers()
-            // we requested Depth: 1, but may still receive collections which are direct members
-            .filterNotCollections()
-            // filter the items we want to download
+    ): SyncCollectionResult {
+        var syncToken: SyncToken? = null
+        var furtherResults = false
+        remoteItems
+            // filter the items we want to download – with side effects
             .filter { item ->
-                val response = item.response
-                when {
-                    // 2xx means "new/changed member"
-                    response.isSuccess() -> {
+                when (item) {
+                    is CollectionSyncItem.SyncToken -> {
+                        syncToken = item.token
+                        false
+                    }
+                    is CollectionSyncItem.FurtherChanges -> {
+                        furtherResults = true
+                        false
+                    }
+                    is CollectionSyncItem.RemovedMember -> {
+                        // deletes local entry as side effect
+                        deleteRemovedMember(item.href.lastSegment)
+                        false
+                    }
+                    is CollectionSyncItem.ChangedMember -> {
                         // marks remotely present members as side effect
-                        // TODO: Creating the InternalMemberState here won't be necessary anymore as soon as listChanges is moved to WebDavCollection.
-                        decideDownload(InternalMemberState(response.href, response.requireETag()))
-                    }
-
-                    // 404 means "removed member"
-                    response.status == HttpStatusCode.NotFound -> {
-                        // locally deletes remotely removed members as side effect
-                        deleteRemovedMember(response.hrefName())
-                        false
-                    }
-
-                    else -> {
-                        logger.warning("Ignoring response for ${response.href} (${response.status})")
-                        false
+                        decideDownload(item.memberState)
                     }
                 }
             }
             // we only need the URLs to download
-            .map { item -> item.response.href }
+            .map { item -> (item as CollectionSyncItem.ChangedMember).memberState.href }
             // download items in batches concurrently
             .batchMap(MULTIGET_BATCH_SIZE) { batch -> downloadMembers(batch, capabilities) }
             // process and store downloaded items
             .collect { item -> processDownload(item) }
+        return SyncCollectionResult(syncToken, furtherResults)
     }
 
     /**

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -48,6 +48,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.sync.Semaphore
@@ -668,16 +669,16 @@ abstract class SyncManager<LocalType : LocalResource>(
 
     /**
      * Processes changes reported by a `sync-collection` REPORT (collection-sync algorithm)
-     * with `Depth: 1`. Each item either represents
+     * with a `sync-level` of 1 (one). Each item either represents
      *
-     * - the sync-token or further-changes flag of the response → collected into the returned [SyncCollectionResult],
+     * - the sync-token or further-changes flag of the response → collect into the returned result,
      * - a new/changed member → queue for download, or
      * - a removed member → delete locally.
      *
      * @param remoteItems   items to process, as listed by [WebDavCollection.listChanges]
      * @param capabilities  current capabilities of the remote collection
      *
-     * @return the sync-token / further-results reported for [remoteItems]
+     * @return the received sync-token / further-results
      */
     private suspend fun processChanges(
         remoteItems: Flow<CollectionSyncItem>,
@@ -709,7 +710,8 @@ abstract class SyncManager<LocalType : LocalResource>(
                 }
             }
             // we only need the URLs to download
-            .map { item -> (item as CollectionSyncItem.ChangedMember).memberState.href }
+            .filterIsInstance<CollectionSyncItem.ChangedMember>()
+            .map { item -> item.memberState.href }
             // download items in batches concurrently
             .batchMap(MULTIGET_BATCH_SIZE) { batch -> downloadMembers(batch, capabilities) }
             // process and store downloaded items

--- a/core/src/main/kotlin/at/bitfire/davdroid/util/DavUtils.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/util/DavUtils.kt
@@ -118,7 +118,10 @@ object DavUtils {
     // extension methods
 
     /**
-     * Safely gets the last segment of the URL, or returns `"/"` if none could be obtained.
+     * Safely gets the last (decoded) segment of the URL, or returns `"/"` if none could be obtained.
+     *
+     * **Attention:** Because it's decoded, it may contain characters like `/` that would
+     * otherwise be path separators. See https://github.com/bitfireAT/davx5-ose/issues/2782.
      */
     val Url.lastSegment: String
         get() = this.segments.lastOrNull { it.isNotEmpty() } ?: "/"

--- a/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollectionTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/resource/remote/BaseWebDavCollectionTest.kt
@@ -5,7 +5,10 @@
 package at.bitfire.davdroid.resource.remote
 
 import at.bitfire.dav4jvm.ktor.DavCollection
+import at.bitfire.dav4jvm.ktor.exception.DavException
+import at.bitfire.dav4jvm.property.webdav.SyncToken
 import at.bitfire.davdroid.resource.SyncState
+import at.bitfire.synctools.test.assertThrows
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -18,6 +21,7 @@ import io.ktor.http.Url
 import io.ktor.http.content.TextContent
 import io.ktor.http.headersOf
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -337,6 +341,134 @@ class BaseWebDavCollectionTest {
         ).querySyncState()
 
         assertEquals(SyncState(SyncState.Type.SYNC_TOKEN, "http://example.com/ns/sync/token123"), syncState)
+    }
+
+    @Test
+    fun `listChanges() emits the sync-token`() = runTest {
+        val items = collection(
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                    "<multistatus xmlns=\"DAV:\">\n" +
+                    "  <sync-token>http://example.com/ns/sync/1234</sync-token>\n" +
+                    "</multistatus>"
+        ).listChanges(since = null).toList()
+
+        assertEquals(listOf(CollectionSyncItem.SyncToken(SyncToken("http://example.com/ns/sync/1234"))), items)
+    }
+
+    @Test
+    fun `listChanges() with 507 on the request-URI emits FurtherChanges`() = runTest {
+        // RFC 6578 section 3.6/3.10: truncation is signaled by a 507 response for the request-URI itself
+        val items = collection(
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                    "<multistatus xmlns=\"DAV:\">\n" +
+                    "  <response>\n" +
+                    "    <href>/dav/</href>\n" +
+                    "    <status>HTTP/1.1 507 Insufficient Storage</status>\n" +
+                    "    <error><number-of-matches-within-limits/></error>\n" +
+                    "  </response>\n" +
+                    "  <sync-token>http://example.com/ns/sync/1234</sync-token>\n" +
+                    "</multistatus>"
+        ).listChanges(since = null).toList()
+
+        assertEquals(
+            listOf(
+                CollectionSyncItem.FurtherChanges,
+                CollectionSyncItem.SyncToken(SyncToken("http://example.com/ns/sync/1234"))
+            ),
+            items
+        )
+    }
+
+    @Test
+    fun `listChanges() emits ChangedMember for 2xx member responses`() = runTest {
+        // RFC 6578 section 3.2: a changed/added member is a response with propstat and no top-level status
+        val items = collection(
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                    "<multistatus xmlns=\"DAV:\">\n" +
+                    "  <response>\n" +
+                    "    <href>/dav/event1.ics</href>\n" +
+                    "    <propstat>\n" +
+                    "      <prop><getetag>\"event-etag\"</getetag></prop>\n" +
+                    "      <status>HTTP/1.1 200 OK</status>\n" +
+                    "    </propstat>\n" +
+                    "  </response>\n" +
+                    "  <sync-token>http://example.com/ns/sync/1234</sync-token>\n" +
+                    "</multistatus>"
+        ).listChanges(since = null).toList()
+
+        assertEquals(
+            listOf(
+                CollectionSyncItem.ChangedMember(
+                    InternalMemberState(
+                        Url("https://example.com/dav/event1.ics"),
+                        "event-etag"
+                    )
+                ),
+                CollectionSyncItem.SyncToken(SyncToken("http://example.com/ns/sync/1234"))
+            ),
+            items
+        )
+    }
+
+    @Test
+    fun `listChanges() throws when a changed member has no ETag`() = runTest {
+        val flow = collection(
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                    "<multistatus xmlns=\"DAV:\">\n" +
+                    "  <response>\n" +
+                    "    <href>/dav/event1.ics</href>\n" +
+                    "    <propstat>\n" +
+                    "      <prop/>\n" +
+                    "      <status>HTTP/1.1 200 OK</status>\n" +
+                    "    </propstat>\n" +
+                    "  </response>\n" +
+                    "  <sync-token>http://example.com/ns/sync/1234</sync-token>\n" +
+                    "</multistatus>"
+        ).listChanges(since = null)
+
+        assertThrows<DavException> { flow.toList() }
+    }
+
+    @Test
+    fun `listChanges() emits RemovedMember for 404 member responses`() = runTest {
+        // RFC 6578 section 3.2: a removed member is a response with status 404 and no propstat
+        val items = collection(
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                    "<multistatus xmlns=\"DAV:\">\n" +
+                    "  <response>\n" +
+                    "    <href>/dav/removed.ics</href>\n" +
+                    "    <status>HTTP/1.1 404 Not Found</status>\n" +
+                    "  </response>\n" +
+                    "  <sync-token>http://example.com/ns/sync/1234</sync-token>\n" +
+                    "</multistatus>"
+        ).listChanges(since = null).toList()
+
+        assertEquals(
+            listOf(
+                CollectionSyncItem.RemovedMember(Url("https://example.com/dav/removed.ics")),
+                CollectionSyncItem.SyncToken(SyncToken("http://example.com/ns/sync/1234"))
+            ),
+            items
+        )
+    }
+
+    @Test
+    fun `listChanges() ignores members marked as collections`() = runTest {
+        val items = collection(
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                    "<multistatus xmlns=\"DAV:\">\n" +
+                    "  <response>\n" +
+                    "    <href>/dav/subcollection/</href>\n" +
+                    "    <propstat>\n" +
+                    "      <prop><resourcetype><collection/></resourcetype><getetag>\"sub-etag\"</getetag></prop>\n" +
+                    "      <status>HTTP/1.1 200 OK</status>\n" +
+                    "    </propstat>\n" +
+                    "  </response>\n" +
+                    "  <sync-token>http://example.com/ns/sync/1234</sync-token>\n" +
+                    "</multistatus>"
+        ).listChanges(since = null).toList()
+
+        assertEquals(listOf(CollectionSyncItem.SyncToken(SyncToken("http://example.com/ns/sync/1234"))), items)
     }
 
 


### PR DESCRIPTION
### Purpose

Continues #2755: extracts the last remaining WebDAV logic from SyncManager into WebDavCollection.

### Short description

- Add `CollectionSyncItem` for `sync-collection` REPORT results (sync-token, further-changes, changed/removed member).
- Move `listChanges` (RFC 6578) from `SyncManager` into `WebDavCollection`/`BaseWebDavCollection`.
- Refactor `processChanges` to return an immutable `SyncCollectionResult`.
- Clarify decoded-file-name docs; link ambiguity found during review – #2782

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have self-reviewed the PR.
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.