### PR TITLE
Do not exclude at.bitfire.** from optimization/shrinking

### DIFF
--- a/core/core-proguard-rules.pro
+++ b/core/core-proguard-rules.pro
@@ -1,6 +1,5 @@
 
 # keep rules
--keep class at.bitfire.** { *; }        # all DAVx5 code is required
 -keep class org.xmlpull.** { *; }
 
 # Additional rules which are now required since missing classes can't be ignored in R8 anymore.

--- a/synctools/consumer-rules.pro
+++ b/synctools/consumer-rules.pro
@@ -1,6 +1,9 @@
 
-# keep all iCalendar properties/parameters (referenced over ServiceLoader)
--keep class net.fortuna.ical4j.** { *; }
+# keep all iCalendar properties/parameters – https://github.com/ical4j/ical4j/issues/717
+-keep,allowoptimization class net.fortuna.ical4j.** { *; }
+
+# ical4j: SystemAwareTimeZoneRegistry$Factory is loaded dynamically from ical4j.properties
+-keep,allowoptimization class at.bitfire.synctools.icalendar.SystemAwareTimeZoneRegistry$Factory { *; }
 
 # ical4j: don't warn when these are missing
 -dontwarn com.github.benmanes.caffeine.**
@@ -13,10 +16,10 @@
 -dontwarn org.joda.convert.ToString
 -dontwarn org.jparsec.**
 
-# keep all vCard properties/parameters (used via reflection)
--keep class ezvcard.io.scribe.** { *; }
--keep class ezvcard.property.** { *; }
--keep class ezvcard.parameter.** { *; }
+# keep all vCard properties/parameters – https://github.com/mangstadt/ez-vcard/issues/84
+-keep,allowoptimization class ezvcard.io.scribe.** { *; }
+-keep,allowoptimization class ezvcard.property.** { *; }
+-keep,allowoptimization class ezvcard.parameter.** { *; }
 
 # AGP seems to remove this class, but ezvcard.io uses it. See https://github.com/bitfireAT/davx5/issues/499
 -keep class javax.xml.namespace.QName { *; }


### PR DESCRIPTION
Android Studio complains about this rule:
"Overly broad keep rule affecting more than 100 classes. Scope rules using annotations, specific classes, or using specific field/method selectors"

And reading through [1], let's drop this -keep rule.

Before:
17,6 MiB (davx5-405190003-4.5.19-ose-release.apk)

After:
17,1 MiB (davx5-405190003-4.5.19-ose-release.apk)

The resulting .apk didn't produce any failures during testing.

[1] https://android-developers.googleblog.com/2026/08/app-quality-memory-optimization-secure-onboarding.html

