### PR TITLE
Propagate Sync Cancellation and Exceptions Correctly

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/AddressBookSyncerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/AddressBookSyncerTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ */
+
+package at.bitfire.davdroid.sync
+
+import android.accounts.AccountManager
+import android.content.ContentProviderClient
+import android.os.DeadObjectException
+import at.bitfire.davdroid.db.Collection
+import at.bitfire.davdroid.resource.LocalAddressBook
+import at.bitfire.synctools.storage.LocalStorageException
+import at.bitfire.synctools.test.assertThrows
+import io.ktor.http.Url
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.junit4.MockKRule
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.util.logging.Logger
+
+class AddressBookSyncerTest {
+
+    @get:Rule
+    val mockkRule = MockKRule(this)
+
+    @RelaxedMockK
+    lateinit var accountManager: AccountManager
+
+    @RelaxedMockK
+    lateinit var logger: Logger
+
+    private val addressBook: LocalAddressBook = mockk(relaxed = true)
+    private val contactsSyncManager: ContactsSyncManager = mockk(relaxed = true)
+    private val contactsSyncManagerFactory: ContactsSyncManager.Factory = mockk()
+    private val provider: ContentProviderClient = mockk(relaxed = true)
+    private val settings = SyncSettingsFixtures.default()
+    private val syncResult = SyncResult()
+
+    private val collection = Collection(
+        id = 1,
+        type = Collection.TYPE_ADDRESSBOOK,
+        url = Url("https://example.com/addressbook/")
+    )
+
+    private lateinit var syncer: AddressBookSyncer
+
+    @Before
+    fun setUp() {
+        syncer = AddressBookSyncer(
+            accountId = mockk(relaxed = true),
+            resync = null,
+            syncFrameworkUpload = false,
+            syncResult = syncResult,
+            settings = settings,
+            accountManager = { accountManager },
+            addressBookStore = mockk(relaxed = true),
+            contactsSyncManagerFactory = contactsSyncManagerFactory,
+            ioDispatcher = Dispatchers.Unconfined
+        ).apply {
+            httpClientBuilder = mockk(relaxed = true)
+            logger = this@AddressBookSyncerTest.logger
+        }
+
+        // group method hasn't changed, so that handleGroupMethodChange() doesn't do anything
+        every { accountManager.getUserData(any(), any()) } returns settings.groupMethod.name
+
+        every {
+            contactsSyncManagerFactory.contactsSyncManager(
+                accountId = any(),
+                httpClient = any(),
+                syncResult = any(),
+                provider = any(),
+                localAddressBook = any(),
+                collectionInfo = any(),
+                remoteCollection = any(),
+                resync = any(),
+                syncFrameworkUpload = any(),
+                settings = any()
+            )
+        } returns contactsSyncManager
+    }
+
+
+    @Test
+    fun testSyncCollection_rethrowsCancellation() = runTest {
+        coEvery { contactsSyncManager.performSync() } throws CancellationException()
+
+        /* Cancellation must not be swallowed here: only the Syncer/BaseSyncWorker may decide what to do
+        about it (see issue #2663). */
+        assertThrows<CancellationException> {
+            syncer.syncCollection(provider, addressBook, collection)
+        }
+        assertFalse(syncResult.hasError)
+    }
+
+    @Test
+    fun testSyncCollection_rethrowsDeadObjectException() = runTest {
+        coEvery { contactsSyncManager.performSync() } throws
+                LocalStorageException("Couldn't access local storage", DeadObjectException())
+
+        // Same for the DeadObjectException, which the Syncer treats as soft error
+        assertThrows<LocalStorageException> {
+            syncer.syncCollection(provider, addressBook, collection)
+        }
+    }
+
+}

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncerTest.kt
@@ -6,10 +6,13 @@ package at.bitfire.davdroid.sync
 
 import android.accounts.Account
 import android.content.ContentProviderClient
