### PR TITLE
Make `LocalResource.updateSequence()`/`deleteLocal()`/`resetDeleted()` suspend

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/LocalTestResource.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/LocalTestResource.kt
@@ -32,10 +32,10 @@ class LocalTestResource: LocalResource {
     }
 
     override suspend fun updateUid(uid: String) { /* no-op */ }
-    override fun updateSequence(sequence: Int) = throw NotImplementedError()
+    override suspend fun updateSequence(sequence: Int) = throw NotImplementedError()
 
-    override fun deleteLocal() {}  // no-op: test callers handle deletion via the collection
-    override fun resetDeleted() = throw NotImplementedError()
+    override suspend fun deleteLocal() {}  // no-op: test callers handle deletion via the collection
+    override suspend fun resetDeleted() = throw NotImplementedError()
 
     override fun getDebugSummary() = "Test Resource"
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalContact.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalContact.kt
@@ -96,7 +96,7 @@ class LocalContact(
         androidContact.flags = flags
     }
 
-    override fun updateSequence(sequence: Int) = throw NotImplementedError()
+    override suspend fun updateSequence(sequence: Int) = throw NotImplementedError()
 
     override suspend fun updateUid(uid: String) {
         val values = contentValuesOf(RawContactColumns.UID to uid)
@@ -105,13 +105,16 @@ class LocalContact(
         }
     }
 
