### PR TITLE
Fix opaque log message for account configuration

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/servicedetection/DavResourceFinder.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/servicedetection/DavResourceFinder.kt
@@ -461,7 +461,7 @@ class DavResourceFinder @AssistedInject constructor(
 
     // data classes
 
-    class Configuration(
+    data class Configuration(
         val cardDAV: ServiceInfo?,
         val calDAV: ServiceInfo?,
 


### PR DESCRIPTION
Convert DavResourceFinder.Configuration to a data class to provide a human-readable toString() implementation. This ensures that account configuration details are visible in logs instead of memory addresses.

Closes #2877