+import android.os.DeadObjectException
 import at.bitfire.davdroid.accounts.AccountId
 import at.bitfire.davdroid.accounts.LegacyAccount
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.resource.LocalDataStore
+import at.bitfire.synctools.storage.LocalStorageException
+import at.bitfire.synctools.test.assertThrows
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -21,12 +24,15 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import java.util.Optional
 import java.util.logging.Logger
 
 class SyncerTest {
@@ -39,12 +45,19 @@ class SyncerTest {
 
     val dataStore: LocalTestStore = mockk(relaxed = true)
     val provider: ContentProviderClient = mockk(relaxed = true)
+    val syncResult = SyncResult()
 
     private val accountId = LegacyAccount(Account("test", "test"))
 
     @SpyK
     @InjectMockKs
-    var syncer = TestSyncer(accountId, null, SyncResult(), SyncSettingsFixtures.default(), dataStore)
+    var syncer = TestSyncer(accountId, null, syncResult, SyncSettingsFixtures.default(), dataStore).apply {
+        /* Dependencies that are only used by invoke(). They have to be set before the spy is created, because
+        the spy only gets a copy of the fields, while the lazy syncNotificationManager still resolves them
+        on the original object. */
+        syncNotificationManagerFactory = mockk(relaxed = true)
+        syncValidator = Optional.empty()
+    }
 
 
     @Test
@@ -155,6 +168,40 @@ class SyncerTest {
         syncer.syncCollectionContents(provider, localCollections, dbCollections)
         coVerify(exactly = 1) { syncer.syncCollection(provider, localCollection1, dbCollection1) }
         coVerify(exactly = 1) { syncer.syncCollection(provider, localCollection2, dbCollection2) }
+    }
+
+
+    @Test
+    fun testInvoke_cancellation_isRethrown() = runTest {
+        every { dataStore.acquireContentProvider(any()) } returns provider
+        coEvery { syncer.sync(provider) } throws CancellationException()
+
+        // Cancellation is not a sync error, but has to be passed on to the worker
+        assertThrows<CancellationException> {
+            syncer()
+        }
+        assertFalse(syncResult.hasError)
+    }
+
+    @Test
+    fun testInvoke_deadObjectException_isSoftError() = runTest {
+        every { dataStore.acquireContentProvider(any()) } returns provider
+        coEvery { syncer.sync(provider) } throws
+                LocalStorageException("Couldn't access local storage", DeadObjectException())
+
+        syncer()
+        assertTrue(syncResult.softError)
+        assertFalse(syncResult.hardError)
+    }
+
+    @Test
+    fun testInvoke_unclassifiedException_isHardError() = runTest {
+        every { dataStore.acquireContentProvider(any()) } returns provider
+        coEvery { syncer.sync(provider) } throws Exception("Some unexpected problem")
+
+        syncer()
+        assertTrue(syncResult.hardError)
+        assertFalse(syncResult.softError)
     }
 
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt
@@ -77,7 +77,11 @@ class AddressBookSyncer @AssistedInject constructor(
     }
 
     /**
-     * Synchronizes an address book
+     * Synchronizes an address book.
+     *
+     * Sync errors of the address book contents are handled (logged, notified, recorded in [syncResult])
+     * by [SyncManager] itself. Everything it re-throws – as well as exceptions of
+     * [handleGroupMethodChange] – is passed on to [invoke], which classifies it.
      *
      * @param addressBook       local address book
      * @param httpClient        HTTP client to use for network requests
@@ -93,26 +97,21 @@ class AddressBookSyncer @AssistedInject constructor(
         syncResult: SyncResult,
         collection: Collection
     ) {
-        try {
-            handleGroupMethodChange(addressBook, provider)
+        handleGroupMethodChange(addressBook, provider)
 
-            val syncManager = contactsSyncManagerFactory.contactsSyncManager(
-                accountId = accountId,
-                httpClient = httpClient,
-                syncResult = syncResult,
-                provider = provider,
-                localAddressBook = addressBook,
-                collectionInfo = collection,
-                remoteCollection = CardDavCollection(httpClient, collection.url),
-                resync = resync,
-                syncFrameworkUpload = syncFrameworkUpload,
-                settings = settings
-            )
-            syncManager.performSync()
-
-        } catch(e: Exception) {
-            logger.log(Level.SEVERE, "Couldn't sync contacts", e)
-        }
+        val syncManager = contactsSyncManagerFactory.contactsSyncManager(
+            accountId = accountId,
+            httpClient = httpClient,
+            syncResult = syncResult,
+            provider = provider,
+            localAddressBook = addressBook,
+            collectionInfo = collection,
+            remoteCollection = CardDavCollection(httpClient, collection.url),
+            resync = resync,
+            syncFrameworkUpload = syncFrameworkUpload,
+            settings = settings
+        )
+        syncManager.performSync()
 
         logger.info("Contacts sync complete")
     }

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
@@ -263,7 +263,7 @@ abstract class Syncer<StoreType: LocalDataStore<CollectionType>, CollectionType:
     /**
      * Acquires the content provider, runs the sync, and handles exceptions that are not handled by the SyncManager itself.
      *
-     * Handled exceptions are recorded in [syncResult] as soft or hard error.
+     * Handled exceptions are logged; most are also recorded in [syncResult] as soft or hard errors.
      *
      * @throws CancellationException if the sync has been canceled – not recorded in [syncResult], but passed
      * on to the caller (see [at.bitfire.davdroid.sync.worker.BaseSyncWorker])

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/Syncer.kt
@@ -20,6 +20,7 @@ import at.bitfire.davdroid.resource.LocalDataStore
 import at.bitfire.davdroid.sync.account.InvalidAccountException
 import at.bitfire.davdroid.util.causedBy
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
 import java.io.Closeable
 import java.util.Optional
 import java.util.logging.Level
@@ -261,6 +262,11 @@ abstract class Syncer<StoreType: LocalDataStore<CollectionType>, CollectionType:
 
     /**
      * Acquires the content provider, runs the sync, and handles exceptions that are not handled by the SyncManager itself.
+     *
+     * Handled exceptions are recorded in [syncResult] as soft or hard error.
+     *
+     * @throws CancellationException if the sync has been canceled – not recorded in [syncResult], but passed
+     * on to the caller (see [at.bitfire.davdroid.sync.worker.BaseSyncWorker])
      */
     suspend operator fun invoke() {
         logger.info("${dataStore.authority} sync of $accountId initiated (resync=$resync)")
@@ -301,12 +307,20 @@ abstract class Syncer<StoreType: LocalDataStore<CollectionType>, CollectionType:
                 - have occurred during Syncer operation (for instance when creating/deleting local collections) —
                   content provider access here can also throw a DeadObjectException wrapped by the storage layer,
                 - or have been re-thrown from SyncManager (like the unwrapped DeadObjectException). */
-                if (e.causedBy<DeadObjectException>() != null) {
+                when {
+                    /* The sync has been canceled (usually because WorkManager stopped our worker). Cancellation is
+                    not a sync error and must never be swallowed: the coroutine has to stop here, and the worker has
+                    to pass the cancellation on to WorkManager. See BaseSyncWorker. */
+                    e is CancellationException ->
+                        throw e
+
                     // content provider process died, or (Android 14+) was killed for being frozen/cached; see SyncExceptionHandler
-                    logger.log(Level.WARNING, "Received DeadObjectException, treating as soft error", e)
-                    syncResult.softError = true
-                } else when (e) {
-                    is InvalidAccountException ->
+                    e.causedBy<DeadObjectException>() != null -> {
+                        logger.log(Level.WARNING, "Received DeadObjectException, treating as soft error", e)
+                        syncResult.softError = true
+                    }
+
+                    e is InvalidAccountException ->
                         logger.log(Level.WARNING, "Account was removed during synchronization", e)
 
                     else -> {

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
@@ -62,7 +62,7 @@ import kotlin.time.Duration.Companion.seconds
  *   conditions are not met (anymore): [Result.success], too – skipping is not an error, the next sync run
  *   will do the work.
  * - Soft error (temporary problem, like a network error) with attempts left: [Result.retry], so that
- *   WorkManager runs the work again later (at most [MAX_RUN_ATTEMPTS] attempts).
+ *   WorkManager runs the work again later (at most [MAX_RUN_ATTEMPTS] retries after the initial run).
  * - Soft error without attempts left: [Result.failure] and a notification, because we're giving up.
  * - Hard error (the user has to take action, for instance fix their credentials): [Result.failure].
  *   [at.bitfire.davdroid.sync.SyncManager] has already notified the user about the details.

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/worker/BaseSyncWorker.kt
@@ -32,6 +32,7 @@ import at.bitfire.davdroid.sync.SyncSettingsProvider
 import at.bitfire.davdroid.sync.TaskSyncer
 import at.bitfire.davdroid.sync.TasksAppManager
 import at.bitfire.davdroid.sync.account.InvalidAccountException
+import at.bitfire.davdroid.sync.worker.BaseSyncWorker.Companion.MAX_RUN_ATTEMPTS
 import at.bitfire.davdroid.sync.worker.BaseSyncWorker.Companion.NO_RESYNC
 import at.bitfire.davdroid.sync.worker.BaseSyncWorker.Companion.RESYNC_ENTRIES
 import at.bitfire.davdroid.sync.worker.BaseSyncWorker.Companion.RESYNC_LIST
@@ -39,12 +40,52 @@ import at.bitfire.davdroid.sync.worker.BaseSyncWorker.Companion.commonTag
 import at.bitfire.davdroid.ui.NotificationRegistry
 import at.bitfire.synctools.storage.TaskProvider
 import dagger.Lazy
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import java.util.Collections
+import java.util.logging.Level
 import java.util.logging.Logger
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
 
+/**
+ * Base class of the sync workers: takes the account and the data type to be synchronized from the input
+ * data, selects the matching [at.bitfire.davdroid.sync.Syncer] and runs it.
+ *
+ * ## Results reported to WorkManager
+ *
+ * WorkManager derives the state it records for a work from the [Result] we return, so we map the outcome
+ * of a sync run like this:
+ *
+ * - Sync ran without errors: [Result.success]
+ * - Sync was skipped, because another worker is already syncing the same data or because the sync
+ *   conditions are not met (anymore): [Result.success], too – skipping is not an error, the next sync run
+ *   will do the work.
+ * - Soft error (temporary problem, like a network error) with attempts left: [Result.retry], so that
+ *   WorkManager runs the work again later (at most [MAX_RUN_ATTEMPTS] attempts).
+ * - Soft error without attempts left: [Result.failure] and a notification, because we're giving up.
+ * - Hard error (the user has to take action, for instance fix their credentials): [Result.failure].
+ *   [at.bitfire.davdroid.sync.SyncManager] has already notified the user about the details.
+ * - The account doesn't exist (anymore), or there's no usable tasks provider: [Result.failure].
+ *
+ * Note that [Result.failure] also fails work that has been appended to this work – one-time syncs are
+ * enqueued with [androidx.work.ExistingWorkPolicy.APPEND_OR_REPLACE] – so a sync request that came in while
+ * this sync was running is dropped and has to be requested again.
+ *
+ * ## Cancellation
+ *
+ * A canceled sync is not mapped to a [Result] at all: the [CancellationException] is passed on to
+ * WorkManager, which then:
+ *
+ * - runs the work again if it has stopped the worker itself (constraints not met anymore, execution
+ *   timeout, quota, …),
+ * - leaves the work `CANCELLED` if the work has been canceled explicitly (like by
+ *   [SyncWorkerManager.cancelAllWork]), or
+ * - records the run as failed if something within the app has canceled the sync coroutine (periodic work
+ *   is simply run again in the next interval).
+ *
+ * That's why no sync code may swallow a [CancellationException].
+ */
 abstract class BaseSyncWorker(
     context: Context,
     private val workerParams: WorkerParameters
@@ -136,6 +177,12 @@ abstract class BaseSyncWorker(
 
             val settings = syncSettingsProvider.create(accountSettings)
             return doSyncWork(accountId, dataType, settings)
+
+        } catch (e: CancellationException) {
+            // Not an error: log it (so that it can be told apart from a failed sync) and pass it on to WorkManager.
+            logger.log(Level.INFO, "Sync was cancelled", e)
+            throw e
+
         } finally {
             logger.info("${javaClass.simpleName} finished for $syncTag")
             runningSyncs -= syncTag


### PR DESCRIPTION
### Purpose

It's true, like stated in the issue, that `Syncer.invoke()`'s `catch (e: Exception)` has no `CancellationException` case, so a cancellation falls into the generic `else` branch, is logged at `SEVERE` and turned into `syncResult.hardError = true` instead of being re-thrown. This affects events/tasks/jtx (contacts never get there because of the extra catch described below).

The message `Couldn't sync contacts`, as mentioned in the issue comes from `AddressBookSyncer`, not from `Syncer.invoke()` (whose message is `Couldn't sync com.android.contacts`), and the logged `SyncResult` has no error set at all.

So the "swallow point" is `AddressBookSyncer.syncAddressBook()` (`core/src/main/kotlin/at/bitfire/davdroid/sync/AddressBookSyncer.kt:113`):

```kotlin
} catch(e: Exception) {
    logger.log(Level.SEVERE, "Couldn't sync contacts", e)
}
logger.info("Contacts sync complete")
```

This full on catch "swallows" everything without recording an error in `syncResult`, so the worker reports `Result.success()`.

The other syncers (`CalendarSyncer`, `JtxSyncer`, `TaskSyncer`) do not have such an exception catch, they let
exceptions reach `Syncer.invoke()` instead.


### Short description

1. **`AddressBookSyncer.kt`:** Remove the full on `catch (e: Exception)` from `syncAddressBook()` so `performSync()` re-thrown exceptions (including cancellation and `DeadObjectException`) and `handleGroupMethodChange()` exceptions reach `Syncer.invoke()`. Per-collection error handling already happens in `SyncManager`/`SyncExceptionHandler`.

2. **`Syncer.kt`:** In `invoke()`, re-throw `CancellationException`. Keep `DeadObjectException` as a soft error, `InvalidAccountException` as a warning, and all other exceptions as hard errors.

3. **`BaseSyncWorker.kt`:**  In `doIoWork()`, explicitly log `CancellationException` at INFO and re-throw it. Update `doSyncWork()` KDoc to document the intended result/error mapping.

4. **Tests:** Update `SyncerTest.kt` to keep `SyncResult` and test cancellation propagation, `DeadObjectException` as `softError`, and unknown exception as `hardError`. Add `AddressBookSyncerTest.kt` to verify a `CancellationException` from `ContactsSyncManager.performSync()` travels through `syncCollection()`.



### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.

