### PR TITLE
Make `LocalResource.updateFlags()` suspending

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/LocalTestResource.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/LocalTestResource.kt
@@ -27,7 +27,7 @@ class LocalTestResource: LocalResource {
         this.scheduleTag = scheduleTag
     }
 
-    override fun updateFlags(flags: Int) {
+    override suspend fun updateFlags(flags: Int) {
         this.flags = flags
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalAddressBook.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalAddressBook.kt
@@ -123,16 +123,17 @@ open class LocalAddressBook @AssistedInject constructor(
             batch.commit()
         }
 
-    override suspend fun removeNotDirtyMarked(flags: Int): Int {
-        val batch = ContactsBatchOperation(ab.provider)
-        ab.deleteRawContacts(
-            "NOT ${RawContacts.DIRTY} AND ${RawContactColumns.FLAGS}=?", arrayOf(flags.toString()),
-            batch
-        )
-        if (includeGroups)
-            ab.deleteGroups("NOT ${Groups.DIRTY} AND ${GroupColumns.FLAGS}=?", arrayOf(flags.toString()), batch)
-        return batch.commit()
-    }
+    override suspend fun removeNotDirtyMarked(flags: Int): Int =
+        withContext(Dispatchers.IO) {
+            val batch = ContactsBatchOperation(ab.provider)
+            ab.deleteRawContacts(
+                "NOT ${RawContacts.DIRTY} AND ${RawContactColumns.FLAGS}=?", arrayOf(flags.toString()),
+                batch
+            )
+            if (includeGroups)
+                ab.deleteGroups("NOT ${Groups.DIRTY} AND ${GroupColumns.FLAGS}=?", arrayOf(flags.toString()), batch)
+            batch.commit()
+        }
 
     /**
      * Renames an address book account and moves the contacts and groups (without making them dirty).

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalCalendar.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalCalendar.kt
@@ -85,29 +85,30 @@ class LocalCalendar(
             )
         }
 
-    override suspend fun removeNotDirtyMarked(flags: Int): Int {
-        // list all non-dirty events with the given flags and delete every row + its exceptions
-        val batch = CalendarBatchOperation(androidCalendar.client)
-        androidCalendar.iterateEventRows(
-            arrayOf(Events._ID),
-            // `dirty` can be 0, 1, or null. "NOT dirty" is not enough.
-            """
-                ${Events.CALENDAR_ID}=?
-                AND (${Events.DIRTY} IS NULL OR ${Events.DIRTY}=0)
-                AND ${Events.ORIGINAL_ID} IS NULL
-                AND ${EventsContract.COLUMN_FLAGS}=?
-            """.trimIndent(),
-            arrayOf(androidCalendar.id.toString(), flags.toString())
-        ) { values ->
-            val id = values.getAsLong(Events._ID)
+    override suspend fun removeNotDirtyMarked(flags: Int): Int =
+        withContext(Dispatchers.IO) {
+            // list all non-dirty events with the given flags and delete every row + its exceptions
+            val batch = CalendarBatchOperation(androidCalendar.client)
+            androidCalendar.iterateEventRows(
+                arrayOf(Events._ID),
+                // `dirty` can be 0, 1, or null. "NOT dirty" is not enough.
+                """
+                    ${Events.CALENDAR_ID}=?
+                    AND (${Events.DIRTY} IS NULL OR ${Events.DIRTY}=0)
+                    AND ${Events.ORIGINAL_ID} IS NULL
+                    AND ${EventsContract.COLUMN_FLAGS}=?
+                """.trimIndent(),
+                arrayOf(androidCalendar.id.toString(), flags.toString())
+            ) { values ->
+                val id = values.getAsLong(Events._ID)
 
-            // delete event and possible exceptions (content provider doesn't delete exceptions itself)
-            batch += BatchOperation.CpoBuilder
-                .newDelete(androidCalendar.eventsUri)
-                .withSelection("${Events._ID}=? OR ${Events.ORIGINAL_ID}=?", arrayOf(id.toString(), id.toString()))
+                // delete event and possible exceptions (content provider doesn't delete exceptions itself)
+                batch += BatchOperation.CpoBuilder
+                    .newDelete(androidCalendar.eventsUri)
+                    .withSelection("${Events._ID}=? OR ${Events.ORIGINAL_ID}=?", arrayOf(id.toString(), id.toString()))
+            }
+            batch.commit()
         }
-        return batch.commit()
-    }
 
     override suspend fun forgetETags() {
         withContext(Dispatchers.IO) {

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalCollection.kt
@@ -70,7 +70,6 @@ interface LocalCollection<out T: LocalResource> {
      */
     suspend fun removeNotDirtyMarked(flags: Int): Int
 
-
     /**
      * Forgets the ETags of all members so that they will be reloaded from the server during sync.
      *

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalContact.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalContact.kt
@@ -88,9 +88,11 @@ class LocalContact(
         androidContact.update(data)
     }
 
-    override fun updateFlags(flags: Int) {
+    override suspend fun updateFlags(flags: Int) {
         val values = contentValuesOf(RawContactColumns.FLAGS to flags)
-        provider.update(androidContact.rawContactSyncURI(), values, null, null)
+        withContext(Dispatchers.IO) {
+            androidContact.update(values)
+        }
         androidContact.flags = flags
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalEvent.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalEvent.kt
@@ -67,10 +67,12 @@ class LocalEvent(
         }
     }
 
-    override fun updateFlags(flags: Int) {
-        calendar.updateEventRow(id, contentValuesOf(
-            EventsContract.COLUMN_FLAGS to flags
-        ))
+    override suspend fun updateFlags(flags: Int) {
+        withContext(Dispatchers.IO) {
+            calendar.updateEventRow(id, contentValuesOf(
+                EventsContract.COLUMN_FLAGS to flags
+            ))
+        }
     }
 
     override fun updateSequence(sequence: Int) {

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalGroup.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalGroup.kt
@@ -113,9 +113,11 @@ class LocalGroup(
         androidGroup.update(data)
     }
 
-    override fun updateFlags(flags: Int) {
+    override suspend fun updateFlags(flags: Int) {
         val values = contentValuesOf(GroupColumns.FLAGS to flags)
-        provider.update(androidGroup.groupSyncURI(), values, null, null)
+        withContext(Dispatchers.IO) {
+            androidGroup.update(values)
+        }
         androidGroup.flags = flags
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalJtxCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalJtxCollection.kt
@@ -85,17 +85,18 @@ class LocalJtxCollection(internal val jtxCollection: JtxCollection) :
             )
         }
 
-    override suspend fun removeNotDirtyMarked(flags: Int): Int {
-        val batch = JtxBatchOperation(jtxCollection.client)
-        recurringCollection.queryJtxObjectsAndExceptions(
-            "NOT ${JtxICalObject.DIRTY} AND ${JtxICalObject.FLAGS}=?",
-            arrayOf(flags.toString())
-        ).collect { objectAndExceptions ->
-            val id = objectAndExceptions.main.entityValues.getAsLong(JtxICalObject.ID)!!
-            recurringCollection.deleteJtxObjectAndExceptions(id, batch)
+    override suspend fun removeNotDirtyMarked(flags: Int): Int =
+        withContext(Dispatchers.IO) {
+            val batch = JtxBatchOperation(jtxCollection.client)
+            recurringCollection.queryJtxObjectsAndExceptions(
+                "NOT ${JtxICalObject.DIRTY} AND ${JtxICalObject.FLAGS}=?",
+                arrayOf(flags.toString())
+            ).collect { objectAndExceptions ->
+                val id = objectAndExceptions.main.entityValues.getAsLong(JtxICalObject.ID)!!
+                recurringCollection.deleteJtxObjectAndExceptions(id, batch)
+            }
+            batch.commit()
         }
-        return batch.commit()
-    }
 
     override suspend fun forgetETags() {
         withContext(Dispatchers.IO) {

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalJtxObject.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalJtxObject.kt
@@ -63,12 +63,14 @@ class LocalJtxObject(
         }
     }
 
-    override fun updateFlags(flags: Int) {
+    override suspend fun updateFlags(flags: Int) {
         val values = contentValuesOf(
             JtxContract.JtxICalObject.FLAGS to flags,
         )
 
-        collection.updateJtxObjectRow(id, values)
+        withContext(Dispatchers.IO) {
+            collection.updateJtxObjectRow(id, values)
+        }
     }
 
     override suspend fun updateUid(uid: String) {

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalResource.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalResource.kt
@@ -67,8 +67,10 @@ interface LocalResource {
      * Does not affect `this` object itself (which is immutable).
      *
      * At the moment, the only allowed values are 0 and [FLAG_REMOTELY_PRESENT].
+     *
+     * @throws at.bitfire.synctools.storage.LocalStorageException on content provider errors
      */
-    fun updateFlags(flags: Int)
+    suspend fun updateFlags(flags: Int)
 
     /**
      * Updates the local UID of the resource in the content provider.

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalTask.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalTask.kt
@@ -77,12 +77,14 @@ class LocalTask(
         }
     }
 
-    override fun updateFlags(flags: Int) {
-        taskList.updateTaskRow(
-            id, contentValuesOf(
-                DmfsTasksContract.COLUMN_FLAGS to flags
+    override suspend fun updateFlags(flags: Int) {
+        withContext(Dispatchers.IO) {
+            taskList.updateTaskRow(
+                id, contentValuesOf(
+                    DmfsTasksContract.COLUMN_FLAGS to flags
+                )
             )
-        )
+        }
     }
 
     override fun updateSequence(sequence: Int) {

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalTaskList.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalTaskList.kt
@@ -100,10 +100,12 @@ class LocalTaskList (
         }
 
     override suspend fun removeNotDirtyMarked(flags: Int) =
-        dmfsTaskList.deleteTasks(
-            "${Tasks.LIST_ID}=? AND NOT ${Tasks._DIRTY} AND ${DmfsTasksContract.COLUMN_FLAGS}=?",
-            arrayOf(dmfsTaskList.id.toString(), flags.toString())
-        )
+        withContext(Dispatchers.IO) {
+            dmfsTaskList.deleteTasks(
+                "${Tasks.LIST_ID}=? AND NOT ${Tasks._DIRTY} AND ${DmfsTasksContract.COLUMN_FLAGS}=?",
+                arrayOf(dmfsTaskList.id.toString(), flags.toString())
+            )
+        }
 
     override suspend fun forgetETags() {
         withContext(Dispatchers.IO) {


### PR DESCRIPTION
Another step of #2828 (taking #2784 into account).

### Purpose

Continues making `at.bitfire.davdroid.resource.local` (the `Local*` classes between `SyncManager` and the content providers) a proper suspending API.

### Short description

- Made `LocalResource.updateFlags()` `suspend`; each implementation wraps just its blocking `ContentProvider` call in a narrow `withContext(Dispatchers.IO)`.
- `LocalContact`/`LocalGroup` now reuse the `synctools` `update()` methods added in #2839 instead of calling `ContentProviderClient.update()` directly.
- Fixed `LocalCollection.removeNotDirtyMarked()`, which was already `suspend` but never actually dispatched onto `Dispatchers.IO`.

### Checklist
- [x] The PR has a proper title, description and label.
- [x] I have self-reviewed the PR.
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.