### PR TITLE
Place calendar components after timezone definition

### DIFF
--- a/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/ICalendarGenerator.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/icalendar/ICalendarGenerator.kt
@@ -15,6 +15,7 @@ import net.fortuna.ical4j.model.PropertyContainer
 import net.fortuna.ical4j.model.PropertyList
 import net.fortuna.ical4j.model.TemporalAdapter
 import net.fortuna.ical4j.model.TimeZoneRegistryFactory
+import net.fortuna.ical4j.model.component.CalendarComponent
 import net.fortuna.ical4j.model.component.VEvent
 import net.fortuna.ical4j.model.component.VTimeZone
 import net.fortuna.ical4j.model.parameter.TzId
@@ -52,10 +53,11 @@ class ICalendarGenerator {
         // keep record of used timezone IDs and earliest DTSTART in order to be able to add VTIMEZONEs
         var earliestStart: Temporal? = null
         val usedTimezoneIds = mutableSetOf<String>()
+        val components = mutableSetOf<CalendarComponent>()
 
         // add main event
         if (event.main != null) {
-            ical += event.main
+            components += event.main
 
             earliestStart = event.main.dtStart<Temporal>()?.date
             usedTimezoneIds += timeZonesOf(event.main)
@@ -63,7 +65,7 @@ class ICalendarGenerator {
 
         // recurrence exceptions
         for (exception in event.exceptions) {
-            ical += exception
+            components += exception
 
             exception.dtStart<Temporal>()?.date?.let { start ->
                 if (earliestStart == null || TemporalAdapter.isBefore(start, earliestStart))
@@ -101,6 +103,11 @@ class ICalendarGenerator {
             val minifiedVTimeZone = VTimeZoneMinifier().minify(vTimeZone, earliestStart)
             ical += minifiedVTimeZone
         }
+
+        // Add all the components after the VTIMEZONEs, so that the VTIMEZONEs are always at the top of the iCalendar,
+        // and they can be used by single-pass parsers
+        for (component in components)
+            ical += component
 
         CalendarOutputter(false).output(ical, to)
     }

--- a/synctools/src/test/kotlin/at/bitfire/synctools/icalendar/ICalendarGeneratorTest.kt
+++ b/synctools/src/test/kotlin/at/bitfire/synctools/icalendar/ICalendarGeneratorTest.kt
@@ -66,25 +66,6 @@ class ICalendarGeneratorTest {
         assertEquals("BEGIN:VCALENDAR\r\n" +
                 "VERSION:2.0\r\n" +
                 "PRODID:TestUA/1.0\r\n" +
-                // main event
-                "BEGIN:VEVENT\r\n" +
-                "UID:SAMPLEUID\r\n" +
-                "DTSTART;TZID=Europe/Berlin:20190101T100000\r\n" +
-                "DTEND:20190101T160000Z\r\n" +
-                "DTSTAMP:20251028T185101Z\r\n" +
-                "RRULE:FREQ=DAILY;COUNT=5\r\n" +
-                "BEGIN:VALARM\r\n" +
-                "TRIGGER:-PT1H\r\n" +
-                "END:VALARM\r\n" +
-                "END:VEVENT\r\n" +
-                // exception
-                "BEGIN:VEVENT\r\n" +
-                "UID:SAMPLEUID\r\n" +
-                "RECURRENCE-ID;TZID=Europe/Berlin:20190102T100000\r\n" +
-                "DTSTART;TZID=Europe/London:20190101T110000\r\n" +
-                "DTEND:20190101T170000Z\r\n" +
-                "DTSTAMP:20251028T185101Z\r\n" +
-                "END:VEVENT\r\n" +
                 // time zone: Europe/Berlin
                 "BEGIN:VTIMEZONE\r\n" +
                 "TZID:Europe/Berlin\r\n" +
@@ -121,6 +102,25 @@ class ICalendarGeneratorTest {
                 "RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\n" +
                 "END:DAYLIGHT\r\n" +
                 "END:VTIMEZONE\r\n" +
+                // main event
+                "BEGIN:VEVENT\r\n" +
+                "UID:SAMPLEUID\r\n" +
+                "DTSTART;TZID=Europe/Berlin:20190101T100000\r\n" +
+                "DTEND:20190101T160000Z\r\n" +
+                "DTSTAMP:20251028T185101Z\r\n" +
+                "RRULE:FREQ=DAILY;COUNT=5\r\n" +
+                "BEGIN:VALARM\r\n" +
+                "TRIGGER:-PT1H\r\n" +
+                "END:VALARM\r\n" +
+                "END:VEVENT\r\n" +
+                // exception
+                "BEGIN:VEVENT\r\n" +
+                "UID:SAMPLEUID\r\n" +
+                "RECURRENCE-ID;TZID=Europe/Berlin:20190102T100000\r\n" +
+                "DTSTART;TZID=Europe/London:20190101T110000\r\n" +
+                "DTEND:20190101T170000Z\r\n" +
+                "DTSTAMP:20251028T185101Z\r\n" +
+                "END:VEVENT\r\n" +
                 "END:VCALENDAR\r\n", iCal.toString())
     }
 
@@ -156,15 +156,15 @@ class ICalendarGeneratorTest {
             "BEGIN:VCALENDAR\r\n" +
                     "VERSION:2.0\r\n" +
                     "PRODID:TestUA/1.0\r\n" +
+                    "BEGIN:VTIMEZONE\r\n" +
+                    ".*TZID:Europe/Kiev\r\n" +
+                    ".*END:VTIMEZONE\r\n" +
                     "BEGIN:VEVENT\r\n" +
                     "UID:KIEVTEST\r\n" +
                     "DTSTART;TZID=Europe/Kiev:20230101T120000\r\n" +
                     "DTEND;TZID=Europe/Kiev:20230101T140000\r\n" +
                     "DTSTAMP:20230101T120000Z\r\n" +
-                    "END:VEVENT\r\n" +
-                    "BEGIN:VTIMEZONE\r\n" +
-                    ".*TZID:Europe/Kiev\r\n" +
-                    ".*END:VTIMEZONE",
+                    "END:VEVENT",
             setOf(RegexOption.MULTILINE, RegexOption.DOT_MATCHES_ALL)
         )
         assertTrue(iCal.toString().contains(pattern))


### PR DESCRIPTION
### Organizational

> [!IMPORTANT]
> Please make sure an issue or discussion for this change **exists and was acknowledged** by the
> core team before submitting. Uncoordinated pull requests may conflict with the project roadmap
> and could be closed without merging — which would be a pity.
> See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

- [x] **An issue or discussion that proposes this change exists and was acknowledged by the core team.**
  (The PR is still welcome otherwise, but could be closed at any time without much attention
  when it doesn't fit.)

**✨ AI contributions – only check if applicable:**

- [x] **This PR and its concept was mainly driven by a human.** This does not apply when an issue
is just referenced/copied into an AI prompt and then the result is submitted as PR.

PRs that are mainly driven by AI often have little worth, as everybody could just copy the issue
into a prompt. The worth of a good PR often comes from the main idea, architectural decisions etc.
behind it. **So while all PRs are welcome, such PRs may be reviewed with less human attention and closed
at any time when they don't fit.**


### Purpose

See #2815. Some icalendar parsers only run a single pass on the document, which makes them not able to read timezones when the `VTIMEZONE` definition is after the `VEVENT`.

### Short description

- Moved the event addition after `VTIMEZONE` insertion.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

