### PR TITLE
Make `LocalResource.clearDirty()` suspending

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,8 @@ Android library. The sync engine, database layer, and Jetpack Compose UI for DAV
 
 **Repository pattern** — DAOs (in `db/`) are always wrapped by a repository in `repository/`. UI code and sync managers talk to repositories, never to DAOs directly.
 
+**Blocking/suspending boundary** — `resource/` (the `Local*` classes wrapping `:synctools`) and `repository/` must expose non-blocking, suspending APIs. Callers must not need to wrap calls into these packages in `withContext` themselves; if the underlying `:synctools` call is blocking, the `resource/`/`repository/` method wraps it in `withContext(ioDispatcher)` internally (narrowly, around the actual blocking call).
+
 **DAO/repository naming convention** — applies to both DAO methods (`db/`) and their repository wrappers (
 `repository/`):
 
@@ -90,6 +92,10 @@ Technically a standalone Android library for bidirectional conversion between iC
 providers (Calendar, Contacts, Tasks, Jtx). It is only consumed by `:core`.
 
 **No Hilt or Dagger.** This is a pure library — no DI framework, no Android application components. Dependencies are passed via constructors or obtained directly (e.g. `ContentResolver`). Keep it that way. For logging, use `val logger\nget() = java.util.Logger.getLogger(javaClass.name)`.
+
+**Blocking is fine here.** `:synctools` methods are allowed to block — they're the layer that actually talks to `ContentProviderClient`. It's `:core`'s job (see the `:core` Blocking/suspending boundary note above) to dispatch to an IO thread when calling into `:synctools`.
+
+**Wrap `RemoteException`.** Any method that calls `ContentProviderClient` must catch `android.os.RemoteException` and rethrow it wrapped in `at.bitfire.synctools.storage.LocalStorageException` (see the many existing examples, e.g. `AndroidCalendar.updateEventRow()`).
 
 #### Public API
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,8 +46,6 @@ Android library. The sync engine, database layer, and Jetpack Compose UI for DAV
 
 **Repository pattern** — DAOs (in `db/`) are always wrapped by a repository in `repository/`. UI code and sync managers talk to repositories, never to DAOs directly.
 
-**Blocking/suspending boundary** — `resource/` (the `Local*` classes wrapping `:synctools`) and `repository/` must expose non-blocking, suspending APIs. Callers must not need to wrap calls into these packages in `withContext` themselves; if the underlying `:synctools` call is blocking, the `resource/`/`repository/` method wraps it in `withContext(ioDispatcher)` internally (narrowly, around the actual blocking call).
-
 **DAO/repository naming convention** — applies to both DAO methods (`db/`) and their repository wrappers (
 `repository/`):
 
@@ -92,10 +90,6 @@ Technically a standalone Android library for bidirectional conversion between iC
 providers (Calendar, Contacts, Tasks, Jtx). It is only consumed by `:core`.
 
 **No Hilt or Dagger.** This is a pure library — no DI framework, no Android application components. Dependencies are passed via constructors or obtained directly (e.g. `ContentResolver`). Keep it that way. For logging, use `val logger\nget() = java.util.Logger.getLogger(javaClass.name)`.
