### PR TITLE
Have back icon button go to previous page instead of always quitting the login flow

### DIFF
--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreen.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreen.kt
@@ -42,13 +42,11 @@ fun LoginScreen(
         factory.create(initialLoginType, skipLoginTypePage, initialLoginInfo)
     }
 
-    // handle back/up navigation
+    // handle back/up navigation: both go a single step back in the login flow; they only differ
+    // in how they leave the login flow when there's no previous page anymore
     BackHandler {
-        model.navBack()
-    }
-    if (model.finish) {
-        onFinish(null)
-        return
+        if (!model.navBack())
+            onFinish(null)
     }
 
     // get specific help URL from current login type (may be null → show "tested with" page)
@@ -57,7 +55,10 @@ fun LoginScreen(
     LoginScreenContent(
         page = model.page,
         helpUri = loginType.helpUrl,
-        onNavUp = onNavUp,
+        onNavUp = {
+            if (!model.navBack())
+                onNavUp()
+        },
         onFinish = onFinish
     )
 }

--- a/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenViewModel.kt
+++ b/core/src/main/kotlin/at/bitfire/davdroid/ui/setup/LoginScreenViewModel.kt
@@ -83,9 +83,6 @@ class LoginScreenViewModel @AssistedInject constructor(
     var page by mutableStateOf(startPage)
         private set
 
-    var finish by mutableStateOf(false)
-        private set
-
 
     // navigation events
 
@@ -126,26 +123,35 @@ class LoginScreenViewModel @AssistedInject constructor(
         }
     }
 
-    fun navBack() {
+    /**
+     * Navigates to the previous page of the login flow.
+     *
+     * @return  *true* if there was a previous page to go to;
+     *          *false* if the flow is at its first page and the caller should leave it
+     */
+    fun navBack(): Boolean =
         when (page) {
-            Page.LoginType ->
-                finish = true
+            Page.LoginType -> false
 
             Page.LoginDetails ->
                 if (loginTypesProvider.maybeNonInteractive)
-                    finish = true
-                else
+                    false
+                else {
                     page = Page.LoginType
+                    true
+                }
 
             Page.DetectResources -> {
                 cancelResourceDetection()
                 page = Page.LoginDetails
+                true
             }
 
-            Page.AccountDetails ->
+            Page.AccountDetails -> {
                 page = Page.LoginDetails
+                true
+            }
         }
-    }
 
 
     // UI element state – first page: login type


### PR DESCRIPTION
### Purpose

Materials ["Reverse Chronological Navigation"](https://m2.material.io/design/navigation/understanding-navigation.html#reverse-navigation) does indeed say the two back buttons functionality should differ. The system back button should then go to previous screen in login flow (child task) and the in app back icon button should quit the flow. 

This is the current behavior, but it is perceived as confusing and then frustrating as it loses user-input which results in really bad UX. 

Luckily, however, the android guidelines differ, and are very clear:

> [Android docs on principles of navigation](https://developer.android.com/guide/navigation/principles):
> The Up button appears in the app bar at the top of the screen. **Within your app's task, the Up and Back buttons behave identically.** 

I think that's what we should do. If really desired, we could add a X button at the top right of the toolbar for the "up" navigation, which would then quit the login flow completely, but I don't think it's necessary really. 

### Short description

- Have the login icon button step back in the flow.
- Quit the login flow only where there is no previous page to go back to.
- block back navigation while account creation is in progress

### Checklist

- [X] The PR has a proper title, description and label.
- [X] I have [self-reviewed the PR](https://patrickdinh.medium.com/review-your-own-pull-requests-5634cad10b7a).
- [X] I have added documentation to complex functions and functions that can be used by other modules.
- [X] I have added reasonable tests or consciously decided to not add tests. (We don't have UI tests)

