### PR TITLE
Add debug signing config option for release builds

### DIFF
--- a/app-ose/build.gradle.kts
+++ b/app-ose/build.gradle.kts
@@ -92,7 +92,8 @@ android {
 
             isShrinkResources = true
 
-            // must be after signingConfigs {} block
+            // Must be after signingConfigs {} block. Uncomment following line to test release build with debug signing key:
+            // signingConfig = signingConfigs.getByName("debug")
             signingConfig = signingConfigs.findByName("bitfire")
         }
     }


### PR DESCRIPTION
Adds a commented-out debug signing configuration option for release builds, allowing developers to easily enable debug signing when needed for testing or development purposes.