-    override fun deleteLocal() {
-        androidContact.delete()
+    override suspend fun deleteLocal() {
+        withContext(Dispatchers.IO) {
+            androidContact.delete()
+        }
     }
 
-    override fun resetDeleted() {
-        val values = contentValuesOf(ContactsContract.Groups.DELETED to 0)
-        provider.update(androidContact.rawContactSyncURI(), values, null, null)
+    override suspend fun resetDeleted() {
+        withContext(Dispatchers.IO) {
+            androidContact.update(contentValuesOf(ContactsContract.Groups.DELETED to 0))
+        }
     }
 
     override fun getDebugSummary() =

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalContact.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalContact.kt
@@ -8,7 +8,6 @@ import android.content.ContentUris
 import android.content.ContentValues
 import android.content.Context
 import android.net.Uri
-import android.provider.ContactsContract
 import android.provider.ContactsContract.RawContacts
 import android.provider.ContactsContract.RawContacts.getContactLookupUri
 import androidx.core.content.contentValuesOf
@@ -113,7 +112,7 @@ class LocalContact(
 
     override suspend fun resetDeleted() {
         withContext(Dispatchers.IO) {
-            androidContact.update(contentValuesOf(ContactsContract.Groups.DELETED to 0))
+            androidContact.update(contentValuesOf(RawContacts.DELETED to 0))
         }
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalEvent.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalEvent.kt
@@ -75,10 +75,14 @@ class LocalEvent(
         }
     }
 
-    override fun updateSequence(sequence: Int) {
-        calendar.updateEventRow(id, contentValuesOf(
-            EventsContract.COLUMN_SEQUENCE to sequence
-        ))
+    override suspend fun updateSequence(sequence: Int) {
+        withContext(Dispatchers.IO) {
+            calendar.updateEventRow(
+                id, contentValuesOf(
+                    EventsContract.COLUMN_SEQUENCE to sequence
+                )
+            )
+        }
     }
 
     override suspend fun updateUid(uid: String) {
@@ -89,14 +93,20 @@ class LocalEvent(
         }
     }
 
-    override fun deleteLocal() {
-        recurringCalendar.deleteEventAndExceptions(id)
+    override suspend fun deleteLocal() {
+        withContext(Dispatchers.IO) {
+            recurringCalendar.deleteEventAndExceptions(id)
+        }
     }
 
-    override fun resetDeleted() {
-        calendar.updateEventRow(id, contentValuesOf(
-            Events.DELETED to 0
-        ))
+    override suspend fun resetDeleted() {
+        withContext(Dispatchers.IO) {
+            calendar.updateEventRow(
+                id, contentValuesOf(
+                    Events.DELETED to 0
+                )
+            )
+        }
     }
 
     override fun getDebugSummary() =

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalGroup.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalGroup.kt
@@ -121,7 +121,7 @@ class LocalGroup(
         androidGroup.flags = flags
     }
 
-    override fun updateSequence(sequence: Int) = throw NotImplementedError()
+    override suspend fun updateSequence(sequence: Int) = throw NotImplementedError()
 
     override suspend fun updateUid(uid: String) {
         val values = contentValuesOf(GroupColumns.UID to uid)
@@ -130,13 +130,16 @@ class LocalGroup(
         }
     }
 
-    override fun deleteLocal() {
-        androidGroup.delete()
+    override suspend fun deleteLocal() {
+        withContext(Dispatchers.IO) {
+            androidGroup.delete()
+        }
     }
 
-    override fun resetDeleted() {
-        val values = contentValuesOf(Groups.DELETED to 0)
-        provider.update(androidGroup.groupSyncURI(), values, null, null)
+    override suspend fun resetDeleted() {
+        withContext(Dispatchers.IO) {
+            androidGroup.update(contentValuesOf(Groups.DELETED to 0))
+        }
     }
 
     override fun getDebugSummary() =

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalJtxObject.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalJtxObject.kt
@@ -83,24 +83,22 @@ class LocalJtxObject(
         }
     }
 
-    override fun updateSequence(sequence: Int) {
-        val values = contentValuesOf(
-            JtxContract.JtxICalObject.SEQUENCE to sequence,
-        )
-
-        collection.updateJtxObjectRow(id, values)
+    override suspend fun updateSequence(sequence: Int) {
+        withContext(Dispatchers.IO) {
+            collection.updateJtxObjectRow(id, contentValuesOf(JtxContract.JtxICalObject.SEQUENCE to sequence))
+        }
     }
 
-    override fun deleteLocal() {
-        recurringCollection.deleteJtxObjectAndExceptions(id)
+    override suspend fun deleteLocal() {
+        withContext(Dispatchers.IO) {
+            recurringCollection.deleteJtxObjectAndExceptions(id)
+        }
     }
 
-    override fun resetDeleted() {
-        val values = contentValuesOf(
-            JtxContract.JtxICalObject.DELETED to 0,
-        )
-
-        collection.updateJtxObjectRow(id, values)
+    override suspend fun resetDeleted() {
+        withContext(Dispatchers.IO) {
+            collection.updateJtxObjectRow(id, contentValuesOf(JtxContract.JtxICalObject.DELETED to 0))
+        }
     }
 
     override fun getDebugSummary(): String {

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalResource.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalResource.kt
@@ -84,18 +84,23 @@ interface LocalResource {
      * Updates the local SEQUENCE of the resource in the content provider.
      *
      * @throws NotImplementedError  if SEQUENCE update is not supported
+     * @throws at.bitfire.synctools.storage.LocalStorageException on content provider errors
      */
-    fun updateSequence(sequence: Int)
+    suspend fun updateSequence(sequence: Int)
 
     /**
      * Deletes the data object from the content provider.
+     *
+     * @throws at.bitfire.synctools.storage.LocalStorageException on content provider errors
      */
-    fun deleteLocal()
+    suspend fun deleteLocal()
 
     /**
      * Undoes deletion of the data object from the content provider.
+     *
+     * @throws at.bitfire.synctools.storage.LocalStorageException on content provider errors
      */
-    fun resetDeleted()
+    suspend fun resetDeleted()
 
     /**
      * User-readable debug summary of this local resource (used in debug info)

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalTask.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalTask.kt
@@ -87,10 +87,14 @@ class LocalTask(
         }
     }
 
-    override fun updateSequence(sequence: Int) {
-        taskList.updateTaskRow(id, contentValuesOf(
-            Tasks.SYNC_VERSION to sequence
-        ))
+    override suspend fun updateSequence(sequence: Int) {
+        withContext(Dispatchers.IO) {
+            taskList.updateTaskRow(
+                id, contentValuesOf(
+                    Tasks.SYNC_VERSION to sequence
+                )
+            )
+        }
     }
 
     override suspend fun updateUid(uid: String) {
@@ -101,11 +105,13 @@ class LocalTask(
         }
     }
 
-    override fun deleteLocal() {
-        recurringTaskList.deleteTaskAndExceptions(id)
+    override suspend fun deleteLocal() {
+        withContext(Dispatchers.IO) {
+            recurringTaskList.deleteTaskAndExceptions(id)
+        }
     }
 
-    override fun resetDeleted() {
+    override suspend fun resetDeleted() {
         throw NotImplementedError()
     }
 

--- a/core/src/test/kotlin/at/bitfire/davdroid/sync/ReadOnlyPolicyTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/sync/ReadOnlyPolicyTest.kt
@@ -49,8 +49,8 @@ class ReadOnlyPolicyTest {
 
         assertTrue(policy.resetDeleted(collection))
 
-        verify { resource1.resetDeleted() }
-        verify { resource2.resetDeleted() }
+        coVerify { resource1.resetDeleted() }
+        coVerify { resource2.resetDeleted() }
         verify { collection.lastSyncState = null }
     }
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidContact.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidContact.kt
@@ -191,11 +191,15 @@ class AndroidContact(
     /**
      * Deletes an existing contact from the contacts provider.
      *
-     * @return number of affected rows
-     *
-     * @throws RemoteException on contacts provider errors
+     * @throws LocalStorageException on contacts provider errors
      */
-    fun delete() = addressBook.provider.delete(rawContactSyncURI(), null, null)
+    fun delete() {
+        try {
+            addressBook.provider.delete(rawContactSyncURI(), null, null)
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't delete raw contact $id", e)
+        }
+    }
 
     /**
      * Updates this raw contact's main row with the given values.

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidGroup.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidGroup.kt
@@ -184,7 +184,18 @@ class AndroidGroup(
         return uri
     }
 
-    fun delete() = addressBook.provider.delete(groupSyncURI(), null, null)
+    /**
+     * Deletes this group from the contacts provider.
+     *
+     * @throws LocalStorageException on contact provider errors
+     */
+    fun delete() {
+        try {
+            addressBook.provider.delete(groupSyncURI(), null, null)
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't delete group $id", e)
+        }
+    }
 
     /**
      * Lists all members of this group.


### PR DESCRIPTION
Another step of #2828 (taking #2784 into account).

### Purpose

Continues making `at.bitfire.davdroid.resource.local` (the `Local*` classes between `SyncManager` and the content providers) a proper suspending API.

### Short description

- Made `LocalResource.updateSequence()`, `deleteLocal()` and `resetDeleted()` `suspend`; each implementation wraps just its blocking `ContentProvider` call in a narrow `withContext(Dispatchers.IO)`.
- `AndroidContact.delete()`/`AndroidGroup.delete()` now wrap `RemoteException` as `LocalStorageException`, per #2784.
- Adjusted `LocalTestResource` and `ReadOnlyPolicyTest` for the new suspend signatures.

### Checklist
- [x] The PR has a proper title, description and label.
- [x] I have self-reviewed the PR.
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.