### PR TITLE
Make `LocalAddressBook`'s group-membership helpers suspend

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/LocalTestResource.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/LocalTestResource.kt
@@ -32,10 +32,10 @@ class LocalTestResource: LocalResource {
     }
 
     override suspend fun updateUid(uid: String) { /* no-op */ }
-    override fun updateSequence(sequence: Int) = throw NotImplementedError()
+    override suspend fun updateSequence(sequence: Int) = throw NotImplementedError()
 
-    override fun deleteLocal() {}  // no-op: test callers handle deletion via the collection
-    override fun resetDeleted() = throw NotImplementedError()
+    override suspend fun deleteLocal() {}  // no-op: test callers handle deletion via the collection
+    override suspend fun resetDeleted() = throw NotImplementedError()
 
     override fun getDebugSummary() = "Test Resource"
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalAddressBook.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalAddressBook.kt
@@ -9,7 +9,6 @@ import android.content.ContentProviderClient
 import android.content.ContentValues
 import android.content.Context
 import android.provider.ContactsContract
-import android.provider.ContactsContract.CommonDataKinds.GroupMembership
 import android.provider.ContactsContract.Groups
 import android.provider.ContactsContract.RawContacts
 import androidx.annotation.OpenForTesting
@@ -23,7 +22,6 @@ import at.bitfire.synctools.mapping.contacts.Contact
 import at.bitfire.synctools.storage.LocalStorageException
 import at.bitfire.synctools.storage.contacts.AddressContract.GroupColumns
 import at.bitfire.synctools.storage.contacts.AddressContract.RawContactColumns
-import at.bitfire.synctools.storage.contacts.AddressContract.asSyncAdapter
 import at.bitfire.synctools.storage.contacts.AndroidAddressBook
 import at.bitfire.synctools.storage.contacts.AndroidContact
 import at.bitfire.synctools.storage.contacts.AndroidGroup
