### PR TITLE
[VCardParser] Clarify handling of invalid vCards

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -68,6 +68,9 @@ android {
                 }
             }
         }
+        unitTests {
+            isIncludeAndroidResources = true
+        }
     }
 }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
@@ -31,7 +31,6 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import ezvcard.VCardVersion
-import ezvcard.io.CannotParseException
 import io.ktor.client.HttpClient
 import io.ktor.http.ContentType
 import io.ktor.http.content.TextContent
@@ -229,21 +228,15 @@ class ContactsSyncManager @AssistedInject constructor(
     private suspend fun processCard(fileName: String, eTag: String, reader: Reader, downloader: Contact.Downloader) {
         logger.info("Processing CardDAV resource $fileName")
 
-        val newData = try {
-            // parse vCard
-            val vCard = VCardParser().parse(reader).firstOrNull()
-            if (vCard == null) {
-                logger.warning("Received vCard without data, ignoring")
-                return
-            }
-
-            // map to Contact
-            ContactReader.fromVCard(vCard, downloader)
-        } catch (e: CannotParseException) {
-            logger.log(Level.SEVERE, "Received invalid vCard, ignoring", e)
-            notifyInvalidResource(e, fileName)
+        // parse vCard
+        val vCard = VCardParser().parse(reader)
+        if (vCard == null) {
+            logger.warning("Received vCard without data, ignoring")
             return
         }
+
+        // map to Contact
+        val newData = ContactReader.fromVCard(vCard, downloader)
 
         groupStrategy.verifyContactBeforeSaving(newData)
 

--- a/core/src/test/resources/robolectric.properties
+++ b/core/src/test/resources/robolectric.properties
@@ -1,0 +1,7 @@
+#
+# Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+#
+
+# Android 37 is not available yet
+# Comment the following line out when Robolectric supports API level 37
+sdk=36

--- a/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/contacts/AndroidContactTest.kt
+++ b/synctools/src/androidTest/kotlin/at/bitfire/synctools/storage/contacts/AndroidContactTest.kt
@@ -21,7 +21,6 @@ import at.bitfire.synctools.vcard.property.XAbDate
 import ezvcard.property.Birthday
 import ezvcard.property.Email
 import ezvcard.util.PartialDate
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.AfterClass
 import org.junit.Assert.assertArrayEquals
@@ -111,9 +110,9 @@ class AndroidContactTest {
                 "TEL;CELL=;PREF=:+12345\r\n" +
                 "EMAIL;PREF=invalid:test@example.com\r\n" +
                 "END:VCARD\r\n"
-        val contacts = parseVCards(vCard)
+        val contact = parseVCard(vCard)
 
-        val dbContact = AndroidContact(addressBook, contacts.first(), null, null)
+        val dbContact = AndroidContact(addressBook, contact, null, null)
         dbContact.add()
 
         val dbContact2 = addressBook.findContactById(dbContact.id!!)
@@ -170,11 +169,7 @@ class AndroidContactTest {
     }
 
 
-    private fun parseVCards(vCardStr: String): List<Contact> =
-        VCardParser().parse(StringReader(vCardStr)).map { vCard ->
-            runBlocking {
-                ContactReader(vCard).toContact()
-            }
-        }
+    private suspend fun parseVCard(vCardStr: String): Contact =
+        ContactReader(VCardParser().parse(StringReader(vCardStr))!!).toContact()
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/vcard/VCardParser.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/vcard/VCardParser.kt
@@ -14,20 +14,20 @@ import javax.annotation.WillNotClose
 class VCardParser {
 
     /**
-     * Parses vCard data from a [Reader] into a list of [VCard] objects.
+     * Parses the first vCard from a [Reader].
      *
      * Defaults to vCard version 3.0 and supports custom property scribes.
      *
+     * Malformed vCard content is currently parsed leniently (invalid lines or
+     * values are skipped) rather than throwing an exception.
+     *
      * @param reader The [Reader] providing the vCard data to parse. Will not be closed by this method.
-     * @return List of parsed [VCard] objects.
+     * @return the first parsed [VCard], or `null` if the reader didn't contain one.
      */
-    fun parse(@WillNotClose reader: Reader): List<VCard> {
+    fun parse(@WillNotClose reader: Reader): VCard? =
         // By default, CardDAV assumes vCard 3
-        val vCards = VCardReader(reader, VCardVersion.V3_0)
+        VCardReader(reader, VCardVersion.V3_0)
             .registerCustomScribes()
-            .readAll()
-
-        return vCards
-    }
+            .readNext()
 
 }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/ContactReaderTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/ContactReaderTest.kt
@@ -132,10 +132,9 @@ class ContactReaderTest {
             "FN:John Doe\n\n" +
             "BDAY:20010415T000000+0200\n\n" +
             "END:VCARD\n\n"
-        val contacts = VCardParser().parse(StringReader(vCard)).map { ContactReader.fromVCard(it) }
+        val contact = ContactReader.fromVCard(VCardParser().parse(StringReader(vCard))!!)
 
-        assertEquals(1, contacts.size)
-        contacts.first().birthDay.let { birthday ->
+        contact.birthDay.let { birthday ->
             assertNotNull(birthday)
 
             val date = birthday?.date
@@ -327,7 +326,7 @@ class ContactReaderTest {
             values.add("Dept")
         }
         val c = ContactReader.fromVCard(VCard().apply {
-            setOrganization(org)
+            organization = org
         })
         assertEquals(org, c.organization)
     }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/ContactTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/mapping/contacts/ContactTest.kt
@@ -34,7 +34,7 @@ import java.util.LinkedList
 class ContactTest {
 
     private suspend fun parseVCard(reader: Reader): Contact {
-        val vCard = VCardParser().parse(reader).first()
+        val vCard = VCardParser().parse(reader)!!
         return ContactReader.fromVCard(vCard)
     }
 

--- a/synctools/src/test/kotlin/at/bitfire/synctools/vcard/VCardParserTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/vcard/VCardParserTest.kt
@@ -8,6 +8,7 @@ import at.bitfire.synctools.vcard.property.XAbDate
 import ezvcard.VCardVersion
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Test
 import java.io.StringReader
 
@@ -23,11 +24,10 @@ N:Lastname;Firstname;;;
 END:VCARD"""
 
         val parser = VCardParser()
-        val vCards = parser.parse(StringReader(vCardString))
+        val vCard = parser.parse(StringReader(vCardString))
 
-        assertEquals(1, vCards.size)
-        val vCard = vCards.first()
-        assertEquals(VCardVersion.V3_0, vCard.version)
+        assertNotNull(vCard)
+        assertEquals(VCardVersion.V3_0, vCard!!.version)
         assertEquals("test-uid", vCard.uid.value)
         assertEquals("Test Contact", vCard.formattedName.value)
         assertEquals("Firstname", vCard.structuredName.given)
@@ -44,11 +44,10 @@ N:Lastname;Firstname;;;
 END:VCARD"""
 
         val parser = VCardParser()
-        val vCards = parser.parse(StringReader(vCardString))
+        val vCard = parser.parse(StringReader(vCardString))
 
-        assertEquals(1, vCards.size)
-        val vCard = vCards.first()
-        assertEquals(VCardVersion.V4_0, vCard.version)
+        assertNotNull(vCard)
+        assertEquals(VCardVersion.V4_0, vCard!!.version)
         assertEquals("test-uid-4", vCard.uid.value)
         assertEquals("Test Contact 4", vCard.formattedName.value)
         assertEquals("Firstname", vCard.structuredName.given)
@@ -56,7 +55,7 @@ END:VCARD"""
     }
 
     @Test
-    fun testParse_MultipleVCards() {
+    fun testParse_OnlyFirstOfMultipleVCards() {
         val vCardString = """BEGIN:VCARD
 VERSION:3.0
 UID:uid1
@@ -69,13 +68,11 @@ FN:Contact 2
 END:VCARD"""
 
         val parser = VCardParser()
-        val vCards = parser.parse(StringReader(vCardString))
+        val vCard = parser.parse(StringReader(vCardString))
 
-        assertEquals(2, vCards.size)
-        assertEquals("uid1", vCards[0].uid.value)
-        assertEquals("Contact 1", vCards[0].formattedName.value)
-        assertEquals("uid2", vCards[1].uid.value)
-        assertEquals("Contact 2", vCards[1].formattedName.value)
+        assertNotNull(vCard)
+        assertEquals("uid1", vCard!!.uid.value)
+        assertEquals("Contact 1", vCard.formattedName.value)
     }
 
     @Test
@@ -88,20 +85,62 @@ X-ABDATE:20210729
 END:VCARD"""
 
         val parser = VCardParser()
-        val vCards = parser.parse(StringReader(vCardString))
+        val vCard = parser.parse(StringReader(vCardString))
 
-        assertEquals(1, vCards.size)
-        val vCard = vCards.first()
+        assertNotNull(vCard)
         // X-ABDATE is a custom property that should be parsed as XAbDate
-        val xAbDate = vCard.getProperty(XAbDate::class.java)
+        val xAbDate = vCard!!.getProperty(XAbDate::class.java)
         assertNotNull("X-ABDATE should be parsed as XAbDate", xAbDate)
     }
 
     @Test
     fun testParse_EmptyInput() {
         val parser = VCardParser()
-        val vCards = parser.parse(StringReader(""))
-        assertEquals(0, vCards.size)
+        val vCard = parser.parse(StringReader(""))
+        assertNull(vCard)
+    }
+
+    @Test
+    fun testParse_NonVCardGarbage_ReturnsNull() {
+        // no BEGIN:VCARD/END:VCARD at all, so there's nothing to return - but it doesn't throw either
+        val parser = VCardParser()
+        val vCard = parser.parse(StringReader("this is not a vCard\njust some random text\n"))
+        assertNull(vCard)
+    }
+
+    @Test
+    fun testParse_MalformedLine_IsSkipped() {
+        // a line without a colon is malformed and gets skipped, rest of the vCard still parses
+        val vCardString = """BEGIN:VCARD
+VERSION:3.0
+UID:test-uid
+this line has no colon and is malformed
+FN:Test Contact
+END:VCARD"""
+
+        val parser = VCardParser()
+        val vCard = parser.parse(StringReader(vCardString))
+
+        assertNotNull(vCard)
+        assertEquals("test-uid", vCard!!.uid.value)
+        assertEquals("Test Contact", vCard.formattedName.value)
+    }
+
+    @Test
+    fun testParse_UnparsableValue_DoesNotThrow() {
+        // REV expects a timestamp; a garbage value doesn't cause an exception
+        val vCardString = """BEGIN:VCARD
+VERSION:3.0
+UID:test-uid
+FN:Test Contact
+REV:not-a-valid-timestamp
+END:VCARD"""
+
+        val parser = VCardParser()
+        val vCard = parser.parse(StringReader(vCardString))
+
+        assertNotNull(vCard)
+        assertEquals("test-uid", vCard!!.uid.value)
     }
 
 }

--- a/synctools/src/test/resources/robolectric.properties
+++ b/synctools/src/test/resources/robolectric.properties
@@ -1,7 +1,1 @@
-#
-# Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
-#
-
-# Android 37 is not available yet
-# Comment the following line out when Robolectric supports API level 37
-sdk=36
+../../../../core/src/test/resources/robolectric.properties


### PR DESCRIPTION
### Purpose

CardDAV resources always contain exactly one vCard (RFC 6352 §5.1), and ez-vcard already parses malformed content leniently instead of throwing — so `VCardParser` should reflect that instead of returning a list wrapped in a dead `try`/`catch`.

### Short description

- `VCardParser.parse()` now returns the first `VCard` (or `null`) via `.readNext()`, not a `List<VCard>` — matches how it was always used.
- Removed the dead `try`/`catch (CannotParseException)` in `ContactsSyncManager` — ez-vcard/vinnie never throw on malformed vCard content, they just skip the bad parts.
- Added `VCardParserTest` coverage for that lenient behavior (skipped malformed lines, unparsable values, non-vCard input).

On the go:

- Fixed `:core`'s Robolectric unit tests (`targetSdk` 37 exceeds Robolectric's supported max of 36): pinned `sdk=36`, enabled `includeAndroidResources`; `:synctools` now symlinks the same file instead of duplicating it.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.