### PR TITLE
[SyncManager] Extract upload step into own method

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -166,9 +166,7 @@ abstract class SyncManager<LocalType : LocalResource>(
             var remoteSyncState = initialSyncState
 
             logger.info("Processing local deletes/updates")
-            val modificationsPresent =
-                // bitwise OR guarantees that both expressions are evaluated
-                processLocallyDeleted() or uploadDirty(capabilities)
+            val modificationsPresent = processLocalChanges(capabilities)
 
             if (resync == ResyncType.RESYNC_ENTRIES) {
                 logger.info("Forcing re-synchronization of all entries")
@@ -223,7 +221,19 @@ abstract class SyncManager<LocalType : LocalResource>(
      */
     protected open suspend fun prepare(): Boolean = true
 
-    //region Processing of locally dirty/deleted items
+    //region Processing of local dirty/deleted items
+
+    /**
+     * Processes locally deleted and locally modified (dirty) resources by forwarding them to
+     * the server.
+     *
+     * @param capabilities  current capabilities of the remote collection
+     *
+     * @return whether local resources have been uploaded so that a synchronization is always necessary
+     */
+    private suspend fun processLocalChanges(capabilities: WebDavCollection.Capabilities): Boolean =
+        // bitwise OR guarantees that both expressions are evaluated
+        processLocallyDeleted() or uploadDirty(capabilities)
 
     /**
      * Processes locally deleted entries. This can mean:


### PR DESCRIPTION
### Purpose

Improves readability of `performSync()` by extracting the local-changes step into its own method.

Can later be extracted into an upload strategy.


### Short description

- Extracted `processLocalChanges(capabilities)` from the inline `processLocallyDeleted() or uploadDirty(capabilities)` call in `performSync()`.
- Added KDoc for the new method.


### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.
