### PR TITLE
[DI] Inject `AccountManager` via Hilt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,12 @@ Android library. The sync engine, database layer, and Jetpack Compose UI for DAV
 - Add new Hilt bindings and qualifiers in `di/` (same style as the existing ones).
 - ViewModels use `@HiltViewModel`.
 - WorkManager workers integrate via the Hilt worker factory — do not construct workers manually.
+- Android system services that have no `@Inject` constructor (e.g. `AccountManager`) are bound via `@Provides` in a
+  `di/` module (e.g. `AndroidServicesModule`) — never call their static `.get(context)`/similar factory method directly
+  in a Hilt-managed class.
+- For such bindings, pick the injection shape by how often it's actually *called at runtime* (not how many call sites
+  reference it): inject the type directly when it's on the hot path; inject `dagger.Lazy<T>` when a given instance has a
+  good chance of never needing it; inject `javax.inject.Provider<T>` when it's only invoked rarely.
 
 #### Patterns
 

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/repository/AccountRepositoryTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/repository/AccountRepositoryTest.kt
@@ -59,6 +59,9 @@ class AccountRepositoryTest {
     // Real injections
 
     @Inject
+    lateinit var accountManager: AccountManager
+
+    @Inject
     @ApplicationContext
     lateinit var context: Context
 
@@ -91,7 +94,6 @@ class AccountRepositoryTest {
 
     // Account setup
     private val newName = "Renamed Account"
-    lateinit var am: AccountManager
     lateinit var accountType: String
     lateinit var accountId: LegacyAccount
 
@@ -101,7 +103,6 @@ class AccountRepositoryTest {
         TestUtils.setUpWorkManager(context, workerFactory)
 
         // Account setup
-        am = AccountManager.get(context)
         accountType = context.getString(R.string.account_type)
         accountId = LegacyAccount(TestAccount.create())
 
@@ -112,8 +113,8 @@ class AccountRepositoryTest {
 
     @After
     fun tearDown() {
-        am.getAccountsByType(accountType).forEach { account ->
-            am.removeAccountExplicitly(account)
+        accountManager.getAccountsByType(accountType).forEach { account ->
+            accountManager.removeAccountExplicitly(account)
         }
 
         unmockkObject(AccountsCleanupWorker)
@@ -126,7 +127,7 @@ class AccountRepositoryTest {
     @Test(expected = IllegalArgumentException::class)
     fun testRename_checksForAlreadyExisting() = runTest {
         val existing = Account("Existing Account", accountType)
-        am.addAccountExplicitly(existing, null, null)
+        accountManager.addAccountExplicitly(existing, null, null)
 
         accountRepository.rename(accountId, existing.name)
     }
@@ -142,7 +143,7 @@ class AccountRepositoryTest {
     fun testRename_renamesAccountInAndroid() = runTest {
         accountRepository.rename(accountId, newName)
 
-        val accountsAfter = am.getAccountsByType(accountType)
+        val accountsAfter = accountManager.getAccountsByType(accountType)
         assertTrue(accountsAfter.any { it.name == newName })
     }
 

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStoreTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStoreTest.kt
@@ -13,12 +13,14 @@ import at.bitfire.davdroid.accounts.LegacyAccount
 import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service
+import at.bitfire.davdroid.di.AndroidServicesModule
 import at.bitfire.davdroid.sync.account.TestAccount
 import at.bitfire.davdroid.util.DavUtils.toUrl
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import dagger.hilt.android.testing.UninstallModules
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.RelaxedMockK
@@ -36,6 +38,7 @@ import org.junit.Test
 import javax.inject.Inject
 
 @HiltAndroidTest
+@UninstallModules(AndroidServicesModule::class)
 class LocalAddressBookStoreTest {
 
     @Inject @ApplicationContext
@@ -49,6 +52,9 @@ class LocalAddressBookStoreTest {
 
     @RelaxedMockK
     lateinit var provider: ContentProviderClient
+
+    @BindValue @MockK
+    lateinit var accountManager: AccountManager
 
     @BindValue @MockK(relaxed = true)
     lateinit var addressBookAccountProperties: AddressBookAccountProperties
@@ -183,8 +189,6 @@ class LocalAddressBookStoreTest {
 
     @Test
     fun test_getAll_differentAccount() {
-        val accountManager = AccountManager.get(context)
-        mockkObject(accountManager)
         every { accountManager.getAccountsByType(any()) } returns arrayOf(addressBookAccount)
         val unrelatedAccount = Account("Another Unrelated Account", account.type)
         every { addressBookAccountProperties.getAppAccount(addressBookAccount) } returns LegacyAccount(unrelatedAccount)
@@ -194,8 +198,6 @@ class LocalAddressBookStoreTest {
 
     @Test
     fun test_getAll_sameAccount() {
-        val accountManager = AccountManager.get(context)
-        mockkObject(accountManager)
         every { accountManager.getAccountsByType(any()) } returns arrayOf(addressBookAccount)
         every { addressBookAccountProperties.getAppAccount(addressBookAccount) } returns LegacyAccount(account)
         val result = localAddressBookStore.getAll(account, provider)

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStoreTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStoreTest.kt
@@ -54,7 +54,7 @@ class LocalAddressBookStoreTest {
     @RelaxedMockK
     lateinit var provider: ContentProviderClient
 
-    @BindValue @MockK
+    @BindValue @MockK(relaxed = true)
     lateinit var accountManager: AccountManager
 
     @BindValue @MockK(relaxed = true)
@@ -91,7 +91,10 @@ class LocalAddressBookStoreTest {
             addressBookAccountType
         )
 
-        // AccountSettings (created internally by LocalAddressBookStore) also uses the shared accountManager mock
+        // AccountSettings (created internally by LocalAddressBookStore) also uses the shared accountManager mock.
+        // Relaxed mocks default String? results to "" instead of null, so stub null explicitly before overriding
+        // the one key (settings version) that must have a real value to avoid running migrations.
+        every { accountManager.getUserData(any(), any()) } returns null
         every {
             accountManager.getUserData(
                 account,

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStoreTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStoreTest.kt
@@ -14,6 +14,7 @@ import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service
 import at.bitfire.davdroid.di.AndroidServicesModule
+import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.sync.account.TestAccount
 import at.bitfire.davdroid.util.DavUtils.toUrl
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -89,6 +90,14 @@ class LocalAddressBookStoreTest {
             "MrRobert@example.com",
             addressBookAccountType
         )
+
+        // AccountSettings (created internally by LocalAddressBookStore) also uses the shared accountManager mock
+        every {
+            accountManager.getUserData(
+                account,
+                AccountSettings.KEY_SETTINGS_VERSION
+            )
+        } returns AccountSettings.CURRENT_VERSION.toString()
     }
 
     @After

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalTestAddressBook.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/LocalTestAddressBook.kt
@@ -16,11 +16,10 @@ import java.util.UUID
 import javax.inject.Inject
 
 class LocalTestAddressBook @Inject constructor(
+    private val accountManager: AccountManager,
     @ApplicationContext private val context: Context,
     private val factory: LocalAddressBook.Factory
 ) {
-
-    private val accountManager = AccountManager.get(context)
 
     fun provide(
         accountId: AccountId,

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/settings/AccountSettingsTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/settings/AccountSettingsTest.kt
@@ -22,6 +22,9 @@ import javax.inject.Inject
 @HiltAndroidTest
 class AccountSettingsTest {
 
+    @Inject
+    lateinit var accountManager: AccountManager
+
     @Inject @ApplicationContext
     lateinit var context: Context
 
@@ -53,7 +56,6 @@ class AccountSettingsTest {
             // will run AccountSettings.update
             accountSettingsFactory.create(account, abortOnMissingMigration = true)
 
-            val accountManager = AccountManager.get(context)
             val version = accountManager.getUserData(account, AccountSettings.KEY_SETTINGS_VERSION).toInt()
             assertEquals(AccountSettings.CURRENT_VERSION, version)
         }

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration17Test.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration17Test.kt
@@ -12,7 +12,6 @@ import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service
-import at.bitfire.davdroid.resource.LocalAddressBook
 import at.bitfire.davdroid.sync.account.TestAccount
 import at.bitfire.davdroid.util.DavUtils.toUrl
 import at.bitfire.synctools.util.setAndVerifyUserData
@@ -28,6 +27,9 @@ import javax.inject.Inject
 
 @HiltAndroidTest
 class AccountSettingsMigration17Test {
+
+    @Inject
+    lateinit var accountManager: AccountManager
 
     @Inject @ApplicationContext
     lateinit var context: Context
@@ -55,7 +57,6 @@ class AccountSettingsMigration17Test {
     fun testMigrate_OldAddressBook_CollectionInDB() {
         val localAddressBookUserDataUrl = "url"
         TestAccount.provide(version = 16) { account ->
-            val accountManager = AccountManager.get(context)
             val addressBookAccountType = context.getString(R.string.account_type_address_book)
             var addressBookAccount = Account("Address Book", addressBookAccountType)
             assertTrue(accountManager.addAccountExplicitly(addressBookAccount, null, null))

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration18Test.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration18Test.kt
@@ -34,7 +34,7 @@ import javax.inject.Inject
 @UninstallModules(AndroidServicesModule::class)
 class AccountSettingsMigration18Test {
 
-    @BindValue @MockK
+    @BindValue @MockK(relaxed = true)
     lateinit var accountManager: AccountManager
 
     @Inject @ApplicationContext

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration18Test.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration18Test.kt
@@ -11,16 +11,19 @@ import at.bitfire.davdroid.R
 import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.Service
+import at.bitfire.davdroid.di.AndroidServicesModule
 import at.bitfire.davdroid.settings.migration.AccountSettingsMigration18.Companion.USER_DATA_ACCOUNT_NAME
 import at.bitfire.davdroid.settings.migration.AccountSettingsMigration18.Companion.USER_DATA_ACCOUNT_TYPE
 import at.bitfire.davdroid.settings.migration.AccountSettingsMigration18.Companion.USER_DATA_COLLECTION_ID
 import at.bitfire.davdroid.util.DavUtils.toUrl
 import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import dagger.hilt.android.testing.UninstallModules
 import io.mockk.every
+import io.mockk.impl.annotations.MockK
 import io.mockk.junit4.MockKRule
-import io.mockk.mockkObject
 import io.mockk.verify
 import org.junit.Before
 import org.junit.Rule
@@ -28,7 +31,11 @@ import org.junit.Test
 import javax.inject.Inject
 
 @HiltAndroidTest
+@UninstallModules(AndroidServicesModule::class)
 class AccountSettingsMigration18Test {
+
+    @BindValue @MockK
+    lateinit var accountManager: AccountManager
 
     @Inject @ApplicationContext
     lateinit var context: Context
@@ -57,8 +64,6 @@ class AccountSettingsMigration18Test {
         val addressBookAccountType = context.getString(R.string.account_type_address_book)
         var addressBookAccount = Account("Address Book", addressBookAccountType)
 
-        val accountManager = AccountManager.get(context)
-        mockkObject(accountManager)
         every { accountManager.getAccountsByType(addressBookAccountType) } returns arrayOf(addressBookAccount)
         every { accountManager.getUserData(addressBookAccount, USER_DATA_COLLECTION_ID) } returns "123"
 
@@ -75,8 +80,6 @@ class AccountSettingsMigration18Test {
         val addressBookAccountType = context.getString(R.string.account_type_address_book)
         var addressBookAccount = Account("Address Book", addressBookAccountType)
 
-        val accountManager = AccountManager.get(context)
-        mockkObject(accountManager)
         every { accountManager.getAccountsByType(addressBookAccountType) } returns arrayOf(addressBookAccount)
         every { accountManager.getUserData(addressBookAccount, USER_DATA_COLLECTION_ID) } returns "123"
 
@@ -110,8 +113,6 @@ class AccountSettingsMigration18Test {
         val addressBookAccountType = context.getString(R.string.account_type_address_book)
         var addressBookAccount = Account("Address Book", addressBookAccountType)
 
-        val accountManager = AccountManager.get(context)
-        mockkObject(accountManager)
         every { accountManager.getAccountsByType(addressBookAccountType) } returns arrayOf(addressBookAccount)
         every { accountManager.getUserData(addressBookAccount, USER_DATA_COLLECTION_ID) } returns "100"
 

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration20Test.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration20Test.kt
@@ -44,6 +44,9 @@ import javax.inject.Inject
 class AccountSettingsMigration20Test {
 
     @Inject
+    lateinit var accountManager: AccountManager
+
+    @Inject
     lateinit var calendarStore: LocalCalendarStore
 
     @Inject @ApplicationContext
@@ -70,7 +73,6 @@ class AccountSettingsMigration20Test {
         Manifest.permission.READ_CALENDAR, Manifest.permission.WRITE_CALENDAR
     )
 
-    private val accountManager by lazy { AccountManager.get(context) }
     private lateinit var account: Account
 
     @Before

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/account/AccountsCleanupWorkerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/account/AccountsCleanupWorkerTest.kt
@@ -13,7 +13,6 @@ import androidx.work.testing.TestListenableWorkerBuilder
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.TestUtils
 import at.bitfire.davdroid.accounts.LegacyAccount
-import at.bitfire.davdroid.accounts.toAccountId
 import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.Service
 import at.bitfire.davdroid.resource.AddressBookAccountProperties
@@ -38,6 +37,9 @@ class AccountsCleanupWorkerTest {
     val hiltRule = HiltAndroidRule(this)
 
     @Inject
+    lateinit var accountManager: AccountManager
+
+    @Inject
     lateinit var accountsCleanupWorkerFactory: AccountsCleanupWorker.Factory
 
     @Inject
@@ -55,7 +57,6 @@ class AccountsCleanupWorkerTest {
     @Inject
     lateinit var workerFactory: HiltWorkerFactory
 
-    lateinit var accountManager: AccountManager
     lateinit var addressBookAccountType: String
     lateinit var addressBookAccount: Account
     lateinit var service: Service
@@ -65,7 +66,6 @@ class AccountsCleanupWorkerTest {
         hiltRule.inject()
         TestUtils.setUpWorkManager(context, workerFactory)
 
-        accountManager = AccountManager.get(context)
         service = createTestService()
 
         addressBookAccountType = context.getString(R.string.account_type_address_book)

--- a/core/src/main/kotlin/at/bitfire/davdroid/accounts/AndroidAccountManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/accounts/AndroidAccountManager.kt
@@ -6,16 +6,15 @@ package at.bitfire.davdroid.accounts
 
 import android.accounts.Account
 import android.accounts.AccountManager
-import android.content.Context
 import android.os.Build
-import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
+import javax.inject.Provider
 
 /**
  * A class to manage Android [Account]s.
  */
 class AndroidAccountManager @Inject constructor(
-    @ApplicationContext private val context: Context
+    private val accountManager: Provider<AccountManager>
 ) {
     fun getAndroidAccount(accountId: AccountId): Account {
         return when (accountId) {
@@ -35,7 +34,7 @@ class AndroidAccountManager @Inject constructor(
             // Warning: If setAccountVisibility is called, Android 12 broadcasts the
             // AccountManager.LOGIN_ACCOUNTS_CHANGED_ACTION Intent. This cancels running syncs and starts them again!
             // So make sure setAccountVisibility is only called when necessary.
-            val accountManager = AccountManager.get(context)
+            val accountManager = accountManager.get()
             val account = getAndroidAccount(accountId)
 
             if (accountManager.getAccountVisibility(account, packageName) != AccountManager.VISIBILITY_VISIBLE) {

--- a/core/src/main/kotlin/at/bitfire/davdroid/db/AppDatabase.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/AppDatabase.kt
@@ -33,7 +33,6 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import java.io.Writer
-import javax.inject.Provider
 import javax.inject.Singleton
 
 /**
@@ -76,7 +75,7 @@ abstract class AppDatabase: RoomDatabase() {
         @Provides
         @Singleton
         fun appDatabase(
-            accountManager: Provider<AccountManager>,
+            accountManager: AccountManager,
             autoMigrations: Set<@JvmSuppressWildcards AutoMigrationSpec>,
             @ApplicationContext context: Context,
             manualMigrations: Set<@JvmSuppressWildcards Migration>,
@@ -108,9 +107,8 @@ abstract class AppDatabase: RoomDatabase() {
                     }
 
                     // remove all accounts because they're unfortunately useless without database
-                    val am = accountManager.get()
-                    for (account in am.getAccountsByType(context.getString(R.string.account_type)))
-                        am.removeAccountExplicitly(account)
+                    for (account in accountManager.getAccountsByType(context.getString(R.string.account_type)))
+                        accountManager.removeAccountExplicitly(account)
                 }
             })
             .build()

--- a/core/src/main/kotlin/at/bitfire/davdroid/db/AppDatabase.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/db/AppDatabase.kt
@@ -33,6 +33,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import java.io.Writer
+import javax.inject.Provider
 import javax.inject.Singleton
 
 /**
@@ -75,6 +76,7 @@ abstract class AppDatabase: RoomDatabase() {
         @Provides
         @Singleton
         fun appDatabase(
+            accountManager: Provider<AccountManager>,
             autoMigrations: Set<@JvmSuppressWildcards AutoMigrationSpec>,
             @ApplicationContext context: Context,
             manualMigrations: Set<@JvmSuppressWildcards Migration>,
@@ -106,7 +108,7 @@ abstract class AppDatabase: RoomDatabase() {
                     }
 
                     // remove all accounts because they're unfortunately useless without database
-                    val am = AccountManager.get(context)
+                    val am = accountManager.get()
                     for (account in am.getAccountsByType(context.getString(R.string.account_type)))
                         am.removeAccountExplicitly(account)
                 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/di/AndroidServicesModule.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/di/AndroidServicesModule.kt
@@ -6,15 +6,17 @@ package at.bitfire.davdroid.di
 
 import android.accounts.AccountManager
 import android.content.Context
-import dagger.Binds
+import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 
+@Module
 @InstallIn(SingletonComponent::class)
-interface AndroidServicesModule {
+object AndroidServicesModule {
 
-    @Binds
+    @Provides
     fun accountManager(@ApplicationContext context: Context): AccountManager =
         AccountManager.get(context)
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/di/AndroidServicesModule.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/di/AndroidServicesModule.kt
@@ -12,6 +12,12 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 
+/**
+ * Provides Android system services that have no `@Inject` constructor, so callers depend on the
+ * injected type instead of each caller creating its own instance via a static factory method.
+ * This decouples call sites from how the service is obtained, gives every consumer the same
+ * instance, and lets tests substitute a mock via `@BindValue` instead of mocking the static getter.
+ */
 @Module
 @InstallIn(SingletonComponent::class)
 object AndroidServicesModule {

--- a/core/src/main/kotlin/at/bitfire/davdroid/di/AndroidServicesModule.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/di/AndroidServicesModule.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.di
+
+import android.accounts.AccountManager
+import android.content.Context
+import dagger.Binds
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+
+@InstallIn(SingletonComponent::class)
+interface AndroidServicesModule {
+
+    @Binds
+    fun accountManager(@ApplicationContext context: Context): AccountManager =
+        AccountManager.get(context)
+
+}

--- a/core/src/main/kotlin/at/bitfire/davdroid/repository/AccountRepository.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/repository/AccountRepository.kt
@@ -51,6 +51,7 @@ import javax.inject.Inject
  * [at.bitfire.davdroid.resource.LocalAddressBook].
  */
 class AccountRepository @Inject constructor(
+    private val accountManager: AccountManager,
     private val accountSettingsFactory: AccountSettings.Factory,
     private val automaticSyncManager: Lazy<AutomaticSyncManager>,
     @ApplicationContext private val context: Context,
@@ -66,7 +67,6 @@ class AccountRepository @Inject constructor(
 ) {
 
     private val accountType = context.getString(R.string.account_type)
-    private val accountManager = AccountManager.get(context)
 
     private val accountRenameFlow = MutableSharedFlow<AccountRename>()
     

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/AddressBookAccountProperties.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/AddressBookAccountProperties.kt
@@ -18,10 +18,9 @@ import javax.inject.Inject
  * Deals with reading and writing user data of an address book account.
  */
 class AddressBookAccountProperties @Inject constructor(
+    private val accountManager: AccountManager,
     @ApplicationContext private val context: Context
 ) {
-    private val accountManager by lazy { AccountManager.get(context) }
-
     private val mainAccountType = context.getString(R.string.account_type)
     private val addressBookAccountType = context.getString(R.string.account_type_address_book)
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.flow.merge
 import java.io.FileNotFoundException
 import java.util.Optional
 import java.util.logging.Logger
+import javax.inject.Provider
 import kotlin.jvm.optionals.getOrNull
 
 /**
@@ -61,6 +62,7 @@ open class LocalAddressBook @AssistedInject constructor(
     @Assisted _addressBookAccount: Account,
     @Assisted provider: ContentProviderClient,
     @Assisted val groupMethod: GroupMethod,
+    private val accountManager: Provider<AccountManager>,
     private val accountSettingsFactory: AccountSettings.Factory,
     private val addressBookAccountProperties: AddressBookAccountProperties,
     @ApplicationContext private val context: Context,
@@ -78,8 +80,6 @@ open class LocalAddressBook @AssistedInject constructor(
             groupMethod: GroupMethod
         ): LocalAddressBook
     }
-
-    private val accountManager by lazy { AccountManager.get(context) }
 
     internal val ab = AndroidAddressBook(context, _addressBookAccount, provider, groupMethod)
 
@@ -171,7 +171,7 @@ open class LocalAddressBook @AssistedInject constructor(
         addressBookAccount = newAccount
 
         // delete old account
-        accountManager.removeAccountExplicitly(oldAccount)
+        accountManager.get().removeAccountExplicitly(oldAccount)
 
         return true
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
@@ -33,8 +33,10 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import java.util.logging.Logger
 import javax.inject.Inject
+import javax.inject.Provider
 
 class LocalAddressBookStore @Inject constructor(
+    private val accountManager: Provider<AccountManager>,
     private val accountRepository: AccountRepository,
     private val accountSettingsFactory: AccountSettings.Factory,
     private val addressBookAccountProperties: AddressBookAccountProperties,
@@ -190,7 +192,7 @@ class LocalAddressBookStore @Inject constructor(
         val oldAccountId = oldAccount.toAccountId()
         val newAccountId = newAccount.toAccountId()
 
-        val accountManager = AccountManager.get(context)
+        val accountManager = accountManager.get()
         accountManager.getAccountsByType(context.getString(R.string.account_type_address_book))
             .filter { addressBookAccount ->
                 addressBookAccountProperties.getAppAccount(addressBookAccount) == oldAccountId
@@ -201,7 +203,7 @@ class LocalAddressBookStore @Inject constructor(
     }
 
     override fun delete(localCollection: LocalAddressBook) {
-        val accountManager = AccountManager.get(context)
+        val accountManager = accountManager.get()
         accountManager.removeAccountExplicitly(localCollection.addressBookAccount)
     }
 
@@ -211,7 +213,7 @@ class LocalAddressBookStore @Inject constructor(
      * @param id    [Collection.id] to look for
      */
     fun deleteByCollectionId(id: Long) {
-        val accountManager = AccountManager.get(context)
+        val accountManager = accountManager.get()
         val addressBookAccount = accountManager.getAccountsByType(context.getString(R.string.account_type_address_book)).firstOrNull { account ->
             addressBookAccountProperties.getCollectionId(account) == id
         }
@@ -226,7 +228,7 @@ class LocalAddressBookStore @Inject constructor(
      * @return List of address book accounts.
      */
     fun getAddressBookAccounts(accountId: AccountId): List<Account> {
-        val accountManager = AccountManager.get(context)
+        val accountManager = accountManager.get()
         return accountManager.getAccountsByType(context.getString(R.string.account_type_address_book))
             .filter { addressBookAccount ->
                 addressBookAccountProperties.getAppAccount(addressBookAccount) == accountId
@@ -240,7 +242,7 @@ class LocalAddressBookStore @Inject constructor(
      * @return List of address book accounts as flow.
      */
     fun getAddressBookAccountsFlow(accountId: AccountId): Flow<List<Account>> = callbackFlow {
-        val accountManager = AccountManager.get(context)
+        val accountManager = accountManager.get()
         val listener = OnAccountsUpdateListener { _ ->
             trySend(getAddressBookAccounts(accountId))
         }

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
@@ -192,8 +192,7 @@ class LocalAddressBookStore @Inject constructor(
         val oldAccountId = oldAccount.toAccountId()
         val newAccountId = newAccount.toAccountId()
 
-        val accountManager = accountManager.get()
-        accountManager.getAccountsByType(context.getString(R.string.account_type_address_book))
+        accountManager.get().getAccountsByType(context.getString(R.string.account_type_address_book))
             .filter { addressBookAccount ->
                 addressBookAccountProperties.getAppAccount(addressBookAccount) == oldAccountId
             }
@@ -203,8 +202,7 @@ class LocalAddressBookStore @Inject constructor(
     }
 
     override fun delete(localCollection: LocalAddressBook) {
-        val accountManager = accountManager.get()
-        accountManager.removeAccountExplicitly(localCollection.addressBookAccount)
+        accountManager.get().removeAccountExplicitly(localCollection.addressBookAccount)
     }
 
     /**
@@ -227,13 +225,11 @@ class LocalAddressBookStore @Inject constructor(
      * @param accountId [AccountId] of the app account that owns the address books.
      * @return List of address book accounts.
      */
-    fun getAddressBookAccounts(accountId: AccountId): List<Account> {
-        val accountManager = accountManager.get()
-        return accountManager.getAccountsByType(context.getString(R.string.account_type_address_book))
+    fun getAddressBookAccounts(accountId: AccountId): List<Account> =
+        accountManager.get().getAccountsByType(context.getString(R.string.account_type_address_book))
             .filter { addressBookAccount ->
                 addressBookAccountProperties.getAppAccount(addressBookAccount) == accountId
             }
-    }
 
     /**
      * Returns all address book accounts that belong to the given account in a flow.

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettings.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/AccountSettings.kt
@@ -45,6 +45,7 @@ import javax.inject.Provider
 class AccountSettings @AssistedInject constructor(
     @Assisted val account: Account,
     @Assisted val abortOnMissingMigration: Boolean,
+    private val accountManager: AccountManager,
     private val automaticSyncManager: AutomaticSyncManager,
     @ApplicationContext private val context: Context,
     private val logger: Logger,
@@ -66,7 +67,6 @@ class AccountSettings @AssistedInject constructor(
             throw IllegalThreadStateException("AccountSettings may not be used on main thread")
     }
 
-    val accountManager: AccountManager = AccountManager.get(context)
     init {
         if (account.type != context.getString(R.string.account_type))
             throw IllegalArgumentException("Invalid account type for AccountSettings(): ${account.type}")
@@ -153,8 +153,7 @@ class AccountSettings @AssistedInject constructor(
             SyncDataType.EVENTS -> KEY_SYNC_INTERVAL_CALENDARS
             SyncDataType.TASKS -> KEY_SYNC_INTERVAL_TASKS
         }
-        val seconds = accountManager.getUserData(account, key)?.toLong()
-        return when (seconds) {
+        return when (val seconds = accountManager.getUserData(account, key)?.toLong()) {
             null -> settingsManager.getLongOrNull(Settings.DEFAULT_SYNC_INTERVAL)   // no setting → default value
             SYNC_INTERVAL_MANUALLY -> null      // manual sync
             else -> seconds

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration11.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration11.kt
@@ -18,14 +18,13 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntKey
 import dagger.multibindings.IntoMap
 import javax.inject.Inject
-import javax.inject.Provider
 
 /**
  * The tasks sync interval should be stored in account settings. It's used to set the sync interval
  * again when the tasks provider is switched.
  */
 class AccountSettingsMigration11 @Inject constructor(
-    private val accountManager: Provider<AccountManager>,
+    private val accountManager: AccountManager,
     private val tasksAppManager: TasksAppManager
 ): AccountSettingsMigration {
 
@@ -33,8 +32,11 @@ class AccountSettingsMigration11 @Inject constructor(
         tasksAppManager.currentProvider()?.let { provider ->
             val interval = getSyncFrameworkInterval(account, provider.authority)
             if (interval != null)
-                accountManager.get()
-                    .setAndVerifyUserData(account, AccountSettings.KEY_SYNC_INTERVAL_TASKS, interval.toString())
+                accountManager.setAndVerifyUserData(
+                    account,
+                    AccountSettings.KEY_SYNC_INTERVAL_TASKS,
+                    interval.toString()
+                )
         }
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration11.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration11.kt
@@ -7,7 +7,6 @@ package at.bitfire.davdroid.settings.migration
 import android.accounts.Account
 import android.accounts.AccountManager
 import android.content.ContentResolver
-import android.content.Context
 import at.bitfire.davdroid.settings.AccountSettings
 import at.bitfire.davdroid.settings.AccountSettings.Companion.SYNC_INTERVAL_MANUALLY
 import at.bitfire.davdroid.sync.TasksAppManager
@@ -15,27 +14,27 @@ import at.bitfire.synctools.util.setAndVerifyUserData
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntKey
 import dagger.multibindings.IntoMap
 import javax.inject.Inject
+import javax.inject.Provider
 
 /**
  * The tasks sync interval should be stored in account settings. It's used to set the sync interval
  * again when the tasks provider is switched.
  */
 class AccountSettingsMigration11 @Inject constructor(
-    @ApplicationContext private val context: Context,
+    private val accountManager: Provider<AccountManager>,
     private val tasksAppManager: TasksAppManager
 ): AccountSettingsMigration {
 
     override fun migrate(account: Account) {
-        val accountManager: AccountManager = AccountManager.get(context)
         tasksAppManager.currentProvider()?.let { provider ->
             val interval = getSyncFrameworkInterval(account, provider.authority)
             if (interval != null)
-                accountManager.setAndVerifyUserData(account, AccountSettings.KEY_SYNC_INTERVAL_TASKS, interval.toString())
+                accountManager.get()
+                    .setAndVerifyUserData(account, AccountSettings.KEY_SYNC_INTERVAL_TASKS, interval.toString())
         }
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration17.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration17.kt
@@ -27,12 +27,14 @@ import dagger.multibindings.IntoMap
 import java.util.logging.Level
 import java.util.logging.Logger
 import javax.inject.Inject
+import javax.inject.Provider
 
 /**
  * With DAVx5 4.4.3 address book account names now contain the collection ID as a unique
  * identifier. We need to update the address book account names.
  */
 class AccountSettingsMigration17 @Inject constructor(
+    private val accountManager: Provider<AccountManager>,
     private val accountSettingsFactory: AccountSettings.Factory,
     private val collectionRepository: DavCollectionRepository,
     @ApplicationContext private val context: Context,
@@ -53,7 +55,7 @@ class AccountSettingsMigration17 @Inject constructor(
         }?.use { provider ->
             val service = serviceRepository.getByAccountAndTypeBlocking(account.name, Service.TYPE_CARDDAV) ?: return@use
 
-            val accountManager = AccountManager.get(context)
+            val accountManager = accountManager.get()
             // Get all old address books of this account, i.e. the ones which have a "real_account_name" of this account.
             // After this migration is run, address books won't be associated to accounts anymore but only to their respective collection/URL.
             val oldAddressBookAccounts = accountManager.getAccountsByType(addressBookAccountType)

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration17.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration17.kt
@@ -27,14 +27,13 @@ import dagger.multibindings.IntoMap
 import java.util.logging.Level
 import java.util.logging.Logger
 import javax.inject.Inject
-import javax.inject.Provider
 
 /**
  * With DAVx5 4.4.3 address book account names now contain the collection ID as a unique
  * identifier. We need to update the address book account names.
  */
 class AccountSettingsMigration17 @Inject constructor(
-    private val accountManager: Provider<AccountManager>,
+    private val accountManager: AccountManager,
     private val accountSettingsFactory: AccountSettings.Factory,
     private val collectionRepository: DavCollectionRepository,
     @ApplicationContext private val context: Context,
@@ -55,7 +54,6 @@ class AccountSettingsMigration17 @Inject constructor(
         }?.use { provider ->
             val service = serviceRepository.getByAccountAndTypeBlocking(account.name, Service.TYPE_CARDDAV) ?: return@use
 
-            val accountManager = accountManager.get()
             // Get all old address books of this account, i.e. the ones which have a "real_account_name" of this account.
             // After this migration is run, address books won't be associated to accounts anymore but only to their respective collection/URL.
             val oldAddressBookAccounts = accountManager.getAccountsByType(addressBookAccountType)

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration18.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration18.kt
@@ -19,7 +19,6 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntKey
 import dagger.multibindings.IntoMap
 import javax.inject.Inject
-import javax.inject.Provider
 
 /**
  * v17 had removed the binding between address book accounts and accounts and introduced
@@ -33,13 +32,12 @@ import javax.inject.Provider
  * So this migration again assigns address book accounts to accounts.
  */
 class AccountSettingsMigration18 @Inject constructor(
-    private val accountManager: Provider<AccountManager>,
+    private val accountManager: AccountManager,
     @ApplicationContext private val context: Context,
     private val db: AppDatabase
 ): AccountSettingsMigration {
 
     override fun migrate(account: Account) {
-        val accountManager = accountManager.get()
         db.serviceDao().getByAccountAndTypeBlocking(account.name, Service.TYPE_CARDDAV)?.let { service ->
             db.collectionDao().getByServiceBlocking(service.id).forEach { collection ->
                 // Find associated address book account by collection ID (if it exists)

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration18.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration18.kt
@@ -19,6 +19,7 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntKey
 import dagger.multibindings.IntoMap
 import javax.inject.Inject
+import javax.inject.Provider
 
 /**
  * v17 had removed the binding between address book accounts and accounts and introduced
@@ -32,12 +33,13 @@ import javax.inject.Inject
  * So this migration again assigns address book accounts to accounts.
  */
 class AccountSettingsMigration18 @Inject constructor(
+    private val accountManager: Provider<AccountManager>,
     @ApplicationContext private val context: Context,
     private val db: AppDatabase
 ): AccountSettingsMigration {
 
     override fun migrate(account: Account) {
-        val accountManager = AccountManager.get(context)
+        val accountManager = accountManager.get()
         db.serviceDao().getByAccountAndTypeBlocking(account.name, Service.TYPE_CARDDAV)?.let { service ->
             db.collectionDao().getByServiceBlocking(service.id).forEach { collection ->
                 // Find associated address book account by collection ID (if it exists)

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration20.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration20.kt
@@ -27,7 +27,6 @@ import dagger.multibindings.IntKey
 import dagger.multibindings.IntoMap
 import org.dmfs.tasks.contract.TaskContract.TaskLists
 import javax.inject.Inject
-import javax.inject.Provider
 
 /**
  * [at.bitfire.davdroid.sync.Syncer] now users collection IDs instead of URLs to match
@@ -38,7 +37,7 @@ import javax.inject.Provider
  * all local collections would be deleted and re-created.
  */
 class AccountSettingsMigration20 @Inject constructor(
-    private val accountManager: Provider<AccountManager>,
+    private val accountManager: AccountManager,
     private val addressBookStore: LocalAddressBookStore,
     private val calendarStore: LocalCalendarStore,
     private val collectionRepository: DavCollectionRepository,
@@ -61,7 +60,7 @@ class AccountSettingsMigration20 @Inject constructor(
     internal fun migrateAddressBooks(account: Account, cardDavServiceId: Long) {
         addressBookStore.acquireContentProvider()?.use { provider ->
             for (addressBook in addressBookStore.getAll(account, provider)) {
-                val url = accountManager.get().getUserData(addressBook.addressBookAccount, ADDRESS_BOOK_USER_DATA_URL)
+                val url = accountManager.getUserData(addressBook.addressBookAccount, ADDRESS_BOOK_USER_DATA_URL)
                     ?: continue
                 val collection = collectionRepository.getByServiceAndUrl(cardDavServiceId, url) ?: continue
                 addressBook.dbCollectionId = collection.id

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration20.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration20.kt
@@ -6,7 +6,6 @@ package at.bitfire.davdroid.settings.migration
 
 import android.accounts.Account
 import android.accounts.AccountManager
-import android.content.Context
 import android.provider.CalendarContract
 import androidx.annotation.OpenForTesting
 import androidx.core.content.contentValuesOf
@@ -23,12 +22,12 @@ import at.techbee.jtx.JtxContract
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntKey
 import dagger.multibindings.IntoMap
 import org.dmfs.tasks.contract.TaskContract.TaskLists
 import javax.inject.Inject
+import javax.inject.Provider
 
 /**
  * [at.bitfire.davdroid.sync.Syncer] now users collection IDs instead of URLs to match
@@ -39,15 +38,13 @@ import javax.inject.Inject
  * all local collections would be deleted and re-created.
  */
 class AccountSettingsMigration20 @Inject constructor(
-    @ApplicationContext context: Context,
+    private val accountManager: Provider<AccountManager>,
     private val addressBookStore: LocalAddressBookStore,
     private val calendarStore: LocalCalendarStore,
     private val collectionRepository: DavCollectionRepository,
     private val serviceRepository: DavServiceRepository,
     private val tasksAppManager: TasksAppManager
 ): AccountSettingsMigration {
-
-    val accountManager = AccountManager.get(context)
 
     override fun migrate(account: Account) {
         serviceRepository.getByAccountAndTypeBlocking(account.name, Service.TYPE_CARDDAV)?.let { cardDavService ->
@@ -64,7 +61,8 @@ class AccountSettingsMigration20 @Inject constructor(
     internal fun migrateAddressBooks(account: Account, cardDavServiceId: Long) {
         addressBookStore.acquireContentProvider()?.use { provider ->
             for (addressBook in addressBookStore.getAll(account, provider)) {
-                val url = accountManager.getUserData(addressBook.addressBookAccount, ADDRESS_BOOK_USER_DATA_URL) ?: continue
+                val url = accountManager.get().getUserData(addressBook.addressBookAccount, ADDRESS_BOOK_USER_DATA_URL)
+                    ?: continue
                 val collection = collectionRepository.getByServiceAndUrl(cardDavServiceId, url) ?: continue
                 addressBook.dbCollectionId = collection.id
             }

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration7.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration7.kt
@@ -19,10 +19,9 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntKey
 import dagger.multibindings.IntoMap
 import javax.inject.Inject
-import javax.inject.Provider
 
 class AccountSettingsMigration7 @Inject constructor(
-    private val accountManager: Provider<AccountManager>,
+    private val accountManager: AccountManager,
     @ApplicationContext private val context: Context
 ): AccountSettingsMigration {
 
@@ -34,7 +33,6 @@ class AccountSettingsMigration7 @Inject constructor(
         }
 
         // update allowed WiFi settings key
-        val accountManager = accountManager.get()
         val onlySSID = accountManager.getUserData(account, "wifi_only_ssid")
         accountManager.setAndVerifyUserData(account, AccountSettings.KEY_WIFI_ONLY_SSIDS, onlySSID)
         accountManager.setAndVerifyUserData(account, "wifi_only_ssid", null)

--- a/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration7.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration7.kt
@@ -19,8 +19,10 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntKey
 import dagger.multibindings.IntoMap
 import javax.inject.Inject
+import javax.inject.Provider
 
 class AccountSettingsMigration7 @Inject constructor(
+    private val accountManager: Provider<AccountManager>,
     @ApplicationContext private val context: Context
 ): AccountSettingsMigration {
 
@@ -32,7 +34,7 @@ class AccountSettingsMigration7 @Inject constructor(
         }
 
         // update allowed WiFi settings key
-        val accountManager = AccountManager.get(context)
+        val accountManager = accountManager.get()
         val onlySSID = accountManager.getUserData(account, "wifi_only_ssid")
         accountManager.setAndVerifyUserData(account, AccountSettings.KEY_WIFI_ONLY_SSIDS, onlySSID)
         accountManager.setAndVerifyUserData(account, "wifi_only_ssid", null)

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
@@ -23,6 +23,7 @@ import io.ktor.client.HttpClient
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import java.util.logging.Level
+import javax.inject.Provider
 
 /**
  * Sync logic for address books
@@ -33,6 +34,7 @@ class AddressBookSyncer @AssistedInject constructor(
     @Assisted val syncFrameworkUpload: Boolean,
     @Assisted syncResult: SyncResult,
     @Assisted settings: SyncSettings,
+    private val accountManager: Provider<AccountManager>,
     addressBookStore: LocalAddressBookStore,
     private val contactsSyncManagerFactory: ContactsSyncManager.Factory,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher
@@ -130,7 +132,7 @@ class AddressBookSyncer @AssistedInject constructor(
     ) {
         val groupMethod = settings.groupMethod.name
 
-        val accountManager = AccountManager.get(context)
+        val accountManager = accountManager.get()
         accountManager.getUserData(addressBook.addressBookAccount, PREVIOUS_GROUP_METHOD)?.let { previousGroupMethod ->
             if (previousGroupMethod != groupMethod) {
                 logger.info("Group method changed, deleting all local contacts/groups")

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/account/AccountsCleanupWorker.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/account/AccountsCleanupWorker.kt
@@ -29,6 +29,7 @@ import java.util.logging.Logger
 class AccountsCleanupWorker @AssistedInject constructor(
     @Assisted val context: Context,
     @Assisted workerParameters: WorkerParameters,
+    private val accountManager: AccountManager,
     private val accountRepository: AccountRepository,
     private val addressBookAccountProperties: AddressBookAccountProperties,
     private val db: AppDatabase,
@@ -40,8 +41,6 @@ class AccountsCleanupWorker @AssistedInject constructor(
     interface Factory {
         fun create(appContext: Context, workerParams: WorkerParameters): AccountsCleanupWorker
     }
-
-    private val accountManager = AccountManager.get(context)
 
     override fun doWork(): Result {
         lockAccountsCleanup()

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoGenerator.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoGenerator.kt
@@ -64,7 +64,6 @@ import java.util.TimeZone
 import java.util.logging.Level
 import java.util.logging.Logger
 import javax.inject.Inject
-import javax.inject.Provider
 import kotlin.use
 import at.bitfire.synctools.storage.calendar.EventsContract.asSyncAdapter as asCalendarSyncAdapter
 import at.bitfire.synctools.storage.contacts.AddressContract.asSyncAdapter as asContactsSyncAdapter
@@ -72,7 +71,7 @@ import at.techbee.jtx.JtxContract.asSyncAdapter as asJtxSyncAdapter
 
 @WorkerThread
 class DebugInfoGenerator @Inject constructor(
-    private val accountManager: Provider<AccountManager>,
+    private val accountManager: AccountManager,
     private val accountRepository: AccountRepository,
     private val accountSettingsFactory: AccountSettings.Factory,
     private val addressBookAccountProperties: AddressBookAccountProperties,
@@ -321,7 +320,6 @@ class DebugInfoGenerator @Inject constructor(
 
         // accounts
         writer.append("\nACCOUNTS")
-        val accountManager = accountManager.get()
         val accountIds = accountRepository.getAllBlocking()
         for (accountId in accountIds)
             dumpAccount(accountId, writer)

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoGenerator.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/DebugInfoGenerator.kt
@@ -64,6 +64,7 @@ import java.util.TimeZone
 import java.util.logging.Level
 import java.util.logging.Logger
 import javax.inject.Inject
+import javax.inject.Provider
 import kotlin.use
 import at.bitfire.synctools.storage.calendar.EventsContract.asSyncAdapter as asCalendarSyncAdapter
 import at.bitfire.synctools.storage.contacts.AddressContract.asSyncAdapter as asContactsSyncAdapter
@@ -71,6 +72,7 @@ import at.techbee.jtx.JtxContract.asSyncAdapter as asJtxSyncAdapter
 
 @WorkerThread
 class DebugInfoGenerator @Inject constructor(
+    private val accountManager: Provider<AccountManager>,
     private val accountRepository: AccountRepository,
     private val accountSettingsFactory: AccountSettings.Factory,
     private val addressBookAccountProperties: AddressBookAccountProperties,
@@ -319,7 +321,7 @@ class DebugInfoGenerator @Inject constructor(
 
         // accounts
         writer.append("\nACCOUNTS")
-        val accountManager = AccountManager.get(context)
+        val accountManager = accountManager.get()
         val accountIds = accountRepository.getAllBlocking()
         for (accountId in accountIds)
             dumpAccount(accountId, writer)

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/GoogleLoginViewModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/GoogleLoginViewModel.kt
@@ -27,10 +27,12 @@ import net.openid.appauth.AuthorizationService
 import java.util.Locale
 import java.util.logging.Level
 import java.util.logging.Logger
+import javax.inject.Provider
 
 @HiltViewModel(assistedFactory = GoogleLoginViewModel.Factory::class)
 class GoogleLoginViewModel @AssistedInject constructor(
     @Assisted val initialLoginInfo: LoginInfo,
+    private val accountManager: Provider<AccountManager>,
     private val authService: AuthorizationService,
     @ApplicationContext val context: Context,
     private val logger: Logger,
@@ -121,12 +123,10 @@ class GoogleLoginViewModel @AssistedInject constructor(
         uiState = uiState.copy(result = null)
     }
 
-    private fun findGoogleAccount(): String? {
-        val accountManager = AccountManager.get(context)
-        return accountManager
+    private fun findGoogleAccount(): String? =
+        accountManager.get()
             .getAccountsByType("com.google")
             .map { it.name }
             .firstOrNull()
-    }
 
 }


### PR DESCRIPTION
### Purpose

`AccountManager` was obtained via the static `AccountManager.get(context)` call scattered across many Hilt-managed classes. This made call sites depend on how the service is created, and made testing awkward — tests either exercised the real device `AccountManager` or fell back to `mockkObject` on it instead of Hilt's normal `@BindValue` mocking.

**By using proper DI, we become independent of how the service is actually being created, and we can change the bindings like for tests.**

We also go a very little step into the multi-platform direction – we could for instance inject objects from support libraries that emulate a `NotificationManager` with the same API (but are created differently) instead of the original `NotificationManager`.

### Short description

- Added `AndroidServicesModule`, a Hilt module providing `AccountManager` as a single binding.
- Replaced `AccountManager.get(context)` with constructor injection across affected classes, choosing direct injection or `Provider<AccountManager>` based on actual call frequency, not call-site count.
- Updated tests to either inject the real `AccountManager` or mock it via `@BindValue`, replacing manual `AccountManager.get(context)`/`mockkObject` usage.
- Documented the pattern (system-service bindings, direct/`Lazy`/`Provider` choice) in `AGENTS.md`.

**Not in scope/for future PRs:** Inject other Android services over Hilt, too.

CC @bitfireAT/app-dev for potential feedback/comments etc

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.