### PR TITLE
Make `LocalCollection.markNotDirty()` and `forgetETags()` suspending

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/local/LocalCalendarTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/resource/local/LocalCalendarTest.kt
@@ -96,7 +96,7 @@ class LocalCalendarTest {
      * @param contentValues values to set on the event. Required:
      * - [Events.DIRTY]
      */
-    private fun testMarkNotDirty(contentValues: ContentValues) {
+    private fun testMarkNotDirty(contentValues: ContentValues) = runTest {
         val id = androidCalendar.addEvent(Entity(
             contentValuesOf(
                 Events.CALENDAR_ID to androidCalendar.id,

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/LocalTestCollection.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/LocalTestCollection.kt
@@ -24,7 +24,7 @@ class LocalTestCollection(
 
     override suspend fun findByName(name: String) = entries.firstOrNull { it.fileName == name }
 
-    override fun markNotDirty(flags: Int): Int {
+    override suspend fun markNotDirty(flags: Int): Int {
         var updated = 0
         for (dirty in entries.filter { it.dirty }) {
             dirty.flags = flags
@@ -39,7 +39,7 @@ class LocalTestCollection(
         return numBefore - entries.size
     }
 
-    override fun forgetETags() {
+    override suspend fun forgetETags() {
     }
 
     override fun countAll() = entries.size

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalAddressBook.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalAddressBook.kt
@@ -34,10 +34,12 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.withContext
 import java.io.FileNotFoundException
 import java.util.Optional
 import java.util.logging.Logger
@@ -108,17 +110,18 @@ open class LocalAddressBook @AssistedInject constructor(
 
     /* operations on the collection (address book) itself */
 
-    override fun markNotDirty(flags: Int): Int {
-        val batch = ContactsBatchOperation(ab.provider)
-        ab.updateRawContactRows(
-            contentValuesOf(RawContactColumns.FLAGS to flags),
-            "${RawContacts.DIRTY}=0", null,
-            batch
-        )
-        if (includeGroups)
-            ab.updateGroups(contentValuesOf(GroupColumns.FLAGS to flags), "NOT ${Groups.DIRTY}", null, batch)
-        return batch.commit()
-    }
+    override suspend fun markNotDirty(flags: Int): Int =
+        withContext(Dispatchers.IO) {
+            val batch = ContactsBatchOperation(ab.provider)
+            ab.updateRawContactRows(
+                contentValuesOf(RawContactColumns.FLAGS to flags),
+                "${RawContacts.DIRTY}=0", null,
+                batch
+            )
+            if (includeGroups)
+                ab.updateGroups(contentValuesOf(GroupColumns.FLAGS to flags), "NOT ${Groups.DIRTY}", null, batch)
+            batch.commit()
+        }
 
     override suspend fun removeNotDirtyMarked(flags: Int): Int {
         val batch = ContactsBatchOperation(ab.provider)
@@ -275,12 +278,14 @@ open class LocalAddressBook @AssistedInject constructor(
         else
             findDirtyContacts()
 
-    override fun forgetETags() {
-        val batch = ContactsBatchOperation(ab.provider)
-        if (includeGroups)
-            ab.updateGroups(contentValuesOf(GroupColumns.ETAG to null), null, null, batch)
-        ab.updateRawContactRows(contentValuesOf(RawContactColumns.ETAG to null), null, null, batch)
-        batch.commit()
+    override suspend fun forgetETags() {
+        withContext(Dispatchers.IO) {
+            val batch = ContactsBatchOperation(ab.provider)
+            if (includeGroups)
+                ab.updateGroups(contentValuesOf(GroupColumns.ETAG to null), null, null, batch)
+            ab.updateRawContactRows(contentValuesOf(RawContactColumns.ETAG to null), null, null, batch)
+            batch.commit()
+        }
     }
 
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalCalendar.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalCalendar.kt
@@ -13,8 +13,10 @@ import at.bitfire.synctools.storage.calendar.AndroidRecurringCalendar
 import at.bitfire.synctools.storage.calendar.CalendarBatchOperation
 import at.bitfire.synctools.storage.calendar.EventAndExceptions
 import at.bitfire.synctools.storage.calendar.EventsContract
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
 
 /**
  * Application-specific subclass of [AndroidCalendar] for local calendars.
@@ -69,17 +71,19 @@ class LocalCalendar(
             LocalEvent(recurringCalendar, it)
         }
 
-    override fun markNotDirty(flags: Int) =
-        androidCalendar.updateEventRows(
-            contentValuesOf(EventsContract.COLUMN_FLAGS to flags),
-            // `dirty` can be 0, 1, or null. "NOT dirty" is not enough.
-            """
-                ${Events.CALENDAR_ID}=?
-                AND (${Events.DIRTY} IS NULL OR ${Events.DIRTY}=0)
-                AND ${Events.ORIGINAL_ID} IS NULL
-            """.trimIndent(),
-            arrayOf(androidCalendar.id.toString())
-        )
+    override suspend fun markNotDirty(flags: Int) =
+        withContext(Dispatchers.IO) {
+            androidCalendar.updateEventRows(
+                contentValuesOf(EventsContract.COLUMN_FLAGS to flags),
+                // `dirty` can be 0, 1, or null. "NOT dirty" is not enough.
+                """
+                    ${Events.CALENDAR_ID}=?
+                    AND (${Events.DIRTY} IS NULL OR ${Events.DIRTY}=0)
+                    AND ${Events.ORIGINAL_ID} IS NULL
+                """.trimIndent(),
+                arrayOf(androidCalendar.id.toString())
+            )
+        }
 
     override suspend fun removeNotDirtyMarked(flags: Int): Int {
         // list all non-dirty events with the given flags and delete every row + its exceptions
@@ -105,11 +109,13 @@ class LocalCalendar(
         return batch.commit()
     }
 
-    override fun forgetETags() {
-        androidCalendar.updateEventRows(
-            contentValuesOf(EventsContract.COLUMN_ETAG to null),
-            "${Events.CALENDAR_ID}=?", arrayOf(androidCalendar.id.toString())
-        )
+    override suspend fun forgetETags() {
+        withContext(Dispatchers.IO) {
+            androidCalendar.updateEventRows(
+                contentValuesOf(EventsContract.COLUMN_ETAG to null),
+                "${Events.CALENDAR_ID}=?", arrayOf(androidCalendar.id.toString())
+            )
+        }
     }
 
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalCollection.kt
@@ -55,8 +55,10 @@ interface LocalCollection<out T: LocalResource> {
      * @param flags    value of flags to set (for instance, [LocalResource.FLAG_REMOTELY_PRESENT]])
      *
      * @return         number of marked entries
+     *
+     * @throws at.bitfire.synctools.storage.LocalStorageException on content provider errors
      */
-    fun markNotDirty(flags: Int): Int
+    suspend fun markNotDirty(flags: Int): Int
 
     /**
      * Removes entries which are not dirty with a given flag combination.
@@ -71,8 +73,10 @@ interface LocalCollection<out T: LocalResource> {
 
     /**
      * Forgets the ETags of all members so that they will be reloaded from the server during sync.
+     *
+     * @throws at.bitfire.synctools.storage.LocalStorageException on content provider errors
      */
-    fun forgetETags()
+    suspend fun forgetETags()
 
     /**
      * Counts all resources in this collection.

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalJtxCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalJtxCollection.kt
@@ -11,8 +11,10 @@ import at.bitfire.synctools.storage.jtx.JtxEntityAndExceptions
 import at.bitfire.synctools.storage.jtx.JtxRecurringCollection
 import at.techbee.jtx.JtxContract
 import at.techbee.jtx.JtxContract.JtxICalObject
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
 
 /**
  * Application-specific implementation for jtx collections.
@@ -75,11 +77,13 @@ class LocalJtxCollection(internal val jtxCollection: JtxCollection) :
             }
     }
 
-    override fun markNotDirty(flags: Int): Int =
-        jtxCollection.updateJtxObjectRows(
-            contentValuesOf(JtxICalObject.FLAGS to flags),
-            "NOT ${JtxICalObject.DIRTY}", null
-        )
+    override suspend fun markNotDirty(flags: Int): Int =
+        withContext(Dispatchers.IO) {
+            jtxCollection.updateJtxObjectRows(
+                contentValuesOf(JtxICalObject.FLAGS to flags),
+                "NOT ${JtxICalObject.DIRTY}", null
+            )
+        }
 
     override suspend fun removeNotDirtyMarked(flags: Int): Int {
         val batch = JtxBatchOperation(jtxCollection.client)
@@ -93,8 +97,10 @@ class LocalJtxCollection(internal val jtxCollection: JtxCollection) :
         return batch.commit()
     }
 
-    override fun forgetETags() {
-        jtxCollection.updateJtxObjectRows(contentValuesOf(JtxICalObject.ETAG to null), null, null)
+    override suspend fun forgetETags() {
+        withContext(Dispatchers.IO) {
+            jtxCollection.updateJtxObjectRows(contentValuesOf(JtxICalObject.ETAG to null), null, null)
+        }
     }
 
     fun add(jtxEntityAndExceptions: JtxEntityAndExceptions): Long {

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalTaskList.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalTaskList.kt
@@ -10,8 +10,10 @@ import at.bitfire.synctools.storage.tasks.DmfsRecurringTaskList
 import at.bitfire.synctools.storage.tasks.DmfsTaskList
 import at.bitfire.synctools.storage.tasks.DmfsTasksContract
 import at.bitfire.synctools.storage.tasks.TaskAndExceptions
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
 import org.dmfs.tasks.contract.TaskContract
 import org.dmfs.tasks.contract.TaskContract.TaskListColumns
 import org.dmfs.tasks.contract.TaskContract.Tasks
@@ -88,12 +90,14 @@ class LocalTaskList (
         }
     }
 
-    override fun markNotDirty(flags: Int): Int =
-        dmfsTaskList.updateTasks(
-            contentValuesOf(DmfsTasksContract.COLUMN_FLAGS to flags),
-            "${Tasks.LIST_ID}=? AND ${Tasks._DIRTY}=0",
-            arrayOf(dmfsTaskList.id.toString())
-        )
+    override suspend fun markNotDirty(flags: Int): Int =
+        withContext(Dispatchers.IO) {
+            dmfsTaskList.updateTasks(
+                contentValuesOf(DmfsTasksContract.COLUMN_FLAGS to flags),
+                "${Tasks.LIST_ID}=? AND ${Tasks._DIRTY}=0",
+                arrayOf(dmfsTaskList.id.toString())
+            )
+        }
 
     override suspend fun removeNotDirtyMarked(flags: Int) =
         dmfsTaskList.deleteTasks(
@@ -101,12 +105,14 @@ class LocalTaskList (
             arrayOf(dmfsTaskList.id.toString(), flags.toString())
         )
 
-    override fun forgetETags() {
-        dmfsTaskList.updateTasks(
-            contentValuesOf(DmfsTasksContract.COLUMN_ETAG to null),
-            "${Tasks.LIST_ID}=?",
-            arrayOf(dmfsTaskList.id.toString())
-        )
+    override suspend fun forgetETags() {
+        withContext(Dispatchers.IO) {
+            dmfsTaskList.updateTasks(
+                contentValuesOf(DmfsTasksContract.COLUMN_ETAG to null),
+                "${Tasks.LIST_ID}=?",
+                arrayOf(dmfsTaskList.id.toString())
+            )
+        }
     }
 
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -508,7 +508,7 @@ abstract class SyncManager<LocalType : LocalResource>(
      *
      * Used together with [deleteNotPresentRemotely].
      */
-    protected fun resetPresentRemotely() {
+    protected suspend fun resetPresentRemotely() {
         val number = localCollection.markNotDirty(0)
         logger.info("Number of local non-dirty entries: $number")
     }


### PR DESCRIPTION
Another step of #2828 (taking #2784 into account).

### Purpose

Continues making `at.bitfire.davdroid.resource.local` (the `Local*` classes between `SyncManager` and the content providers) a proper suspending API.

### Short description

- Made `LocalCollection.markNotDirty()` and `forgetETags()` `suspend`; each implementation wraps just its blocking `ContentProvider` bulk-update call in a narrow `withContext(Dispatchers.IO)`.
- Made `SyncManager.resetPresentRemotely()` `suspend`, since it calls `markNotDirty()`.
- Adjusted the `LocalCalendar` test and test doubles for the new suspend signatures.

### Checklist
- [x] The PR has a proper title, description and label.
- [x] I have self-reviewed the PR.
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.