### PR TITLE
Make `LocalResource.updateUid()` suspending

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/LocalTestResource.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/LocalTestResource.kt
@@ -31,7 +31,7 @@ class LocalTestResource: LocalResource {
         this.flags = flags
     }
 
-    override fun updateUid(uid: String) { /* no-op */ }
+    override suspend fun updateUid(uid: String) { /* no-op */ }
     override fun updateSequence(sequence: Int) = throw NotImplementedError()
 
     override fun deleteLocal() {}  // no-op: test callers handle deletion via the collection

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/TestSyncManager.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/TestSyncManager.kt
@@ -47,7 +47,7 @@ class TestSyncManager @AssistedInject constructor(
     }
 
     var didGenerateUpload = false
-    override fun generateUpload(
+    override suspend fun generateUpload(
         resource: LocalTestResource,
         capabilities: WebDavCollection.Capabilities
     ): GeneratedResource {

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalContact.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalContact.kt
@@ -96,9 +96,11 @@ class LocalContact(
 
     override fun updateSequence(sequence: Int) = throw NotImplementedError()
 
-    override fun updateUid(uid: String) {
+    override suspend fun updateUid(uid: String) {
         val values = contentValuesOf(RawContactColumns.UID to uid)
-        provider.update(androidContact.rawContactSyncURI(), values, null, null)
+        withContext(Dispatchers.IO) {
+            androidContact.update(values)
+        }
     }
 
     override fun deleteLocal() {

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalEvent.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalEvent.kt
@@ -79,10 +79,12 @@ class LocalEvent(
         ))
     }
 
-    override fun updateUid(uid: String) {
-        calendar.updateEventRow(id, contentValuesOf(
-            Events.UID_2445 to uid
-        ))
+    override suspend fun updateUid(uid: String) {
+        withContext(Dispatchers.IO) {
+            calendar.updateEventRow(id, contentValuesOf(
+                Events.UID_2445 to uid
+            ))
+        }
     }
 
     override fun deleteLocal() {

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalGroup.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalGroup.kt
@@ -121,9 +121,11 @@ class LocalGroup(
 
     override fun updateSequence(sequence: Int) = throw NotImplementedError()
 
-    override fun updateUid(uid: String) {
+    override suspend fun updateUid(uid: String) {
         val values = contentValuesOf(GroupColumns.UID to uid)
-        provider.update(androidGroup.groupSyncURI(), values, null, null)
+        withContext(Dispatchers.IO) {
+            androidGroup.update(values)
+        }
     }
 
     override fun deleteLocal() {

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalJtxObject.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalJtxObject.kt
@@ -71,12 +71,14 @@ class LocalJtxObject(
         collection.updateJtxObjectRow(id, values)
     }
 
-    override fun updateUid(uid: String) {
+    override suspend fun updateUid(uid: String) {
         val values = contentValuesOf(
             JtxContract.JtxICalObject.UID to uid,
         )
 
-        collection.updateJtxObjectRow(id, values)
+        withContext(Dispatchers.IO) {
+            collection.updateJtxObjectRow(id, values)
+        }
     }
 
     override fun updateSequence(sequence: Int) {

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalResource.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalResource.kt
@@ -73,8 +73,10 @@ interface LocalResource {
     /**
      * Updates the local UID of the resource in the content provider.
      * Usually used to persist a UID that has been created during an upload of a locally created resource.
+     *
+     * @throws at.bitfire.synctools.storage.LocalStorageException on content provider errors
      */
-    fun updateUid(uid: String)
+    suspend fun updateUid(uid: String)
 
     /**
      * Updates the local SEQUENCE of the resource in the content provider.

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalTask.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalTask.kt
@@ -91,10 +91,12 @@ class LocalTask(
         ))
     }
 
-    override fun updateUid(uid: String) {
-        taskList.updateTaskRow(id, contentValuesOf(
-            Tasks._UID to uid
-        ))
+    override suspend fun updateUid(uid: String) {
+        withContext(Dispatchers.IO) {
+            taskList.updateTaskRow(id, contentValuesOf(
+                Tasks._UID to uid
+            ))
+        }
     }
 
     override fun deleteLocal() {

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/CalendarSyncManager.kt
@@ -91,7 +91,7 @@ class CalendarSyncManager @AssistedInject constructor(
         else
             SyncAlgorithm.COLLECTION_SYNC
 
-    override fun generateUpload(resource: LocalEvent, capabilities: WebDavCollection.Capabilities): GeneratedResource {
+    override suspend fun generateUpload(resource: LocalEvent, capabilities: WebDavCollection.Capabilities): GeneratedResource {
         val localEvent = resource.androidEvent
         logger.log(Level.FINE, "Preparing upload of event #{0}: {1}", arrayOf(resource.id, localEvent))
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/ContactsSyncManager.kt
@@ -156,7 +156,7 @@ class ContactsSyncManager @AssistedInject constructor(
         return super.uploadDirty(capabilities)
     }
 
-    override fun generateUpload(
+    override suspend fun generateUpload(
         resource: LocalAddress,
         capabilities: WebDavCollection.Capabilities
     ): GeneratedResource {

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/JtxSyncManager.kt
@@ -71,7 +71,7 @@ class JtxSyncManager @AssistedInject constructor(
     }
 
 
-    override fun generateUpload(
+    override suspend fun generateUpload(
         resource: LocalJtxObject,
         capabilities: WebDavCollection.Capabilities
     ): GeneratedResource {

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -422,7 +422,7 @@ abstract class SyncManager<LocalType : LocalResource>(
      * @return iCalendar or vCard (content + Content-Type) that can be uploaded to the server
      */
     @VisibleForTesting
-    internal abstract fun generateUpload(
+    internal abstract suspend fun generateUpload(
         resource: LocalType,
         capabilities: WebDavCollection.Capabilities
     ): GeneratedResource

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/TasksSyncManager.kt
@@ -76,7 +76,7 @@ class TasksSyncManager @AssistedInject constructor(
 
     override fun syncAlgorithm(capabilities: WebDavCollection.Capabilities) = SyncAlgorithm.PROPFIND_REPORT
 
-    override fun generateUpload(resource: LocalTask, capabilities: WebDavCollection.Capabilities): GeneratedResource {
+    override suspend fun generateUpload(resource: LocalTask, capabilities: WebDavCollection.Capabilities): GeneratedResource {
         val localTask = resource.taskAndExceptions
         logger.log(Level.FINE, "Preparing upload of task #{0}: {1}", arrayOf(resource.id, localTask))
 


### PR DESCRIPTION
Another step of #2828 (taking #2784 into account).

### Purpose

Continues making `at.bitfire.davdroid.resource.local` (the `Local*` classes between `SyncManager` and the content providers) a proper suspending API.

### Short description

- Made `LocalResource.updateUid()` `suspend`; each implementation wraps just its blocking `ContentProvider` call in a narrow `withContext(Dispatchers.IO)`.
- `LocalContact`/`LocalGroup` now reuse the `synctools` `update()` methods added in #2839 instead of calling `ContentProviderClient.update()` directly.
- Made `SyncManager.generateUpload()` (and its sync-manager subclass overrides) `suspend`, since `updateUid()` is called from within it.

### Checklist
- [x] The PR has a proper title, description and label.
- [x] I have self-reviewed the PR.
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.