### PR TITLE
Disable Dependabot cooldown for l10n submodule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,5 @@ updates:
       prefix: "[l10n] "
     labels:
       - "dependencies"
+    cooldown:
+      default-days: 0   # the l10n submodule has frequent Weblate commits; always pick the latest


### PR DESCRIPTION
### Purpose

Since July 2026, Dependabot applies a default 3-day cooldown to all version updates. The `l10n` submodule (`davx5-translations`) gets frequent Weblate commits – so the cooldown filters out all recent commits and Dependabot picks an outdated commit.

This caused [PR #2854](https://github.com/bitfireAT/davx5-ose/pull/2854) to bump `l10n` to `b61ffc6`, a commit that predates the re-addition of `credits/weblate-translators.json` in the l10n repo. The missing file made `AboutViewModelTest.test_loadWeblateTranslators` fail.
