### PR TITLE
Fix sync conflict for locally modified, but remotely deleted resources + related cases

### DIFF
--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/LocalTestCollection.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/LocalTestCollection.kt
@@ -26,8 +26,8 @@ class LocalTestCollection(
 
     override suspend fun markNotDirty(flags: Int): Int {
         var updated = 0
-        for (dirty in entries.filter { it.dirty }) {
-            dirty.flags = flags
+        for (notDirty in entries.filter { !it.dirty }) {
+            notDirty.flags = flags
             updated++
         }
         return updated

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncManagerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncManagerTest.kt
@@ -576,6 +576,32 @@ class SyncManagerTest {
     }
 
     @Test
+    fun testPerformSync_UploadNewMember_409Conflict() = runTest {
+        // 409 when creating a new resource doesn't tell us that the server has a version which we could
+        // download instead: RFC 4918 9.7.1 requires it when the collection itself is not there (anymore).
+        // So it's a sync error and the local resource must be kept (and stay dirty).
+        val collection = LocalTestCollection().apply {
+            lastSyncState = SyncState(SyncState.Type.CTAG, "old-ctag")
+            entries += LocalTestResource().apply {
+                dirty = true
+            }
+        }
+        enqueueQueryCapabilities("ctag1")
+
+        // PUT -> 409 Conflict
+        mockEngineQueue.enqueue(HttpStatusCode.Conflict)
+
+        val syncManager = syncManager(collection)
+        syncManager.performSync()
+
+        assertTrue(syncManager.syncResult.hasError)
+        assertEquals(1, collection.entries.size)
+        assertTrue(collection.entries.first().dirty)
+        assertEquals(1, numberOfPutRequests())
+        assertEquals(SyncState(SyncState.Type.CTAG, "old-ctag"), collection.lastSyncState)
+    }
+
+    @Test
     fun testPerformSync_UploadNewMember_404NotFound() = runTest {
         // 404 when creating a new resource means that the collection itself is not there (anymore),
         // which is a sync error. The local resource must be kept (and stay dirty).

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncManagerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncManagerTest.kt
@@ -7,6 +7,7 @@ package at.bitfire.davdroid.sync
 import android.content.Context
 import androidx.core.app.NotificationManagerCompat
 import androidx.hilt.work.HiltWorkerFactory
+import at.bitfire.dav4jvm.property.webdav.SyncToken
 import at.bitfire.davdroid.MockEngineQueue
 import at.bitfire.davdroid.TestUtils
 import at.bitfire.davdroid.TestUtils.assertWithin
@@ -14,6 +15,7 @@ import at.bitfire.davdroid.accounts.LegacyAccount
 import at.bitfire.davdroid.db.Collection
 import at.bitfire.davdroid.repository.DavSyncStatsRepository
 import at.bitfire.davdroid.resource.local.SyncState
+import at.bitfire.davdroid.resource.remote.CollectionSyncItem
 import at.bitfire.davdroid.resource.remote.InternalMemberState
 import at.bitfire.davdroid.resource.remote.TestWebDavCollection
 import at.bitfire.davdroid.resource.remote.WebDavCollection
@@ -563,6 +565,78 @@ class SyncManagerTest {
         assertTrue(syncManager.syncResult.hasError)
         assertEquals(1, collection.entries.size)
         assertTrue(collection.entries.first().dirty)
+        assertEquals(1, numberOfPutRequests())
+    }
+
+    @Test
+    fun testPerformSync_CollectionSync_UploadModifiedMember_403Forbidden_NeedPrivileges() = runTest {
+        // The resource itself hasn't been changed on the server, so a sync-collection REPORT wouldn't
+        // report it. Discarding the local change must force a full re-listing, otherwise the local
+        // version would never be overwritten by the server's version.
+        val collection = LocalTestCollection().apply {
+            lastSyncState = SyncState(SyncState.Type.SYNC_TOKEN, "token1")
+            entries += LocalTestResource().apply {
+                fileName = "not-writable.txt"
+                eTag = "some-etag"
+                dirty = true
+            }
+        }
+        enqueueQueryCapabilities()
+
+        // PUT -> 403 Forbidden with DAV:need-privileges precondition
+        mockEngineQueue.enqueue(
+            HttpStatusCode.Forbidden,
+            "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n" +
+                    "<error xmlns=\"DAV:\"><need-privileges/></error>",
+            headersOf(HttpHeaders.ContentType, "text/xml")
+        )
+
+        val syncManager = syncManager(collection).apply {
+            chosenSyncAlgorithm = SyncManager.SyncAlgorithm.COLLECTION_SYNC
+        }
+        // server doesn't report any changes
+        every { syncManager.remoteCollection.listChanges(any()) } returns flowOf(
+            CollectionSyncItem.SyncToken(SyncToken("token2"))
+        )
+        syncManager.performSync()
+
+        // initial sync (= full listing), because the sync state has been reset
+        verify(exactly = 1) { syncManager.remoteCollection.listChanges(null) }
+        assertFalse(syncManager.syncResult.hasError)
+        assertTrue(collection.entries.isEmpty())
+        assertEquals(1, numberOfPutRequests())
+    }
+
+    @Test
+    fun testPerformSync_CollectionSync_UploadNewMember_412PreconditionFailed() = runTest {
+        // The resource which is already on the server may be older than our sync-token, so a
+        // sync-collection REPORT wouldn't report it. Discarding the local change must force a full
+        // re-listing, otherwise the local resource would stay behind forever (it has no file name, so
+        // it's neither uploaded again nor recognized as a member of the collection).
+        val collection = LocalTestCollection().apply {
+            lastSyncState = SyncState(SyncState.Type.SYNC_TOKEN, "token1")
+            entries += LocalTestResource().apply {
+                dirty = true
+            }
+        }
+        enqueueQueryCapabilities()
+
+        // PUT -> 412 Precondition Failed
+        mockEngineQueue.enqueue(HttpStatusCode.PreconditionFailed)
+
+        val syncManager = syncManager(collection).apply {
+            chosenSyncAlgorithm = SyncManager.SyncAlgorithm.COLLECTION_SYNC
+        }
+        // server doesn't report any changes
+        every { syncManager.remoteCollection.listChanges(any()) } returns flowOf(
+            CollectionSyncItem.SyncToken(SyncToken("token2"))
+        )
+        syncManager.performSync()
+
+        // initial sync (= full listing), because the sync state has been reset
+        verify(exactly = 1) { syncManager.remoteCollection.listChanges(null) }
+        assertFalse(syncManager.syncResult.hasError)
+        assertTrue(collection.entries.isEmpty())
         assertEquals(1, numberOfPutRequests())
     }
 

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncManagerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncManagerTest.kt
@@ -392,6 +392,37 @@ class SyncManagerTest {
     }
 
     @Test
+    fun testPerformSync_UploadModifiedMember_409Conflict_DataRejected() = runTest {
+        // A 409 which reports a CalDAV/CardDAV precondition means that our data was rejected, so there's
+        // no server version which could replace the local one: assert sync error and that the local change is kept.
+        val collection = LocalTestCollection().apply {
+            lastSyncState = SyncState(SyncState.Type.CTAG, "old-ctag")
+            entries += LocalTestResource().apply {
+                fileName = "existing-file.txt"
+                eTag = "some-etag"
+                dirty = true
+            }
+        }
+        enqueueQueryCapabilities("ctag1")
+
+        // PUT -> 409 Conflict with CALDAV:no-uid-conflict precondition
+        mockEngineQueue.enqueue(
+            HttpStatusCode.Conflict,
+            "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n" +
+                    "<error xmlns=\"DAV:\"><no-uid-conflict xmlns=\"urn:ietf:params:xml:ns:caldav\"/></error>",
+            headersOf(HttpHeaders.ContentType, "text/xml")
+        )
+
+        val syncManager = syncManager(collection)
+        syncManager.performSync()
+
+        assertTrue(syncManager.syncResult.hasError)
+        assertEquals(1, collection.entries.size)
+        assertTrue(collection.entries.first().dirty)
+        assertEquals(SyncState(SyncState.Type.CTAG, "old-ctag"), collection.lastSyncState)
+    }
+
+    @Test
     fun testPerformSync_UploadModifiedMember_404NotFound() = runTest {
         // Servers which don't answer 412 when the resource is gone must be handled like 412,
         // especially the upload must not be retried as a new resource ("the server always wins").

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncManagerTest.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/SyncManagerTest.kt
@@ -25,6 +25,7 @@ import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import io.ktor.client.HttpClient
 import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
 import io.ktor.http.headersOf
@@ -35,6 +36,7 @@ import io.mockk.junit4.MockKRule
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -105,6 +107,11 @@ class SyncManagerTest {
             headersOf(HttpHeaders.ContentType, "text/xml")
         )
     }
+
+    /** Number of `PUT` requests which have been sent to the mock engine. */
+    private fun numberOfPutRequests() =
+        mockEngineQueue.engine.requestHistory.count { it.method == HttpMethod.Put }
+
 
     @Before
     fun setUp() {
@@ -271,7 +278,7 @@ class SyncManagerTest {
     }
 
     @Test
-    fun testPerformSync_UploadModifiedMember_412PreconditionFailed() = runTest {
+    fun testPerformSync_UploadModifiedMember_412PreconditionFailed_ChangedOnServer() = runTest {
         val collection = LocalTestCollection().apply {
             lastSyncState = SyncState(SyncState.Type.CTAG, "old-ctag")
             entries += LocalTestResource().apply {
@@ -317,6 +324,246 @@ class SyncManagerTest {
         assertFalse(syncManager.syncResult.hasError)
         assertEquals(1, collection.entries.size)
         assertEquals("changed-etag-from-server", collection.entries.first().eTag)
+        // local change has been discarded, so the resource is not dirty anymore
+        assertFalse(collection.entries.first().dirty)
+        // the upload must not be retried within the same sync
+        assertEquals(1, numberOfPutRequests())
+    }
+
+    @Test
+    fun testPerformSync_UploadModifiedMember_412PreconditionFailed_DeletedOnServer() = runTest {
+        // The resource has been deleted on the server, so our If-Match doesn't match anymore
+        // (RFC 9110 13.1.1). The local change is discarded and the resource is deleted locally.
+        val collection = LocalTestCollection().apply {
+            lastSyncState = SyncState(SyncState.Type.CTAG, "old-ctag")
+            entries += LocalTestResource().apply {
+                fileName = "deleted-on-server.txt"
+                eTag = "etag-of-the-resource-which-has-been-deleted-on-server"
+                dirty = true
+            }
+        }
+        enqueueQueryCapabilities("ctag1")
+
+        // PUT -> 412 Precondition Failed
+        mockEngineQueue.enqueue(HttpStatusCode.PreconditionFailed)
+
+        // modifications sent, so DAVx5 will query CTag again
+        enqueueQueryCapabilities("ctag1")
+
+        // server doesn't list the resource anymore
+        val syncManager = syncManager(collection)
+        syncManager.performSync()
+
+        verify(exactly = 1) { syncManager.remoteCollection.listFilteredMembers() }
+        assertTrue(syncManager.didGenerateUpload)
+        assertTrue(syncManager.processedDownloads.isEmpty())
+        assertFalse(syncManager.syncResult.hasError)
+        assertTrue(collection.entries.isEmpty())
+        assertEquals(1, numberOfPutRequests())
+    }
+
+    @Test
+    fun testPerformSync_UploadModifiedMember_409Conflict() = runTest {
+        // We can't resolve a conflict interactively, so 409 is treated like 412.
+        val collection = LocalTestCollection().apply {
+            lastSyncState = SyncState(SyncState.Type.CTAG, "old-ctag")
+            entries += LocalTestResource().apply {
+                fileName = "deleted-on-server.txt"
+                eTag = "some-etag"
+                dirty = true
+            }
+        }
+        enqueueQueryCapabilities("ctag1")
+
+        // PUT -> 409 Conflict
+        mockEngineQueue.enqueue(HttpStatusCode.Conflict)
+
+        // modifications sent, so DAVx5 will query CTag again
+        enqueueQueryCapabilities("ctag1")
+
+        val syncManager = syncManager(collection)
+        syncManager.performSync()
+
+        assertFalse(syncManager.syncResult.hasError)
+        assertTrue(collection.entries.isEmpty())
+        assertEquals(1, numberOfPutRequests())
+    }
+
+    @Test
+    fun testPerformSync_UploadModifiedMember_404NotFound() = runTest {
+        // Servers which don't answer 412 when the resource is gone must be handled like 412,
+        // especially the upload must not be retried as a new resource ("the server always wins").
+        val collection = LocalTestCollection().apply {
+            lastSyncState = SyncState(SyncState.Type.CTAG, "old-ctag")
+            entries += LocalTestResource().apply {
+                fileName = "deleted-on-server.txt"
+                eTag = "some-etag"
+                dirty = true
+            }
+        }
+        enqueueQueryCapabilities("ctag1")
+
+        // PUT -> 404 Not Found
+        mockEngineQueue.enqueue(HttpStatusCode.NotFound)
+
+        // modifications sent, so DAVx5 will query CTag again
+        enqueueQueryCapabilities("ctag1")
+
+        val syncManager = syncManager(collection)
+        syncManager.performSync()
+
+        assertFalse(syncManager.syncResult.hasError)
+        assertTrue(collection.entries.isEmpty())
+        assertEquals(1, numberOfPutRequests())
+    }
+
+    @Test
+    fun testPerformSync_UploadModifiedMember_410Gone() = runTest {
+        val collection = LocalTestCollection().apply {
+            lastSyncState = SyncState(SyncState.Type.CTAG, "old-ctag")
+            entries += LocalTestResource().apply {
+                fileName = "deleted-on-server.txt"
+                eTag = "some-etag"
+                dirty = true
+            }
+        }
+        enqueueQueryCapabilities("ctag1")
+
+        // PUT -> 410 Gone
+        mockEngineQueue.enqueue(HttpStatusCode.Gone)
+
+        // modifications sent, so DAVx5 will query CTag again
+        enqueueQueryCapabilities("ctag1")
+
+        val syncManager = syncManager(collection)
+        syncManager.performSync()
+
+        assertFalse(syncManager.syncResult.hasError)
+        assertTrue(collection.entries.isEmpty())
+        assertEquals(1, numberOfPutRequests())
+    }
+
+    @Test
+    fun testPerformSync_UploadModifiedMember_403Forbidden_NeedPrivileges() = runTest {
+        // The collection is effectively read-only for us, so the local change is discarded.
+        val collection = LocalTestCollection().apply {
+            lastSyncState = SyncState(SyncState.Type.CTAG, "old-ctag")
+            entries += LocalTestResource().apply {
+                fileName = "not-writable.txt"
+                eTag = "some-etag"
+                dirty = true
+            }
+        }
+        enqueueQueryCapabilities("ctag1")
+
+        // PUT -> 403 Forbidden with DAV:need-privileges precondition
+        mockEngineQueue.enqueue(
+            HttpStatusCode.Forbidden,
+            "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n" +
+                    "<error xmlns=\"DAV:\"><need-privileges/></error>",
+            headersOf(HttpHeaders.ContentType, "text/xml")
+        )
+
+        // modifications sent, so DAVx5 will query CTag again
+        enqueueQueryCapabilities("ctag1")
+
+        val syncManager = syncManager(collection)
+        syncManager.performSync()
+
+        assertFalse(syncManager.syncResult.hasError)
+        assertTrue(collection.entries.isEmpty())
+        assertEquals(1, numberOfPutRequests())
+    }
+
+    @Test
+    fun testPerformSync_UploadModifiedMember_403Forbidden_Other() = runTest {
+        // A 403 which is not caused by missing permissions is a sync error; the local change is kept.
+        val collection = LocalTestCollection().apply {
+            lastSyncState = SyncState(SyncState.Type.CTAG, "old-ctag")
+            entries += LocalTestResource().apply {
+                fileName = "existing-file.txt"
+                eTag = "some-etag"
+                dirty = true
+            }
+        }
+        enqueueQueryCapabilities("ctag1")
+
+        // PUT -> 403 Forbidden without further information
+        mockEngineQueue.enqueue(HttpStatusCode.Forbidden)
+
+        val syncManager = syncManager(collection)
+        syncManager.performSync()
+
+        assertTrue(syncManager.syncResult.hasError)
+        assertEquals(1, collection.entries.size)
+        assertTrue(collection.entries.first().dirty)
+    }
+
+    @Test
+    fun testPerformSync_UploadNewMember_412PreconditionFailed() = runTest {
+        // A new resource is uploaded with If-None-Match: *, so 412 means that the file name (which is
+        // derived from the UID) is already taken on the server. The local change is discarded and the
+        // server's version is downloaded instead, so that there's exactly one local resource afterwards.
+        val collection = LocalTestCollection().apply {
+            lastSyncState = SyncState(SyncState.Type.CTAG, "old-ctag")
+            entries += LocalTestResource().apply {
+                dirty = true
+            }
+        }
+        enqueueQueryCapabilities("ctag1")
+
+        // PUT -> 412 Precondition Failed
+        mockEngineQueue.enqueue(HttpStatusCode.PreconditionFailed)
+
+        // modifications sent, so DAVx5 will query CTag again
+        enqueueQueryCapabilities("ctag1")
+
+        val syncManager = syncManager(collection).apply {
+            (remoteCollection as TestWebDavCollection).listFilteredMembersResult = listOf(
+                InternalMemberState(Url("$BASE_URL/generated-file.txt"), "etag-from-server")
+            )
+        }
+        every { syncManager.remoteCollection.multiget(any(), any()) } returns flowOf(
+            WebDavCollection.MultiGetItem(
+                Url("$BASE_URL/generated-file.txt"),
+                "etag-from-server",
+                content = "ignored"
+            )
+        )
+        syncManager.performSync()
+
+        assertFalse(syncManager.syncResult.hasError)
+        assertEquals(1, collection.entries.size)
+        collection.entries.first().let { entry ->
+            assertEquals("generated-file.txt", entry.fileName)
+            assertEquals("etag-from-server", entry.eTag)
+            assertFalse(entry.dirty)
+        }
+        assertEquals(1, numberOfPutRequests())
+    }
+
+    @Test
+    fun testPerformSync_UploadNewMember_404NotFound() = runTest {
+        // 404 when creating a new resource means that the collection itself is not there (anymore),
+        // which is a sync error. The local resource must be kept (and stay dirty).
+        val collection = LocalTestCollection().apply {
+            lastSyncState = SyncState(SyncState.Type.CTAG, "old-ctag")
+            entries += LocalTestResource().apply {
+                dirty = true
+            }
+        }
+        enqueueQueryCapabilities("ctag1")
+
+        // PUT -> 404 Not Found
+        mockEngineQueue.enqueue(HttpStatusCode.NotFound)
+
+        val syncManager = syncManager(collection)
+        syncManager.performSync()
+
+        assertTrue(syncManager.syncResult.hasError)
+        assertEquals(1, collection.entries.size)
+        assertTrue(collection.entries.first().dirty)
+        assertEquals(1, numberOfPutRequests())
     }
 
     @Test
@@ -435,6 +682,30 @@ class SyncManagerTest {
         assertTrue(syncManager.processedDownloads.isEmpty())
         assertFalse(syncManager.syncResult.hasError)
         assertTrue(collection.entries.isEmpty())
+    }
+
+    @Test
+    fun testPerformSync_KeepVanishedMemberWhichBecameDirtyDuringSync() = runTest {
+        // A resource which is created locally *while* the sync is running has never had a chance to be
+        // uploaded, so it must not be deleted by deleteNotPresentRemotely() although the server didn't
+        // list it. This is why resetPresentRemotely()/deleteNotPresentRemotely() ignore dirty entries.
+        val collection = LocalTestCollection().apply {
+            lastSyncState = SyncState(SyncState.Type.CTAG, "old-ctag")
+        }
+        enqueueQueryCapabilities(cTag = "new-ctag")
+
+        val syncManager = syncManager(collection)
+        every { syncManager.remoteCollection.listFilteredMembers() } returns flow {
+            // user creates a local resource while the (empty) remote listing is being processed
+            collection.entries += LocalTestResource().apply {
+                dirty = true
+            }
+        }
+        syncManager.performSync()
+
+        assertFalse(syncManager.syncResult.hasError)
+        assertEquals(1, collection.entries.size)
+        assertTrue(collection.entries.first().dirty)
     }
 
     @Test

--- a/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/TestSyncManager.kt
+++ b/core/src/androidTest/kotlin/at/bitfire/davdroid/sync/TestSyncManager.kt
@@ -61,7 +61,8 @@ class TestSyncManager @AssistedInject constructor(
         )
     }
 
-    override fun syncAlgorithm(capabilities: WebDavCollection.Capabilities) = SyncAlgorithm.PROPFIND_REPORT
+    var chosenSyncAlgorithm = SyncAlgorithm.PROPFIND_REPORT
+    override fun syncAlgorithm(capabilities: WebDavCollection.Capabilities) = chosenSyncAlgorithm
 
     var processedDownloads = emptyList<WebDavCollection.MultiGetItem>()
     override suspend fun processDownload(result: WebDavCollection.MultiGetItem) {

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -311,13 +311,10 @@ abstract class SyncManager<LocalType : LocalResource>(
      *
      * @param local         resource to upload
      * @param capabilities  current capabilities of the remote collection
-     * @param forceAsNew    whether the ETag (and Schedule-Tag) of [local] are ignored and the resource
-     *                      is created as a new resource on the server
      */
     protected suspend fun uploadDirty(
         local: LocalType,
-        capabilities: WebDavCollection.Capabilities,
-        forceAsNew: Boolean = false
+        capabilities: WebDavCollection.Capabilities
     ) {
         val existingFileName = local.fileName
 
@@ -328,7 +325,7 @@ abstract class SyncManager<LocalType : LocalResource>(
 
         try {
             uploadUrl.withExceptionContext {
-                if (existingFileName == null || forceAsNew) {
+                if (existingFileName == null) {
                     // create new resource on server
                     logger.log(Level.INFO, "Uploading new resource {0} -> {1}", arrayOf<Any?>(local.id, fileName))
 
@@ -381,36 +378,63 @@ abstract class SyncManager<LocalType : LocalResource>(
             when (val ex = e.unwrapContext().cause) {
                 is ForbiddenException -> {
                     // HTTP 403 Forbidden
-                    // If and only if the upload failed because of missing permissions, treat it like 412.
-                    if (ex.errors.contains(Error(WebDAV.NeedPrivileges)))
-                        logger.log(Level.INFO, "Couldn't upload because of missing permissions, ignoring", ex)
-                    else
+                    // If and only if the upload failed because of missing permissions, the collection is
+                    // effectively read-only for us, so we do the same as ReadOnlyPolicy.resetDirty().
+                    if (ex.errors.contains(Error(WebDAV.NeedPrivileges))) {
+                        logger.log(
+                            Level.INFO,
+                            "Couldn't upload because of missing permissions, discarding local change",
+                            ex
+                        )
+                        discardLocalChange(local)
+                    } else
                         throw e
                 }
+
                 is NotFoundException, is GoneException -> {
-                    // HTTP 404 Not Found (i.e. either original resource or the whole collection is not there anymore)
-                    if (!forceAsNew) {      // first try; if this fails with 404, too, the collection is gone
-                        logger.info("Original version of locally modified resource is not there (anymore), trying as fresh upload")
-                        uploadDirty(local, capabilities, forceAsNew = true)
-                        return
-                    } else {
-                        // we tried with forceAsNew, collection probably gone
+                    // HTTP 404 Not Found / 410 Gone
+                    if (existingFileName == null) {
+                        // We wanted to create a new resource, so the collection itself is not there (anymore).
                         throw e
+                    } else {
+                        // The resource we wanted to update is not there (anymore). RFC 9110 13.1.1 requires
+                        // 412 in this case, but some servers answer 404/410 - handle it the same way (see below).
+                        logger.info("Resource to update is not there (anymore), discarding local change")
+                        discardLocalChange(local)
                     }
                 }
-                is ConflictException -> {
-                    // HTTP 409 Conflict
-                    // We can't interact with the user to resolve the conflict, so we treat 409 like 412.
-                    logger.info("Edit conflict, ignoring")
+
+                is ConflictException, is PreconditionFailedException -> {
+                    // HTTP 409 Conflict / 412 Precondition failed
+                    //
+                    // When updating, our If-Match / If-Schedule-Tag-Match didn't match, so the resource
+                    // has been modified or deleted on the server in the meanwhile (RFC 9110 13.1.1).
+                    //
+                    // When creating, our If-None-Match: * didn't match, so the server already has a
+                    // resource with that file name. Because the file name is derived from the UID, that's
+                    // usually our own resource from a previous, partially completed sync.
+                    //
+                    // In both cases we can't interact with the user to resolve the conflict, so the
+                    // server's version wins and is downloaded instead.
+                    logger.info("Upload rejected because of a conflict on the server, discarding local change")
+                    discardLocalChange(local)
                 }
-                is PreconditionFailedException -> {
-                    // HTTP 412 Precondition failed: Resource has been modified on the server in the meanwhile.
-                    // Ignore this condition so that the resource can be downloaded and reset again.
-                    logger.info("Resource has been modified on the server before upload, ignoring")
-                }
+
                 else -> throw e
             }
         }
+    }
+
+    /**
+     * Discards a local modification which couldn't be uploaded because of a conflict with the server
+     * ("the server always wins"): clears the dirty flag and resets the ETag/Schedule-Tag, so that the
+     * resource is either
+     *
+     * - downloaded again and overwritten with the server's version (if it's still on the server), or
+     * - deleted locally by [deleteNotPresentRemotely] / [deleteRemovedMember] (if it's not there anymore).
+     */
+    private suspend fun discardLocalChange(local: LocalType) {
+        local.clearDirty(fileName = Optional.empty(), eTag = null, scheduleTag = null)
     }
 
     /**

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -404,8 +404,8 @@ abstract class SyncManager<LocalType : LocalResource>(
                     }
                 }
 
-                is ConflictException, is PreconditionFailedException -> {
-                    // HTTP 409 Conflict / 412 Precondition failed
+                is PreconditionFailedException -> {
+                    // HTTP 412 Precondition failed
                     //
                     // When updating, our If-Match / If-Schedule-Tag-Match didn't match, so the resource
                     // has been modified or deleted on the server in the meanwhile (RFC 9110 13.1.1).
@@ -416,8 +416,40 @@ abstract class SyncManager<LocalType : LocalResource>(
                     //
                     // In both cases we can't interact with the user to resolve the conflict, so the
                     // server's version wins and is downloaded instead.
-                    logger.info("Upload rejected because of a conflict on the server, discarding local change")
+                    logger.info("Upload rejected because of a failed precondition, discarding local change")
                     discardLocalChange(local)
+                }
+
+                is ConflictException -> {
+                    // HTTP 409 Conflict
+                    //
+                    // This can mean
+                    //   - that the server has a version which we could download instead of the local one,
+                    //   - the collection itself is not there (anymore) - RFC 4918 9.7.1 requires 409 for
+                    //     a PUT without an appropriately scoped parent collection, or
+                    //   - the server rejected our data - CalDAV/CardDAV preconditions may be reported as
+                    //     403 or 409 (RFC 4791 5.3.2.1, RFC 6352 6.3.2.1).
+                    //
+                    // Only in the first case there's a server version which could replace the local one,
+                    // and it's also the only case without a DAV:error element, because there's no error
+                    // condition for a failed If-Match. So we only discard the local change when we were
+                    // updating an existing member and the server didn't tell us any reason. Otherwise we
+                    // report an error (which notifies the user) and keep the dirty flag for the next sync.
+                    when {
+                        ex.errors.isNotEmpty() ->
+                            // server named a reason; none of the error conditions means that it has a
+                            // version for us to download
+                            throw e
+
+                        existingFileName == null ->
+                            // we wanted to create a new resource, so the collection is probably not there (anymore)
+                            throw e
+
+                        else -> {
+                            logger.info("Update rejected with 409 without further information, handling it like 412, discarding local change")
+                            discardLocalChange(local)
+                        }
+                    }
                 }
 
                 else -> throw e

--- a/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/sync/SyncManager.kt
@@ -432,9 +432,20 @@ abstract class SyncManager<LocalType : LocalResource>(
      *
      * - downloaded again and overwritten with the server's version (if it's still on the server), or
      * - deleted locally by [deleteNotPresentRemotely] / [deleteRemovedMember] (if it's not there anymore).
+     *
+     * Also forces a full re-listing, see below.
      */
     private suspend fun discardLocalChange(local: LocalType) {
         local.clearDirty(fileName = Optional.empty(), eTag = null, scheduleTag = null)
+
+        /* Resetting the ETag is only enough for SyncAlgorithm.PROPFIND_REPORT, where the full listing is
+        compared to the local ETags. With SyncAlgorithm.COLLECTION_SYNC, the server only reports members
+        which have changed since the last sync-token – and the resource we have just reset may not be among
+        them (for instance when the upload failed because of missing privileges, or when a locally created
+        resource collided with a server resource which is older than the sync-token). So we force a full
+        re-listing to make sure that the local resource is really overwritten by (or deleted along with)
+        the server's version, like ReadOnlyPolicy.resetDirty() does. */
+        localCollection.lastSyncState = null
     }
 
     /**


### PR DESCRIPTION
### Purpose

Given a locally modified resource which was also deleted on the server DAVx⁵ does a conditional `PUT` and gets a 412 which is correct per [RFC 9110 13.1.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.1), but not handled properly. DAVx⁵ only loggs it and keeps the dirty flag; `resetPresentRemotely()`/`deleteNotPresentRemotely()` skip dirty rows, so the resource never gets removed. Every following sync repeats the same failing `PUT` so it ends up as an endless loop, only fixable by disabling/re-enabling the collection.

Other error codes like 409 (same problem), 404 / 410 (lets client win) and 403 also need to be put into alignment.

### Short description

Following the [DAVx⁵ advertised conflict resolution strategy](https://manual.davx5.com/technical_information.html#conflict-handling), means that the server always wins. With this in mind the fix for the above described issue as well as for handling other error codes "correctly", is to: 

- Add a new helper method `discardLocalChange(local)`, which removes the local changes and resets sync-state/token, such that the resource in question can afterwards either be re-downloaded (if still on the server) or deleted locally. 
- Discard on **412** responses for updates *and* creates. On a create the file name comes from the UID, so a collision means the server already has that resource! Ignoring it would make DAVx⁵ keep looping.
- Discard on  **404 / 410** responses for update. `forceAsNew` (which let the *local* edit win) is removed.
- Rethrow on **404 / 410** for create (unchanged), when the collection itself is gone.
- Discard on **403 + `need-privileges`**, matching the existing "treat it like 412" comment and the read-only policy.
- Discard on **409** only for updates where the server didn't send a `DAV:error` at all. A 409 can also mean that the collection is missing ([RFC 4918                                             
  9.7.1](https://www.rfc-editor.org/rfc/rfc4918.html#section-9.7.1)) or that our data was rejected (`no-uid-conflict`, `valid-calendar-data`, `max-instances`, … – [RFC 4791 5.3.2.1](https://www.rfc-editor.org/rfc/rfc4791.html#section-5.3.2.1), [RFC 6352 6.3.2.1](https://www.rfc-editor.org/rfc/rfc6352.html#section-6.3.2.1)), and then there's nothing to download instead. A failed `If-Match` is the only case with a server version for us, and also the only one without an error condition – so any reason the server reports keeps the dirty flag and notifies with an error instead of silently dropping the local version.

Note:  Making `resetPresentRemotely`/`deleteNotPresentRemotely` include dirty rows is not done. That protection is needed for resources created while a sync is running.

Tests
- Fixed `LocalTestCollection.markNotDirty()`: it edited entries that *are* dirty, the opposite of all production implementations - like `LocalJtxCollection` etc.
- Edit the existing 412, changing its title to `..._412PreconditionFailed_ChangedOnServer` and add assertions that the row is no longer dirty and exactly one `PUT` was sent.
- New tests for
  - 412/409/404/410 with the resource deleted on the server
  - 403 with and without `need-privileges`
  - create + 412: check there is a single entry left which carries the server's file name/ETag
  - create + 404: check there is a sync error and the row stays dirty
  - 403 need-privileges at collection-sync: check the sync-state is reset and local change discarded
  - 412 at collection-sync when creating a new resource: check the sync-state is reset and local change discarded
  - New `testPerformSync_UploadModifiedMember_409Conflict_DataRejected` to guard against discarding changes on 409 update when precondition fails.
  - New `testPerformSync_UploadNewMember_409Conflict` to guard against discarding a new resource on 409, where the collection itself may be gone
- New `testPerformSync_KeepVanishedMemberWhichBecameDirtyDuringSync` to guard against `deleteNotPresentRemotely()` removing a resource which becomes dirty during sync.



### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests.