@@ -311,36 +309,34 @@ open class LocalAddressBook @AssistedInject constructor(
         ab.queryGroupRows(null, where, whereArgs).map { LocalGroup(AndroidGroup(ab, it)) }
 
     @Throws(FileNotFoundException::class)
-    fun findContactById(id: Long): LocalContact =
-        ab.getRawContactRowOrNull("${RawContacts._ID}=?", arrayOf(id.toString()))
-            ?.let { LocalContact(this, AndroidContact(ab, it)) }
+    suspend fun findContactById(id: Long): LocalContact =
+        withContext(Dispatchers.IO) {
+            ab.getRawContactRowOrNull("${RawContacts._ID}=?", arrayOf(id.toString()))
+        }?.let { LocalContact(this, AndroidContact(ab, it)) }
             ?: throw FileNotFoundException()
 
-    fun findContactByUid(uid: String): LocalContact? =
-        ab.getRawContactRowOrNull("${RawContactColumns.UID}=?", arrayOf(uid))
-            ?.let { LocalContact(this, AndroidContact(ab, it)) }
+    suspend fun findContactByUid(uid: String): LocalContact? =
+        withContext(Dispatchers.IO) {
+            ab.getRawContactRowOrNull("${RawContactColumns.UID}=?", arrayOf(uid))
+        }?.let { LocalContact(this, AndroidContact(ab, it)) }
 
     @Throws(FileNotFoundException::class)
-    fun findGroupById(id: Long): LocalGroup =
-        ab.getGroupOrNull("${Groups._ID}=?", arrayOf(id.toString()))
-            ?.let { LocalGroup(AndroidGroup(ab, it)) }
+    suspend fun findGroupById(id: Long): LocalGroup =
+        withContext(Dispatchers.IO) {
+            ab.getGroupOrNull("${Groups._ID}=?", arrayOf(id.toString()))
+        }?.let { LocalGroup(AndroidGroup(ab, it)) }
             ?: throw FileNotFoundException()
 
 
-    fun getContactIdsByGroupMembership(groupId: Long): List<Long> = buildList {
-        ab.provider.query(
-            ContactsContract.Data.CONTENT_URI.asSyncAdapter(), arrayOf(GroupMembership.RAW_CONTACT_ID),
-            "(${GroupMembership.MIMETYPE}=? AND ${GroupMembership.GROUP_ROW_ID}=?)",
-            arrayOf(GroupMembership.CONTENT_ITEM_TYPE, groupId.toString()), null
-        )?.use { cursor ->
-            while (cursor.moveToNext())
-                add(cursor.getLong(0))
+    suspend fun getContactIdsByGroupMembership(groupId: Long): List<Long> =
+        withContext(Dispatchers.IO) {
+            ab.getContactIdsByGroupMembership(groupId)
         }
-    }
 
-    fun getContactUidFromId(contactId: Long): String? =
-        ab.getRawContactRowOrNull("${RawContacts._ID}=?", arrayOf(contactId.toString()))
-            ?.getAsString(RawContactColumns.UID)
+    suspend fun getContactUidFromId(contactId: Long): String? =
+        withContext(Dispatchers.IO) {
+            ab.getRawContactRowOrNull("${RawContacts._ID}=?", arrayOf(contactId.toString()))
+        }?.getAsString(RawContactColumns.UID)
 
 
     /* special group operations */
@@ -394,7 +390,9 @@ open class LocalAddressBook @AssistedInject constructor(
                     .forEach { contact -> verifier.updateHashCode(contact, batch) }
             }
 
-            batch.commit()
+            withContext(Dispatchers.IO) {
+                batch.commit()
+            }
         }
     }
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalCollection.kt
@@ -46,6 +46,8 @@ interface LocalCollection<out T: LocalResource> {
      *
      * @param name file name to look for
      * @return resource with the given name, or null if none
+     *
+     * @throws at.bitfire.synctools.storage.LocalStorageException on content provider errors
      */
     suspend fun findByName(name: String): T?
 

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalContact.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalContact.kt
@@ -96,7 +96,7 @@ class LocalContact(
         androidContact.flags = flags
     }
 
-    override fun updateSequence(sequence: Int) = throw NotImplementedError()
+    override suspend fun updateSequence(sequence: Int) = throw NotImplementedError()
 
     override suspend fun updateUid(uid: String) {
         val values = contentValuesOf(RawContactColumns.UID to uid)
@@ -105,13 +105,16 @@ class LocalContact(
         }
     }
 
-    override fun deleteLocal() {
-        androidContact.delete()
+    override suspend fun deleteLocal() {
+        withContext(Dispatchers.IO) {
+            androidContact.delete()
+        }
     }
 
-    override fun resetDeleted() {
-        val values = contentValuesOf(ContactsContract.Groups.DELETED to 0)
-        provider.update(androidContact.rawContactSyncURI(), values, null, null)
+    override suspend fun resetDeleted() {
+        withContext(Dispatchers.IO) {
+            androidContact.update(contentValuesOf(ContactsContract.Groups.DELETED to 0))
+        }
     }
 
     override fun getDebugSummary() =

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalEvent.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalEvent.kt
@@ -75,10 +75,14 @@ class LocalEvent(
         }
     }
 
-    override fun updateSequence(sequence: Int) {
-        calendar.updateEventRow(id, contentValuesOf(
-            EventsContract.COLUMN_SEQUENCE to sequence
-        ))
+    override suspend fun updateSequence(sequence: Int) {
+        withContext(Dispatchers.IO) {
+            calendar.updateEventRow(
+                id, contentValuesOf(
+                    EventsContract.COLUMN_SEQUENCE to sequence
+                )
+            )
+        }
     }
 
     override suspend fun updateUid(uid: String) {
@@ -89,14 +93,20 @@ class LocalEvent(
         }
     }
 
-    override fun deleteLocal() {
-        recurringCalendar.deleteEventAndExceptions(id)
+    override suspend fun deleteLocal() {
+        withContext(Dispatchers.IO) {
+            recurringCalendar.deleteEventAndExceptions(id)
+        }
     }
 
-    override fun resetDeleted() {
-        calendar.updateEventRow(id, contentValuesOf(
-            Events.DELETED to 0
-        ))
+    override suspend fun resetDeleted() {
+        withContext(Dispatchers.IO) {
+            calendar.updateEventRow(
+                id, contentValuesOf(
+                    Events.DELETED to 0
+                )
+            )
+        }
     }
 
     override fun getDebugSummary() =

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalGroup.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalGroup.kt
@@ -121,7 +121,7 @@ class LocalGroup(
         androidGroup.flags = flags
     }
 
-    override fun updateSequence(sequence: Int) = throw NotImplementedError()
+    override suspend fun updateSequence(sequence: Int) = throw NotImplementedError()
 
     override suspend fun updateUid(uid: String) {
         val values = contentValuesOf(GroupColumns.UID to uid)
@@ -130,13 +130,16 @@ class LocalGroup(
         }
     }
 
-    override fun deleteLocal() {
-        androidGroup.delete()
+    override suspend fun deleteLocal() {
+        withContext(Dispatchers.IO) {
+            androidGroup.delete()
+        }
     }
 
-    override fun resetDeleted() {
-        val values = contentValuesOf(Groups.DELETED to 0)
-        provider.update(androidGroup.groupSyncURI(), values, null, null)
+    override suspend fun resetDeleted() {
+        withContext(Dispatchers.IO) {
+            androidGroup.update(contentValuesOf(Groups.DELETED to 0))
+        }
     }
 
     override fun getDebugSummary() =

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalJtxCollection.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalJtxCollection.kt
@@ -70,11 +70,12 @@ class LocalJtxCollection(internal val jtxCollection: JtxCollection) :
             .map { LocalJtxObject(recurringCollection, it) }
 
     override suspend fun findByName(name: String): LocalJtxObject? {
-        return recurringCollection
-            .findJtxObjectAndExceptions("${JtxICalObject.FILENAME}=?", arrayOf(name))
-            ?.let { jtxObjectAndExceptions ->
-                LocalJtxObject(recurringCollection, jtxObjectAndExceptions)
-            }
+        val result = withContext(Dispatchers.IO) {
+            recurringCollection.findJtxObjectAndExceptions("${JtxICalObject.FILENAME}=?", arrayOf(name))
+        }
+        return result?.let { jtxObjectAndExceptions ->
+            LocalJtxObject(recurringCollection, jtxObjectAndExceptions)
+        }
     }
 
     override suspend fun markNotDirty(flags: Int): Int =

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalJtxObject.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalJtxObject.kt
@@ -83,24 +83,22 @@ class LocalJtxObject(
         }
     }
 
-    override fun updateSequence(sequence: Int) {
-        val values = contentValuesOf(
-            JtxContract.JtxICalObject.SEQUENCE to sequence,
-        )
-
-        collection.updateJtxObjectRow(id, values)
+    override suspend fun updateSequence(sequence: Int) {
+        withContext(Dispatchers.IO) {
+            collection.updateJtxObjectRow(id, contentValuesOf(JtxContract.JtxICalObject.SEQUENCE to sequence))
+        }
     }
 
-    override fun deleteLocal() {
-        recurringCollection.deleteJtxObjectAndExceptions(id)
+    override suspend fun deleteLocal() {
+        withContext(Dispatchers.IO) {
+            recurringCollection.deleteJtxObjectAndExceptions(id)
+        }
     }
 
-    override fun resetDeleted() {
-        val values = contentValuesOf(
-            JtxContract.JtxICalObject.DELETED to 0,
-        )
-
-        collection.updateJtxObjectRow(id, values)
+    override suspend fun resetDeleted() {
+        withContext(Dispatchers.IO) {
+            collection.updateJtxObjectRow(id, contentValuesOf(JtxContract.JtxICalObject.DELETED to 0))
+        }
     }
 
     override fun getDebugSummary(): String {

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalJtxObject.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalJtxObject.kt
@@ -44,7 +44,9 @@ class LocalJtxObject(
         get() = mainValues.getAsInteger(JtxContract.JtxICalObject.FLAGS) ?: 0
 
     suspend fun update(data: JtxEntityAndExceptions) {
-        recurringCollection.updateJtxObjectAndExceptions(id, data)
+        withContext(Dispatchers.IO) {
+            recurringCollection.updateJtxObjectAndExceptions(id, data)
+        }
     }
 
     override suspend fun clearDirty(fileName: Optional<String>, eTag: String?, scheduleTag: String?) {

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalResource.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalResource.kt
@@ -84,18 +84,23 @@ interface LocalResource {
      * Updates the local SEQUENCE of the resource in the content provider.
      *
      * @throws NotImplementedError  if SEQUENCE update is not supported
+     * @throws at.bitfire.synctools.storage.LocalStorageException on content provider errors
      */
-    fun updateSequence(sequence: Int)
+    suspend fun updateSequence(sequence: Int)
 
     /**
      * Deletes the data object from the content provider.
+     *
+     * @throws at.bitfire.synctools.storage.LocalStorageException on content provider errors
      */
-    fun deleteLocal()
+    suspend fun deleteLocal()
 
     /**
      * Undoes deletion of the data object from the content provider.
+     *
+     * @throws at.bitfire.synctools.storage.LocalStorageException on content provider errors
      */
-    fun resetDeleted()
+    suspend fun resetDeleted()
 
     /**
      * User-readable debug summary of this local resource (used in debug info)

--- a/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalTask.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/resource/local/LocalTask.kt
@@ -87,10 +87,14 @@ class LocalTask(
         }
     }
 
-    override fun updateSequence(sequence: Int) {
-        taskList.updateTaskRow(id, contentValuesOf(
-            Tasks.SYNC_VERSION to sequence
-        ))
+    override suspend fun updateSequence(sequence: Int) {
+        withContext(Dispatchers.IO) {
+            taskList.updateTaskRow(
+                id, contentValuesOf(
+                    Tasks.SYNC_VERSION to sequence
+                )
+            )
+        }
     }
 
     override suspend fun updateUid(uid: String) {
@@ -101,11 +105,13 @@ class LocalTask(
         }
     }
 
-    override fun deleteLocal() {
-        recurringTaskList.deleteTaskAndExceptions(id)
+    override suspend fun deleteLocal() {
+        withContext(Dispatchers.IO) {
+            recurringTaskList.deleteTaskAndExceptions(id)
+        }
     }
 
-    override fun resetDeleted() {
+    override suspend fun resetDeleted() {
         throw NotImplementedError()
     }
 

--- a/core/src/test/kotlin/at/bitfire/davdroid/sync/ReadOnlyPolicyTest.kt
+++ b/core/src/test/kotlin/at/bitfire/davdroid/sync/ReadOnlyPolicyTest.kt
@@ -49,8 +49,8 @@ class ReadOnlyPolicyTest {
 
         assertTrue(policy.resetDeleted(collection))
 
-        verify { resource1.resetDeleted() }
-        verify { resource2.resetDeleted() }
+        coVerify { resource1.resetDeleted() }
+        coVerify { resource2.resetDeleted() }
         verify { collection.lastSyncState = null }
     }
 

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidAddressBook.kt
@@ -15,6 +15,7 @@ import android.graphics.BitmapFactory
 import android.net.Uri
 import android.os.RemoteException
 import android.provider.ContactsContract
+import android.provider.ContactsContract.CommonDataKinds.GroupMembership
 import android.provider.ContactsContract.CommonDataKinds.Photo
 import android.provider.ContactsContract.Groups
 import android.provider.ContactsContract.RawContacts
@@ -204,13 +205,42 @@ class AndroidAddressBook(
      * @param where      optional selection
      * @param whereArgs  optional arguments for [where]
      * @return the matching row, or `null` if none matches
+     *
+     * @throws LocalStorageException on content provider errors
      */
     fun getRawContactRowOrNull(where: String?, whereArgs: Array<String>?): ContentValues? {
-        provider.query(rawContactsSyncUri(), null, where, whereArgs, null)?.use { cursor ->
-            if (cursor.moveToNext())
-                return cursor.toContentValues()
+        try {
+            provider.query(rawContactsSyncUri(), null, where, whereArgs, null)?.use { cursor ->
+                if (cursor.moveToNext())
+                    return cursor.toContentValues()
+            }
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't query raw contact", e)
         }
         return null
+    }
+
+    /**
+     * Finds the IDs of all raw contacts that are members of a given group.
+     *
+     * @param groupId  ID of the group
+     * @return IDs of the raw contacts that are members of the group
+     *
+     * @throws LocalStorageException on content provider errors
+     */
+    fun getContactIdsByGroupMembership(groupId: Long): List<Long> = buildList {
+        try {
+            provider.query(
+                ContactsContract.Data.CONTENT_URI.asSyncAdapter(), arrayOf(GroupMembership.RAW_CONTACT_ID),
+                "(${GroupMembership.MIMETYPE}=? AND ${GroupMembership.GROUP_ROW_ID}=?)",
+                arrayOf(GroupMembership.CONTENT_ITEM_TYPE, groupId.toString()), null
+            )?.use { cursor ->
+                while (cursor.moveToNext())
+                    add(cursor.getLong(0))
+            }
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't query group memberships of group $groupId", e)
+        }
     }
 
     /**
@@ -302,11 +332,17 @@ class AndroidAddressBook(
      * @param where      optional selection
      * @param whereArgs  optional arguments for [where]
      * @return the matching row, or `null` if none matches
+     *
+     * @throws LocalStorageException on content provider errors
      */
     fun getGroupOrNull(where: String?, whereArgs: Array<String>?): ContentValues? {
-        provider.query(groupsSyncUri(), null, where, whereArgs, null)?.use { cursor ->
-            if (cursor.moveToNext())
-                return cursor.toContentValues()
+        try {
+            provider.query(groupsSyncUri(), null, where, whereArgs, null)?.use { cursor ->
+                if (cursor.moveToNext())
+                    return cursor.toContentValues()
+            }
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't query group", e)
         }
         return null
     }

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidContact.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidContact.kt
@@ -191,11 +191,15 @@ class AndroidContact(
     /**
      * Deletes an existing contact from the contacts provider.
      *
-     * @return number of affected rows
-     *
-     * @throws RemoteException on contacts provider errors
+     * @throws LocalStorageException on contacts provider errors
      */
-    fun delete() = addressBook.provider.delete(rawContactSyncURI(), null, null)
+    fun delete() {
+        try {
+            addressBook.provider.delete(rawContactSyncURI(), null, null)
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't delete raw contact $id", e)
+        }
+    }
 
     /**
      * Updates this raw contact's main row with the given values.

--- a/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidGroup.kt
+++ b/synctools/src/main/kotlin/at/bitfire/synctools/storage/contacts/AndroidGroup.kt
@@ -184,7 +184,18 @@ class AndroidGroup(
         return uri
     }
 
-    fun delete() = addressBook.provider.delete(groupSyncURI(), null, null)
+    /**
+     * Deletes this group from the contacts provider.
+     *
+     * @throws LocalStorageException on contact provider errors
+     */
+    fun delete() {
+        try {
+            addressBook.provider.delete(groupSyncURI(), null, null)
+        } catch (e: RemoteException) {
+            throw LocalStorageException("Couldn't delete group $id", e)
+        }
+    }
 
     /**
      * Lists all members of this group.


### PR DESCRIPTION
Another step of #2828 (taking #2784 into account).

### Purpose

Continues making `at.bitfire.davdroid.resource.local` (the `Local*` classes between `SyncManager` and the content providers) a proper suspending API.

### Short description

- Made `LocalAddressBook`'s group-membership lookup helpers (used by `applyPendingMemberships()`) suspend, each dispatching its content-provider call onto `Dispatchers.IO`.
- Moved the raw group-membership query out of `core` into a new `synctools` method, wrapping `RemoteException` as `LocalStorageException` like its siblings.
- Fixed two other `Local*` methods that were already suspend but never actually dispatched their content-provider access onto `Dispatchers.IO`.
- Documented `findByName()`'s exception behavior.

### Checklist
- [x] The PR has a proper title, description and label.
- [x] I have self-reviewed the PR.
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.