### PR TITLE
Throw exception when retrying an upload

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/webdav/StreamingFileDescriptor.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/webdav/StreamingFileDescriptor.kt
@@ -119,6 +119,13 @@ class StreamingFileDescriptor @AssistedInject constructor(
     private suspend fun uploadNow(readFd: ParcelFileDescriptor) {
         val body = ChannelWriterContent(
             body = {
+                if (!readFd.fileDescriptor.valid()) {
+                    // AutoCloseInputStream will close the file descriptor after the first time the stream has been
+                    // read. We'll throw here if a failed request is being retried, because we can't read from the
+                    // source file descriptor a second time.
+                    throw IOException("Source file descriptor is no longer valid. " +
+                            "Possibly caused by a failed upload request being retried.")
+                }
                 ParcelFileDescriptor.AutoCloseInputStream(readFd).use { input ->
                     transferred = input.toByteReadChannel().copyTo(this)
                 }


### PR DESCRIPTION
Throw an exception with a more helpful error message when attempting to retry a failed upload.

Without this change, the upload will fail with `io.ktor.utils.io.ClosedByteChannelException: read failed: EBADF (Bad file descriptor)`.

In the error case we will still end up with a 0-byte file because `DocumentsProvider.createDocument()` (that will create an empty remote file) needs to be called before `DocumentsProvider.openDocument()` can be called to upload the file.

Closes #2734