### PR TITLE
Only use `dependencies` label for dependabot submodule updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,4 @@ updates:
     commit-message:
       prefix: "[l10n] "
     labels:
-      - "ci-cd"
       - "dependencies"
-      - "chore"


### PR DESCRIPTION
### Organizational

> [!IMPORTANT]
> Please make sure an issue or discussion for this change **exists and was acknowledged** by the
> core team before submitting. Uncoordinated pull requests may conflict with the project roadmap
> and could be closed without merging — which would be a pity.
> See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

- [x] **An issue or discussion that proposes this change exists and was acknowledged by the core team.**
  (The PR is still welcome otherwise, but could be closed at any time without much attention
  when it doesn't fit.)

**✨ AI contributions – only check if applicable:**

- [x] **This PR and its concept was mainly driven by a human.** This does not apply when an issue
is just referenced/copied into an AI prompt and then the result is submitted as PR.

PRs that are mainly driven by AI often have little worth, as everybody could just copy the issue
into a prompt. The worth of a good PR often comes from the main idea, architectural decisions etc.
behind it. **So while all PRs are welcome, such PRs may be reviewed with less human attention and closed
at any time when they don't fit.**


### Purpose

Simplify labels set by dependabot updates of the translations submodule.

### Short description

- Remove the `ci-cd` and `chore` labels from the PRs.

### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.

