### PR TITLE
Disable dependenciesInfo block for reproducible builds

### DIFF
--- a/app-ose/build.gradle.kts
+++ b/app-ose/build.gradle.kts
@@ -54,6 +54,13 @@ android {
         generateLocaleConfig = true
     }
 
+    // The dependencies info block is only useful for Google Play [https://developer.android.com/build/dependencies#dependency-info-play]
+    // and encrypted with Google's public key (encryption is non-deterministic by design → breaks reproducible builds).
+    dependenciesInfo {
+        includeInApk = false
+        includeInBundle = false
+    }
+
     @Suppress("UnstableApiUsage")
     testOptions {
         managedDevices {


### PR DESCRIPTION
### Purpose

Disables the `dependenciesInfo` block in the build configuration to ensure reproducible builds. The `dependenciesInfo` block includes metadata that can vary between builds, which prevents builds from being byte-for-byte reproducible.


### Short description

- Disabled the `dependenciesInfo` block in the build configuration.
- This ensures that build outputs are reproducible by removing non-deterministic dependency metadata.


### Checklist

- [x] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [x] I have added documentation to complex functions and functions that can be used by other modules.
- [x] I have added reasonable tests or consciously decided to not add tests.