### PR TITLE
Improve failed resource detection page

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/DetectResourcesPage.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/DetectResourcesPage.kt
@@ -13,7 +13,10 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Block
+import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.CloudOff
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Key
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
@@ -24,6 +27,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
@@ -35,7 +40,11 @@ import at.bitfire.davdroid.ui.DebugInfoActivity
 import at.bitfire.davdroid.ui.ExternalUris
 import at.bitfire.davdroid.ui.ExternalUris.withStatParams
 import at.bitfire.davdroid.ui.UiUtils.toAnnotatedString
+import at.bitfire.davdroid.ui.composable.ActionCard
+import at.bitfire.davdroid.ui.composable.IconCard
 import at.bitfire.davdroid.ui.composable.ProgressBar
+import at.bitfire.davdroid.ui.composable.appPasswordHelpUrl
+
 @Composable
 fun DetectResourcesPage(
     model: LoginScreenViewModel = viewModel()
@@ -103,6 +112,8 @@ fun DetectResourcesPageContent_NothingFound(
     encountered401: Boolean,
     debugLogFileName: DebugDirectory.FileName?
 ) {
+    val context = LocalContext.current
+
     Column(Modifier.padding(8.dp)) {
         Text(
             stringResource(R.string.login_configuration_detection),
@@ -110,8 +121,12 @@ fun DetectResourcesPageContent_NothingFound(
             modifier = Modifier.padding(bottom = 16.dp)
         )
 
-        Card(Modifier.fillMaxWidth()) {
-            Column(Modifier.padding(8.dp)) {
+        Card(
+            Modifier
+                .fillMaxWidth()
+                .padding(bottom = 8.dp)
+        ) {
+            Column(Modifier.padding(16.dp)) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Icon(Icons.Default.CloudOff, contentDescription = null, modifier = Modifier.padding(end = 8.dp))
                     Text(
@@ -124,51 +139,63 @@ fun DetectResourcesPageContent_NothingFound(
                 Text(
                     stringResource(R.string.login_no_service_info),
                     style = MaterialTheme.typography.bodyLarge,
-                    modifier = Modifier.padding(top = 16.dp, bottom = 8.dp)
+                    modifier = Modifier.padding(top = 16.dp)
                 )
-
-                val context = LocalContext.current
-                val urlServices = ExternalUris.Homepage.baseUrl.buildUpon()
-                    .appendPath(ExternalUris.Homepage.PATH_TESTED_SERVICES)
-                    .withStatParams(context, "DetectResourcesPage")
-                    .build()
-                val testedServices = HtmlCompat.fromHtml(
-                    stringResource(R.string.login_see_tested_services, urlServices),
-                    HtmlCompat.FROM_HTML_MODE_COMPACT
-                ).toAnnotatedString()
-                Text(
-                    text = testedServices,
-                    style = MaterialTheme.typography.bodyLarge,
-                    modifier = Modifier.padding(vertical = 8.dp)
-                )
-
-                if (encountered401)
-                    Text(
-                        stringResource(R.string.login_check_credentials),
-                        modifier = Modifier.padding(vertical = 8.dp),
-                        style = MaterialTheme.typography.bodyLarge
-                    )
-
-                if (debugLogFileName != null) {
-                    Text(
-                        stringResource(R.string.login_logs_available),
-                        style = MaterialTheme.typography.bodyLarge,
-                        modifier = Modifier.padding(vertical = 8.dp)
-                    )
-
-                    Button(
-                        onClick = {
-                            val intent = DebugInfoActivity.IntentBuilder(context)
-                                .withDebugLogFile(debugLogFileName)
-                                .build()
-                            context.startActivity(intent)
-                        }
-                    ) {
-                        Text(stringResource(R.string.login_view_logs))
-                    }
-                }
             }
         }
+
+        // most likely cause when the server answered with 401, so show it first
+        if (encountered401)
+            IconCard(
+                icon = Icons.Default.Key,
+                modifier = Modifier.padding(bottom = 8.dp)
+            ) {
+                Text(
+                    AnnotatedString.fromHtml(
+                        stringResource(
+                            R.string.login_check_credentials,
+                            appPasswordHelpUrl().toString()
+                        )
+                    ),
+                    style = MaterialTheme.typography.bodyLarge
+                )
+            }
+
+        val urlServices = ExternalUris.Homepage.baseUrl.buildUpon()
+            .appendPath(ExternalUris.Homepage.PATH_TESTED_SERVICES)
+            .withStatParams(context, "DetectResourcesPage")
+            .build()
+        IconCard(
+            icon = Icons.Default.Info,
+            modifier = Modifier.padding(bottom = 8.dp)
+        ) {
+            Text(
+                AnnotatedString.fromHtml(
+                    stringResource(
+                        R.string.login_see_tested_services,
+                        urlServices
+                    )
+                ),
+                style = MaterialTheme.typography.bodyLarge
+            )
+        }
+
+        if (debugLogFileName != null)
+            ActionCard(
+                icon = Icons.Default.BugReport,
+                actionText = stringResource(R.string.login_view_logs),
+                onAction = {
+                    val intent = DebugInfoActivity.IntentBuilder(context)
+                        .withDebugLogFile(debugLogFileName)
+                        .build()
+                    context.startActivity(intent)
+                }
+            ) {
+                Text(
+                    stringResource(R.string.login_logs_available),
+                    style = MaterialTheme.typography.bodyLarge
+                )
+            }
     }
 }
 
@@ -237,6 +264,15 @@ fun DetectResourcesPage_NothingFound_401() {
     DetectResourcesPageContent_NothingFound(
         encountered401 = true,
         debugLogFileName = null
+    )
+}
+
+@Composable
+@Preview
+fun DetectResourcesPage_NothingFound_401_WithLogs() {
+    DetectResourcesPageContent_NothingFound(
+        encountered401 = true,
+        debugLogFileName = DebugDirectory.FileName("davdroid-detection.log")
     )
 }
 

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -342,9 +342,9 @@
     <string name="login_configuration_detection">Configuration detection</string>
     <string name="login_querying_server">Please wait, querying server…</string>
     <string name="login_no_service">Couldn\'t find CalDAV or CardDAV service.</string>
-    <string name="login_no_service_info">The base URL doesn\'t seem to be an accessible CalDAV/CardDAV URL and service detection was not successful.</string>
-    <string name="login_see_tested_services"><![CDATA[Please see the manual of your service provider and <a href="%s">our list of tested services</a> and their base URLs.]]></string>
-    <string name="login_check_credentials">Please also double-check authentication (usually username and password).</string>
+    <string name="login_no_service_info">There\'s no CalDAV or CardDAV service at the base URL you entered, and automatic detection didn\'t find one either. Usually this means that the base URL is wrong.</string>
+    <string name="login_see_tested_services"><![CDATA[The correct base URL is usually documented by your service provider. You can also look it up in <a href="%s">our list of tested services</a>.]]></string>
+    <string name="login_check_credentials"><![CDATA[The server rejected the login. Please double-check your username and password. Some providers require an <a href="%s">app password</a> instead of your regular password.]]></string>
     <string name="login_logs_available">Further technical information is available in the logs.</string>
     <string name="login_view_logs">View logs</string>
     <string name="login_invalid_use_case">Invalid use-case</string>


### PR DESCRIPTION
### Purpose

Improve hints and layout of failed resource detection page, such that users more easily understand what is going on.

### Short description

UI:
- Separate cards
- Add icons

Wording:
* `login_no_service`: Couldn't find CalDAV or CardDAV service. => unchanged
* `login_no_service_info`: The base URL doesn't seem to be an accessible CalDAV/CardDAV URL and service detection was not successful. => There's no CalDAV or CardDAV service at the base URL you entered, and automatic detection didn't find one either. Usually this means that the base URL is wrong.
* `login_check_credentials`: Please also double-check authentication (usually username and password). => The server rejected the login. Please double-check your user name and password. Some providers require an `<a href="%s">app password</a>` instead of your regular password.
* `login_see_tested_services`: Please see the manual of your service provider and <a href="%s">our list of tested services</a> and their base URLs. => The correct base URL is usually documented by your service provider. You can also look it up in <a href="%s">our list of tested services</a>.
* `login_logs_available`: Further technical information is available in the logs. => unchanged
* `login_view_logs`: View logs => unchanged


<details>

| <img width="716" height="1438" alt="image" src="https://github.com/user-attachments/assets/e93a2192-baf8-402e-ba80-5abd7032f25f" />  | <img width="693" height="1128" alt="image" src="https://github.com/user-attachments/assets/86c87f45-886f-4a19-bff1-ed539f89161b" /> |
|---|---|




</details>


### Checklist

- [X] The PR has a proper title, description and label.
- [x] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.

