### PR TITLE
Add workflow to mirror english original strings to `davx5-translations`

### DIFF
--- a/.github/workflows/mirror-english-strings.yml
+++ b/.github/workflows/mirror-english-strings.yml
@@ -1,0 +1,52 @@
+name: Mirror English strings
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - core/src/main/res/values/strings.xml
+  workflow_dispatch:
+
+concurrency:
+  group: mirror-english-strings
+  cancel-in-progress: false
+
+jobs:
+  mirror-english-strings:
+    name: Mirror English strings to davx5-translations
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Create davx5-translations token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.TRANSLATIONS_APP_ID }}
+          private-key: ${{ secrets.TRANSLATIONS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: davx5-translations
+
+      - name: Check out davx5-translations
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ github.repository_owner }}/davx5-translations
+          ref: main
+          path: davx5-translations
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Copy English strings
+        run: cp core/src/main/res/values/strings.xml davx5-translations/sources/ose/strings.xml
+
+      - name: Commit sources/ose/strings.xml
+        uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          repository: davx5-translations
+          branch: main
+          file_pattern: sources/ose/strings.xml
+          commit_message: "Mirror English strings (ose) from davx5-ose@${{ github.sha }}"
+          commit_user_name: mirror-original-english-strings[bot]
+          commit_user_email: 316112360+mirror-original-english-strings[bot]@users.noreply.github.com
+          commit_author: mirror-original-english-strings[bot] <316112360+mirror-original-english-strings[bot]@users.noreply.github.com>


### PR DESCRIPTION
### Purpose

To ease overall maintenance. Move all DAVx5 weblate translation to a separate `davx5-translations` repository. This PR is just adding the workflow to copy the source strings into the [`davx5-translations`](https://github.com/bitfireAT/davx5-translations) translations repo. Weblate operates on that `davx5-translations` translations repo. A later PR will add the repo as git submodule so we can access the translations here.


### Short description

Workflow run description.

1. **Trigger** — Workflow starts on a push to `main` that changes `strings.xml`, or manually via `workflow_dispatch`.

2. **Checkout current repo** — Clones this repository so the workflow can access the strings file.

3. **Create App token** — Authenticates as [mirror-original-english-strings GitHub App](https://github.com/organizations/bitfireAT/settings/apps/mirror-original-english-strings) to generate a temporary token scoped to the `davx5-translations` repo.

4. **Checkout `davx5-translations`** — Clones the target repo into a local subfolder, using the App token for access.

5. **Copy the file** — Copies `strings.xml` from this repo into `davx5-translations/sources/ose/strings.xml`.

6. **Commit & push** — Auto-commits the copied file to `davx5-translations`'s `main` branch (if changed), using a bot identity and referencing the source commit SHA.

### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.

