### PR TITLE
`AccountId` refactoring (part 14)

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/CalendarSyncManagerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/CalendarSyncManagerTest.kt
@@ -14,7 +14,6 @@ import android.provider.CalendarContract.Events
 import androidx.core.content.contentValuesOf
 import androidx.test.rule.GrantPermissionRule
 import at.bitfire.davdroid.accounts.LegacyAccount
-import at.bitfire.davdroid.accounts.toAndroidAccount
 import at.bitfire.davdroid.resource.LocalCalendar
 import at.bitfire.davdroid.resource.LocalEvent
 import at.bitfire.davdroid.resource.remote.CalDavCollection
@@ -73,7 +72,7 @@ class CalendarSyncManagerTest {
         providerClient = context.contentResolver.acquireContentProviderClient(CalendarContract.AUTHORITY)!!
 
         // create LocalCalendar
-        val androidCalendarProvider = AndroidCalendarProvider(accountId.toAndroidAccount(), providerClient)
+        val androidCalendarProvider = AndroidCalendarProvider(accountId.androidAccount, providerClient)
         androidCalendar = androidCalendarProvider.createAndGetCalendar(contentValuesOf(
             Calendars.NAME to "Sample Calendar"
         ))

--- a/core/src/main/kotlin/at/bitfire/davdroid/accounts/TemporaryHelpers.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/accounts/TemporaryHelpers.kt
@@ -7,15 +7,6 @@ package at.bitfire.davdroid.accounts
 import android.accounts.Account as AndroidAccount
 
 @Deprecated("Only used during conversion from android.accounts.Account to AccountId")
-fun AccountId.toAndroidAccount(): AndroidAccount {
-    require(this is LegacyAccount) { 
-        "Account instance must be a LegacyAccount, but was ${this.javaClass.canonicalName}" 
-    }
-    
-    return androidAccount
-}
-
-@Deprecated("Only used during conversion from android.accounts.Account to AccountId")
 fun AndroidAccount.toAccountId(): AccountId {
     return LegacyAccount(this)
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBook.kt
@@ -15,8 +15,6 @@ import android.provider.ContactsContract.RawContacts
 import androidx.annotation.OpenForTesting
 import androidx.core.content.contentValuesOf
 import at.bitfire.davdroid.accounts.AccountId
-import at.bitfire.davdroid.accounts.toAccountId
-import at.bitfire.davdroid.accounts.toAndroidAccount
 import at.bitfire.davdroid.resource.workaround.ContactDirtyVerifier
 import at.bitfire.davdroid.settings.AccountSettingsFactory
 import at.bitfire.davdroid.sync.SyncDataType

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/LocalAddressBookStore.kt
@@ -17,7 +17,6 @@ import androidx.core.content.contentValuesOf
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.accounts.AccountId
 import at.bitfire.davdroid.accounts.toAccountId
-import at.bitfire.davdroid.accounts.toAndroidAccount
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.repository.AccountRepository
 import at.bitfire.davdroid.repository.DavServiceRepository

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncValidator.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncValidator.kt
@@ -4,7 +4,7 @@
 
 package at.bitfire.davdroid.sync
 
-import android.accounts.Account
+import at.bitfire.davdroid.accounts.AccountId
 import dagger.BindsOptionalOf
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -19,10 +19,10 @@ interface SyncValidator {
     /**
      * Called before synchronization when a sync adapter is started. Can be used for license checks etc. Must be thread-safe.
      *
-     * @param account The account about to be synchronized
+     * @param accountId [AccountId] of the account about to be synchronized
      * @return whether synchronization shall take place (false to abort)
      */
-    suspend fun beforeSync(account: Account): Boolean
+    suspend fun beforeSync(accountId: AccountId): Boolean
 
 }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
@@ -10,7 +10,6 @@ import android.os.DeadObjectException
 import androidx.annotation.VisibleForTesting
 import at.bitfire.davdroid.accounts.AccountId
 import at.bitfire.davdroid.accounts.AndroidAccountManager
-import at.bitfire.davdroid.accounts.toAndroidAccount
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.db.ServiceType
 import at.bitfire.davdroid.network.HttpClientBuilder
@@ -290,7 +289,7 @@ abstract class Syncer<StoreType: LocalDataStore<CollectionType>, CollectionType:
             try {
                 val runSync = syncValidator.getOrNull()?.let { instance ->
                     logger.info("Registered sync validator: ${instance::class.java.name}")
-                    instance.beforeSync(accountId.toAndroidAccount())
+                    instance.beforeSync(accountId)
                 } ?: /* no sync validator, in OSE for example */ true
 
                 if (runSync)

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
@@ -17,8 +17,8 @@ import at.bitfire.davdroid.IoCoroutineWorker
 import at.bitfire.davdroid.R
 import at.bitfire.davdroid.accounts.AccountId
 import at.bitfire.davdroid.accounts.LegacyAccount
-import at.bitfire.davdroid.accounts.toAndroidAccount
 import at.bitfire.davdroid.push.PushNotificationManager
+import at.bitfire.davdroid.repository.AccountRepository
 import at.bitfire.davdroid.settings.AccountSettingsFactory
 import at.bitfire.davdroid.sync.AddressBookSyncer
 import at.bitfire.davdroid.sync.CalendarSyncer
@@ -49,6 +49,9 @@ abstract class BaseSyncWorker(
     context: Context,
     private val workerParams: WorkerParameters
 ) : IoCoroutineWorker(context, workerParams) {
+
+    @Inject
+    lateinit var accountRepository: AccountRepository
 
     @Inject
     lateinit var accountSettingsFactory: AccountSettingsFactory
@@ -187,8 +190,7 @@ abstract class BaseSyncWorker(
 
         // Check for errors
         if (syncResult.hasError) {
-            val account = accountId.toAndroidAccount()
-            val softErrorNotificationTag = "${account.type}-${account.name}-$dataType"
+            val softErrorNotificationTag = "$accountId-$dataType"
 
             // On soft errors the sync is retried a few times before considered failed
             if (syncResult.softError) {
@@ -207,12 +209,13 @@ abstract class BaseSyncWorker(
                 }
 
                 logger.warning("Max retries on soft errors reached ($runAttemptCount of $MAX_RUN_ATTEMPTS). Treating as failed")
+                val accountName = accountRepository.getAccountName(accountId)
                 notificationRegistry.notifyIfPossible(NotificationRegistry.NOTIFY_SYNC_ERROR, tag = softErrorNotificationTag) {
                     NotificationCompat.Builder(applicationContext, notificationRegistry.CHANNEL_SYNC_IO_ERRORS)
                         .setSmallIcon(R.drawable.ic_sync_problem_notify)
-                        .setContentTitle(account.name)
+                        .setContentTitle(accountName)
                         .setContentText(applicationContext.getString(R.string.sync_error_retry_limit_reached))
-                        .setSubText(account.name)
+                        .setSubText(accountName)
                         .setOnlyAlertOnce(true)
                         .setPriority(NotificationCompat.PRIORITY_MIN)
                         .setCategory(NotificationCompat.CATEGORY_ERROR)

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/worker/SyncWorkerManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/worker/SyncWorkerManager.kt
@@ -23,7 +23,6 @@ import androidx.work.WorkQuery
 import androidx.work.WorkRequest
 import androidx.work.await
 import at.bitfire.davdroid.accounts.AccountId
-import at.bitfire.davdroid.accounts.toAndroidAccount
 import at.bitfire.davdroid.push.PushNotificationManager
 import at.bitfire.davdroid.sync.ResyncType
 import at.bitfire.davdroid.sync.SyncDataType

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreenViewModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountScreenViewModel.kt
@@ -11,8 +11,6 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import at.bitfire.davdroid.accounts.AccountId
-import at.bitfire.davdroid.accounts.toAccountId
-import at.bitfire.davdroid.accounts.toAndroidAccount
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.di.qualifier.IoDispatcher
 import at.bitfire.davdroid.repository.AccountRepository

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsActivity.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/AccountSettingsActivity.kt
@@ -12,7 +12,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.TaskStackBuilder
 import at.bitfire.davdroid.accounts.AccountId
 import at.bitfire.davdroid.accounts.AccountIdIntentSerializer
-import at.bitfire.davdroid.accounts.toAndroidAccount
 import at.bitfire.davdroid.ui.account.AccountActivity.Companion.editAccountActivityIntent
 import dagger.hilt.android.AndroidEntryPoint
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionScreenViewModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CollectionScreenViewModel.kt
@@ -4,7 +4,6 @@
 
 package at.bitfire.davdroid.ui.account
 
-import android.accounts.Account
 import android.content.ContentProviderClient
 import android.content.Context
 import android.database.ContentObserver
@@ -16,7 +15,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import at.bitfire.davdroid.accounts.toAccountId
+import at.bitfire.davdroid.accounts.AccountId
 import at.bitfire.davdroid.db.AppDatabase
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.di.qualifier.ApplicationScope
@@ -103,9 +102,10 @@ class CollectionScreenViewModel @AssistedInject constructor(
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
     /** Flow that provides the account associated with the current collection */
-    val account: Flow<Account?> = collection.filterNotNull().map { collection ->
-        val service = serviceRepository.get(collection.serviceId)
-        service?.let { accountRepository.fromName(it.accountName) }
+    val accountId: Flow<AccountId?> = collection.filterNotNull().map { collection ->
+        serviceRepository.get(collection.serviceId)?.let { service ->
+            accountRepository.getAccountIdFromName(service.accountName)
+        }
     }
 
 
@@ -148,18 +148,18 @@ class CollectionScreenViewModel @AssistedInject constructor(
     val lastSynced = syncStatsRepository.getLastSyncedFlow(collectionId)
 
     /** The account's "past event time limit", or null if not set or not relevant for the collection. */
-    val pastEventTimeLimit = combine(collection.filterNotNull(), account.filterNotNull()) { collection, account ->
+    val pastEventTimeLimit = combine(collection.filterNotNull(), accountId.filterNotNull()) { collection, accountId ->
         if (collection.type == Collection.TYPE_CALENDAR) {
-            getTimeRangePastDays(account)
+            getTimeRangePastDays(accountId)
         } else  {
             // doesn't apply to address books
             null
         }
     }
 
-    private suspend fun getTimeRangePastDays(account: Account): Int? {
+    private suspend fun getTimeRangePastDays(accountId: AccountId): Int? {
         return withContext(ioDispatcher) {
-            val accountSettings = accountSettingsFactory.create(account.toAccountId())
+            val accountSettings = accountSettingsFactory.create(accountId)
             accountSettings.getTimeRangePastDays()
         }
     }
@@ -167,9 +167,9 @@ class CollectionScreenViewModel @AssistedInject constructor(
     @OptIn(ExperimentalCoroutinesApi::class)
     val localItemCounts: Flow<List<LocalItemsCount>> = combine(
         collection.filterNotNull(),
-        account.filterNotNull()
-    ) { collection, account ->
-        countLocalItemsFlow(collection, account)
+        accountId.filterNotNull()
+    ) { collection, accountId ->
+        countLocalItemsFlow(collection, accountId)
     }.flatMapLatest { it }
 
 
@@ -224,19 +224,19 @@ class CollectionScreenViewModel @AssistedInject constructor(
         val deleted: Int
     )
 
-    private fun countLocalItemsFlow(collection: Collection, account: Account): Flow<List<LocalItemsCount>> {
+    private fun countLocalItemsFlow(collection: Collection, accountId: AccountId): Flow<List<LocalItemsCount>> {
         // Build one flow per local data store relevant to this collection type (will later be combined).
         val storeFlows: List<Flow<LocalItemsCount?>> = when (collection.type) {
             Collection.TYPE_ADDRESSBOOK -> listOf(
                 observeLocalDataStore(
-                    account = account,
+                    accountId = accountId,
                     localDataStore = localAddressBookStore.get(),
                     watchUris = listOf(ContactsContract.RawContacts.CONTENT_URI)
                 )
             )
             Collection.TYPE_CALENDAR -> buildList {
                 add(observeLocalDataStore(
-                    account = account,
+                    accountId = accountId,
                     localDataStore = localCalendarStore.get(),
                     watchUris = listOf(
                         CalendarContract.Calendars.CONTENT_URI,
@@ -246,7 +246,7 @@ class CollectionScreenViewModel @AssistedInject constructor(
 
                 tasksAppManager.get().getDataStore()?.let { taskListStore ->
                     add(observeLocalDataStore(
-                        account = account,
+                        accountId = accountId,
                         localDataStore = taskListStore,
                         watchUris = listOf(TaskContract.getContentUri(taskListStore.authority))
                     ))
@@ -262,7 +262,7 @@ class CollectionScreenViewModel @AssistedInject constructor(
     }
 
     private fun observeLocalDataStore(
-        account: Account,
+        accountId: AccountId,
         localDataStore: LocalDataStore<*>,
         watchUris: List<Uri>
     ): Flow<LocalItemsCount?> = callbackFlow {
@@ -282,7 +282,7 @@ class CollectionScreenViewModel @AssistedInject constructor(
         }
 
         fun queryAndSend() {
-            val count = localDataStore.getByDbCollectionId(account.toAccountId(), client, collectionId)?.let { store ->
+            val count = localDataStore.getByDbCollectionId(accountId, client, collectionId)?.let { store ->
                 LocalItemsCount(
                     contentProviderName = getProviderAppName(localDataStore.authority),
                     total = store.countAll(),

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateAddressBookViewModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateAddressBookViewModel.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import at.bitfire.davdroid.accounts.AccountId
-import at.bitfire.davdroid.accounts.toAndroidAccount
 import at.bitfire.davdroid.db.HomeSet
 import at.bitfire.davdroid.di.qualifier.ApplicationScope
 import at.bitfire.davdroid.repository.DavCollectionRepository

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateCalendarViewModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/account/CreateCalendarViewModel.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import at.bitfire.davdroid.accounts.AccountId
-import at.bitfire.davdroid.accounts.toAndroidAccount
 import at.bitfire.davdroid.db.HomeSet
 import at.bitfire.davdroid.di.qualifier.ApplicationScope
 import at.bitfire.davdroid.repository.DavCollectionRepository


### PR DESCRIPTION
Getting closer to the end. This PR removes the `AccountId.toAndroidAccount()` helper.

Part of #2033