### PR TITLE
[SyncNotificationManager] Take notification tag ownership

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/LocalTestCollection.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/LocalTestCollection.kt
@@ -12,9 +12,6 @@ class LocalTestCollection(
     override val dbCollectionId: Long = 0L
 ): LocalCollection<LocalTestResource> {
 
-    override val tag = "LocalTestCollection"
-    override val title = "Local Test Collection"
-
     override var lastSyncState: SyncState? = null
 
     val entries = mutableListOf<LocalTestResource>()

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncerTest.kt
@@ -81,7 +81,6 @@ class SyncerTest {
     fun testUpdateCollections_deletesCollection() = runTest {
         val localCollection = mockk<LocalTestCollection> {
             every { dbCollectionId } returns 0L
-            every { title } returns "Collection to be deleted locally"
         }
 
         // Should delete the localCollection if dbCollection (remote) does not exist
@@ -97,7 +96,6 @@ class SyncerTest {
     fun testUpdateCollections_updatesCollection() = runTest {
         val localCollection = mockk<LocalTestCollection> {
             every { dbCollectionId } returns 0L
-            every { title } returns "The Local Collection"
         }
         val dbCollection = mockk<Collection> {
             every { id } returns 0L

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -85,12 +85,6 @@ open class LocalAddressBook @AssistedInject constructor(
 
     var addressBookAccount: Account by ab::addressBookAccount
 
-    override val tag: String
-        get() = "contacts-${addressBookAccount.name}"
-
-    override val title
-        get() = addressBookAccount.name
-
     val includeGroups
         get() = groupMethod == GroupMethod.GROUP_VCARDS
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCalendar.kt
@@ -39,12 +39,6 @@ class LocalCalendar @AssistedInject constructor(
     override val dbCollectionId: Long?
         get() = androidCalendar.syncId?.toLongOrNull()
 
-    override val tag: String
-        get() = "events-${androidCalendar.account.name}-${androidCalendar.id}"
-
-    override val title: String
-        get() = androidCalendar.displayName ?: androidCalendar.id.toString()
-
     override val readOnly
         get() = androidCalendar.accessLevel <= Calendars.CAL_ACCESS_READ
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalCollection.kt
@@ -13,14 +13,8 @@ import kotlinx.coroutines.flow.Flow
  */
 interface LocalCollection<out T: LocalResource> {
 
-    /** a tag that uniquely identifies the collection (DAVx5-wide) */
-    val tag: String
-
     /** ID of the collection in the database (corresponds to [at.bitfire.davdroid.db.Collection.id]) */
     val dbCollectionId: Long?
-
-    /** collection title (used for user notifications etc.) **/
-    val title: String
 
     var lastSyncState: SyncState?
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalJtxCollection.kt
@@ -25,14 +25,8 @@ class LocalJtxCollection(internal val jtxCollection: JtxCollection) :
     override val readOnly: Boolean
         get() = jtxCollection.readonly
 
-    override val tag: String
-        get() = "jtx-${jtxCollection.account.name}-${jtxCollection.id}"
-
     override val dbCollectionId: Long?
         get() = jtxCollection.syncId
-
-    override val title: String
-        get() = jtxCollection.displayName ?: jtxCollection.id.toString()
 
     override var lastSyncState: SyncState?
         get() = SyncState.fromString(jtxCollection.provider.readCollectionSyncState(jtxCollection.id))

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskList.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalTaskList.kt
@@ -34,12 +34,6 @@ class LocalTaskList (
     override val dbCollectionId: Long?
         get() = dmfsTaskList.syncId?.toLongOrNull()
 
-    override val tag: String
-        get() = "tasks-${dmfsTaskList.account.name}-${dmfsTaskList.id}"
-
-    override val title: String
-        get() = dmfsTaskList.name ?: dmfsTaskList.id.toString()
-
     /** The task list's [SyncState] is stored in serialized JSON format in the [COLUMN_TASKLIST_SYNC_STATE] column. */
     override var lastSyncState: SyncState?
         get() {

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -19,6 +19,7 @@ import at.bitfire.dav4jvm.ktor.exception.NotFoundException
 import at.bitfire.dav4jvm.ktor.exception.PreconditionFailedException
 import at.bitfire.dav4jvm.ktor.exception.ServiceUnavailableException
 import at.bitfire.dav4jvm.ktor.exception.UnauthorizedException
+import at.bitfire.dav4jvm.ktor.resolve
 import at.bitfire.dav4jvm.property.webdav.SyncToken
 import at.bitfire.dav4jvm.property.webdav.WebDAV
 import at.bitfire.davdroid.R
@@ -148,7 +149,7 @@ abstract class SyncManager<LocalType : LocalResource>(
         // keep generic ioDispatcher until all LocalStorage calls are suspending or wrapped in withContext(ioDispatcher)
 
         // dismiss previous error notifications
-        syncNotificationManager.dismissCollectionError(localCollectionTag = localCollection.tag)
+        syncNotificationManager.dismissCollectionError(collectionId = collectionInfo.id)
 
         try {
             logger.info("Preparing synchronization")
@@ -827,24 +828,23 @@ abstract class SyncManager<LocalType : LocalResource>(
         }
 
         syncNotificationManager.notifyException(
-            dataType,
-            localCollection.tag,
-            message,
-            localCollection,
-            e,
-            local,
-            remote
+            syncDataType = dataType,
+            collectionId = collectionInfo.id,
+            message = message,
+            title = collectionInfo.title(),
+            e = e,
+            local = local,
+            remote = remote
         )
     }
 
     protected suspend fun notifyInvalidResource(e: Throwable, fileName: String) =
         syncNotificationManager.notifyInvalidResource(
-            dataType,
-            localCollection.tag,
-            collectionInfo,
-            e,
-            fileName,
-            notifyInvalidResourceTitle()
+            dataType = dataType,
+            collectionId = collectionInfo.id,
+            e = e,
+            remote = collectionInfo.url.resolve(fileName),
+            title = notifyInvalidResourceTitle()
         )
 
     protected abstract fun notifyInvalidResourceTitle(): String

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncNotificationManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncNotificationManager.kt
@@ -15,12 +15,9 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.net.toUri
 import at.bitfire.dav4jvm.ktor.exception.UnauthorizedException
-import at.bitfire.dav4jvm.ktor.resolve
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.accounts.AccountId
-import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.repository.AccountRepository
-import at.bitfire.davdroid.resource.LocalCollection
 import at.bitfire.davdroid.resource.LocalResource
 import at.bitfire.davdroid.ui.DebugInfoActivity
 import at.bitfire.davdroid.ui.NotificationRegistry
@@ -101,24 +98,24 @@ class SyncNotificationManager @AssistedInject constructor(
      * local resource, its collection, the URL, the exception and a user message.
      *
      * @param syncDataType      The type of data which was synced.
-     * @param notificationTag   The tag to use for the notification.
+     * @param collectionId      ID of the affected collection, used to derive the notification tag.
      * @param message           The message to show to the user.
-     * @param localCollection   The affected local collection.
+     * @param title             The title of the notification (usually the affected collection's title).
      * @param e                 The exception that occurred.
      * @param local             The affected local resource.
      * @param remote            The remote URL that caused the exception.
      */
     suspend fun notifyException(
         syncDataType: SyncDataType,
-        notificationTag: String,
+        collectionId: Long,
         message: String,
-        localCollection: LocalCollection<*>,
+        title: String,
         e: Throwable,
         local: LocalResource?,
         remote: Url?
     ) {
         val accountName = accountRepository.getAccountName(accountId)
-        notificationRegistry.notifyIfPossible(NotificationRegistry.NOTIFY_SYNC_ERROR, tag = notificationTag) {
+        notificationRegistry.notifyIfPossible(NotificationRegistry.NOTIFY_SYNC_ERROR, tag = buildTag(collectionId)) {
             val contentIntent: Intent
             if (e is UnauthorizedException) {
                 contentIntent = AccountSettingsActivity.createIntent(context, accountId)
@@ -141,7 +138,7 @@ class SyncNotificationManager @AssistedInject constructor(
 
             val builder = NotificationCompat.Builder(context, channel)
             builder.setSmallIcon(R.drawable.ic_sync_problem_notify)
-                .setContentTitle(localCollection.title)
+                .setContentTitle(title)
                 .setContentText(message)
                 .setStyle(NotificationCompat.BigTextStyle(builder).bigText(message))
                 .setSubText(accountName)
@@ -164,22 +161,23 @@ class SyncNotificationManager @AssistedInject constructor(
      * Use [dismissCollectionError] to dismiss the notification.
      *
      * @param dataType          The type of data which was synced.
-     * @param notificationTag   The tag to use for the notification.
-     * @param collection        The affected collection.
-     * @param fileName          The name of the file containing the invalid resource.
+     * @param collectionId      ID of the affected collection, used to derive the notification tag.
+     * @param remote            URL of the resource that couldn't be processed, if it could be resolved.
      * @param title             The title of the notification.
      */
     suspend fun notifyInvalidResource(
         dataType: SyncDataType,
-        notificationTag: String,
-        collection: Collection,
+        collectionId: Long,
         e: Throwable,
-        fileName: String,
+        remote: Url?,
         title: String
     ) {
         val accountName = accountRepository.getAccountName(accountId)
-        notificationRegistry.notifyIfPossible(NotificationRegistry.NOTIFY_INVALID_RESOURCE, tag = notificationTag) {
-            val intent = buildDebugInfoIntent(dataType, e, null, collection.url.resolve(fileName))
+        notificationRegistry.notifyIfPossible(
+            NotificationRegistry.NOTIFY_INVALID_RESOURCE,
+            tag = buildTag(collectionId)
+        ) {
+            val intent = buildDebugInfoIntent(dataType, e, null, remote)
 
             val builder = NotificationCompat.Builder(context, notificationRegistry.CHANNEL_SYNC_WARNINGS)
             builder.setSmallIcon(R.drawable.ic_warning_notify)
@@ -201,13 +199,19 @@ class SyncNotificationManager @AssistedInject constructor(
     /**
      * Dismisses the (error) notification for a specific collection.
      *
-     * @param localCollectionTag The tag of the local collection which is used as notification tag also.
+     * @param collectionId ID of the collection whose notification should be dismissed.
      */
-    fun dismissCollectionError(localCollectionTag: String) =
-        dismissNotification(localCollectionTag)
+    fun dismissCollectionError(collectionId: Long) =
+        dismissNotification(buildTag(collectionId))
 
 
     // helpers
+
+    /**
+     * Builds the notification tag for a given collection. Used to uniquely identify (and dismiss)
+     * sync error/warning notifications for that collection.
+     */
+    private fun buildTag(collectionId: Long) = "collection-$collectionId"
 
     /**
      * Dismisses the sync error notification for a specific tag.

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncNotificationManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncNotificationManager.kt
@@ -45,6 +45,7 @@ class SyncNotificationManager @AssistedInject constructor(
 
     /**
      * Tries to inform the user that the content provider is missing or disabled.
+     *
      * Use [dismissProviderError] to dismiss the notification.
      *
      * @param authority The authority of the content provider.
@@ -94,8 +95,10 @@ class SyncNotificationManager @AssistedInject constructor(
         dismissNotification(authority)
 
     /**
-     * Tries to inform the user that an exception occurred during synchronization. Includes the affected
+     * Notifies the user that an exception occurred during synchronization. Includes the affected
      * local resource, its collection, the URL, the exception and a user message.
+     *
+     * Use [dismissCollectionError] to dismiss the notification.
      *
      * @param syncDataType      The type of data which was synced.
      * @param collectionId      ID of the affected collection, used to derive the notification tag.
@@ -156,12 +159,12 @@ class SyncNotificationManager @AssistedInject constructor(
     }
 
     /**
-     * Sends a notification to inform the user that a push notification has been received, the
-     * sync has been scheduled, but it still has not run.
-     * Use [dismissCollectionError] to dismiss the notification.
+     * Sends a notification to inform the user that a resource couldn't be processed during sync
+     * and was ignored.
      *
      * @param dataType          The type of data which was synced.
      * @param collectionId      ID of the affected collection, used to derive the notification tag.
+     * @param e                 The exception that occurred while processing the resource.
      * @param remote            URL of the resource that couldn't be processed, if it could be resolved.
      * @param title             The title of the notification.
      */

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
@@ -159,7 +159,7 @@ abstract class Syncer<StoreType: LocalDataStore<CollectionType>, CollectionType:
                 logger.log(
                     Level.INFO,
                     "Deleting local collection {0} without matching remote collection",
-                    arrayOf(localCollection.title)
+                    arrayOf(localCollection.dbCollectionId)
                 )
                 dataStore.delete(localCollection)
                 updatedLocalCollections -= localCollection
@@ -168,7 +168,7 @@ abstract class Syncer<StoreType: LocalDataStore<CollectionType>, CollectionType:
                 logger.log(
                     Level.FINE,
                     "Updating local collection {0} with {1}",
-                    arrayOf(localCollection.title, dbCollection)
+                    arrayOf(dbCollection.title(), dbCollection)
                 )
                 dataStore.update(provider, localCollection, dbCollection)
                 newDbCollections -= dbCollection.id

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
@@ -168,7 +168,7 @@ abstract class Syncer<StoreType: LocalDataStore<CollectionType>, CollectionType:
                 logger.log(
                     Level.FINE,
                     "Updating local collection {0} with {1}",
-                    arrayOf(dbCollection.title(), dbCollection)
+                    arrayOf(localCollection.dbCollectionId, dbCollection)
                 )
                 dataStore.update(provider, localCollection, dbCollection)
                 newDbCollections -= dbCollection.id


### PR DESCRIPTION
### Purpose

`SyncNotificationManager` is now responsible for creating its notification tag and making sure that it gets a collection title. No need to expose that in `LocalCollection` anymore.

### Short description

- Removed `LocalCollection.tag`/`.title` (redundant with `Collection.id`/`.title()`).
- `SyncNotificationManager` now builds its own notification tag from a `collectionId`.
- `notifyException`/`notifyInvalidResource`/`dismissCollectionError` take `collectionId`/`title`/`remote` directly instead of whole collection objects.