-
-**Blocking is fine here.** `:synctools` methods are allowed to block — they're the layer that actually talks to `ContentProviderClient`. It's `:core`'s job (see the `:core` Blocking/suspending boundary note above) to dispatch to an IO thread when calling into `:synctools`.
-
-**Wrap `RemoteException`.** Any method that calls `ContentProviderClient` must catch `android.os.RemoteException` and rethrow it wrapped in `at.bitfire.synctools.storage.LocalStorageException` (see the many existing examples, e.g. `AndroidCalendar.updateEventRow()`).
 
 #### Public API
 

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/local/LocalAddressBookTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/local/LocalAddressBookTest.kt
@@ -30,7 +30,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import ezvcard.property.Telephone
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.AfterClass
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -66,7 +66,7 @@ class LocalAddressBookTest {
 
 
     @Test
-    fun test_readOnly() {
+    fun test_readOnly() = runTest {
         localTestAddressBook.provide(accountId, provider) { addressBook ->
             // insert contact with phone number and a group
             val localContact = addressBook.addContact(
@@ -108,7 +108,7 @@ class LocalAddressBookTest {
      * Tests whether contacts are moved (and not lost) when an address book is renamed.
      */
     @Test
-    fun test_renameAccount_retainsContacts() {
+    fun test_renameAccount_retainsContacts() = runTest {
         localTestAddressBook.provide(accountId, provider) { addressBook ->
             // insert contact with data row
             val uid = "12345"
@@ -142,7 +142,7 @@ class LocalAddressBookTest {
      * Tests whether groups are moved (and not lost) when an address book is renamed.
      */
     @Test
-    fun test_renameAccount_retainsGroups() {
+    fun test_renameAccount_retainsGroups() = runTest {
         localTestAddressBook.provide(accountId, provider) { addressBook ->
             // insert group
             val localGroup = addressBook.addGroup(Contact(displayName = "Test Group"), null, null, 0)
@@ -168,7 +168,7 @@ class LocalAddressBookTest {
 
 
     @Test
-    fun testApplyPendingMemberships_addPendingMembership() {
+    fun testApplyPendingMemberships_addPendingMembership() = runTest {
         localTestAddressBook.provide(accountId, provider, GroupMethod.GROUP_VCARDS) { localAddressBook ->
             val contact1 = localAddressBook.addContact(Contact().apply {
                 uid = "test1"
@@ -184,7 +184,7 @@ class LocalAddressBookTest {
             )
 
             // pending membership -> contact1 should be added to group
-            runBlocking { localAddressBook.applyPendingMemberships() }
+            localAddressBook.applyPendingMemberships()
 
             // check group membership
             localAddressBook.ab.provider.query(
@@ -218,7 +218,7 @@ class LocalAddressBookTest {
     }
 
     @Test
-    fun testApplyPendingMemberships_removeMembership() {
+    fun testApplyPendingMemberships_removeMembership() = runTest {
         localTestAddressBook.provide(accountId, provider, GroupMethod.GROUP_VCARDS) { localAddressBook ->
             val contact1 = localAddressBook.addContact(Contact().apply {
                 uid = "test1"
@@ -233,7 +233,7 @@ class LocalAddressBookTest {
             batch.commit()
 
             // no pending memberships -> membership should be removed
-            runBlocking { localAddressBook.applyPendingMemberships() }
+            localAddressBook.applyPendingMemberships()
 
             // check group membership
             localAddressBook.ab.provider.query(

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/local/LocalGroupTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/local/LocalGroupTest.kt
@@ -68,7 +68,7 @@ class LocalGroupTest {
     }
 
     @Test
-    fun testClearDirty_addCachedGroupMembership() {
+    fun testClearDirty_addCachedGroupMembership() = runTest {
         localTestAddressBook.provide(accountId, provider, GroupMethod.CATEGORIES) { localAddressBook ->
             val group = newGroup(localAddressBook)
 
@@ -105,7 +105,7 @@ class LocalGroupTest {
     }
 
     @Test
-    fun testClearDirty_removeCachedGroupMembership() {
+    fun testClearDirty_removeCachedGroupMembership() = runTest {
         localTestAddressBook.provide(accountId, provider, GroupMethod.CATEGORIES) { localAddressBook ->
             val group = newGroup(localAddressBook)
 
@@ -158,7 +158,7 @@ class LocalGroupTest {
     }
 
     @Test
-    fun testUpdate() {
+    fun testUpdate() = runTest {
         localTestAddressBook.provide(accountId, provider) {
             val group = newGroup(it)
             group.update(Contact(displayName = "New Group Name"), null, null, null, 0)

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/local/LocalTestAddressBook.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/local/LocalTestAddressBook.kt
@@ -12,6 +12,7 @@ import at.bitfire.davdroid.R
 import at.bitfire.davdroid.accounts.AccountId
 import at.bitfire.synctools.vcard.GroupMethod
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.runBlocking
 import java.util.UUID
 import javax.inject.Inject
 
@@ -25,11 +26,11 @@ class LocalTestAddressBook @Inject constructor(
         accountId: AccountId,
         provider: ContentProviderClient,
         groupMethod: GroupMethod = GroupMethod.GROUP_VCARDS,
-        block: (LocalAddressBook) -> Unit
+        block: suspend (LocalAddressBook) -> Unit
     ) {
         val ab = create(accountId, provider, groupMethod)
         try {
-            block(ab)
+            runBlocking { block(ab) }
         } finally {
             delete(ab)
         }

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/local/LocalTestAddressBook.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/local/LocalTestAddressBook.kt
@@ -12,7 +12,6 @@ import at.bitfire.davdroid.R
 import at.bitfire.davdroid.accounts.AccountId
 import at.bitfire.synctools.vcard.GroupMethod
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.runBlocking
 import java.util.UUID
 import javax.inject.Inject
 
@@ -22,7 +21,7 @@ class LocalTestAddressBook @Inject constructor(
     private val factory: LocalAddressBook.Factory
 ) {
 
-    fun provide(
+    suspend fun provide(
         accountId: AccountId,
         provider: ContentProviderClient,
         groupMethod: GroupMethod = GroupMethod.GROUP_VCARDS,
@@ -30,7 +29,7 @@ class LocalTestAddressBook @Inject constructor(
     ) {
         val ab = create(accountId, provider, groupMethod)
         try {
-            runBlocking { block(ab) }
+            block(ab)
         } finally {
             delete(ab)
         }

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration20Test.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/settings/migration/AccountSettingsMigration20Test.kt
@@ -34,6 +34,7 @@ import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import io.mockk.junit4.MockKRule
 import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -92,7 +93,7 @@ class AccountSettingsMigration20Test {
 
 
     @Test
-    fun testMigrateAddressBooks_UrlMatchesCollection() {
+    fun testMigrateAddressBooks_UrlMatchesCollection() = runTest {
         // set up legacy address-book with URL, but without collection ID
         val url = "https://example.com/"
 

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/LocalTestResource.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/LocalTestResource.kt
@@ -19,7 +19,7 @@ class LocalTestResource: LocalResource {
     var deleted = false
     var dirty = false
 
-    override fun clearDirty(fileName: Optional<String>, eTag: String?, scheduleTag: String?) {
+    override suspend fun clearDirty(fileName: Optional<String>, eTag: String?, scheduleTag: String?) {
         dirty = false
         if (fileName.isPresent)
             this.fileName = fileName.get()

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalContact.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalContact.kt
@@ -16,6 +16,8 @@ import at.bitfire.synctools.mapping.contacts.Contact
 import at.bitfire.synctools.storage.contacts.AddressContract.RawContactColumns
 import at.bitfire.synctools.storage.contacts.AndroidContact
 import com.google.common.base.MoreObjects
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.util.Optional
 import kotlin.jvm.optionals.getOrNull
 
@@ -50,7 +52,7 @@ class LocalContact(
         androidContact.setContact(null)
     }
 
-    override fun clearDirty(fileName: Optional<String>, eTag: String?, scheduleTag: String?) {
+    override suspend fun clearDirty(fileName: Optional<String>, eTag: String?, scheduleTag: String?) {
         if (scheduleTag != null)
             throw IllegalArgumentException("Contacts must not have a Schedule-Tag")
 
@@ -63,7 +65,9 @@ class LocalContact(
         // Android 7 workaround
         localAddressBook.dirtyVerifier.getOrNull()?.setHashCodeColumn(this, values)
 
-        provider.update(androidContact.rawContactSyncURI(), values, null, null)
+        withContext(Dispatchers.IO) {
+            androidContact.update(values)
+        }
 
         if (fileName.isPresent)
             androidContact.fileName = fileName.get()

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalContact.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalContact.kt
@@ -62,10 +62,10 @@ class LocalContact(
         values.put(RawContactColumns.ETAG, eTag)
         values.put(RawContacts.DIRTY, 0)
 
-        // Android 7 workaround
-        localAddressBook.dirtyVerifier.getOrNull()?.setHashCodeColumn(this, values)
-
         withContext(Dispatchers.IO) {
+            // Android 7 workaround
+            localAddressBook.dirtyVerifier.getOrNull()?.setHashCodeColumn(this@LocalContact, values)
+
             androidContact.update(values)
         }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalEvent.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalEvent.kt
@@ -14,6 +14,8 @@ import at.bitfire.synctools.storage.calendar.AndroidRecurringCalendar
 import at.bitfire.synctools.storage.calendar.EventAndExceptions
 import at.bitfire.synctools.storage.calendar.EventsContract
 import com.google.common.base.MoreObjects
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.apache.commons.lang3.StringUtils
 import java.util.Optional
 
@@ -52,7 +54,7 @@ class LocalEvent(
 
     // LocalResource implementation
 
-    override fun clearDirty(fileName: Optional<String>, eTag: String?, scheduleTag: String?) {
+    override suspend fun clearDirty(fileName: Optional<String>, eTag: String?, scheduleTag: String?) {
         val values = contentValuesOf(
             Events.DIRTY to 0,
             EventsContract.COLUMN_ETAG to eTag,
@@ -60,7 +62,9 @@ class LocalEvent(
         )
         if (fileName.isPresent)
             values.put(Events._SYNC_ID, fileName.get())
-        calendar.updateEventRow(id, values)
+        withContext(Dispatchers.IO) {
+            calendar.updateEventRow(id, values)
+        }
     }
 
     override fun updateFlags(flags: Int) {

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalGroup.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalGroup.kt
@@ -20,6 +20,8 @@ import at.bitfire.synctools.storage.contacts.AddressContract.asSyncAdapter
 import at.bitfire.synctools.storage.contacts.AndroidGroup
 import at.bitfire.synctools.storage.contacts.ContactsBatchOperation
 import com.google.common.base.MoreObjects
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.util.Optional
 
 class LocalGroup(
@@ -45,7 +47,7 @@ class LocalGroup(
         set(_) = throw NotImplementedError()
 
 
-    override fun clearDirty(fileName: Optional<String>, eTag: String?, scheduleTag: String?) {
+    override suspend fun clearDirty(fileName: Optional<String>, eTag: String?, scheduleTag: String?) {
         if (scheduleTag != null)
             throw IllegalArgumentException("Contact groups must not have a Schedule-Tag")
         val id = requireNotNull(id)
@@ -55,32 +57,36 @@ class LocalGroup(
             values.put(GroupColumns.FILENAME, fileName.get())
         values.putNull(GroupColumns.ETAG)     // don't save changed ETag but null, so that the group is downloaded again, so that pendingMembers is updated
         values.put(Groups.DIRTY, 0)
-        androidGroup.update(values)
+        withContext(Dispatchers.IO) {
+            androidGroup.update(values)
+        }
 
         if (fileName.isPresent)
             androidGroup.fileName = fileName.get()
         androidGroup.eTag = null
 
         // update cached group memberships
-        val batch = ContactsBatchOperation(provider)
+        withContext(Dispatchers.IO) {
+            val batch = ContactsBatchOperation(provider)
 
-        // delete old cached group memberships
-        batch += BatchOperation.CpoBuilder
-            .newDelete(ContactsContract.Data.CONTENT_URI.asSyncAdapter())
-            .withSelection(
-                CachedGroupMembership.MIMETYPE + "=? AND " + CachedGroupMembership.GROUP_ID + "=?",
-                arrayOf(CachedGroupMembership.CONTENT_ITEM_TYPE, id.toString())
-            )
-
-        // insert updated cached group memberships
-        for (member in androidGroup.getMembers())
+            // delete old cached group memberships
             batch += BatchOperation.CpoBuilder
-                .newInsert(ContactsContract.Data.CONTENT_URI.asSyncAdapter())
-                .withValue(CachedGroupMembership.MIMETYPE, CachedGroupMembership.CONTENT_ITEM_TYPE)
-                .withValue(CachedGroupMembership.RAW_CONTACT_ID, member)
-                .withValue(CachedGroupMembership.GROUP_ID, id)
+                .newDelete(ContactsContract.Data.CONTENT_URI.asSyncAdapter())
+                .withSelection(
+                    CachedGroupMembership.MIMETYPE + "=? AND " + CachedGroupMembership.GROUP_ID + "=?",
+                    arrayOf(CachedGroupMembership.CONTENT_ITEM_TYPE, id.toString())
+                )
 
-        batch.commit()
+            // insert updated cached group memberships
+            for (member in androidGroup.getMembers())
+                batch += BatchOperation.CpoBuilder
+                    .newInsert(ContactsContract.Data.CONTENT_URI.asSyncAdapter())
+                    .withValue(CachedGroupMembership.MIMETYPE, CachedGroupMembership.CONTENT_ITEM_TYPE)
+                    .withValue(CachedGroupMembership.RAW_CONTACT_ID, member)
+                    .withValue(CachedGroupMembership.GROUP_ID, id)
+
+            batch.commit()
+        }
     }
 
     /**

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalGroup.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalGroup.kt
@@ -52,6 +52,7 @@ class LocalGroup(
             throw IllegalArgumentException("Contact groups must not have a Schedule-Tag")
         val id = requireNotNull(id)
 
+        // update in content provider
         val values = ContentValues(3)
         if (fileName.isPresent)
             values.put(GroupColumns.FILENAME, fileName.get())
@@ -61,6 +62,7 @@ class LocalGroup(
             androidGroup.update(values)
         }
 
+        // update in-memory state
         if (fileName.isPresent)
             androidGroup.fileName = fileName.get()
         androidGroup.eTag = null

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalJtxObject.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalJtxObject.kt
@@ -13,6 +13,8 @@ import at.bitfire.synctools.storage.jtx.JtxObjectAndExceptions
 import at.bitfire.synctools.storage.jtx.JtxRecurringCollection
 import at.techbee.jtx.JtxContract
 import com.google.common.base.MoreObjects
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.apache.commons.lang3.StringUtils
 import java.util.Optional
 
@@ -45,7 +47,7 @@ class LocalJtxObject(
         recurringCollection.updateJtxObjectAndExceptions(id, data)
     }
 
-    override fun clearDirty(fileName: Optional<String>, eTag: String?, scheduleTag: String?) {
+    override suspend fun clearDirty(fileName: Optional<String>, eTag: String?, scheduleTag: String?) {
         val values = contentValuesOf(
             JtxContract.JtxICalObject.DIRTY to 0,
             JtxContract.JtxICalObject.ETAG to eTag,
@@ -56,7 +58,9 @@ class LocalJtxObject(
             values.put(JtxContract.JtxICalObject.FILENAME, fileName.get())
         }
 
-        collection.updateJtxObjectRow(id, values)
+        withContext(Dispatchers.IO) {
+            collection.updateJtxObjectRow(id, values)
+        }
     }
 
     override fun updateFlags(flags: Int) {

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalResource.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalResource.kt
@@ -57,6 +57,8 @@ interface LocalResource {
      * @param eTag          ETag of the uploaded resource as returned by the server (null if the server didn't return one)
      * @param scheduleTag   CalDAV only: `Schedule-Tag` of the uploaded resource as returned by the server
      *                      (null if not applicable or if the server didn't return one)
+     *
+     * @throws at.bitfire.synctools.storage.LocalStorageException on content provider errors
      */
     suspend fun clearDirty(fileName: Optional<String>, eTag: String?, scheduleTag: String? = null)
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalResource.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalResource.kt
@@ -58,7 +58,7 @@ interface LocalResource {
      * @param scheduleTag   CalDAV only: `Schedule-Tag` of the uploaded resource as returned by the server
      *                      (null if not applicable or if the server didn't return one)
      */
-    fun clearDirty(fileName: Optional<String>, eTag: String?, scheduleTag: String? = null)
+    suspend fun clearDirty(fileName: Optional<String>, eTag: String?, scheduleTag: String? = null)
 
     /**
      * Sets (local) flags of the resource in the content provider.

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalTask.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalTask.kt
@@ -13,6 +13,8 @@ import at.bitfire.synctools.storage.tasks.DmfsRecurringTaskList
 import at.bitfire.synctools.storage.tasks.DmfsTasksContract
 import at.bitfire.synctools.storage.tasks.TaskAndExceptions
 import com.google.common.base.MoreObjects
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.apache.commons.lang3.StringUtils
 import org.dmfs.tasks.contract.TaskContract.Tasks
 import java.util.Optional
@@ -60,7 +62,7 @@ class LocalTask(
 
     // LocalResource implementation
 
-    override fun clearDirty(fileName: Optional<String>, eTag: String?, scheduleTag: String?) {
+    override suspend fun clearDirty(fileName: Optional<String>, eTag: String?, scheduleTag: String?) {
         if (scheduleTag != null)
             logger.fine("Schedule-Tag for tasks not supported, won't save")
 
@@ -70,7 +72,9 @@ class LocalTask(
         )
         if (fileName.isPresent)
             values.put(Tasks._SYNC_ID, fileName.get())
-        taskList.updateTaskRow(id, values)
+        withContext(Dispatchers.IO) {
+            taskList.updateTaskRow(id, values)
+        }
     }
 
     override fun updateFlags(flags: Int) {

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -437,7 +437,7 @@ abstract class SyncManager<LocalType : LocalResource>(
      * @param scheduleTag   resulting `Schedule-Tag` of the upload (from the server)
      * @param context       properties that have been generated before the upload and that shall be persisted by this method
      */
-    private fun onSuccessfulUpload(
+    private suspend fun onSuccessfulUpload(
         local: LocalType,
         newFileName: String,
         eTag: String?,

--- a/core/src/test/kotlin/at/bitfire/davdroid/sync/ReadOnlyPolicyTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/sync/ReadOnlyPolicyTest.kt
@@ -6,6 +6,7 @@ package at.bitfire.davdroid.sync
 
 import at.bitfire.davdroid.resource.local.LocalCollection
 import at.bitfire.davdroid.resource.local.LocalResource
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit4.MockKRule
@@ -69,7 +70,7 @@ class ReadOnlyPolicyTest {
 
         assertTrue(policy.resetDirty(collection))
 
-        verify { resource.clearDirty(Optional.empty(), null, null) }
+        coVerify { resource.clearDirty(Optional.empty(), null, null) }
         verify { collection.lastSyncState = null }
     }
 

--- a/core/src/test/kotlin/at/bitfire/davdroid/sync/groups/CategoriesStrategyTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/sync/groups/CategoriesStrategyTest.kt
@@ -6,6 +6,7 @@ package at.bitfire.davdroid.sync.groups
 
 import at.bitfire.davdroid.resource.local.LocalAddressBook
 import at.bitfire.davdroid.resource.local.LocalGroup
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit4.MockKRule
@@ -60,7 +61,7 @@ class CategoriesStrategyTest {
         strategy.resolveLocalGroupChanges()
 
         verify { group.markMembersDirty() }
-        verify { group.clearDirty(Optional.empty(), null) }
+        coVerify { group.clearDirty(Optional.empty(), null) }
     }
 
 }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidContact.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidContact.kt
@@ -197,6 +197,19 @@ class AndroidContact(
      */
     fun delete() = addressBook.provider.delete(rawContactSyncURI(), null, null)
 
+    /**
+     * Updates this raw contact's main row with the given values.
+     *
+     * @throws LocalStorageException on contact provider errors
+     */
+    fun update(values: ContentValues) {
+        try {
+            addressBook.provider.update(rawContactSyncURI(), values, null, null)
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't update raw contact $id", e)
+        }
+    }
+
 
     private fun buildContact(builder: BatchOperation.CpoBuilder, update: Boolean) {
         if (!update)

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidGroup.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidGroup.kt
@@ -169,9 +169,18 @@ class AndroidGroup(
         return update(contentValues())
     }
 
+    /**
+     * Updates this group's main row with the given values.
+     *
+     * @throws LocalStorageException on contact provider errors
+     */
     fun update(values: ContentValues): Uri {
         val uri = groupSyncURI()
-        addressBook.provider.update(uri, values, null, null)
+        try {
+            addressBook.provider.update(uri, values, null, null)
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't update group $id", e)
+        }
         return uri
     }
 


### PR DESCRIPTION
A first step of #2828 (taking #2784 into account).

### Purpose

First step towards making `at.bitfire.davdroid.resource.local` (the `Local*` classes between `SyncManager` and the content providers) a proper suspending API, so callers get correct dispatching without relying on an enclosing `withContext` (#2828).

**Out of scope:** modifying `Local*` to use Hilt in order to inject `Dispatchers.IO`.

Converting every blocking method at once would touch too many call sites, so this PR only converts `LocalResource.clearDirty()` — the rest follow in separate PRs.

### Short description

- Made `LocalResource.clearDirty()` `suspend`; each implementation now wraps just its blocking `ContentProvider` call in a narrow `withContext(Dispatchers.IO)`.
- `LocalContact`/`LocalGroup` no longer call `ContentProviderClient.update()` directly — moved into new/updated `synctools` methods, which wrap `RemoteException` in `LocalStorageException` per #2784.
- Updated the sync layer and its unit tests for the now-suspending `clearDirty()`.
- Made `LocalTestAddressBook.provide()` suspend (dropping an internal `runBlocking`), updating its instrumented-test callers to use `runTest`.

### Checklist
- [x] The PR has a proper title, description and label.
- [x] I have self-reviewed the PR.
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.